### PR TITLE
Updated PyCon board pages

### DIFF
--- a/_board/circuitplayground_express_digikey_pycon2019.md
+++ b/_board/circuitplayground_express_digikey_pycon2019.md
@@ -40,4 +40,13 @@ Here's some of the great goodies baked in to each Circuit Playground Express:
 
 ## Tutorials
 * [Circuit Playground Express Overview](https://learn.adafruit.com/adafruit-circuit-playground-express)
+* [CircuitPython Made Easy on Circuit Playground Express](https://learn.adafruit.com/circuitpython-made-easy-on-circuit-playground-express/)
 
+## Downloads
+* [PyCon 2019 Circuit Playground Express Default Files](https://github.com/adafruit/PyCon2019/tree/master/Default_Files)
+* [PyCon 2019 Open Spaces Example Content](https://github.com/adafruit/PyCon2019/)
+* [Pycon 2019 Circuit Playground Express Quickstart Worksheet](https://github.com/adafruit/PyCon2019/blob/master/PyCon%202019%20Circuit%20Playground%20Express%20Quickstart.pdf)
+
+## More Information
+* [CircuitPython Open Spaces Planned for PyCon 2019](https://blog.adafruit.com/2019/04/01/circuitpython-open-spaces-planned-for-pycon-2019-pycon-circuitplaygroundexpress-adafruit-adafruit-circuitpython/)
+* [Digi-Key and Adafruit at PyCon - All attendees will receive a Circuit Playground Express!](https://blog.adafruit.com/2019/02/23/digi-key-and-adafruit-at-pycon-all-attendees-will-receive-a-circuit-playground-express-digikey-adafruit-pycon-pycon2019/)

--- a/_board/gemma_m0_pycon2018.md
+++ b/_board/gemma_m0_pycon2018.md
@@ -38,6 +38,11 @@ Gemma M0 features:
 
 Fully assembled and tested Gemma M0 with CircuitPython & example code programmed in.
 
-## Contribute
+## Tutorials
+* [Adafruit Gemma M0](https://learn.adafruit.com/adafruit-gemma-m0)
 
+## Downloads
+* [PyCon 2018 Gemma Files](https://github.com/adafruit/CircuitPython_Badge_README/tree/master/final_versions/PYCON_2018)
+
+## Contribute
 Have some info to add for this board? Edit the source for this page [here](https://github.com/adafruit/circuitpython-org/edit/master/_board/{{ page.board_id }}.md).


### PR DESCRIPTION
Added more information links to both PyCon 2018 and PyCon 2019 board pages.