### PR TITLE
Fix Travis Failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ language: python
 python: "3.6"
 
 install:
-  - pip install --user -r adabot/requirements.txt
+  - pip install -r adabot/requirements.txt
 
 script:
   - cd adabot


### PR DESCRIPTION
After removing the matrix setup when dropping the `rvm` section in `.travis.yml`, I forgot to remove the `--user` flag from the pip install command. Which causes:
```
pip 19.0.3 from /home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/pip (python 3.6)
0.39s$ pip install --user -r adabot/requirements.txt
Can not perform a '--user' install. User site-packages are not visible in this virtualenv.
The command "pip install --user -r adabot/requirements.txt" failed and exited with 1 during .
```
This...fixes that. Me hopes. 🎲 