### PR TITLE
Only Run the GitHub Actions Workflow On the Adafruit Repository

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -8,8 +8,23 @@ on:
     - cron: 0 10 * * *
 
 jobs:
+  check-repo-owner:
+    # This job is so the entire workflow will end successfully and give some
+    # output to explain why it hasn't run on a non-Adafruit fork.
+    runs-on: ubuntu-latest
+    steps:
+      - name: repository
+        env:
+          OWNER_IS_ADAFRUIT: ${{ startswith(github.repository, 'adafruit') }}
+        run: |
+          echo "This workflow will only run if Adafruit is the repository owner."
+          echo "Repository owner is Adafruit: $OWNER_IS_ADAFRUIT"
   build:
     runs-on: ubuntu-latest
+    # Only run the build on Adafruit's repository. Forks won't have the secrets.
+    # Its necessary to do this here, since 'schedule' events cannot (currently)
+    # be limited (they run on all forks' default branches).
+    if: startswith(github.repository, 'adafruit')
     steps:
     - uses: actions/checkout@v1
       with:


### PR DESCRIPTION
Ever since the GitHub Actions workflow to build the site was put in, the cron job has also been running on my fork (I'm a beta participant in Actions).

Obviously, it fails since I don't have the secrets, which triggers a daily email about the failure. Its a minor nuisance, but once Actions availability increases this might get out of hand.

Unfortunately, the way that `schedule` events currently work, it cannot be limited itself. I tried on a rest repo.

This change will only run the `build` job if the repository is owned by Adafruit. I added a job to print out if the repository's owner is Adafruit; otherwise its just a blank completed run that constantly shows "Starting your workflow runs...".