### PR TITLE
Add adabot For Auto-updating Libraries/Contrib Info

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "awesome-circuitpython"]
 	path = awesome-circuitpython
 	url = https://github.com/adafruit/awesome-circuitpython
+[submodule "adabot"]
+	path = adabot
+	url = https://github.com/adafruit/adabot.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,23 @@
-language: ruby
-rvm:
-  - 2.5.3
-install:
-  - gem install git
-script:
-    -
+# TravisCI config for circuitpython.org
+
+dist: xenial
+
+matrix:
+  include:
+    - language: ruby
+      rvm: 2.5.3
+      name: "rvm"
+      install:
+        - gem install git
+      script:
+        -
+
+    - language: python
+      python: "3.6"
+      name: "adabot auto-updater"
+      install:
+          - pip install --user -r adabot/requirements.txt
+      script:
+        - cd adabot
+        - python -u -m adabot.update_cp_org_libraries
+      if: $TRAVIS_EVENT_TYPE="cron"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,15 @@
 # TravisCI config for circuitpython.org
 
+# only run if triggered by a cron
+if: $TRAVIS_EVENT_TYPE="cron"
+
 dist: xenial
+language: python
+python: "3.6"
 
-matrix:
-  include:
-    - language: ruby
-      rvm: 2.5.3
-      name: "rvm"
-      install:
-        - gem install git
-      script:
-        -
+install:
+  - pip install --user -r adabot/requirements.txt
 
-    - language: python
-      python: "3.6"
-      name: "adabot auto-updater"
-      install:
-          - pip install --user -r adabot/requirements.txt
-      script:
-        - cd adabot
-        - python -u -m adabot.update_cp_org_libraries
-      if: $TRAVIS_EVENT_TYPE="cron"
+script:
+  - cd adabot
+  - python -u -m adabot.update_cp_org_libraries


### PR DESCRIPTION
The next (last?) part to #119.

Two environment variables will need to be added to Travis:
- `ADABOT_GITHUB_ACCESS_TOKEN`: self explanatory
- `CP_ORG_UPDATER_RUN_DAY`: Sets the day of the week that the script will actually run. Day is a number between 0 & 6, with 0 being Monday. (Travis cron will be set to run daily. This ensures the script runs on the day we want since Travis won't guarantee that a weekly cron will run on a certain day.)

I was unsure that the `rvm` stuff in the original `.travis.yml` was necessary, since the `script` section is empty. If its not needed I can remove it. Also, I just thought about this: I could also exclude it from the daily cron, using the `$TRAVIS_EVENT_TYPE` env var if need be.