### PR TITLE
Downloads Images Ratio

### DIFF
--- a/assets/sass/pages/_downloads.scss
+++ b/assets/sass/pages/_downloads.scss
@@ -54,8 +54,23 @@
     grid-row-gap: 1.5em;
 
     .download {
-      img {
+      height: 100%;
+
+      .img-responsive-4by3 {
+        height: 0;
+        overflow: hidden;
+        padding-top: 75%;
+        position: relative;
         width: 100%;
+      }
+
+      img {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        max-width: 100%;
+        max-height: 100%;
+        transform: translate(-50%, -50%);
       }
 
       a {

--- a/assets/sass/pages/_downloads.scss
+++ b/assets/sass/pages/_downloads.scss
@@ -54,6 +54,7 @@
     grid-row-gap: 1.5em;
 
     .download {
+      height: 100%;
       img {
         width: 100%;
       }

--- a/assets/sass/pages/_downloads.scss
+++ b/assets/sass/pages/_downloads.scss
@@ -54,7 +54,6 @@
     grid-row-gap: 1.5em;
 
     .download {
-      height: 100%;
       img {
         width: 100%;
       }

--- a/downloads.html
+++ b/downloads.html
@@ -22,7 +22,9 @@ permalink: /downloads
     {% assign info = info[0] %}
     <div class="download" data-id="{{ board.id }}">
       <a href="{{ info.url | relative_url }}">
-        <img src="{{ info.board_image | relative_url }}">
+        <div class="img-responsive-4by3">
+          <img src="{{ info.board_image | relative_url }}">
+        </div>
         <div class="details">
           <h3>{{ info.name | default: board.id }}</h3>
           By {{ info.manufacturer }}


### PR DESCRIPTION
Sets all board images on the downloads page to a fixed aspect ratio, shrinking any images down to fit within a 4:3 box, center aligned.

Example:
![Downloads](https://user-images.githubusercontent.com/311256/54392929-d67b4980-4676-11e9-9b69-4df191f68d41.png)
