### PR TITLE
Remove unsupported boards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ _site
 .jekyll-metadata
 .DS_Store
 _drafts/
+.bundle
+vendor

--- a/README.md
+++ b/README.md
@@ -9,3 +9,14 @@ and a larger image (700 px width) in each respective directory (assets/images/bo
 and process them in something like https://squoosh.app/ to reduce file size. If
 you only have one image, place it in the 'original' folder.
 3. Create a pull request with the file changes.
+
+**To test your changes locally:**
+
+1. You need "ruby" and "ruby-bundler" installed locally.  These instructions
+were tested with ruby 2.5 and ruby-bundler 1.17.3 on a Debian Stretch system.
+2. As needed, `git submodule update --init --recursive` to fetch the submodules
+3. One time, run `bundle install --path vendor/bundle`
+4. Run `bundle exec jekyll serve` to generate the site locally
+5. Visit the displayed "server address"
+6. After most local edits, the content will be updated.  You will need to
+reload (ctrl-r or F5) your browser

--- a/_data/files.json
+++ b/_data/files.json
@@ -1641,11 +1641,6 @@
         ]
     },
     {
-        "downloads": 16,
-        "id": "feather_huzzah",
-        "versions": []
-    },
-    {
         "downloads": 88,
         "id": "feather_m0_adalogger",
         "versions": [
@@ -2404,11 +2399,6 @@
                 "version": "5.0.0-alpha.4"
             }
         ]
-    },
-    {
-        "downloads": 8,
-        "id": "feather_nrf52832",
-        "versions": []
     },
     {
         "downloads": 85,


### PR DESCRIPTION
Pull request #286 was incomplete, it left "unknown" boards in the list.  This finishes removing Feather Huzzah and Feather nRF52832 from the index of boards.

Testing performed: Built locally and looked at the "downloads" page