### PR TITLE
Automated website update for release 5.0.0-alpha.3

### DIFF
--- a/_data/files.json
+++ b/_data/files.json
@@ -1,6 +1,6 @@
 [
     {
-        "downloads": 42,
+        "downloads": 47,
         "id": "arduino_mkr1300",
         "versions": [
             {
@@ -45,46 +45,46 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_mkr1300-ID-5.0.0-alpha.2.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_mkr1300-ID-5.0.0-alpha.3.bin"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_mkr1300-de_DE-5.0.0-alpha.2.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_mkr1300-de_DE-5.0.0-alpha.3.bin"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_mkr1300-en_US-5.0.0-alpha.2.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_mkr1300-en_US-5.0.0-alpha.3.bin"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_mkr1300-en_x_pirate-5.0.0-alpha.2.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_mkr1300-en_x_pirate-5.0.0-alpha.3.bin"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_mkr1300-es-5.0.0-alpha.2.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_mkr1300-es-5.0.0-alpha.3.bin"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_mkr1300-fil-5.0.0-alpha.2.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_mkr1300-fil-5.0.0-alpha.3.bin"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_mkr1300-fr-5.0.0-alpha.2.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_mkr1300-fr-5.0.0-alpha.3.bin"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_mkr1300-it_IT-5.0.0-alpha.2.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_mkr1300-it_IT-5.0.0-alpha.3.bin"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_mkr1300-pl-5.0.0-alpha.2.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_mkr1300-pl-5.0.0-alpha.3.bin"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_mkr1300-pt_BR-5.0.0-alpha.2.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_mkr1300-pt_BR-5.0.0-alpha.3.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_mkr1300-zh_Latn_pinyin-5.0.0-alpha.2.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_mkr1300-zh_Latn_pinyin-5.0.0-alpha.3.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 21,
+        "downloads": 23,
         "id": "arduino_mkrzero",
         "versions": [
             {
@@ -129,46 +129,46 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_mkrzero-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_mkrzero-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_mkrzero-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_mkrzero-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_mkrzero-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_mkrzero-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_mkrzero-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_mkrzero-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_mkrzero-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_mkrzero-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_mkrzero-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_mkrzero-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_mkrzero-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_mkrzero-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_mkrzero-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_mkrzero-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_mkrzero-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_mkrzero-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_mkrzero-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_mkrzero-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_mkrzero-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_mkrzero-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 42,
+        "downloads": 58,
         "id": "arduino_zero",
         "versions": [
             {
@@ -213,41 +213,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_zero-ID-5.0.0-alpha.2.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_zero-ID-5.0.0-alpha.3.bin"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_zero-de_DE-5.0.0-alpha.2.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_zero-de_DE-5.0.0-alpha.3.bin"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_zero-en_US-5.0.0-alpha.2.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_zero-en_US-5.0.0-alpha.3.bin"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_zero-en_x_pirate-5.0.0-alpha.2.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_zero-en_x_pirate-5.0.0-alpha.3.bin"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_zero-es-5.0.0-alpha.2.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_zero-es-5.0.0-alpha.3.bin"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_zero-fil-5.0.0-alpha.2.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_zero-fil-5.0.0-alpha.3.bin"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_zero-fr-5.0.0-alpha.2.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_zero-fr-5.0.0-alpha.3.bin"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_zero-it_IT-5.0.0-alpha.2.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_zero-it_IT-5.0.0-alpha.3.bin"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_zero-pl-5.0.0-alpha.2.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_zero-pl-5.0.0-alpha.3.bin"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_zero-pt_BR-5.0.0-alpha.2.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_zero-pt_BR-5.0.0-alpha.3.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-arduino_zero-zh_Latn_pinyin-5.0.0-alpha.2.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-arduino_zero-zh_Latn_pinyin-5.0.0-alpha.3.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -297,41 +297,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-bast_pro_mini_m0-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-bast_pro_mini_m0-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-bast_pro_mini_m0-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-bast_pro_mini_m0-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-bast_pro_mini_m0-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-bast_pro_mini_m0-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-bast_pro_mini_m0-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-bast_pro_mini_m0-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-bast_pro_mini_m0-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-bast_pro_mini_m0-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-bast_pro_mini_m0-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-bast_pro_mini_m0-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-bast_pro_mini_m0-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-bast_pro_mini_m0-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-bast_pro_mini_m0-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-bast_pro_mini_m0-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-bast_pro_mini_m0-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-bast_pro_mini_m0-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-bast_pro_mini_m0-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-bast_pro_mini_m0-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-bast_pro_mini_m0-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-bast_pro_mini_m0-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -381,41 +381,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-capablerobot_usbhub-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-capablerobot_usbhub-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-capablerobot_usbhub-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-capablerobot_usbhub-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-capablerobot_usbhub-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-capablerobot_usbhub-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-capablerobot_usbhub-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-capablerobot_usbhub-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-capablerobot_usbhub-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-capablerobot_usbhub-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-capablerobot_usbhub-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-capablerobot_usbhub-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-capablerobot_usbhub-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-capablerobot_usbhub-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-capablerobot_usbhub-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-capablerobot_usbhub-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-capablerobot_usbhub-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-capablerobot_usbhub-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-capablerobot_usbhub-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-capablerobot_usbhub-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-capablerobot_usbhub-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-capablerobot_usbhub-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -465,91 +465,91 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-catwan_usbstick-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-catwan_usbstick-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-catwan_usbstick-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-catwan_usbstick-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-catwan_usbstick-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-catwan_usbstick-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-catwan_usbstick-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-catwan_usbstick-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-catwan_usbstick-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-catwan_usbstick-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-catwan_usbstick-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-catwan_usbstick-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-catwan_usbstick-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-catwan_usbstick-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-catwan_usbstick-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-catwan_usbstick-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-catwan_usbstick-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-catwan_usbstick-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-catwan_usbstick-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-catwan_usbstick-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-catwan_usbstick-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-catwan_usbstick-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 3,
+        "downloads": 22,
         "id": "circuitplayground_bluefruit",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_bluefruit-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_bluefruit-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_bluefruit-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_bluefruit-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_bluefruit-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_bluefruit-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_bluefruit-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_bluefruit-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_bluefruit-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_bluefruit-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_bluefruit-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_bluefruit-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_bluefruit-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_bluefruit-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_bluefruit-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_bluefruit-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_bluefruit-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_bluefruit-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_bluefruit-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_bluefruit-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_bluefruit-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_bluefruit-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 1292,
+        "downloads": 1657,
         "id": "circuitplayground_express",
         "versions": [
             {
@@ -594,46 +594,46 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 6,
+        "downloads": 8,
         "id": "circuitplayground_express_4h",
         "versions": [
             {
@@ -678,46 +678,46 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_4h-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_4h-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_4h-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_4h-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_4h-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_4h-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_4h-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_4h-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_4h-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_4h-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_4h-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_4h-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_4h-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_4h-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_4h-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_4h-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_4h-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_4h-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_4h-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_4h-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_4h-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_4h-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 76,
+        "downloads": 94,
         "id": "circuitplayground_express_crickit",
         "versions": [
             {
@@ -762,46 +762,46 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_crickit-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_crickit-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_crickit-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_crickit-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_crickit-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_crickit-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_crickit-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_crickit-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_crickit-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_crickit-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_crickit-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_crickit-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_crickit-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_crickit-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_crickit-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_crickit-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_crickit-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_crickit-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_crickit-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_crickit-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_crickit-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_crickit-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 4,
+        "downloads": 6,
         "id": "circuitplayground_express_digikey_pycon2019",
         "versions": [
             {
@@ -846,41 +846,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -930,41 +930,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-cp32-m4-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-cp32-m4-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-cp32-m4-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-cp32-m4-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-cp32-m4-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-cp32-m4-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-cp32-m4-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-cp32-m4-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-cp32-m4-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-cp32-m4-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-cp32-m4-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-cp32-m4-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-cp32-m4-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-cp32-m4-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-cp32-m4-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-cp32-m4-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-cp32-m4-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-cp32-m4-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-cp32-m4-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-cp32-m4-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-cp32-m4-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-cp32-m4-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -1014,41 +1014,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datalore_ip_m4-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datalore_ip_m4-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datalore_ip_m4-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datalore_ip_m4-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datalore_ip_m4-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datalore_ip_m4-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datalore_ip_m4-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datalore_ip_m4-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datalore_ip_m4-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datalore_ip_m4-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datalore_ip_m4-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datalore_ip_m4-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datalore_ip_m4-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datalore_ip_m4-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datalore_ip_m4-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datalore_ip_m4-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datalore_ip_m4-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datalore_ip_m4-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datalore_ip_m4-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datalore_ip_m4-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datalore_ip_m4-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datalore_ip_m4-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -1098,41 +1098,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_distance-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_distance-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_distance-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_distance-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_distance-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_distance-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_distance-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_distance-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_distance-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_distance-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_distance-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_distance-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_distance-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_distance-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_distance-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_distance-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_distance-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_distance-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_distance-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_distance-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_distance-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_distance-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -1182,41 +1182,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_imu-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_imu-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_imu-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_imu-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_imu-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_imu-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_imu-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_imu-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_imu-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_imu-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_imu-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_imu-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_imu-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_imu-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_imu-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_imu-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_imu-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_imu-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_imu-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_imu-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_imu-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_imu-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -1266,41 +1266,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_light-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_light-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_light-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_light-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_light-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_light-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_light-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_light-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_light-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_light-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_light-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_light-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_light-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_light-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_light-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_light-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_light-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_light-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_light-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_light-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_light-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_light-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -1350,46 +1350,46 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_weather-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_weather-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_weather-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_weather-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_weather-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_weather-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_weather-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_weather-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_weather-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_weather-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_weather-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_weather-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_weather-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_weather-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_weather-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_weather-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_weather-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_weather-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_weather-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_weather-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-datum_weather-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-datum_weather-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 2,
+        "downloads": 3,
         "id": "electronut_labs_blip",
         "versions": [
             {
@@ -1434,41 +1434,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-electronut_labs_blip-ID-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-electronut_labs_blip-ID-5.0.0-alpha.3.hex"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-electronut_labs_blip-de_DE-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-electronut_labs_blip-de_DE-5.0.0-alpha.3.hex"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-electronut_labs_blip-en_US-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-electronut_labs_blip-en_US-5.0.0-alpha.3.hex"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-electronut_labs_blip-en_x_pirate-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-electronut_labs_blip-en_x_pirate-5.0.0-alpha.3.hex"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-electronut_labs_blip-es-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-electronut_labs_blip-es-5.0.0-alpha.3.hex"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-electronut_labs_blip-fil-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-electronut_labs_blip-fil-5.0.0-alpha.3.hex"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-electronut_labs_blip-fr-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-electronut_labs_blip-fr-5.0.0-alpha.3.hex"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-electronut_labs_blip-it_IT-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-electronut_labs_blip-it_IT-5.0.0-alpha.3.hex"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-electronut_labs_blip-pl-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-electronut_labs_blip-pl-5.0.0-alpha.3.hex"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-electronut_labs_blip-pt_BR-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-electronut_labs_blip-pt_BR-5.0.0-alpha.3.hex"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-electronut_labs_blip-zh_Latn_pinyin-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-electronut_labs_blip-zh_Latn_pinyin-5.0.0-alpha.3.hex"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -1518,41 +1518,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-electronut_labs_papyr-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-electronut_labs_papyr-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-electronut_labs_papyr-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-electronut_labs_papyr-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-electronut_labs_papyr-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-electronut_labs_papyr-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-electronut_labs_papyr-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-electronut_labs_papyr-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-electronut_labs_papyr-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-electronut_labs_papyr-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-electronut_labs_papyr-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-electronut_labs_papyr-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-electronut_labs_papyr-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-electronut_labs_papyr-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-electronut_labs_papyr-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-electronut_labs_papyr-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-electronut_labs_papyr-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-electronut_labs_papyr-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-electronut_labs_papyr-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-electronut_labs_papyr-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-electronut_labs_papyr-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-electronut_labs_papyr-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -1602,41 +1602,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-escornabot_makech-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-escornabot_makech-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-escornabot_makech-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-escornabot_makech-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-escornabot_makech-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-escornabot_makech-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-escornabot_makech-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-escornabot_makech-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-escornabot_makech-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-escornabot_makech-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-escornabot_makech-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-escornabot_makech-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-escornabot_makech-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-escornabot_makech-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-escornabot_makech-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-escornabot_makech-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-escornabot_makech-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-escornabot_makech-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-escornabot_makech-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-escornabot_makech-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-escornabot_makech-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-escornabot_makech-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -1646,7 +1646,7 @@
         "versions": []
     },
     {
-        "downloads": 71,
+        "downloads": 88,
         "id": "feather_m0_adalogger",
         "versions": [
             {
@@ -1702,57 +1702,57 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_adalogger-ID-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_adalogger-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_adalogger-ID-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_adalogger-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_adalogger-de_DE-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_adalogger-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_adalogger-de_DE-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_adalogger-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_adalogger-en_US-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_adalogger-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_adalogger-en_US-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_adalogger-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_adalogger-es-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_adalogger-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_adalogger-es-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_adalogger-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_adalogger-fil-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_adalogger-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_adalogger-fil-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_adalogger-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_adalogger-fr-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_adalogger-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_adalogger-fr-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_adalogger-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_adalogger-it_IT-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_adalogger-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_adalogger-it_IT-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_adalogger-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_adalogger-pl-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_adalogger-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_adalogger-pl-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_adalogger-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_adalogger-pt_BR-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_adalogger-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_adalogger-pt_BR-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_adalogger-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_adalogger-zh_Latn_pinyin-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_adalogger-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_adalogger-zh_Latn_pinyin-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_adalogger-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 61,
+        "downloads": 75,
         "id": "feather_m0_basic",
         "versions": [
             {
@@ -1808,57 +1808,57 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_basic-ID-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_basic-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_basic-ID-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_basic-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_basic-de_DE-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_basic-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_basic-de_DE-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_basic-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_basic-en_US-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_basic-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_basic-en_US-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_basic-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_basic-en_x_pirate-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_basic-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_basic-en_x_pirate-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_basic-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_basic-es-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_basic-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_basic-es-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_basic-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_basic-fil-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_basic-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_basic-fil-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_basic-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_basic-fr-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_basic-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_basic-fr-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_basic-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_basic-it_IT-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_basic-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_basic-it_IT-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_basic-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_basic-pl-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_basic-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_basic-pl-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_basic-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_basic-pt_BR-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_basic-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_basic-pt_BR-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_basic-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_basic-zh_Latn_pinyin-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_basic-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_basic-zh_Latn_pinyin-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_basic-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 243,
+        "downloads": 286,
         "id": "feather_m0_express",
         "versions": [
             {
@@ -1903,41 +1903,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_express-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_express-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_express-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_express-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_express-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_express-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_express-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_express-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_express-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_express-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_express-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_express-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_express-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_express-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_express-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_express-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_express-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_express-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_express-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_express-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_express-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_express-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -1987,46 +1987,46 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_express_crickit-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_express_crickit-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_express_crickit-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_express_crickit-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_express_crickit-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_express_crickit-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_express_crickit-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_express_crickit-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_express_crickit-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_express_crickit-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_express_crickit-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_express_crickit-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_express_crickit-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_express_crickit-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_express_crickit-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_express_crickit-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_express_crickit-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_express_crickit-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_express_crickit-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_express_crickit-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_express_crickit-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_express_crickit-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 37,
+        "downloads": 46,
         "id": "feather_m0_rfm69",
         "versions": [
             {
@@ -2082,57 +2082,57 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm69-ID-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm69-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm69-ID-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm69-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm69-de_DE-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm69-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm69-de_DE-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm69-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm69-en_US-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm69-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm69-en_US-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm69-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm69-es-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm69-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm69-es-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm69-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm69-fil-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm69-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm69-fil-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm69-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm69-fr-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm69-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm69-fr-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm69-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm69-it_IT-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm69-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm69-it_IT-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm69-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm69-pl-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm69-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm69-pl-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm69-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm69-pt_BR-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm69-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm69-pt_BR-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm69-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm69-zh_Latn_pinyin-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm69-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm69-zh_Latn_pinyin-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm69-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 69,
+        "downloads": 86,
         "id": "feather_m0_rfm9x",
         "versions": [
             {
@@ -2188,52 +2188,52 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm9x-ID-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm9x-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm9x-ID-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm9x-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm9x-de_DE-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm9x-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm9x-de_DE-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm9x-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm9x-en_US-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm9x-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm9x-en_US-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm9x-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm9x-es-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm9x-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm9x-es-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm9x-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm9x-fil-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm9x-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm9x-fil-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm9x-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm9x-fr-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm9x-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm9x-fr-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm9x-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm9x-it_IT-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm9x-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm9x-it_IT-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm9x-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm9x-pl-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm9x-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm9x-pl-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm9x-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm9x-zh_Latn_pinyin-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_rfm9x-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm9x-zh_Latn_pinyin-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_rfm9x-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -2283,46 +2283,46 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_supersized-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_supersized-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_supersized-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_supersized-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_supersized-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_supersized-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_supersized-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_supersized-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_supersized-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_supersized-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_supersized-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_supersized-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_supersized-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_supersized-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_supersized-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_supersized-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_supersized-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_supersized-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_supersized-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_supersized-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m0_supersized-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m0_supersized-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 366,
+        "downloads": 481,
         "id": "feather_m4_express",
         "versions": [
             {
@@ -2367,41 +2367,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m4_express-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m4_express-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m4_express-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m4_express-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m4_express-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m4_express-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m4_express-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m4_express-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m4_express-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m4_express-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m4_express-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m4_express-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m4_express-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m4_express-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m4_express-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m4_express-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m4_express-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m4_express-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m4_express-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m4_express-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_m4_express-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_m4_express-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -2411,7 +2411,7 @@
         "versions": []
     },
     {
-        "downloads": 73,
+        "downloads": 84,
         "id": "feather_nrf52840_express",
         "versions": [
             {
@@ -2456,41 +2456,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_nrf52840_express-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_nrf52840_express-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_nrf52840_express-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_nrf52840_express-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_nrf52840_express-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_nrf52840_express-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_nrf52840_express-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_nrf52840_express-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_nrf52840_express-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_nrf52840_express-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_nrf52840_express-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_nrf52840_express-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_nrf52840_express-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_nrf52840_express-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_nrf52840_express-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_nrf52840_express-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_nrf52840_express-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_nrf52840_express-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_nrf52840_express-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_nrf52840_express-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_nrf52840_express-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_nrf52840_express-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -2540,41 +2540,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_radiofruit_zigbee-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_radiofruit_zigbee-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_radiofruit_zigbee-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_radiofruit_zigbee-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_radiofruit_zigbee-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_radiofruit_zigbee-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_radiofruit_zigbee-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_radiofruit_zigbee-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_radiofruit_zigbee-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_radiofruit_zigbee-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_radiofruit_zigbee-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_radiofruit_zigbee-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_radiofruit_zigbee-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_radiofruit_zigbee-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_radiofruit_zigbee-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_radiofruit_zigbee-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_radiofruit_zigbee-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_radiofruit_zigbee-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_radiofruit_zigbee-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_radiofruit_zigbee-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-feather_radiofruit_zigbee-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-feather_radiofruit_zigbee-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -2584,7 +2584,7 @@
         "versions": []
     },
     {
-        "downloads": 193,
+        "downloads": 242,
         "id": "gemma_m0",
         "versions": [
             {
@@ -2629,41 +2629,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-gemma_m0-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-gemma_m0-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-gemma_m0-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-gemma_m0-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-gemma_m0-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-gemma_m0-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-gemma_m0-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-gemma_m0-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-gemma_m0-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-gemma_m0-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-gemma_m0-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-gemma_m0-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-gemma_m0-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-gemma_m0-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-gemma_m0-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-gemma_m0-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-gemma_m0-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-gemma_m0-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-gemma_m0-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-gemma_m0-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-gemma_m0-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-gemma_m0-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -2713,46 +2713,46 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-gemma_m0_pycon2018-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-gemma_m0_pycon2018-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-gemma_m0_pycon2018-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-gemma_m0_pycon2018-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-gemma_m0_pycon2018-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-gemma_m0_pycon2018-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-gemma_m0_pycon2018-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-gemma_m0_pycon2018-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-gemma_m0_pycon2018-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-gemma_m0_pycon2018-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-gemma_m0_pycon2018-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-gemma_m0_pycon2018-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-gemma_m0_pycon2018-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-gemma_m0_pycon2018-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-gemma_m0_pycon2018-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-gemma_m0_pycon2018-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-gemma_m0_pycon2018-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-gemma_m0_pycon2018-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-gemma_m0_pycon2018-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-gemma_m0_pycon2018-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-gemma_m0_pycon2018-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-gemma_m0_pycon2018-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 86,
+        "downloads": 105,
         "id": "grandcentral_m4_express",
         "versions": [
             {
@@ -2797,46 +2797,46 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-grandcentral_m4_express-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-grandcentral_m4_express-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-grandcentral_m4_express-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-grandcentral_m4_express-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-grandcentral_m4_express-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-grandcentral_m4_express-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-grandcentral_m4_express-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-grandcentral_m4_express-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-grandcentral_m4_express-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-grandcentral_m4_express-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-grandcentral_m4_express-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-grandcentral_m4_express-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-grandcentral_m4_express-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-grandcentral_m4_express-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-grandcentral_m4_express-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-grandcentral_m4_express-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-grandcentral_m4_express-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-grandcentral_m4_express-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-grandcentral_m4_express-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-grandcentral_m4_express-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-grandcentral_m4_express-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-grandcentral_m4_express-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 72,
+        "downloads": 101,
         "id": "hallowing_m0_express",
         "versions": [
             {
@@ -2881,91 +2881,91 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-hallowing_m0_express-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-hallowing_m0_express-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-hallowing_m0_express-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-hallowing_m0_express-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-hallowing_m0_express-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-hallowing_m0_express-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-hallowing_m0_express-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-hallowing_m0_express-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-hallowing_m0_express-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-hallowing_m0_express-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-hallowing_m0_express-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-hallowing_m0_express-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-hallowing_m0_express-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-hallowing_m0_express-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-hallowing_m0_express-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-hallowing_m0_express-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-hallowing_m0_express-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-hallowing_m0_express-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-hallowing_m0_express-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-hallowing_m0_express-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-hallowing_m0_express-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-hallowing_m0_express-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 3,
         "id": "hallowing_m4_express",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-hallowing_m4_express-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-hallowing_m4_express-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-hallowing_m4_express-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-hallowing_m4_express-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-hallowing_m4_express-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-hallowing_m4_express-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-hallowing_m4_express-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-hallowing_m4_express-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-hallowing_m4_express-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-hallowing_m4_express-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-hallowing_m4_express-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-hallowing_m4_express-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-hallowing_m4_express-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-hallowing_m4_express-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-hallowing_m4_express-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-hallowing_m4_express-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-hallowing_m4_express-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-hallowing_m4_express-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-hallowing_m4_express-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-hallowing_m4_express-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-hallowing_m4_express-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-hallowing_m4_express-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 127,
+        "downloads": 147,
         "id": "itsybitsy_m0_express",
         "versions": [
             {
@@ -3010,46 +3010,46 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-itsybitsy_m0_express-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-itsybitsy_m0_express-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-itsybitsy_m0_express-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-itsybitsy_m0_express-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-itsybitsy_m0_express-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-itsybitsy_m0_express-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-itsybitsy_m0_express-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-itsybitsy_m0_express-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-itsybitsy_m0_express-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-itsybitsy_m0_express-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-itsybitsy_m0_express-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-itsybitsy_m0_express-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-itsybitsy_m0_express-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-itsybitsy_m0_express-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-itsybitsy_m0_express-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-itsybitsy_m0_express-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-itsybitsy_m0_express-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-itsybitsy_m0_express-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-itsybitsy_m0_express-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-itsybitsy_m0_express-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-itsybitsy_m0_express-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-itsybitsy_m0_express-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 210,
+        "downloads": 255,
         "id": "itsybitsy_m4_express",
         "versions": [
             {
@@ -3094,41 +3094,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-itsybitsy_m4_express-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-itsybitsy_m4_express-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-itsybitsy_m4_express-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-itsybitsy_m4_express-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-itsybitsy_m4_express-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-itsybitsy_m4_express-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-itsybitsy_m4_express-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-itsybitsy_m4_express-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-itsybitsy_m4_express-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-itsybitsy_m4_express-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-itsybitsy_m4_express-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-itsybitsy_m4_express-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-itsybitsy_m4_express-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-itsybitsy_m4_express-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-itsybitsy_m4_express-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-itsybitsy_m4_express-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-itsybitsy_m4_express-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-itsybitsy_m4_express-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-itsybitsy_m4_express-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-itsybitsy_m4_express-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-itsybitsy_m4_express-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-itsybitsy_m4_express-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -3178,46 +3178,46 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-kicksat-sprite-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-kicksat-sprite-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-kicksat-sprite-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-kicksat-sprite-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-kicksat-sprite-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-kicksat-sprite-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-kicksat-sprite-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-kicksat-sprite-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-kicksat-sprite-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-kicksat-sprite-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-kicksat-sprite-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-kicksat-sprite-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-kicksat-sprite-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-kicksat-sprite-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-kicksat-sprite-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-kicksat-sprite-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-kicksat-sprite-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-kicksat-sprite-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-kicksat-sprite-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-kicksat-sprite-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-kicksat-sprite-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-kicksat-sprite-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 10,
+        "downloads": 14,
         "id": "makerdiary_nrf52840_mdk",
         "versions": [
             {
@@ -3262,46 +3262,46 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-makerdiary_nrf52840_mdk-ID-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-makerdiary_nrf52840_mdk-ID-5.0.0-alpha.3.hex"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-makerdiary_nrf52840_mdk-de_DE-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-makerdiary_nrf52840_mdk-de_DE-5.0.0-alpha.3.hex"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_US-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_US-5.0.0-alpha.3.hex"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_x_pirate-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_x_pirate-5.0.0-alpha.3.hex"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-makerdiary_nrf52840_mdk-es-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-makerdiary_nrf52840_mdk-es-5.0.0-alpha.3.hex"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-makerdiary_nrf52840_mdk-fil-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-makerdiary_nrf52840_mdk-fil-5.0.0-alpha.3.hex"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-makerdiary_nrf52840_mdk-fr-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-makerdiary_nrf52840_mdk-fr-5.0.0-alpha.3.hex"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-makerdiary_nrf52840_mdk-it_IT-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-makerdiary_nrf52840_mdk-it_IT-5.0.0-alpha.3.hex"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-makerdiary_nrf52840_mdk-pl-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-makerdiary_nrf52840_mdk-pl-5.0.0-alpha.3.hex"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-makerdiary_nrf52840_mdk-pt_BR-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-makerdiary_nrf52840_mdk-pt_BR-5.0.0-alpha.3.hex"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-makerdiary_nrf52840_mdk-zh_Latn_pinyin-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-makerdiary_nrf52840_mdk-zh_Latn_pinyin-5.0.0-alpha.3.hex"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 20,
+        "downloads": 24,
         "id": "makerdiary_nrf52840_mdk_usb_dongle",
         "versions": [
             {
@@ -3346,41 +3346,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-ID-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-ID-5.0.0-alpha.3.hex"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-de_DE-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-de_DE-5.0.0-alpha.3.hex"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_US-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_US-5.0.0-alpha.3.hex"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_x_pirate-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_x_pirate-5.0.0-alpha.3.hex"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-es-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-es-5.0.0-alpha.3.hex"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fil-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fil-5.0.0-alpha.3.hex"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fr-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fr-5.0.0-alpha.3.hex"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-it_IT-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-it_IT-5.0.0-alpha.3.hex"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pl-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pl-5.0.0-alpha.3.hex"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pt_BR-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pt_BR-5.0.0-alpha.3.hex"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-zh_Latn_pinyin-5.0.0-alpha.2.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-zh_Latn_pinyin-5.0.0-alpha.3.hex"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -3430,46 +3430,46 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-meowmeow-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-meowmeow-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-meowmeow-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-meowmeow-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-meowmeow-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-meowmeow-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-meowmeow-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-meowmeow-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-meowmeow-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-meowmeow-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-meowmeow-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-meowmeow-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-meowmeow-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-meowmeow-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-meowmeow-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-meowmeow-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-meowmeow-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-meowmeow-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-meowmeow-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-meowmeow-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-meowmeow-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-meowmeow-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 233,
+        "downloads": 327,
         "id": "metro_m0_express",
         "versions": [
             {
@@ -3514,46 +3514,46 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m0_express-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m0_express-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m0_express-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m0_express-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m0_express-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m0_express-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m0_express-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m0_express-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m0_express-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m0_express-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m0_express-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m0_express-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m0_express-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m0_express-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m0_express-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m0_express-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m0_express-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m0_express-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m0_express-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m0_express-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m0_express-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m0_express-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 51,
+        "downloads": 64,
         "id": "metro_m4_airlift_lite",
         "versions": [
             {
@@ -3598,46 +3598,46 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m4_airlift_lite-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m4_airlift_lite-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m4_airlift_lite-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m4_airlift_lite-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m4_airlift_lite-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m4_airlift_lite-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m4_airlift_lite-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m4_airlift_lite-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m4_airlift_lite-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m4_airlift_lite-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m4_airlift_lite-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m4_airlift_lite-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m4_airlift_lite-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m4_airlift_lite-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m4_airlift_lite-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m4_airlift_lite-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m4_airlift_lite-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m4_airlift_lite-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m4_airlift_lite-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m4_airlift_lite-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m4_airlift_lite-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m4_airlift_lite-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 129,
+        "downloads": 155,
         "id": "metro_m4_express",
         "versions": [
             {
@@ -3682,41 +3682,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m4_express-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m4_express-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m4_express-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m4_express-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m4_express-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m4_express-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m4_express-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m4_express-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m4_express-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m4_express-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m4_express-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m4_express-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m4_express-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m4_express-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m4_express-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m4_express-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m4_express-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m4_express-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m4_express-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m4_express-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_m4_express-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_m4_express-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -3727,46 +3727,46 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_nrf52840_express-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_nrf52840_express-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_nrf52840_express-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_nrf52840_express-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_nrf52840_express-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_nrf52840_express-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_nrf52840_express-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_nrf52840_express-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_nrf52840_express-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_nrf52840_express-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_nrf52840_express-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_nrf52840_express-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_nrf52840_express-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_nrf52840_express-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_nrf52840_express-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_nrf52840_express-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_nrf52840_express-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_nrf52840_express-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_nrf52840_express-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_nrf52840_express-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-metro_nrf52840_express-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-metro_nrf52840_express-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 7,
+        "downloads": 10,
         "id": "mini_sam_m4",
         "versions": [
             {
@@ -3811,91 +3811,91 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-mini_sam_m4-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-mini_sam_m4-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-mini_sam_m4-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-mini_sam_m4-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-mini_sam_m4-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-mini_sam_m4-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-mini_sam_m4-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-mini_sam_m4-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-mini_sam_m4-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-mini_sam_m4-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-mini_sam_m4-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-mini_sam_m4-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-mini_sam_m4-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-mini_sam_m4-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-mini_sam_m4-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-mini_sam_m4-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-mini_sam_m4-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-mini_sam_m4-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-mini_sam_m4-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-mini_sam_m4-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-mini_sam_m4-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-mini_sam_m4-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
-            }
-        ]
-    },
-    {
-        "downloads": 2,
-        "id": "monster_m4sk",
-        "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-monster_m4sk-ID-5.0.0-alpha.2.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-monster_m4sk-de_DE-5.0.0-alpha.2.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-monster_m4sk-en_US-5.0.0-alpha.2.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-monster_m4sk-en_x_pirate-5.0.0-alpha.2.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-monster_m4sk-es-5.0.0-alpha.2.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-monster_m4sk-fil-5.0.0-alpha.2.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-monster_m4sk-fr-5.0.0-alpha.2.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-monster_m4sk-it_IT-5.0.0-alpha.2.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-monster_m4sk-pl-5.0.0-alpha.2.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-monster_m4sk-pt_BR-5.0.0-alpha.2.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-monster_m4sk-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
         "downloads": 6,
+        "id": "monster_m4sk",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-monster_m4sk-ID-5.0.0-alpha.3.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-monster_m4sk-de_DE-5.0.0-alpha.3.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-monster_m4sk-en_US-5.0.0-alpha.3.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-monster_m4sk-en_x_pirate-5.0.0-alpha.3.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-monster_m4sk-es-5.0.0-alpha.3.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-monster_m4sk-fil-5.0.0-alpha.3.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-monster_m4sk-fr-5.0.0-alpha.3.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-monster_m4sk-it_IT-5.0.0-alpha.3.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-monster_m4sk-pl-5.0.0-alpha.3.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-monster_m4sk-pt_BR-5.0.0-alpha.3.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-monster_m4sk-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-alpha.3"
+            }
+        ]
+    },
+    {
+        "downloads": 8,
         "id": "particle_argon",
         "versions": [
             {
@@ -3940,46 +3940,46 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_argon-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_argon-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_argon-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_argon-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_argon-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_argon-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_argon-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_argon-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_argon-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_argon-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_argon-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_argon-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_argon-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_argon-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_argon-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_argon-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_argon-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_argon-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_argon-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_argon-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_argon-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_argon-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 4,
+        "downloads": 5,
         "id": "particle_boron",
         "versions": [
             {
@@ -4024,46 +4024,46 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_boron-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_boron-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_boron-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_boron-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_boron-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_boron-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_boron-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_boron-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_boron-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_boron-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_boron-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_boron-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_boron-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_boron-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_boron-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_boron-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_boron-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_boron-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_boron-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_boron-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_boron-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_boron-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 17,
+        "downloads": 20,
         "id": "particle_xenon",
         "versions": [
             {
@@ -4108,41 +4108,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_xenon-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_xenon-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_xenon-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_xenon-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_xenon-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_xenon-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_xenon-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_xenon-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_xenon-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_xenon-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_xenon-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_xenon-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_xenon-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_xenon-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_xenon-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_xenon-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_xenon-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_xenon-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_xenon-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_xenon-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-particle_xenon-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-particle_xenon-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -4152,7 +4152,7 @@
         "versions": []
     },
     {
-        "downloads": 19,
+        "downloads": 33,
         "id": "pca10056",
         "versions": [
             {
@@ -4208,57 +4208,57 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10056-ID-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10056-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10056-ID-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10056-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10056-de_DE-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10056-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10056-de_DE-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10056-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10056-en_US-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10056-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10056-en_US-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10056-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10056-en_x_pirate-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10056-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10056-en_x_pirate-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10056-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10056-es-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10056-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10056-es-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10056-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10056-fil-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10056-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10056-fil-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10056-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10056-fr-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10056-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10056-fr-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10056-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10056-it_IT-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10056-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10056-it_IT-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10056-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10056-pl-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10056-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10056-pl-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10056-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10056-pt_BR-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10056-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10056-pt_BR-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10056-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10056-zh_Latn_pinyin-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10056-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10056-zh_Latn_pinyin-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10056-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 50,
+        "downloads": 63,
         "id": "pca10059",
         "versions": [
             {
@@ -4314,57 +4314,57 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10059-ID-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10059-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10059-ID-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10059-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10059-de_DE-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10059-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10059-de_DE-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10059-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10059-en_US-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10059-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10059-en_US-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10059-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10059-en_x_pirate-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10059-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10059-en_x_pirate-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10059-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10059-es-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10059-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10059-es-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10059-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10059-fil-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10059-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10059-fil-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10059-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10059-fr-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10059-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10059-fr-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10059-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10059-it_IT-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10059-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10059-it_IT-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10059-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10059-pl-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10059-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10059-pl-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10059-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10059-pt_BR-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10059-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10059-pt_BR-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10059-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10059-zh_Latn_pinyin-5.0.0-alpha.2.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pca10059-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10059-zh_Latn_pinyin-5.0.0-alpha.3.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pca10059-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 10,
+        "downloads": 16,
         "id": "pewpew10",
         "versions": [
             {
@@ -4409,41 +4409,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pewpew10-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew10-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pewpew10-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew10-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pewpew10-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew10-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pewpew10-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew10-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pewpew10-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew10-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pewpew10-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew10-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pewpew10-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew10-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pewpew10-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew10-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pewpew10-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew10-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pewpew10-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew10-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pewpew10-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew10-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -4493,41 +4493,86 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pewpew13-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew13-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pewpew13-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew13-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pewpew13-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew13-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pewpew13-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew13-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pewpew13-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew13-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pewpew13-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew13-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pewpew13-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew13-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pewpew13-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew13-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pewpew13-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew13-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pewpew13-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew13-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pewpew13-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew13-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
+            }
+        ]
+    },
+    {
+        "downloads": 0,
+        "id": "pewpew_m4",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew_m4-ID-5.0.0-alpha.3.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew_m4-de_DE-5.0.0-alpha.3.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew_m4-en_US-5.0.0-alpha.3.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew_m4-en_x_pirate-5.0.0-alpha.3.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew_m4-es-5.0.0-alpha.3.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew_m4-fil-5.0.0-alpha.3.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew_m4-fr-5.0.0-alpha.3.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew_m4-it_IT-5.0.0-alpha.3.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew_m4-pl-5.0.0-alpha.3.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew_m4-pt_BR-5.0.0-alpha.3.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pewpew_m4-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -4577,46 +4622,46 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pirkey_m0-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pirkey_m0-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pirkey_m0-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pirkey_m0-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pirkey_m0-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pirkey_m0-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pirkey_m0-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pirkey_m0-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pirkey_m0-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pirkey_m0-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pirkey_m0-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pirkey_m0-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pirkey_m0-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pirkey_m0-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pirkey_m0-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pirkey_m0-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pirkey_m0-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pirkey_m0-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pirkey_m0-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pirkey_m0-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pirkey_m0-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pirkey_m0-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 123,
+        "downloads": 148,
         "id": "pybadge",
         "versions": [
             {
@@ -4661,46 +4706,46 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pybadge-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pybadge-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pybadge-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pybadge-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pybadge-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pybadge-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pybadge-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pybadge-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pybadge-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pybadge-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pybadge-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pybadge-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pybadge-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pybadge-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pybadge-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pybadge-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pybadge-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pybadge-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pybadge-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pybadge-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pybadge-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pybadge-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 5,
         "id": "pybadge_airlift",
         "versions": [
             {
@@ -4745,46 +4790,46 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pybadge_airlift-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pybadge_airlift-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pybadge_airlift-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pybadge_airlift-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pybadge_airlift-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pybadge_airlift-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pybadge_airlift-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pybadge_airlift-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pybadge_airlift-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pybadge_airlift-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pybadge_airlift-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pybadge_airlift-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pybadge_airlift-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pybadge_airlift-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pybadge_airlift-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pybadge_airlift-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pybadge_airlift-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pybadge_airlift-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pybadge_airlift-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pybadge_airlift-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pybadge_airlift-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pybadge_airlift-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 233,
+        "downloads": 290,
         "id": "pygamer",
         "versions": [
             {
@@ -4829,41 +4874,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pygamer-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pygamer-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pygamer-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pygamer-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pygamer-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pygamer-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pygamer-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pygamer-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pygamer-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pygamer-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pygamer-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pygamer-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pygamer-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pygamer-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pygamer-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pygamer-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pygamer-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pygamer-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pygamer-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pygamer-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pygamer-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pygamer-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -4913,46 +4958,46 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pygamer_advance-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pygamer_advance-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pygamer_advance-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pygamer_advance-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pygamer_advance-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pygamer_advance-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pygamer_advance-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pygamer_advance-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pygamer_advance-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pygamer_advance-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pygamer_advance-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pygamer_advance-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pygamer_advance-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pygamer_advance-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pygamer_advance-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pygamer_advance-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pygamer_advance-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pygamer_advance-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pygamer_advance-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pygamer_advance-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pygamer_advance-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pygamer_advance-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 355,
+        "downloads": 428,
         "id": "pyportal",
         "versions": [
             {
@@ -4997,91 +5042,91 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyportal-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyportal-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyportal-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyportal-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyportal-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyportal-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyportal-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyportal-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyportal-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyportal-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyportal-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyportal-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyportal-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyportal-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyportal-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyportal-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyportal-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyportal-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyportal-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyportal-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyportal-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyportal-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 1,
+        "downloads": 0,
         "id": "pyportal_titano",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyportal_titano-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyportal_titano-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyportal_titano-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyportal_titano-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyportal_titano-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyportal_titano-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyportal_titano-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyportal_titano-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyportal_titano-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyportal_titano-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyportal_titano-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyportal_titano-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyportal_titano-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyportal_titano-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyportal_titano-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyportal_titano-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyportal_titano-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyportal_titano-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyportal_titano-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyportal_titano-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyportal_titano-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyportal_titano-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 98,
+        "downloads": 111,
         "id": "pyruler",
         "versions": [
             {
@@ -5126,41 +5171,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyruler-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyruler-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyruler-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyruler-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyruler-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyruler-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyruler-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyruler-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyruler-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyruler-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyruler-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyruler-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyruler-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyruler-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyruler-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyruler-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyruler-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyruler-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyruler-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyruler-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-pyruler-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-pyruler-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -5210,41 +5255,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-robohatmm1_m0-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-robohatmm1_m0-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-robohatmm1_m0-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-robohatmm1_m0-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-robohatmm1_m0-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-robohatmm1_m0-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-robohatmm1_m0-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-robohatmm1_m0-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-robohatmm1_m0-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-robohatmm1_m0-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-robohatmm1_m0-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-robohatmm1_m0-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-robohatmm1_m0-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-robohatmm1_m0-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-robohatmm1_m0-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-robohatmm1_m0-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-robohatmm1_m0-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-robohatmm1_m0-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-robohatmm1_m0-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-robohatmm1_m0-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-robohatmm1_m0-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-robohatmm1_m0-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -5255,46 +5300,46 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-robohatmm1_m4-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-robohatmm1_m4-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-robohatmm1_m4-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-robohatmm1_m4-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-robohatmm1_m4-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-robohatmm1_m4-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-robohatmm1_m4-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-robohatmm1_m4-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-robohatmm1_m4-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-robohatmm1_m4-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-robohatmm1_m4-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-robohatmm1_m4-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-robohatmm1_m4-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-robohatmm1_m4-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-robohatmm1_m4-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-robohatmm1_m4-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-robohatmm1_m4-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-robohatmm1_m4-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-robohatmm1_m4-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-robohatmm1_m4-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-robohatmm1_m4-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-robohatmm1_m4-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 10,
+        "downloads": 11,
         "id": "sam32",
         "versions": [
             {
@@ -5339,41 +5384,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sam32-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sam32-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sam32-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sam32-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sam32-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sam32-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sam32-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sam32-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sam32-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sam32-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sam32-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sam32-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sam32-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sam32-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sam32-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sam32-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sam32-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sam32-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sam32-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sam32-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sam32-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sam32-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -5384,46 +5429,46 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-snekboard-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-snekboard-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-snekboard-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-snekboard-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-snekboard-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-snekboard-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-snekboard-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-snekboard-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-snekboard-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-snekboard-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-snekboard-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-snekboard-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-snekboard-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-snekboard-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-snekboard-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-snekboard-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-snekboard-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-snekboard-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-snekboard-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-snekboard-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-snekboard-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-snekboard-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 2,
+        "downloads": 4,
         "id": "sparkfun_lumidrive",
         "versions": [
             {
@@ -5468,41 +5513,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_lumidrive-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_lumidrive-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_lumidrive-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_lumidrive-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_lumidrive-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_lumidrive-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_lumidrive-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_lumidrive-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_lumidrive-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_lumidrive-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_lumidrive-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_lumidrive-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_lumidrive-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_lumidrive-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_lumidrive-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_lumidrive-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_lumidrive-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_lumidrive-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_lumidrive-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_lumidrive-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_lumidrive-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_lumidrive-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -5552,41 +5597,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_nrf52840_mini-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_nrf52840_mini-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_nrf52840_mini-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_nrf52840_mini-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_nrf52840_mini-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_nrf52840_mini-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_nrf52840_mini-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_nrf52840_mini-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_nrf52840_mini-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_nrf52840_mini-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_nrf52840_mini-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_nrf52840_mini-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_nrf52840_mini-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_nrf52840_mini-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_nrf52840_mini-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_nrf52840_mini-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_nrf52840_mini-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_nrf52840_mini-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_nrf52840_mini-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_nrf52840_mini-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_nrf52840_mini-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_nrf52840_mini-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -5636,46 +5681,46 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_redboard_turbo-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_redboard_turbo-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_redboard_turbo-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_redboard_turbo-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_redboard_turbo-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_redboard_turbo-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_redboard_turbo-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_redboard_turbo-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_redboard_turbo-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_redboard_turbo-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_redboard_turbo-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_redboard_turbo-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_redboard_turbo-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_redboard_turbo-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_redboard_turbo-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_redboard_turbo-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_redboard_turbo-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_redboard_turbo-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_redboard_turbo-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_redboard_turbo-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_redboard_turbo-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_redboard_turbo-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 5,
+        "downloads": 8,
         "id": "sparkfun_samd21_dev",
         "versions": [
             {
@@ -5720,46 +5765,46 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_samd21_dev-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_samd21_dev-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_samd21_dev-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_samd21_dev-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_samd21_dev-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_samd21_dev-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_samd21_dev-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_samd21_dev-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_samd21_dev-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_samd21_dev-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_samd21_dev-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_samd21_dev-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_samd21_dev-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_samd21_dev-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_samd21_dev-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_samd21_dev-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_samd21_dev-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_samd21_dev-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_samd21_dev-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_samd21_dev-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_samd21_dev-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_samd21_dev-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 5,
+        "downloads": 6,
         "id": "sparkfun_samd21_mini",
         "versions": [
             {
@@ -5804,46 +5849,136 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_samd21_mini-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_samd21_mini-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_samd21_mini-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_samd21_mini-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_samd21_mini-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_samd21_mini-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_samd21_mini-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_samd21_mini-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_samd21_mini-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_samd21_mini-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_samd21_mini-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_samd21_mini-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_samd21_mini-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_samd21_mini-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_samd21_mini-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_samd21_mini-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_samd21_mini-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_samd21_mini-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_samd21_mini-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_samd21_mini-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-sparkfun_samd21_mini-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-sparkfun_samd21_mini-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 116,
+        "downloads": 0,
+        "id": "stm32f411ve_discovery",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-stm32f411ve_discovery-ID-5.0.0-alpha.3.bin"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-stm32f411ve_discovery-de_DE-5.0.0-alpha.3.bin"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-stm32f411ve_discovery-en_US-5.0.0-alpha.3.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-stm32f411ve_discovery-en_x_pirate-5.0.0-alpha.3.bin"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-stm32f411ve_discovery-es-5.0.0-alpha.3.bin"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-stm32f411ve_discovery-fil-5.0.0-alpha.3.bin"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-stm32f411ve_discovery-fr-5.0.0-alpha.3.bin"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-stm32f411ve_discovery-it_IT-5.0.0-alpha.3.bin"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-stm32f411ve_discovery-pl-5.0.0-alpha.3.bin"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-stm32f411ve_discovery-pt_BR-5.0.0-alpha.3.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-stm32f411ve_discovery-zh_Latn_pinyin-5.0.0-alpha.3.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-alpha.3"
+            }
+        ]
+    },
+    {
+        "downloads": 0,
+        "id": "stm32f412zg_discovery",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-stm32f412zg_discovery-ID-5.0.0-alpha.3.bin"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-stm32f412zg_discovery-de_DE-5.0.0-alpha.3.bin"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-stm32f412zg_discovery-en_US-5.0.0-alpha.3.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-stm32f412zg_discovery-en_x_pirate-5.0.0-alpha.3.bin"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-stm32f412zg_discovery-es-5.0.0-alpha.3.bin"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-stm32f412zg_discovery-fil-5.0.0-alpha.3.bin"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-stm32f412zg_discovery-fr-5.0.0-alpha.3.bin"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-stm32f412zg_discovery-it_IT-5.0.0-alpha.3.bin"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-stm32f412zg_discovery-pl-5.0.0-alpha.3.bin"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-stm32f412zg_discovery-pt_BR-5.0.0-alpha.3.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-stm32f412zg_discovery-zh_Latn_pinyin-5.0.0-alpha.3.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-alpha.3"
+            }
+        ]
+    },
+    {
+        "downloads": 145,
         "id": "trellis_m4_express",
         "versions": [
             {
@@ -5888,46 +6023,46 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trellis_m4_express-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trellis_m4_express-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trellis_m4_express-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trellis_m4_express-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trellis_m4_express-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trellis_m4_express-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trellis_m4_express-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trellis_m4_express-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trellis_m4_express-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trellis_m4_express-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trellis_m4_express-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trellis_m4_express-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trellis_m4_express-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trellis_m4_express-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trellis_m4_express-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trellis_m4_express-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trellis_m4_express-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trellis_m4_express-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trellis_m4_express-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trellis_m4_express-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trellis_m4_express-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trellis_m4_express-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 633,
+        "downloads": 766,
         "id": "trinket_m0",
         "versions": [
             {
@@ -5972,41 +6107,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trinket_m0-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trinket_m0-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trinket_m0-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trinket_m0-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trinket_m0-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trinket_m0-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trinket_m0-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trinket_m0-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trinket_m0-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trinket_m0-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trinket_m0-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trinket_m0-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trinket_m0-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trinket_m0-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trinket_m0-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trinket_m0-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trinket_m0-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trinket_m0-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trinket_m0-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trinket_m0-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trinket_m0-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trinket_m0-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -6056,41 +6191,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trinket_m0_haxpress-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trinket_m0_haxpress-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trinket_m0_haxpress-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trinket_m0_haxpress-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trinket_m0_haxpress-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trinket_m0_haxpress-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trinket_m0_haxpress-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trinket_m0_haxpress-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trinket_m0_haxpress-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trinket_m0_haxpress-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trinket_m0_haxpress-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trinket_m0_haxpress-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trinket_m0_haxpress-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trinket_m0_haxpress-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trinket_m0_haxpress-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trinket_m0_haxpress-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trinket_m0_haxpress-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trinket_m0_haxpress-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trinket_m0_haxpress-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trinket_m0_haxpress-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-trinket_m0_haxpress-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-trinket_m0_haxpress-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
@@ -6140,46 +6275,46 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-uchip-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-uchip-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-uchip-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-uchip-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-uchip-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-uchip-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-uchip-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-uchip-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-uchip-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-uchip-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-uchip-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-uchip-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-uchip-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-uchip-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-uchip-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-uchip-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-uchip-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-uchip-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-uchip-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-uchip-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-uchip-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-uchip-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     },
     {
-        "downloads": 17,
+        "downloads": 18,
         "id": "ugame10",
         "versions": [
             {
@@ -6224,41 +6359,41 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-ugame10-ID-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-ugame10-ID-5.0.0-alpha.3.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-ugame10-de_DE-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-ugame10-de_DE-5.0.0-alpha.3.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-ugame10-en_US-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-ugame10-en_US-5.0.0-alpha.3.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-ugame10-en_x_pirate-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-ugame10-en_x_pirate-5.0.0-alpha.3.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-ugame10-es-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-ugame10-es-5.0.0-alpha.3.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-ugame10-fil-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-ugame10-fil-5.0.0-alpha.3.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-ugame10-fr-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-ugame10-fr-5.0.0-alpha.3.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-ugame10-it_IT-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-ugame10-it_IT-5.0.0-alpha.3.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-ugame10-pl-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-ugame10-pl-5.0.0-alpha.3.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-ugame10-pt_BR-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-ugame10-pt_BR-5.0.0-alpha.3.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.2/adafruit-circuitpython-ugame10-zh_Latn_pinyin-5.0.0-alpha.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-alpha.3/adafruit-circuitpython-ugame10-zh_Latn_pinyin-5.0.0-alpha.3.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-alpha.2"
+                "version": "5.0.0-alpha.3"
             }
         ]
     }


### PR DESCRIPTION
Automated website update for release 5.0.0-alpha.3 by Blinka.

New boards:
* pewpew_m4
* stm32f411ve_discovery
* stm32f412zg_discovery


