### PR TITLE
Add link to release notes on download page

### DIFF
--- a/_layouts/download.html
+++ b/_layouts/download.html
@@ -32,6 +32,9 @@ layout: default
             Unstable builds have the latest features but are more likely to have critical bugs.
             {% endif %}
           </p>
+          <p>
+            <a href="https://github.com/adafruit/circuitpython/releases/tag/{{ version.version }}">Release Notes for {{ version.version }}</a>
+          </p>
           <div class="download-details">
             <label class="language-select">
               <select>

--- a/assets/sass/pages/_download.scss
+++ b/assets/sass/pages/_download.scss
@@ -44,7 +44,7 @@
     }
 
     .download {
-      a {
+      a.download-button, a.download-button-unrecommended {
         display: inline-block;
         width: auto;
         padding: 15px 30px 15px 30px;
@@ -105,7 +105,7 @@
         .language-select:after {
             color: $purple;
         }
-        a {
+        a.download-button, a.download-button-unrecommended {
           background-color: $purple;
         }
       }
@@ -118,10 +118,10 @@
               color: $gray;
           }
 
-        a {
+        a.download-button, a.download-button-unrecommended {
           background-color: $gray;
         }
-        a:hover {
+        a.download-button:hover, a.download-button-unrecommended:hover {
           background-color: $pink;
         }
       }
@@ -131,7 +131,7 @@
               color: $gray;
           }
 
-        a {
+        a.download-button, a.download-button-unrecommended {
           background-color: $gray;
         }
       }


### PR DESCRIPTION
I'm currently linking to release notes on github releases page. Let me know if there is a better location for each version.

Fixes: https://github.com/adafruit/circuitpython-org/issues/54

Example:
https://github.com/adafruit/circuitpython/releases/tag/3.1.2

![Feather_M4_Express_Download](https://user-images.githubusercontent.com/311256/55739537-dd377b00-59ee-11e9-84da-96d85cbdc2bf.png)
