### PR TITLE
For better or for worse, circuitpython.org doesn't have an RSS/Atom feed

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,5 +11,4 @@
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css" integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU" crossorigin="anonymous">
   <link rel="stylesheet" href="{{ "/assets/css/main.css" | relative_url }}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
-  <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">
 </head>


### PR DESCRIPTION
htmlproofer diagnosed this problem:
```
- ./_site/404/index.html
  *  External link http://localhost:4000/feed.xml failed: 404 No error
```