### PR TITLE
contributing: fix links which had '(### days)' in the URL

### DIFF
--- a/libraries/contributing.html
+++ b/libraries/contributing.html
@@ -89,7 +89,7 @@ permalink: /libraries/contributing
            {{repo_issue[0]}}
            <ul>
            {% for issue in repo_issue[1] %}
-             <li><a href="{{ issue }}">{{ issue }}</a></li>
+             <li><a href="{{ issue | split: " " | first }}">{{ issue }}</a></li>
            {% endfor %}
            </ul>
          </li>


### PR DESCRIPTION
.. by splitting the issue text at the first space, so that the URL doesn't include that part.