### PR TITLE
libraries.json: Fix S3 Deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,4 @@ script:
   - mkdir -p web
   - cd adabot
   - python -u -m adabot.update_cp_org_libraries -o $TRAVIS_BUILD_DIR/web/libraries.json
+  - cd ..


### PR DESCRIPTION
This fixes the S3 deployment, as it wasn't finding the generated `web/libraries.json`. 

The `ls web/*` step in the artifact deployment was searching for `adabot/web/*` since Travis changes the directory to run adabot.

I have tested this on a personal repo: https://travis-ci.org/sommersoft/aws_s3_testing/jobs/592865104

Lastly, this was so simple, it deserves a 🤦‍♂. 