### PR TITLE
Restructure Travis Artifact Paths To Address S3 Errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ install:
 addons:
   artifacts:
     paths:
-    - $HOME/web/libraries.json
+    - $(ls web/* | tr "\n" ":")
     target_paths: /adabot
     debug: true
 
 script:
-  - mkdir -p $HOME/web
+  - mkdir -p web
   - cd adabot
-  - python -u -m adabot.update_cp_org_libraries -o $HOME/web/libraries.json
+  - python -u -m adabot.update_cp_org_libraries -o $TRAVIS_BUILD_DIR/web/libraries.json


### PR DESCRIPTION
This should put `libraries.json` in the correct folder on S3, avoiding the `access denied` error.