### PR TITLE
Clean up styles on download page

### DIFF
--- a/_layouts/download.html
+++ b/_layouts/download.html
@@ -32,7 +32,7 @@ layout: default
             Unstable builds have the latest features but are more likely to have critical bugs.
             {% endif %}
           </p>
-          <div>
+          <div class="download-details">
             <label class="language-select">
               <select>
                 {% for file in version.files %}
@@ -61,12 +61,12 @@ layout: default
                 {% endfor %}
               </select>
             </label>
+            <div class="download-buttons">
             {% for file in version.files['en_US'] %}
               <a class="download-button-{{stable}}" href="{{ file }}">DOWNLOAD {{ file | slice: -4, 4 | upcase }} NOW <i class="fas fa-download"></i></a>
             {% endfor %}
-            <div class="clear"></div>
-
-        </div>
+            </div>
+          </div>
       </div>
     {% endfor %}
     {% endif %}

--- a/assets/sass/pages/_download.scss
+++ b/assets/sass/pages/_download.scss
@@ -64,7 +64,7 @@
 
       .language-select {
         float: left;
-        margin-right: 10px;
+        margin-right: 1em;
         border-radius: 5px;
         border: 2px solid $gray;
         overflow: hidden;
@@ -139,10 +139,10 @@
       .download-buttons {
         a {
           width: 100%;
-          height: 45px;
+          height: 49px;
           padding: 0;
           text-align: center;
-          line-height: 45px;
+          line-height: 49px;
           margin-bottom: 1em;
 
           &:last-child {

--- a/assets/sass/pages/_download.scss
+++ b/assets/sass/pages/_download.scss
@@ -34,6 +34,7 @@
       background-color: #fff;
       border-radius: 5px;
       padding: 20px;
+      margin-bottom: 1em;
     }
 
     .details {
@@ -43,6 +44,24 @@
     }
 
     .download {
+      a {
+        display: inline-block;
+        width: auto;
+        padding: 15px 30px 15px 30px;
+        color: #fff;
+        border-radius: 5px;
+        border: none;
+
+        i {
+          padding-left: 10px;
+        }
+      }
+
+      .download-details {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+      }
+
       .language-select {
         float: left;
         margin-right: 10px;
@@ -50,17 +69,16 @@
         border: 2px solid $gray;
         overflow: hidden;
         height: 45px;
-        width: 200px;
         position: relative;
         display: block;
       }
 
       select{
         height: 45px;
+        width: 100%;
         padding: 5px;
         border: 0;
         font-size: 16px;
-        width: 200px;
        -webkit-appearance: none;
         -moz-appearance: none;
         appearance: none;
@@ -118,15 +136,18 @@
         }
       }
 
-      a {
-        float: left;
-        padding: 15px 37px 15px 37px;
-        color: #fff;
-        border-radius: 5px;
-        border: none;
+      .download-buttons {
+        a {
+          width: 100%;
+          height: 45px;
+          padding: 0;
+          text-align: center;
+          line-height: 45px;
+          margin-bottom: 1em;
 
-        i {
-          padding-left: 10px;
+          &:last-child {
+            margin-bottom: 0;
+          }
         }
       }
     }
@@ -140,12 +161,21 @@
 }
 
 @media (max-width: $screen-md) {
-  #download-page .download-section {
-    grid-template-columns: 1fr 1fr;
-  }
+  #download-page {
+    .download-section {
+      grid-template-columns: 1fr 1fr;
 
-  .language-select {
-    margin-bottom: 10px;
+      .download {
+        .download-details {
+          grid-template-columns: repeat(1, 1fr);
+        }
+
+        .language-select {
+          margin-right: 0;
+          margin-bottom: 1em;
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
The one change that differs from the mockup is that I updated the width of the select, as it looked better with some of the longer languages. I can revert it, but it was easy to get it to align well with the grid for all responsive sizes as well with this style.

![Feather_M0_Basic_Download](https://user-images.githubusercontent.com/311256/54238411-6e95f900-44e6-11e9-8f25-cbac69f043a4.png)
