### PR TITLE
Add flag to remove boards from downloads display

### DIFF
--- a/_board/cp32-m4.md
+++ b/_board/cp32-m4.md
@@ -1,16 +1,13 @@
 ---
 layout: download
-board_id: "<board id>"
-title: "<board name> Download"
-name: "<board name>"
-manufacturer: "<board manufacturer>"
+board_id: "cp32-m4"
+title: "cp32-m4 Download"
+name: "cp32-m4"
+manufacturer: "unknown"
 board_url: ""
 board_image: "/assets/images/boards/unknown.jpg"
-downloads_display: true
+downloads_display: false
 features:
-  - ~5 interesting
-  - features
-  - such as bluetooth
 ---
 
 This board hasn't been fully documented yet. Please make a pull request adding more info to this file.
@@ -19,7 +16,6 @@ The description should be written to inform a CircuitPython user what makes the 
 
 ## Purchase
 Add any links to purchase the board
-* [Adafruit](https://www.adafruit.com/product/3857)
 
 ## Contribute
 

--- a/_board/datalore_ip_m4.md
+++ b/_board/datalore_ip_m4.md
@@ -1,16 +1,13 @@
 ---
 layout: download
-board_id: "<board id>"
-title: "<board name> Download"
-name: "<board name>"
-manufacturer: "<board manufacturer>"
+board_id: "datalore_ip_m4"
+title: "datalore_ip_m4 Download"
+name: "datalore_ip_m4"
+manufacturer: "unknown"
 board_url: ""
 board_image: "/assets/images/boards/unknown.jpg"
-downloads_display: true
+downloads_display: false
 features:
-  - ~5 interesting
-  - features
-  - such as bluetooth
 ---
 
 This board hasn't been fully documented yet. Please make a pull request adding more info to this file.
@@ -19,7 +16,6 @@ The description should be written to inform a CircuitPython user what makes the 
 
 ## Purchase
 Add any links to purchase the board
-* [Adafruit](https://www.adafruit.com/product/3857)
 
 ## Contribute
 

--- a/_board/feather_radiofruit_zigbee.md
+++ b/_board/feather_radiofruit_zigbee.md
@@ -1,16 +1,13 @@
 ---
 layout: download
-board_id: "<board id>"
-title: "<board name> Download"
-name: "<board name>"
-manufacturer: "<board manufacturer>"
+board_id: "feather_radiofruit_zigbee"
+title: "feather_radiofruit_zigbee Download"
+name: "feather_radiofruit_zigbee"
+manufacturer: "Adafruit"
 board_url: ""
 board_image: "/assets/images/boards/unknown.jpg"
-downloads_display: true
+downloads_display: false
 features:
-  - ~5 interesting
-  - features
-  - such as bluetooth
 ---
 
 This board hasn't been fully documented yet. Please make a pull request adding more info to this file.
@@ -19,7 +16,6 @@ The description should be written to inform a CircuitPython user what makes the 
 
 ## Purchase
 Add any links to purchase the board
-* [Adafruit](https://www.adafruit.com/product/3857)
 
 ## Contribute
 

--- a/_board/gb_m4.md
+++ b/_board/gb_m4.md
@@ -1,16 +1,13 @@
 ---
 layout: download
-board_id: "<board id>"
-title: "<board name> Download"
-name: "<board name>"
-manufacturer: "<board manufacturer>"
+board_id: "gb_m4"
+title: "gb_m4 Download"
+name: "gb_m4"
+manufacturer: "unknown"
 board_url: ""
 board_image: "/assets/images/boards/unknown.jpg"
-downloads_display: true
+downloads_display: false
 features:
-  - ~5 interesting
-  - features
-  - such as bluetooth
 ---
 
 This board hasn't been fully documented yet. Please make a pull request adding more info to this file.
@@ -19,7 +16,6 @@ The description should be written to inform a CircuitPython user what makes the 
 
 ## Purchase
 Add any links to purchase the board
-* [Adafruit](https://www.adafruit.com/product/3857)
 
 ## Contribute
 

--- a/_board/pca10040.md
+++ b/_board/pca10040.md
@@ -1,16 +1,13 @@
 ---
 layout: download
-board_id: "<board id>"
-title: "<board name> Download"
-name: "<board name>"
-manufacturer: "<board manufacturer>"
+board_id: "pca10040"
+title: "pca10040 Download"
+name: "pca10040"
+manufacturer: "unknown"
 board_url: ""
 board_image: "/assets/images/boards/unknown.jpg"
-downloads_display: true
+downloads_display: false
 features:
-  - ~5 interesting
-  - features
-  - such as bluetooth
 ---
 
 This board hasn't been fully documented yet. Please make a pull request adding more info to this file.
@@ -19,7 +16,6 @@ The description should be written to inform a CircuitPython user what makes the 
 
 ## Purchase
 Add any links to purchase the board
-* [Adafruit](https://www.adafruit.com/product/3857)
 
 ## Contribute
 

--- a/_board/sam32.md
+++ b/_board/sam32.md
@@ -1,16 +1,13 @@
 ---
 layout: download
-board_id: "<board id>"
-title: "<board name> Download"
-name: "<board name>"
-manufacturer: "<board manufacturer>"
+board_id: "sam32"
+title: "sam32 Download"
+name: "sam32"
+manufacturer: "unknown"
 board_url: ""
 board_image: "/assets/images/boards/unknown.jpg"
-downloads_display: true
+downloads_display: false
 features:
-  - ~5 interesting
-  - features
-  - such as bluetooth
 ---
 
 This board hasn't been fully documented yet. Please make a pull request adding more info to this file.
@@ -19,7 +16,6 @@ The description should be written to inform a CircuitPython user what makes the 
 
 ## Purchase
 Add any links to purchase the board
-* [Adafruit](https://www.adafruit.com/product/3857)
 
 ## Contribute
 

--- a/downloads.html
+++ b/downloads.html
@@ -53,6 +53,11 @@ permalink: /downloads
         {% assign info = site.board | where: 'board_id', 'unknown' %}
       {% endif %}
       {% assign info = info[0] %}
+
+      {% if info.downloads_display == false %}
+        {% continue %}
+      {% endif %}
+      
       <div class="download" data-id="{{ board.id }}"
                             data-name="{{ info.name | default: board.id }}"
                             data-downloads="{{ board.downloads }}"


### PR DESCRIPTION
Temporarily remove boards as listed in issue: #106.

New downloads_display flag in front matter on board files. If not set, boards will display. Set to false to exclude a board.

This also fixes the issue where boards like sam32 weren't properly linking to latest files and only showed the Browse S3 and Browse Github links.