### PR TITLE
update to beta.5; by hand due to travis cred issues

### DIFF
--- a/_data/files.json
+++ b/_data/files.json
@@ -6,35 +6,35 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-arduino_mkr1300-ID-4.0.0-beta.4.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-arduino_mkr1300-ID-4.0.0-beta.5.bin"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-arduino_mkr1300-de_DE-4.0.0-beta.4.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-arduino_mkr1300-de_DE-4.0.0-beta.5.bin"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-arduino_mkr1300-en_US-4.0.0-beta.4.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-arduino_mkr1300-en_US-4.0.0-beta.5.bin"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-arduino_mkr1300-en_x_pirate-4.0.0-beta.4.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-arduino_mkr1300-en_x_pirate-4.0.0-beta.5.bin"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-arduino_mkr1300-es-4.0.0-beta.4.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-arduino_mkr1300-es-4.0.0-beta.5.bin"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-arduino_mkr1300-fil-4.0.0-beta.4.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-arduino_mkr1300-fil-4.0.0-beta.5.bin"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-arduino_mkr1300-fr-4.0.0-beta.4.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-arduino_mkr1300-fr-4.0.0-beta.5.bin"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-arduino_mkr1300-it_IT-4.0.0-beta.4.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-arduino_mkr1300-it_IT-4.0.0-beta.5.bin"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-arduino_mkr1300-pt_BR-4.0.0-beta.4.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-arduino_mkr1300-pt_BR-4.0.0-beta.5.bin"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
@@ -45,40 +45,40 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-arduino_mkrzero-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-arduino_mkrzero-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-arduino_mkrzero-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-arduino_mkrzero-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-arduino_mkrzero-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-arduino_mkrzero-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-arduino_mkrzero-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-arduino_mkrzero-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-arduino_mkrzero-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-arduino_mkrzero-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-arduino_mkrzero-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-arduino_mkrzero-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-arduino_mkrzero-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-arduino_mkrzero-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-arduino_mkrzero-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-arduino_mkrzero-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-arduino_mkrzero-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-arduino_mkrzero-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
     {
-        "downloads": 344,
+        "downloads": 346,
         "id": "arduino_zero",
         "versions": [
             {
@@ -93,35 +93,35 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-arduino_zero-ID-4.0.0-beta.4.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-arduino_zero-ID-4.0.0-beta.5.bin"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-arduino_zero-de_DE-4.0.0-beta.4.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-arduino_zero-de_DE-4.0.0-beta.5.bin"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-arduino_zero-en_US-4.0.0-beta.4.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-arduino_zero-en_US-4.0.0-beta.5.bin"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-arduino_zero-en_x_pirate-4.0.0-beta.4.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-arduino_zero-en_x_pirate-4.0.0-beta.5.bin"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-arduino_zero-es-4.0.0-beta.4.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-arduino_zero-es-4.0.0-beta.5.bin"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-arduino_zero-fil-4.0.0-beta.4.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-arduino_zero-fil-4.0.0-beta.5.bin"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-arduino_zero-fr-4.0.0-beta.4.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-arduino_zero-fr-4.0.0-beta.5.bin"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-arduino_zero-it_IT-4.0.0-beta.4.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-arduino_zero-it_IT-4.0.0-beta.5.bin"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-arduino_zero-pt_BR-4.0.0-beta.4.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-arduino_zero-pt_BR-4.0.0-beta.5.bin"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
@@ -132,40 +132,40 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-catwan_usbstick-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-catwan_usbstick-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-catwan_usbstick-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-catwan_usbstick-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-catwan_usbstick-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-catwan_usbstick-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-catwan_usbstick-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-catwan_usbstick-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-catwan_usbstick-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-catwan_usbstick-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-catwan_usbstick-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-catwan_usbstick-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-catwan_usbstick-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-catwan_usbstick-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-catwan_usbstick-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-catwan_usbstick-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-catwan_usbstick-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-catwan_usbstick-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
     {
-        "downloads": 2394,
+        "downloads": 2391,
         "id": "circuitplayground_express",
         "versions": [
             {
@@ -180,40 +180,40 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-circuitplayground_express-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-circuitplayground_express-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-circuitplayground_express-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-circuitplayground_express-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-circuitplayground_express-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-circuitplayground_express-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-circuitplayground_express-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-circuitplayground_express-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-circuitplayground_express-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-circuitplayground_express-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-circuitplayground_express-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-circuitplayground_express-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-circuitplayground_express-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-circuitplayground_express-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-circuitplayground_express-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-circuitplayground_express-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-circuitplayground_express-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-circuitplayground_express-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
     {
-        "downloads": 439,
+        "downloads": 410,
         "id": "circuitplayground_express_crickit",
         "versions": [
             {
@@ -228,35 +228,35 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-circuitplayground_express_crickit-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_crickit-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-circuitplayground_express_crickit-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_crickit-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-circuitplayground_express_crickit-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_crickit-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-circuitplayground_express_crickit-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_crickit-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-circuitplayground_express_crickit-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_crickit-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-circuitplayground_express_crickit-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_crickit-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-circuitplayground_express_crickit-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_crickit-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-circuitplayground_express_crickit-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_crickit-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-circuitplayground_express_crickit-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_crickit-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
@@ -267,35 +267,35 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-cp32-m4-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-cp32-m4-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-cp32-m4-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-cp32-m4-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-cp32-m4-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-cp32-m4-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-cp32-m4-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-cp32-m4-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-cp32-m4-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-cp32-m4-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-cp32-m4-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-cp32-m4-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-cp32-m4-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-cp32-m4-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-cp32-m4-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-cp32-m4-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-cp32-m4-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-cp32-m4-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
@@ -306,35 +306,35 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-datalore_ip_m4-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-datalore_ip_m4-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-datalore_ip_m4-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-datalore_ip_m4-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-datalore_ip_m4-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-datalore_ip_m4-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-datalore_ip_m4-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-datalore_ip_m4-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-datalore_ip_m4-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-datalore_ip_m4-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-datalore_ip_m4-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-datalore_ip_m4-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-datalore_ip_m4-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-datalore_ip_m4-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-datalore_ip_m4-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-datalore_ip_m4-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-datalore_ip_m4-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-datalore_ip_m4-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
@@ -344,7 +344,7 @@
         "versions": []
     },
     {
-        "downloads": 211,
+        "downloads": 204,
         "id": "feather_m0_adalogger",
         "versions": [
             {
@@ -360,49 +360,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_adalogger-ID-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_adalogger-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-ID-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_adalogger-de_DE-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_adalogger-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-de_DE-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_adalogger-en_US-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_adalogger-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-en_US-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_adalogger-es-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_adalogger-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-es-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_adalogger-fil-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_adalogger-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-fil-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_adalogger-fr-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_adalogger-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-fr-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_adalogger-it_IT-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_adalogger-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-it_IT-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_adalogger-pt_BR-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_adalogger-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-pt_BR-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
     {
-        "downloads": 277,
+        "downloads": 274,
         "id": "feather_m0_basic",
         "versions": [
             {
@@ -418,49 +418,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_basic-ID-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_basic-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-ID-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_basic-de_DE-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_basic-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-de_DE-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_basic-en_US-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_basic-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-en_US-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_basic-en_x_pirate-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_basic-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-en_x_pirate-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_basic-es-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_basic-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-es-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_basic-fil-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_basic-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-fil-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_basic-fr-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_basic-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-fr-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_basic-it_IT-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_basic-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-it_IT-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_basic-pt_BR-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_basic-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-pt_BR-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
     {
-        "downloads": 609,
+        "downloads": 598,
         "id": "feather_m0_express",
         "versions": [
             {
@@ -475,40 +475,40 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_express-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_express-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_express-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_express-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_express-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_express-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_express-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_express-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_express-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_express-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_express-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_express-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_express-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_express-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_express-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_express-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_express-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_express-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
     {
-        "downloads": 53,
+        "downloads": 55,
         "id": "feather_m0_express_crickit",
         "versions": [
             {
@@ -523,40 +523,40 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_express_crickit-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_express_crickit-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_express_crickit-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_express_crickit-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_express_crickit-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_express_crickit-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_express_crickit-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_express_crickit-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_express_crickit-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_express_crickit-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_express_crickit-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_express_crickit-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_express_crickit-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_express_crickit-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_express_crickit-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_express_crickit-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_express_crickit-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_express_crickit-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
     {
-        "downloads": 66,
+        "downloads": 60,
         "id": "feather_m0_rfm69",
         "versions": [
             {
@@ -572,49 +572,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm69-ID-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm69-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-ID-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm69-de_DE-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm69-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-de_DE-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm69-en_US-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm69-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-en_US-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm69-es-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm69-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-es-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm69-fil-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm69-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-fil-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm69-fr-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm69-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-fr-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm69-it_IT-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm69-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-it_IT-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm69-pt_BR-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm69-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-pt_BR-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
     {
-        "downloads": 100,
+        "downloads": 93,
         "id": "feather_m0_rfm9x",
         "versions": [
             {
@@ -630,44 +630,44 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm9x-ID-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm9x-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-ID-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm9x-de_DE-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm9x-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-de_DE-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm9x-en_US-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm9x-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-en_US-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm9x-es-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm9x-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-es-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm9x-fil-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm9x-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-fil-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm9x-fr-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm9x-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-fr-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm9x-it_IT-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm9x-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-it_IT-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
@@ -678,40 +678,40 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_supersized-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_supersized-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_supersized-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_supersized-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_supersized-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_supersized-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_supersized-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_supersized-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_supersized-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_supersized-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_supersized-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_supersized-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_supersized-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_supersized-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_supersized-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_supersized-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m0_supersized-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m0_supersized-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
     {
-        "downloads": 558,
+        "downloads": 567,
         "id": "feather_m4_express",
         "versions": [
             {
@@ -726,35 +726,35 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m4_express-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m4_express-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m4_express-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m4_express-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m4_express-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m4_express-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m4_express-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m4_express-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m4_express-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m4_express-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m4_express-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m4_express-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m4_express-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m4_express-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m4_express-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m4_express-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_m4_express-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_m4_express-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
@@ -764,80 +764,80 @@
         "versions": []
     },
     {
-        "downloads": 13,
+        "downloads": 4,
         "id": "feather_nrf52840_express",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_nrf52840_express-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_nrf52840_express-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_nrf52840_express-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_nrf52840_express-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_nrf52840_express-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_nrf52840_express-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_nrf52840_express-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_nrf52840_express-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_nrf52840_express-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_nrf52840_express-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_nrf52840_express-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_nrf52840_express-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_nrf52840_express-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_nrf52840_express-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_nrf52840_express-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_nrf52840_express-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_nrf52840_express-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_nrf52840_express-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
     {
-        "downloads": 17,
+        "downloads": 0,
         "id": "feather_radiofruit_zigbee",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_radiofruit_zigbee-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_radiofruit_zigbee-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_radiofruit_zigbee-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_radiofruit_zigbee-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_radiofruit_zigbee-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_radiofruit_zigbee-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_radiofruit_zigbee-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_radiofruit_zigbee-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_radiofruit_zigbee-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_radiofruit_zigbee-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_radiofruit_zigbee-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_radiofruit_zigbee-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_radiofruit_zigbee-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_radiofruit_zigbee-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_radiofruit_zigbee-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_radiofruit_zigbee-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-feather_radiofruit_zigbee-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-feather_radiofruit_zigbee-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
@@ -847,7 +847,7 @@
         "versions": []
     },
     {
-        "downloads": 398,
+        "downloads": 397,
         "id": "gemma_m0",
         "versions": [
             {
@@ -862,79 +862,79 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-gemma_m0-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-gemma_m0-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-gemma_m0-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-gemma_m0-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-gemma_m0-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-gemma_m0-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-gemma_m0-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-gemma_m0-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-gemma_m0-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-gemma_m0-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-gemma_m0-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-gemma_m0-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-gemma_m0-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-gemma_m0-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-gemma_m0-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-gemma_m0-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-gemma_m0-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-gemma_m0-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
     {
-        "downloads": 14,
+        "downloads": 3,
         "id": "grandcentral_m4_express",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-grandcentral_m4_express-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-grandcentral_m4_express-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-grandcentral_m4_express-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-grandcentral_m4_express-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-grandcentral_m4_express-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-grandcentral_m4_express-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-grandcentral_m4_express-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-grandcentral_m4_express-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-grandcentral_m4_express-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-grandcentral_m4_express-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-grandcentral_m4_express-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-grandcentral_m4_express-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-grandcentral_m4_express-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-grandcentral_m4_express-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-grandcentral_m4_express-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-grandcentral_m4_express-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-grandcentral_m4_express-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-grandcentral_m4_express-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
     {
-        "downloads": 185,
+        "downloads": 181,
         "id": "hallowing_m0_express",
         "versions": [
             {
@@ -949,40 +949,40 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-hallowing_m0_express-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-hallowing_m0_express-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-hallowing_m0_express-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-hallowing_m0_express-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-hallowing_m0_express-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-hallowing_m0_express-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-hallowing_m0_express-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-hallowing_m0_express-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-hallowing_m0_express-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-hallowing_m0_express-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-hallowing_m0_express-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-hallowing_m0_express-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-hallowing_m0_express-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-hallowing_m0_express-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-hallowing_m0_express-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-hallowing_m0_express-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-hallowing_m0_express-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-hallowing_m0_express-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
     {
-        "downloads": 316,
+        "downloads": 318,
         "id": "itsybitsy_m0_express",
         "versions": [
             {
@@ -997,40 +997,40 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-itsybitsy_m0_express-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-itsybitsy_m0_express-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-itsybitsy_m0_express-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-itsybitsy_m0_express-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-itsybitsy_m0_express-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-itsybitsy_m0_express-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-itsybitsy_m0_express-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-itsybitsy_m0_express-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-itsybitsy_m0_express-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-itsybitsy_m0_express-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-itsybitsy_m0_express-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-itsybitsy_m0_express-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-itsybitsy_m0_express-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-itsybitsy_m0_express-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-itsybitsy_m0_express-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-itsybitsy_m0_express-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-itsybitsy_m0_express-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-itsybitsy_m0_express-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
     {
-        "downloads": 266,
+        "downloads": 261,
         "id": "itsybitsy_m4_express",
         "versions": [
             {
@@ -1045,74 +1045,74 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-itsybitsy_m4_express-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-itsybitsy_m4_express-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-itsybitsy_m4_express-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-itsybitsy_m4_express-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-itsybitsy_m4_express-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-itsybitsy_m4_express-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-itsybitsy_m4_express-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-itsybitsy_m4_express-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-itsybitsy_m4_express-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-itsybitsy_m4_express-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-itsybitsy_m4_express-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-itsybitsy_m4_express-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-itsybitsy_m4_express-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-itsybitsy_m4_express-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-itsybitsy_m4_express-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-itsybitsy_m4_express-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-itsybitsy_m4_express-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-itsybitsy_m4_express-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
     {
-        "downloads": 1,
+        "downloads": 0,
         "id": "makerdiary_nrf52840_mdk",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-makerdiary_nrf52840_mdk-ID-4.0.0-beta.4.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk-ID-4.0.0-beta.5.hex"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-makerdiary_nrf52840_mdk-de_DE-4.0.0-beta.4.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk-de_DE-4.0.0-beta.5.hex"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_US-4.0.0-beta.4.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_US-4.0.0-beta.5.hex"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_x_pirate-4.0.0-beta.4.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_x_pirate-4.0.0-beta.5.hex"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-makerdiary_nrf52840_mdk-es-4.0.0-beta.4.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk-es-4.0.0-beta.5.hex"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-makerdiary_nrf52840_mdk-fil-4.0.0-beta.4.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk-fil-4.0.0-beta.5.hex"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-makerdiary_nrf52840_mdk-fr-4.0.0-beta.4.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk-fr-4.0.0-beta.5.hex"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-makerdiary_nrf52840_mdk-it_IT-4.0.0-beta.4.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk-it_IT-4.0.0-beta.5.hex"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-makerdiary_nrf52840_mdk-pt_BR-4.0.0-beta.4.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk-pt_BR-4.0.0-beta.5.hex"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
@@ -1123,79 +1123,79 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-ID-4.0.0-beta.4.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-ID-4.0.0-beta.5.hex"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-de_DE-4.0.0-beta.4.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-de_DE-4.0.0-beta.5.hex"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_US-4.0.0-beta.4.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_US-4.0.0-beta.5.hex"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_x_pirate-4.0.0-beta.4.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_x_pirate-4.0.0-beta.5.hex"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-es-4.0.0-beta.4.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-es-4.0.0-beta.5.hex"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fil-4.0.0-beta.4.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fil-4.0.0-beta.5.hex"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fr-4.0.0-beta.4.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fr-4.0.0-beta.5.hex"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-it_IT-4.0.0-beta.4.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-it_IT-4.0.0-beta.5.hex"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pt_BR-4.0.0-beta.4.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pt_BR-4.0.0-beta.5.hex"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
     {
-        "downloads": 1,
+        "downloads": 0,
         "id": "meowmeow",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-meowmeow-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-meowmeow-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-meowmeow-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-meowmeow-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-meowmeow-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-meowmeow-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-meowmeow-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-meowmeow-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-meowmeow-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-meowmeow-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-meowmeow-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-meowmeow-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-meowmeow-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-meowmeow-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-meowmeow-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-meowmeow-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-meowmeow-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-meowmeow-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
     {
-        "downloads": 311,
+        "downloads": 310,
         "id": "metro_m0_express",
         "versions": [
             {
@@ -1210,40 +1210,40 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-metro_m0_express-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-metro_m0_express-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-metro_m0_express-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-metro_m0_express-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-metro_m0_express-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-metro_m0_express-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-metro_m0_express-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-metro_m0_express-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-metro_m0_express-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-metro_m0_express-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-metro_m0_express-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-metro_m0_express-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-metro_m0_express-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-metro_m0_express-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-metro_m0_express-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-metro_m0_express-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-metro_m0_express-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-metro_m0_express-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
     {
-        "downloads": 314,
+        "downloads": 313,
         "id": "metro_m4_express",
         "versions": [
             {
@@ -1258,35 +1258,35 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-metro_m4_express-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-metro_m4_express-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-metro_m4_express-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-metro_m4_express-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-metro_m4_express-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-metro_m4_express-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-metro_m4_express-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-metro_m4_express-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-metro_m4_express-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-metro_m4_express-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-metro_m4_express-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-metro_m4_express-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-metro_m4_express-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-metro_m4_express-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-metro_m4_express-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-metro_m4_express-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-metro_m4_express-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-metro_m4_express-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
@@ -1297,152 +1297,152 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-mini_sam_m4-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-mini_sam_m4-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-mini_sam_m4-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-mini_sam_m4-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-mini_sam_m4-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-mini_sam_m4-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-mini_sam_m4-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-mini_sam_m4-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-mini_sam_m4-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-mini_sam_m4-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-mini_sam_m4-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-mini_sam_m4-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-mini_sam_m4-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-mini_sam_m4-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-mini_sam_m4-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-mini_sam_m4-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-mini_sam_m4-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-mini_sam_m4-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
     {
-        "downloads": 2,
+        "downloads": 0,
         "id": "particle_argon",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-particle_argon-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-particle_argon-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-particle_argon-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-particle_argon-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-particle_argon-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-particle_argon-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-particle_argon-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-particle_argon-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-particle_argon-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-particle_argon-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-particle_argon-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-particle_argon-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-particle_argon-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-particle_argon-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-particle_argon-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-particle_argon-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-particle_argon-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-particle_argon-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
     {
-        "downloads": 1,
+        "downloads": 0,
         "id": "particle_boron",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-particle_boron-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-particle_boron-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-particle_boron-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-particle_boron-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-particle_boron-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-particle_boron-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-particle_boron-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-particle_boron-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-particle_boron-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-particle_boron-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-particle_boron-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-particle_boron-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-particle_boron-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-particle_boron-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-particle_boron-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-particle_boron-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-particle_boron-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-particle_boron-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
     {
-        "downloads": 3,
+        "downloads": 0,
         "id": "particle_xenon",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-particle_xenon-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-particle_xenon-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-particle_xenon-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-particle_xenon-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-particle_xenon-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-particle_xenon-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-particle_xenon-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-particle_xenon-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-particle_xenon-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-particle_xenon-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-particle_xenon-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-particle_xenon-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-particle_xenon-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-particle_xenon-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-particle_xenon-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-particle_xenon-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-particle_xenon-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-particle_xenon-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
@@ -1452,98 +1452,98 @@
         "versions": []
     },
     {
-        "downloads": 1,
+        "downloads": 2,
         "id": "pca10056",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10056-ID-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10056-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10056-ID-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10056-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10056-de_DE-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10056-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10056-de_DE-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10056-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10056-en_US-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10056-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10056-en_US-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10056-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10056-en_x_pirate-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10056-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10056-en_x_pirate-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10056-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10056-es-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10056-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10056-es-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10056-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10056-fil-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10056-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10056-fil-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10056-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10056-fr-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10056-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10056-fr-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10056-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10056-it_IT-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10056-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10056-it_IT-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10056-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10056-pt_BR-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10056-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10056-pt_BR-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10056-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
     {
-        "downloads": 3,
+        "downloads": 0,
         "id": "pca10059",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10059-ID-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10059-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10059-ID-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10059-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10059-de_DE-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10059-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10059-de_DE-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10059-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10059-en_US-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10059-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10059-en_US-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10059-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10059-en_x_pirate-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10059-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10059-en_x_pirate-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10059-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10059-es-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10059-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10059-es-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10059-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10059-fil-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10059-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10059-fil-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10059-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10059-fr-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10059-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10059-fr-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10059-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10059-it_IT-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10059-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10059-it_IT-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10059-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10059-pt_BR-4.0.0-beta.4.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pca10059-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10059-pt_BR-4.0.0-beta.5.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pca10059-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
@@ -1554,40 +1554,40 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pewpew10-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pewpew10-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pewpew10-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pewpew10-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pewpew10-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pewpew10-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pewpew10-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pewpew10-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pewpew10-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pewpew10-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pewpew10-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pewpew10-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pewpew10-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pewpew10-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pewpew10-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pewpew10-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pewpew10-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pewpew10-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
     {
-        "downloads": 23,
+        "downloads": 22,
         "id": "pirkey_m0",
         "versions": [
             {
@@ -1602,35 +1602,35 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pirkey_m0-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pirkey_m0-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pirkey_m0-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pirkey_m0-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pirkey_m0-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pirkey_m0-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pirkey_m0-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pirkey_m0-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pirkey_m0-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pirkey_m0-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pirkey_m0-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pirkey_m0-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pirkey_m0-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pirkey_m0-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pirkey_m0-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pirkey_m0-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pirkey_m0-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pirkey_m0-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
@@ -1641,152 +1641,152 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pybadge-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pybadge-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pybadge-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pybadge-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pybadge-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pybadge-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pybadge-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pybadge-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pybadge-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pybadge-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pybadge-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pybadge-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pybadge-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pybadge-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pybadge-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pybadge-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pybadge-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pybadge-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
     {
-        "downloads": 14,
+        "downloads": 11,
         "id": "pyportal",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pyportal-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pyportal-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pyportal-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pyportal-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pyportal-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pyportal-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pyportal-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pyportal-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pyportal-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pyportal-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pyportal-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pyportal-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pyportal-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pyportal-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pyportal-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pyportal-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-pyportal-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-pyportal-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
     {
-        "downloads": 3,
+        "downloads": 0,
         "id": "sam32",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sam32-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sam32-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sam32-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sam32-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sam32-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sam32-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sam32-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sam32-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sam32-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sam32-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sam32-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sam32-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sam32-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sam32-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sam32-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sam32-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sam32-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sam32-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
     {
-        "downloads": 2,
+        "downloads": 0,
         "id": "sparkfun_lumidrive",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_lumidrive-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_lumidrive-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_lumidrive-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_lumidrive-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_lumidrive-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_lumidrive-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_lumidrive-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_lumidrive-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_lumidrive-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_lumidrive-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_lumidrive-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_lumidrive-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_lumidrive-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_lumidrive-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_lumidrive-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_lumidrive-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_lumidrive-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_lumidrive-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
@@ -1797,35 +1797,35 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_nrf52840_mini-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_nrf52840_mini-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_nrf52840_mini-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_nrf52840_mini-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_nrf52840_mini-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_nrf52840_mini-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_nrf52840_mini-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_nrf52840_mini-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_nrf52840_mini-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_nrf52840_mini-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_nrf52840_mini-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_nrf52840_mini-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_nrf52840_mini-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_nrf52840_mini-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_nrf52840_mini-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_nrf52840_mini-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_nrf52840_mini-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_nrf52840_mini-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
@@ -1836,35 +1836,35 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_redboard_turbo-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_redboard_turbo-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_redboard_turbo-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_redboard_turbo-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_redboard_turbo-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_redboard_turbo-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_redboard_turbo-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_redboard_turbo-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_redboard_turbo-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_redboard_turbo-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_redboard_turbo-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_redboard_turbo-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_redboard_turbo-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_redboard_turbo-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_redboard_turbo-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_redboard_turbo-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_redboard_turbo-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_redboard_turbo-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
@@ -1875,118 +1875,118 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_samd21_dev-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_dev-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_samd21_dev-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_dev-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_samd21_dev-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_dev-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_samd21_dev-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_dev-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_samd21_dev-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_dev-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_samd21_dev-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_dev-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_samd21_dev-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_dev-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_samd21_dev-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_dev-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_samd21_dev-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_dev-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
     {
-        "downloads": 12,
+        "downloads": 0,
         "id": "sparkfun_samd21_mini",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_samd21_mini-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_mini-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_samd21_mini-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_mini-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_samd21_mini-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_mini-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_samd21_mini-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_mini-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_samd21_mini-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_mini-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_samd21_mini-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_mini-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_samd21_mini-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_mini-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_samd21_mini-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_mini-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-sparkfun_samd21_mini-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_mini-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
     {
-        "downloads": 7,
+        "downloads": 5,
         "id": "trellis_m4_express",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-trellis_m4_express-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-trellis_m4_express-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-trellis_m4_express-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-trellis_m4_express-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-trellis_m4_express-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-trellis_m4_express-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-trellis_m4_express-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-trellis_m4_express-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-trellis_m4_express-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-trellis_m4_express-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-trellis_m4_express-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-trellis_m4_express-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-trellis_m4_express-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-trellis_m4_express-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-trellis_m4_express-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-trellis_m4_express-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-trellis_m4_express-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-trellis_m4_express-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
     {
-        "downloads": 1148,
+        "downloads": 1136,
         "id": "trinket_m0",
         "versions": [
             {
@@ -2001,35 +2001,35 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-trinket_m0-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-trinket_m0-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-trinket_m0-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-trinket_m0-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-trinket_m0-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-trinket_m0-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-trinket_m0-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-trinket_m0-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-trinket_m0-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-trinket_m0-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-trinket_m0-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-trinket_m0-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-trinket_m0-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-trinket_m0-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-trinket_m0-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-trinket_m0-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-trinket_m0-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-trinket_m0-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
@@ -2040,35 +2040,35 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-trinket_m0_haxpress-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-trinket_m0_haxpress-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-trinket_m0_haxpress-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-trinket_m0_haxpress-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-trinket_m0_haxpress-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-trinket_m0_haxpress-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-trinket_m0_haxpress-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-trinket_m0_haxpress-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-trinket_m0_haxpress-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-trinket_m0_haxpress-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-trinket_m0_haxpress-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-trinket_m0_haxpress-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-trinket_m0_haxpress-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-trinket_m0_haxpress-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-trinket_m0_haxpress-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-trinket_m0_haxpress-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-trinket_m0_haxpress-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-trinket_m0_haxpress-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     },
@@ -2079,36 +2079,37 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-ugame10-ID-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-ugame10-ID-4.0.0-beta.5.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-ugame10-de_DE-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-ugame10-de_DE-4.0.0-beta.5.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-ugame10-en_US-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-ugame10-en_US-4.0.0-beta.5.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-ugame10-en_x_pirate-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-ugame10-en_x_pirate-4.0.0-beta.5.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-ugame10-es-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-ugame10-es-4.0.0-beta.5.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-ugame10-fil-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-ugame10-fil-4.0.0-beta.5.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-ugame10-fr-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-ugame10-fr-4.0.0-beta.5.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-ugame10-it_IT-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-ugame10-it_IT-4.0.0-beta.5.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.4/adafruit-circuitpython-ugame10-pt_BR-4.0.0-beta.4.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/4.0.0-beta.5/adafruit-circuitpython-ugame10-pt_BR-4.0.0-beta.5.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "4.0.0-beta.4"
+                "version": "4.0.0-beta.5"
             }
         ]
     }
 ]
+


### PR DESCRIPTION
`build_board_info.py` was unable to run with adabot credentials, so I ran it by hand and did this PR by hand. It's equivalent to the automated PR. Could someone review and approve to get beta.5 into circuitpython.org? Thanks.