### PR TITLE
Automated website update for release 5.0.0-beta.1

### DIFF
--- a/_data/files.json
+++ b/_data/files.json
@@ -1,6 +1,6 @@
 [
     {
-        "downloads": 113,
+        "downloads": 119,
         "id": "arduino_mkr1300",
         "versions": [
             {
@@ -45,46 +45,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_mkr1300-ID-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkr1300-ID-5.0.0-beta.1.bin"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_mkr1300-de_DE-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkr1300-de_DE-5.0.0-beta.1.bin"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_mkr1300-en_US-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkr1300-en_US-5.0.0-beta.1.bin"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_mkr1300-en_x_pirate-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkr1300-en_x_pirate-5.0.0-beta.1.bin"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_mkr1300-es-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkr1300-es-5.0.0-beta.1.bin"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_mkr1300-fil-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkr1300-fil-5.0.0-beta.1.bin"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_mkr1300-fr-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkr1300-fr-5.0.0-beta.1.bin"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_mkr1300-it_IT-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkr1300-it_IT-5.0.0-beta.1.bin"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkr1300-ko-5.0.0-beta.1.bin"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_mkr1300-pl-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkr1300-pl-5.0.0-beta.1.bin"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_mkr1300-pt_BR-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkr1300-pt_BR-5.0.0-beta.1.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_mkr1300-zh_Latn_pinyin-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkr1300-zh_Latn_pinyin-5.0.0-beta.1.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 72,
+        "downloads": 82,
         "id": "arduino_mkrzero",
         "versions": [
             {
@@ -129,91 +132,97 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_mkrzero-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkrzero-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_mkrzero-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkrzero-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_mkrzero-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkrzero-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_mkrzero-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkrzero-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_mkrzero-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkrzero-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_mkrzero-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkrzero-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_mkrzero-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkrzero-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_mkrzero-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkrzero-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkrzero-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_mkrzero-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkrzero-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_mkrzero-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkrzero-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_mkrzero-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkrzero-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 8,
+        "downloads": 21,
         "id": "arduino_nano_33_ble",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_nano_33_ble-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_nano_33_ble-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_nano_33_ble-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_nano_33_ble-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_nano_33_ble-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_nano_33_ble-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_nano_33_ble-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_nano_33_ble-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_nano_33_ble-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_nano_33_ble-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_nano_33_ble-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_nano_33_ble-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_nano_33_ble-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_nano_33_ble-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_nano_33_ble-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_nano_33_ble-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_nano_33_ble-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_nano_33_ble-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_nano_33_ble-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_nano_33_ble-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_nano_33_ble-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_nano_33_ble-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_nano_33_ble-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 168,
+        "downloads": 192,
         "id": "arduino_zero",
         "versions": [
             {
@@ -258,46 +267,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_zero-ID-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_zero-ID-5.0.0-beta.1.bin"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_zero-de_DE-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_zero-de_DE-5.0.0-beta.1.bin"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_zero-en_US-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_zero-en_US-5.0.0-beta.1.bin"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_zero-en_x_pirate-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_zero-en_x_pirate-5.0.0-beta.1.bin"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_zero-es-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_zero-es-5.0.0-beta.1.bin"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_zero-fil-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_zero-fil-5.0.0-beta.1.bin"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_zero-fr-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_zero-fr-5.0.0-beta.1.bin"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_zero-it_IT-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_zero-it_IT-5.0.0-beta.1.bin"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_zero-ko-5.0.0-beta.1.bin"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_zero-pl-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_zero-pl-5.0.0-beta.1.bin"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_zero-pt_BR-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_zero-pt_BR-5.0.0-beta.1.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-arduino_zero-zh_Latn_pinyin-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_zero-zh_Latn_pinyin-5.0.0-beta.1.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 17,
+        "downloads": 18,
         "id": "bast_pro_mini_m0",
         "versions": [
             {
@@ -342,46 +354,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-bast_pro_mini_m0-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-bast_pro_mini_m0-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-bast_pro_mini_m0-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-bast_pro_mini_m0-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-bast_pro_mini_m0-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-bast_pro_mini_m0-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-bast_pro_mini_m0-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-bast_pro_mini_m0-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-bast_pro_mini_m0-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-bast_pro_mini_m0-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-bast_pro_mini_m0-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-bast_pro_mini_m0-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-bast_pro_mini_m0-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-bast_pro_mini_m0-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-bast_pro_mini_m0-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-bast_pro_mini_m0-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-bast_pro_mini_m0-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-bast_pro_mini_m0-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-bast_pro_mini_m0-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-bast_pro_mini_m0-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-bast_pro_mini_m0-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-bast_pro_mini_m0-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-bast_pro_mini_m0-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 16,
+        "downloads": 15,
         "id": "capablerobot_usbhub",
         "versions": [
             {
@@ -426,46 +441,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-capablerobot_usbhub-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-capablerobot_usbhub-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-capablerobot_usbhub-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-capablerobot_usbhub-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-capablerobot_usbhub-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-capablerobot_usbhub-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-capablerobot_usbhub-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-capablerobot_usbhub-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-capablerobot_usbhub-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-capablerobot_usbhub-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-capablerobot_usbhub-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-capablerobot_usbhub-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-capablerobot_usbhub-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-capablerobot_usbhub-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-capablerobot_usbhub-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-capablerobot_usbhub-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-capablerobot_usbhub-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-capablerobot_usbhub-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-capablerobot_usbhub-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-capablerobot_usbhub-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-capablerobot_usbhub-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-capablerobot_usbhub-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-capablerobot_usbhub-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 16,
+        "downloads": 18,
         "id": "catwan_usbstick",
         "versions": [
             {
@@ -510,91 +528,97 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-catwan_usbstick-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-catwan_usbstick-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-catwan_usbstick-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-catwan_usbstick-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-catwan_usbstick-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-catwan_usbstick-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-catwan_usbstick-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-catwan_usbstick-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-catwan_usbstick-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-catwan_usbstick-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-catwan_usbstick-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-catwan_usbstick-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-catwan_usbstick-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-catwan_usbstick-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-catwan_usbstick-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-catwan_usbstick-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-catwan_usbstick-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-catwan_usbstick-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-catwan_usbstick-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-catwan_usbstick-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-catwan_usbstick-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-catwan_usbstick-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-catwan_usbstick-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 115,
+        "downloads": 339,
         "id": "circuitplayground_bluefruit",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_bluefruit-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_bluefruit-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_bluefruit-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_bluefruit-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_bluefruit-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_bluefruit-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_bluefruit-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_bluefruit-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_bluefruit-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_bluefruit-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_bluefruit-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_bluefruit-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_bluefruit-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_bluefruit-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_bluefruit-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_bluefruit-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_bluefruit-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_bluefruit-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_bluefruit-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_bluefruit-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_bluefruit-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_bluefruit-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_bluefruit-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 5995,
+        "downloads": 6900,
         "id": "circuitplayground_express",
         "versions": [
             {
@@ -639,46 +663,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 42,
+        "downloads": 45,
         "id": "circuitplayground_express_4h",
         "versions": [
             {
@@ -723,46 +750,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_4h-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_4h-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_4h-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_4h-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_4h-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_4h-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_4h-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_4h-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_4h-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_4h-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_4h-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_4h-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_4h-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_4h-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_4h-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_4h-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_4h-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_4h-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_4h-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_4h-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_4h-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_4h-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_4h-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 274,
+        "downloads": 324,
         "id": "circuitplayground_express_crickit",
         "versions": [
             {
@@ -807,41 +837,44 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_crickit-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_crickit-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_crickit-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_crickit-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_crickit-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_crickit-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_crickit-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_crickit-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_crickit-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_crickit-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_crickit-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_crickit-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_crickit-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_crickit-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_crickit-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_crickit-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_crickit-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_crickit-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_crickit-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_crickit-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_crickit-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_crickit-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_crickit-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
@@ -891,41 +924,44 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
@@ -936,41 +972,44 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_displayio-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_displayio-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_displayio-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_displayio-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_displayio-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_displayio-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_displayio-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_displayio-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_displayio-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_displayio-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_displayio-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_displayio-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_displayio-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_displayio-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_displayio-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_displayio-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_displayio-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_displayio-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_displayio-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_displayio-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_displayio-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-circuitplayground_express_displayio-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_displayio-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
@@ -1020,41 +1059,44 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-cp32-m4-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-cp32-m4-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-cp32-m4-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-cp32-m4-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-cp32-m4-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-cp32-m4-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-cp32-m4-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-cp32-m4-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-cp32-m4-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-cp32-m4-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-cp32-m4-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-cp32-m4-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-cp32-m4-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-cp32-m4-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-cp32-m4-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-cp32-m4-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-cp32-m4-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-cp32-m4-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-cp32-m4-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-cp32-m4-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-cp32-m4-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-cp32-m4-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-cp32-m4-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
@@ -1104,46 +1146,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datalore_ip_m4-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datalore_ip_m4-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datalore_ip_m4-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datalore_ip_m4-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datalore_ip_m4-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datalore_ip_m4-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datalore_ip_m4-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datalore_ip_m4-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datalore_ip_m4-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datalore_ip_m4-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datalore_ip_m4-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datalore_ip_m4-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datalore_ip_m4-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datalore_ip_m4-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datalore_ip_m4-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datalore_ip_m4-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datalore_ip_m4-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datalore_ip_m4-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datalore_ip_m4-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datalore_ip_m4-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datalore_ip_m4-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datalore_ip_m4-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datalore_ip_m4-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 15,
+        "downloads": 17,
         "id": "datum_distance",
         "versions": [
             {
@@ -1188,46 +1233,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_distance-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_distance-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_distance-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_distance-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_distance-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_distance-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_distance-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_distance-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_distance-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_distance-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_distance-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_distance-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_distance-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_distance-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_distance-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_distance-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_distance-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_distance-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_distance-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_distance-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_distance-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_distance-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_distance-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 19,
+        "downloads": 20,
         "id": "datum_imu",
         "versions": [
             {
@@ -1272,41 +1320,44 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_imu-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_imu-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_imu-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_imu-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_imu-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_imu-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_imu-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_imu-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_imu-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_imu-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_imu-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_imu-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_imu-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_imu-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_imu-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_imu-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_imu-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_imu-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_imu-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_imu-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_imu-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_imu-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_imu-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
@@ -1356,41 +1407,44 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_light-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_light-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_light-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_light-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_light-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_light-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_light-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_light-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_light-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_light-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_light-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_light-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_light-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_light-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_light-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_light-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_light-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_light-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_light-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_light-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_light-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_light-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_light-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
@@ -1440,46 +1494,136 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_weather-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_weather-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_weather-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_weather-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_weather-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_weather-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_weather-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_weather-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_weather-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_weather-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_weather-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_weather-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_weather-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_weather-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_weather-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_weather-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_weather-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_weather-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_weather-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_weather-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_weather-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-datum_weather-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_weather-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 18,
+        "downloads": 0,
+        "id": "edgebadge",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/4.1.0/adafruit-circuitpython-pybadge-ID-4.1.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/4.1.0/adafruit-circuitpython-pybadge-de_DE-4.1.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/4.1.0/adafruit-circuitpython-pybadge-en_US-4.1.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/4.1.0/adafruit-circuitpython-pybadge-en_x_pirate-4.1.0.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/4.1.0/adafruit-circuitpython-pybadge-es-4.1.0.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/4.1.0/adafruit-circuitpython-pybadge-fil-4.1.0.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/4.1.0/adafruit-circuitpython-pybadge-fr-4.1.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/4.1.0/adafruit-circuitpython-pybadge-it_IT-4.1.0.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/4.1.0/adafruit-circuitpython-pybadge-pl-4.1.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/4.1.0/adafruit-circuitpython-pybadge-pt_BR-4.1.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/4.1.0/adafruit-circuitpython-pybadge-zh_Latn_pinyin-4.1.0.uf2"
+                    ]
+                },
+                "stable": true,
+                "version": "4.1.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-edgebadge-ID-5.0.0-beta.1.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-edgebadge-de_DE-5.0.0-beta.1.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-edgebadge-en_US-5.0.0-beta.1.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-edgebadge-en_x_pirate-5.0.0-beta.1.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-edgebadge-es-5.0.0-beta.1.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-edgebadge-fil-5.0.0-beta.1.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-edgebadge-fr-5.0.0-beta.1.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-edgebadge-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-edgebadge-ko-5.0.0-beta.1.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-edgebadge-pl-5.0.0-beta.1.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-edgebadge-pt_BR-5.0.0-beta.1.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-edgebadge-zh_Latn_pinyin-5.0.0-beta.1.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.1"
+            }
+        ]
+    },
+    {
+        "downloads": 19,
         "id": "electronut_labs_blip",
         "versions": [
             {
@@ -1524,41 +1668,44 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-electronut_labs_blip-ID-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_blip-ID-5.0.0-beta.1.hex"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-electronut_labs_blip-de_DE-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_blip-de_DE-5.0.0-beta.1.hex"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-electronut_labs_blip-en_US-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_blip-en_US-5.0.0-beta.1.hex"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-electronut_labs_blip-en_x_pirate-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_blip-en_x_pirate-5.0.0-beta.1.hex"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-electronut_labs_blip-es-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_blip-es-5.0.0-beta.1.hex"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-electronut_labs_blip-fil-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_blip-fil-5.0.0-beta.1.hex"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-electronut_labs_blip-fr-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_blip-fr-5.0.0-beta.1.hex"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-electronut_labs_blip-it_IT-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_blip-it_IT-5.0.0-beta.1.hex"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_blip-ko-5.0.0-beta.1.hex"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-electronut_labs_blip-pl-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_blip-pl-5.0.0-beta.1.hex"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-electronut_labs_blip-pt_BR-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_blip-pt_BR-5.0.0-beta.1.hex"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-electronut_labs_blip-zh_Latn_pinyin-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_blip-zh_Latn_pinyin-5.0.0-beta.1.hex"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
@@ -1608,46 +1755,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-electronut_labs_papyr-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_papyr-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-electronut_labs_papyr-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_papyr-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-electronut_labs_papyr-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_papyr-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-electronut_labs_papyr-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_papyr-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-electronut_labs_papyr-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_papyr-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-electronut_labs_papyr-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_papyr-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-electronut_labs_papyr-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_papyr-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-electronut_labs_papyr-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_papyr-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_papyr-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-electronut_labs_papyr-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_papyr-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-electronut_labs_papyr-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_papyr-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-electronut_labs_papyr-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_papyr-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 16,
+        "downloads": 17,
         "id": "escornabot_makech",
         "versions": [
             {
@@ -1692,46 +1842,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-escornabot_makech-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-escornabot_makech-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-escornabot_makech-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-escornabot_makech-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-escornabot_makech-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-escornabot_makech-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-escornabot_makech-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-escornabot_makech-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-escornabot_makech-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-escornabot_makech-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-escornabot_makech-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-escornabot_makech-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-escornabot_makech-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-escornabot_makech-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-escornabot_makech-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-escornabot_makech-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-escornabot_makech-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-escornabot_makech-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-escornabot_makech-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-escornabot_makech-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-escornabot_makech-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-escornabot_makech-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-escornabot_makech-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 336,
+        "downloads": 384,
         "id": "feather_m0_adalogger",
         "versions": [
             {
@@ -1787,57 +1940,61 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_adalogger-ID-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_adalogger-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-ID-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_adalogger-de_DE-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_adalogger-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-de_DE-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_adalogger-en_US-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_adalogger-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-en_US-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_adalogger-es-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_adalogger-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-es-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_adalogger-fil-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_adalogger-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-fil-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_adalogger-fr-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_adalogger-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-fr-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_adalogger-it_IT-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_adalogger-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-it_IT-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-ko-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_adalogger-pl-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_adalogger-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-pl-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_adalogger-pt_BR-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_adalogger-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-pt_BR-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_adalogger-zh_Latn_pinyin-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_adalogger-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-zh_Latn_pinyin-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 249,
+        "downloads": 289,
         "id": "feather_m0_basic",
         "versions": [
             {
@@ -1893,57 +2050,61 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_basic-ID-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_basic-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-ID-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_basic-de_DE-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_basic-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-de_DE-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_basic-en_US-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_basic-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-en_US-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_basic-en_x_pirate-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_basic-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-en_x_pirate-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_basic-es-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_basic-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-es-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_basic-fil-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_basic-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-fil-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_basic-fr-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_basic-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-fr-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_basic-it_IT-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_basic-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-it_IT-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-ko-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_basic-pl-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_basic-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-pl-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_basic-pt_BR-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_basic-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-pt_BR-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_basic-zh_Latn_pinyin-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_basic-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-zh_Latn_pinyin-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 719,
+        "downloads": 882,
         "id": "feather_m0_express",
         "versions": [
             {
@@ -1988,46 +2149,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_express-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_express-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_express-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_express-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_express-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_express-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_express-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_express-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_express-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_express-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_express-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 35,
+        "downloads": 40,
         "id": "feather_m0_express_crickit",
         "versions": [
             {
@@ -2072,46 +2236,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_express_crickit-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express_crickit-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_express_crickit-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express_crickit-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_express_crickit-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express_crickit-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_express_crickit-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express_crickit-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_express_crickit-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express_crickit-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_express_crickit-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express_crickit-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_express_crickit-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express_crickit-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_express_crickit-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express_crickit-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express_crickit-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_express_crickit-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express_crickit-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_express_crickit-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express_crickit-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_express_crickit-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express_crickit-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 118,
+        "downloads": 136,
         "id": "feather_m0_rfm69",
         "versions": [
             {
@@ -2167,57 +2334,61 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm69-ID-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm69-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-ID-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm69-de_DE-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm69-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-de_DE-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm69-en_US-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm69-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-en_US-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm69-es-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm69-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-es-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm69-fil-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm69-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-fil-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm69-fr-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm69-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-fr-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm69-it_IT-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm69-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-it_IT-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-ko-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm69-pl-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm69-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-pl-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm69-pt_BR-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm69-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-pt_BR-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm69-zh_Latn_pinyin-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm69-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-zh_Latn_pinyin-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 240,
+        "downloads": 264,
         "id": "feather_m0_rfm9x",
         "versions": [
             {
@@ -2273,57 +2444,61 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm9x-ID-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm9x-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-ID-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm9x-de_DE-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm9x-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-de_DE-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm9x-en_US-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm9x-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-en_US-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm9x-es-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm9x-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-es-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm9x-fil-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm9x-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-fil-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm9x-fr-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm9x-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-fr-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm9x-it_IT-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm9x-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-it_IT-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-ko-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm9x-pl-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm9x-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-pl-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm9x-zh_Latn_pinyin-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_rfm9x-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-zh_Latn_pinyin-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 1,
         "id": "feather_m0_supersized",
         "versions": [
             {
@@ -2368,46 +2543,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_supersized-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_supersized-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_supersized-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_supersized-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_supersized-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_supersized-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_supersized-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_supersized-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_supersized-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_supersized-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_supersized-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_supersized-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_supersized-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_supersized-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_supersized-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_supersized-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_supersized-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_supersized-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_supersized-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_supersized-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_supersized-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m0_supersized-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_supersized-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 1166,
+        "downloads": 1404,
         "id": "feather_m4_express",
         "versions": [
             {
@@ -2452,46 +2630,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m4_express-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m4_express-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m4_express-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m4_express-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m4_express-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m4_express-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m4_express-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m4_express-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m4_express-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m4_express-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m4_express-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m4_express-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m4_express-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m4_express-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m4_express-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m4_express-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m4_express-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m4_express-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m4_express-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m4_express-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m4_express-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_m4_express-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m4_express-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 285,
+        "downloads": 344,
         "id": "feather_nrf52840_express",
         "versions": [
             {
@@ -2536,41 +2717,44 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_nrf52840_express-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_nrf52840_express-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_nrf52840_express-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_nrf52840_express-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_nrf52840_express-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_nrf52840_express-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_nrf52840_express-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_nrf52840_express-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_nrf52840_express-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_nrf52840_express-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_nrf52840_express-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_nrf52840_express-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_nrf52840_express-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_nrf52840_express-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_nrf52840_express-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_nrf52840_express-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_nrf52840_express-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_nrf52840_express-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_nrf52840_express-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_nrf52840_express-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_nrf52840_express-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_nrf52840_express-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_nrf52840_express-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
@@ -2620,86 +2804,92 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_radiofruit_zigbee-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_radiofruit_zigbee-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_radiofruit_zigbee-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_radiofruit_zigbee-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_radiofruit_zigbee-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_radiofruit_zigbee-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_radiofruit_zigbee-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_radiofruit_zigbee-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_radiofruit_zigbee-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_radiofruit_zigbee-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_radiofruit_zigbee-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_radiofruit_zigbee-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_radiofruit_zigbee-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_radiofruit_zigbee-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_radiofruit_zigbee-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_radiofruit_zigbee-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_radiofruit_zigbee-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_radiofruit_zigbee-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_radiofruit_zigbee-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_radiofruit_zigbee-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_radiofruit_zigbee-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_radiofruit_zigbee-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_radiofruit_zigbee-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 30,
+        "downloads": 69,
         "id": "feather_stm32f405_express",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_stm32f405_express-ID-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_stm32f405_express-ID-5.0.0-beta.1.bin"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_stm32f405_express-de_DE-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_stm32f405_express-de_DE-5.0.0-beta.1.bin"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_stm32f405_express-en_US-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_stm32f405_express-en_US-5.0.0-beta.1.bin"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_stm32f405_express-en_x_pirate-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_stm32f405_express-en_x_pirate-5.0.0-beta.1.bin"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_stm32f405_express-es-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_stm32f405_express-es-5.0.0-beta.1.bin"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_stm32f405_express-fil-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_stm32f405_express-fil-5.0.0-beta.1.bin"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_stm32f405_express-fr-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_stm32f405_express-fr-5.0.0-beta.1.bin"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_stm32f405_express-it_IT-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_stm32f405_express-it_IT-5.0.0-beta.1.bin"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_stm32f405_express-ko-5.0.0-beta.1.bin"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_stm32f405_express-pl-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_stm32f405_express-pl-5.0.0-beta.1.bin"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_stm32f405_express-pt_BR-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_stm32f405_express-pt_BR-5.0.0-beta.1.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-feather_stm32f405_express-zh_Latn_pinyin-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_stm32f405_express-zh_Latn_pinyin-5.0.0-beta.1.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
@@ -2709,7 +2899,7 @@
         "versions": []
     },
     {
-        "downloads": 656,
+        "downloads": 770,
         "id": "gemma_m0",
         "versions": [
             {
@@ -2754,46 +2944,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-gemma_m0-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-gemma_m0-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-gemma_m0-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-gemma_m0-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-gemma_m0-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-gemma_m0-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-gemma_m0-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-gemma_m0-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-gemma_m0-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-gemma_m0-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-gemma_m0-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 21,
+        "downloads": 22,
         "id": "gemma_m0_pycon2018",
         "versions": [
             {
@@ -2838,46 +3031,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-gemma_m0_pycon2018-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0_pycon2018-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-gemma_m0_pycon2018-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0_pycon2018-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-gemma_m0_pycon2018-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0_pycon2018-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-gemma_m0_pycon2018-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0_pycon2018-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-gemma_m0_pycon2018-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0_pycon2018-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-gemma_m0_pycon2018-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0_pycon2018-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-gemma_m0_pycon2018-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0_pycon2018-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-gemma_m0_pycon2018-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0_pycon2018-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0_pycon2018-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-gemma_m0_pycon2018-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0_pycon2018-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-gemma_m0_pycon2018-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0_pycon2018-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-gemma_m0_pycon2018-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0_pycon2018-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 253,
+        "downloads": 307,
         "id": "grandcentral_m4_express",
         "versions": [
             {
@@ -2922,46 +3118,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-grandcentral_m4_express-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-grandcentral_m4_express-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-grandcentral_m4_express-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-grandcentral_m4_express-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-grandcentral_m4_express-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-grandcentral_m4_express-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-grandcentral_m4_express-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-grandcentral_m4_express-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-grandcentral_m4_express-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-grandcentral_m4_express-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-grandcentral_m4_express-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-grandcentral_m4_express-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-grandcentral_m4_express-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-grandcentral_m4_express-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-grandcentral_m4_express-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-grandcentral_m4_express-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-grandcentral_m4_express-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-grandcentral_m4_express-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-grandcentral_m4_express-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-grandcentral_m4_express-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-grandcentral_m4_express-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-grandcentral_m4_express-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-grandcentral_m4_express-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 342,
+        "downloads": 378,
         "id": "hallowing_m0_express",
         "versions": [
             {
@@ -3006,91 +3205,97 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-hallowing_m0_express-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m0_express-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-hallowing_m0_express-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m0_express-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-hallowing_m0_express-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m0_express-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-hallowing_m0_express-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m0_express-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-hallowing_m0_express-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m0_express-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-hallowing_m0_express-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m0_express-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-hallowing_m0_express-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m0_express-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-hallowing_m0_express-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m0_express-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m0_express-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-hallowing_m0_express-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m0_express-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-hallowing_m0_express-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m0_express-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-hallowing_m0_express-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m0_express-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 7,
+        "downloads": 10,
         "id": "hallowing_m4_express",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-hallowing_m4_express-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m4_express-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-hallowing_m4_express-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m4_express-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-hallowing_m4_express-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m4_express-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-hallowing_m4_express-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m4_express-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-hallowing_m4_express-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m4_express-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-hallowing_m4_express-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m4_express-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-hallowing_m4_express-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m4_express-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-hallowing_m4_express-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m4_express-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m4_express-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-hallowing_m4_express-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m4_express-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-hallowing_m4_express-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m4_express-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-hallowing_m4_express-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m4_express-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 364,
+        "downloads": 451,
         "id": "itsybitsy_m0_express",
         "versions": [
             {
@@ -3135,46 +3340,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_m0_express-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m0_express-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_m0_express-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m0_express-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_m0_express-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m0_express-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_m0_express-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m0_express-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_m0_express-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m0_express-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_m0_express-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m0_express-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_m0_express-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m0_express-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_m0_express-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m0_express-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m0_express-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_m0_express-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m0_express-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_m0_express-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m0_express-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_m0_express-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m0_express-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 798,
+        "downloads": 925,
         "id": "itsybitsy_m4_express",
         "versions": [
             {
@@ -3219,86 +3427,92 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_m4_express-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m4_express-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_m4_express-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m4_express-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_m4_express-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m4_express-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_m4_express-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m4_express-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_m4_express-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m4_express-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_m4_express-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m4_express-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_m4_express-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m4_express-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_m4_express-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m4_express-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m4_express-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_m4_express-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m4_express-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_m4_express-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m4_express-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_m4_express-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m4_express-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 2,
         "id": "itsybitsy_nrf52840_express",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_nrf52840_express-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_nrf52840_express-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_nrf52840_express-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_nrf52840_express-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_nrf52840_express-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_nrf52840_express-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_nrf52840_express-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_nrf52840_express-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_nrf52840_express-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_nrf52840_express-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_nrf52840_express-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_nrf52840_express-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_nrf52840_express-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_nrf52840_express-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_nrf52840_express-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_nrf52840_express-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_nrf52840_express-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_nrf52840_express-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_nrf52840_express-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_nrf52840_express-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_nrf52840_express-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-itsybitsy_nrf52840_express-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_nrf52840_express-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
@@ -3348,46 +3562,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-kicksat-sprite-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-kicksat-sprite-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-kicksat-sprite-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-kicksat-sprite-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-kicksat-sprite-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-kicksat-sprite-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-kicksat-sprite-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-kicksat-sprite-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-kicksat-sprite-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-kicksat-sprite-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-kicksat-sprite-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-kicksat-sprite-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-kicksat-sprite-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-kicksat-sprite-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-kicksat-sprite-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-kicksat-sprite-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-kicksat-sprite-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-kicksat-sprite-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-kicksat-sprite-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-kicksat-sprite-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-kicksat-sprite-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-kicksat-sprite-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-kicksat-sprite-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 30,
+        "downloads": 33,
         "id": "makerdiary_nrf52840_mdk",
         "versions": [
             {
@@ -3432,46 +3649,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-makerdiary_nrf52840_mdk-ID-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk-ID-5.0.0-beta.1.hex"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-makerdiary_nrf52840_mdk-de_DE-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk-de_DE-5.0.0-beta.1.hex"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_US-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_US-5.0.0-beta.1.hex"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_x_pirate-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_x_pirate-5.0.0-beta.1.hex"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-makerdiary_nrf52840_mdk-es-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk-es-5.0.0-beta.1.hex"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-makerdiary_nrf52840_mdk-fil-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk-fil-5.0.0-beta.1.hex"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-makerdiary_nrf52840_mdk-fr-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk-fr-5.0.0-beta.1.hex"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-makerdiary_nrf52840_mdk-it_IT-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk-it_IT-5.0.0-beta.1.hex"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk-ko-5.0.0-beta.1.hex"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-makerdiary_nrf52840_mdk-pl-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk-pl-5.0.0-beta.1.hex"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-makerdiary_nrf52840_mdk-pt_BR-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk-pt_BR-5.0.0-beta.1.hex"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-makerdiary_nrf52840_mdk-zh_Latn_pinyin-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk-zh_Latn_pinyin-5.0.0-beta.1.hex"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 71,
+        "downloads": 75,
         "id": "makerdiary_nrf52840_mdk_usb_dongle",
         "versions": [
             {
@@ -3516,41 +3736,44 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-ID-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-ID-5.0.0-beta.1.hex"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-de_DE-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-de_DE-5.0.0-beta.1.hex"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_US-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_US-5.0.0-beta.1.hex"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_x_pirate-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_x_pirate-5.0.0-beta.1.hex"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-es-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-es-5.0.0-beta.1.hex"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fil-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fil-5.0.0-beta.1.hex"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fr-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fr-5.0.0-beta.1.hex"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-it_IT-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-it_IT-5.0.0-beta.1.hex"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-ko-5.0.0-beta.1.hex"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pl-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pl-5.0.0-beta.1.hex"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pt_BR-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pt_BR-5.0.0-beta.1.hex"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-zh_Latn_pinyin-5.0.0-beta.0.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-zh_Latn_pinyin-5.0.0-beta.1.hex"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
@@ -3600,46 +3823,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-meowmeow-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-meowmeow-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-meowmeow-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-meowmeow-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-meowmeow-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-meowmeow-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-meowmeow-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-meowmeow-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-meowmeow-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-meowmeow-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-meowmeow-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-meowmeow-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-meowmeow-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-meowmeow-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-meowmeow-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-meowmeow-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-meowmeow-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-meowmeow-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-meowmeow-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-meowmeow-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-meowmeow-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-meowmeow-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-meowmeow-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 641,
+        "downloads": 819,
         "id": "metro_m0_express",
         "versions": [
             {
@@ -3684,46 +3910,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m0_express-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m0_express-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m0_express-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m0_express-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m0_express-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m0_express-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m0_express-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m0_express-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m0_express-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m0_express-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m0_express-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m0_express-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m0_express-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m0_express-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m0_express-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m0_express-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m0_express-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m0_express-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m0_express-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m0_express-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m0_express-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m0_express-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m0_express-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 159,
+        "downloads": 201,
         "id": "metro_m4_airlift_lite",
         "versions": [
             {
@@ -3768,46 +3997,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m4_airlift_lite-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_airlift_lite-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m4_airlift_lite-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_airlift_lite-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m4_airlift_lite-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_airlift_lite-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m4_airlift_lite-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_airlift_lite-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m4_airlift_lite-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_airlift_lite-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m4_airlift_lite-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_airlift_lite-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m4_airlift_lite-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_airlift_lite-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m4_airlift_lite-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_airlift_lite-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_airlift_lite-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m4_airlift_lite-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_airlift_lite-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m4_airlift_lite-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_airlift_lite-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m4_airlift_lite-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_airlift_lite-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 374,
+        "downloads": 429,
         "id": "metro_m4_express",
         "versions": [
             {
@@ -3852,91 +4084,97 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m4_express-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_express-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m4_express-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_express-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m4_express-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_express-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m4_express-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_express-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m4_express-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_express-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m4_express-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_express-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m4_express-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_express-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m4_express-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_express-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_express-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m4_express-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_express-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m4_express-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_express-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_m4_express-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_express-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 3,
         "id": "metro_nrf52840_express",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_nrf52840_express-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_nrf52840_express-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_nrf52840_express-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_nrf52840_express-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_nrf52840_express-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_nrf52840_express-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_nrf52840_express-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_nrf52840_express-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_nrf52840_express-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_nrf52840_express-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_nrf52840_express-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_nrf52840_express-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_nrf52840_express-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_nrf52840_express-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_nrf52840_express-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_nrf52840_express-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_nrf52840_express-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_nrf52840_express-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_nrf52840_express-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_nrf52840_express-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_nrf52840_express-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-metro_nrf52840_express-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_nrf52840_express-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 33,
+        "downloads": 35,
         "id": "mini_sam_m4",
         "versions": [
             {
@@ -3981,91 +4219,97 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-mini_sam_m4-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-mini_sam_m4-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-mini_sam_m4-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-mini_sam_m4-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-mini_sam_m4-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-mini_sam_m4-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-mini_sam_m4-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-mini_sam_m4-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-mini_sam_m4-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-mini_sam_m4-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-mini_sam_m4-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-mini_sam_m4-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-mini_sam_m4-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-mini_sam_m4-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-mini_sam_m4-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-mini_sam_m4-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-mini_sam_m4-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-mini_sam_m4-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-mini_sam_m4-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-mini_sam_m4-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-mini_sam_m4-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-mini_sam_m4-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-mini_sam_m4-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 55,
+        "downloads": 26,
         "id": "monster_m4sk",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-monster_m4sk-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-monster_m4sk-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-monster_m4sk-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-monster_m4sk-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-monster_m4sk-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-monster_m4sk-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-monster_m4sk-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-monster_m4sk-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-monster_m4sk-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-monster_m4sk-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-monster_m4sk-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-monster_m4sk-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-monster_m4sk-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-monster_m4sk-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-monster_m4sk-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-monster_m4sk-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-monster_m4sk-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-monster_m4sk-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-monster_m4sk-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-monster_m4sk-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-monster_m4sk-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-monster_m4sk-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-monster_m4sk-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 39,
+        "downloads": 49,
         "id": "particle_argon",
         "versions": [
             {
@@ -4110,41 +4354,44 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_argon-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_argon-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_argon-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_argon-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_argon-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_argon-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_argon-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_argon-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_argon-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_argon-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_argon-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_argon-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_argon-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_argon-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_argon-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_argon-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_argon-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_argon-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_argon-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_argon-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_argon-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_argon-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_argon-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
@@ -4194,46 +4441,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_boron-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_boron-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_boron-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_boron-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_boron-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_boron-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_boron-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_boron-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_boron-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_boron-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_boron-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_boron-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_boron-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_boron-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_boron-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_boron-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_boron-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_boron-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_boron-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_boron-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_boron-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_boron-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_boron-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 48,
+        "downloads": 60,
         "id": "particle_xenon",
         "versions": [
             {
@@ -4278,41 +4528,44 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_xenon-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_xenon-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_xenon-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_xenon-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_xenon-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_xenon-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_xenon-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_xenon-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_xenon-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_xenon-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_xenon-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_xenon-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_xenon-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_xenon-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_xenon-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_xenon-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_xenon-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_xenon-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_xenon-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_xenon-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_xenon-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-particle_xenon-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_xenon-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
@@ -4322,7 +4575,7 @@
         "versions": []
     },
     {
-        "downloads": 82,
+        "downloads": 131,
         "id": "pca10056",
         "versions": [
             {
@@ -4378,57 +4631,61 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10056-ID-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10056-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-ID-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10056-de_DE-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10056-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-de_DE-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10056-en_US-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10056-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-en_US-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10056-en_x_pirate-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10056-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-en_x_pirate-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10056-es-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10056-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-es-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10056-fil-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10056-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-fil-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10056-fr-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10056-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-fr-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10056-it_IT-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10056-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-it_IT-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-ko-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10056-pl-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10056-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-pl-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10056-pt_BR-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10056-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-pt_BR-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10056-zh_Latn_pinyin-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10056-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-zh_Latn_pinyin-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 175,
+        "downloads": 229,
         "id": "pca10059",
         "versions": [
             {
@@ -4484,57 +4741,61 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10059-ID-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10059-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-ID-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10059-de_DE-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10059-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-de_DE-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10059-en_US-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10059-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-en_US-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10059-en_x_pirate-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10059-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-en_x_pirate-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10059-es-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10059-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-es-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10059-fil-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10059-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-fil-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10059-fr-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10059-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-fr-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10059-it_IT-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10059-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-it_IT-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-ko-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10059-pl-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10059-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-pl-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10059-pt_BR-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10059-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-pt_BR-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10059-zh_Latn_pinyin-5.0.0-beta.0.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pca10059-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-zh_Latn_pinyin-5.0.0-beta.1.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 44,
+        "downloads": 48,
         "id": "pewpew10",
         "versions": [
             {
@@ -4579,41 +4840,44 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew10-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew10-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew10-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew10-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew10-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew10-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew10-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew10-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew10-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew10-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew10-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew10-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew10-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew10-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew10-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew10-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew10-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew10-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew10-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew10-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew10-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew10-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew10-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
@@ -4663,41 +4927,44 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew13-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew13-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew13-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew13-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew13-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew13-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew13-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew13-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew13-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew13-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew13-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew13-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew13-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew13-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew13-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew13-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew13-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew13-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew13-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew13-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew13-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew13-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew13-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
@@ -4708,41 +4975,44 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew_m4-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew_m4-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew_m4-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew_m4-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew_m4-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew_m4-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew_m4-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew_m4-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew_m4-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew_m4-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew_m4-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew_m4-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew_m4-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew_m4-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew_m4-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew_m4-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew_m4-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew_m4-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew_m4-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew_m4-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew_m4-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pewpew_m4-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew_m4-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
@@ -4792,46 +5062,97 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pirkey_m0-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pirkey_m0-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pirkey_m0-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pirkey_m0-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pirkey_m0-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pirkey_m0-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pirkey_m0-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pirkey_m0-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pirkey_m0-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pirkey_m0-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pirkey_m0-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pirkey_m0-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pirkey_m0-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pirkey_m0-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pirkey_m0-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pirkey_m0-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pirkey_m0-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pirkey_m0-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pirkey_m0-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pirkey_m0-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pirkey_m0-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pirkey_m0-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pirkey_m0-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 439,
+        "downloads": 0,
+        "id": "pyb_nano_v2",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyb_nano_v2-ID-5.0.0-beta.1.bin"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyb_nano_v2-de_DE-5.0.0-beta.1.bin"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyb_nano_v2-en_US-5.0.0-beta.1.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyb_nano_v2-en_x_pirate-5.0.0-beta.1.bin"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyb_nano_v2-es-5.0.0-beta.1.bin"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyb_nano_v2-fil-5.0.0-beta.1.bin"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyb_nano_v2-fr-5.0.0-beta.1.bin"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyb_nano_v2-it_IT-5.0.0-beta.1.bin"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyb_nano_v2-ko-5.0.0-beta.1.bin"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyb_nano_v2-pl-5.0.0-beta.1.bin"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyb_nano_v2-pt_BR-5.0.0-beta.1.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyb_nano_v2-zh_Latn_pinyin-5.0.0-beta.1.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.1"
+            }
+        ]
+    },
+    {
+        "downloads": 496,
         "id": "pybadge",
         "versions": [
             {
@@ -4876,125 +5197,44 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
-            }
-        ]
-    },
-    {
-        "downloads": 1,
-        "id": "edgebadge",
-        "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.1.0/adafruit-circuitpython-pybadge-ID-4.1.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.1.0/adafruit-circuitpython-pybadge-de_DE-4.1.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.1.0/adafruit-circuitpython-pybadge-en_US-4.1.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.1.0/adafruit-circuitpython-pybadge-en_x_pirate-4.1.0.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.1.0/adafruit-circuitpython-pybadge-es-4.1.0.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.1.0/adafruit-circuitpython-pybadge-fil-4.1.0.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.1.0/adafruit-circuitpython-pybadge-fr-4.1.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.1.0/adafruit-circuitpython-pybadge-it_IT-4.1.0.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.1.0/adafruit-circuitpython-pybadge-pl-4.1.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.1.0/adafruit-circuitpython-pybadge-pt_BR-4.1.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.1.0/adafruit-circuitpython-pybadge-zh_Latn_pinyin-4.1.0.uf2"
-                    ]
-                },
-                "stable": true,
-                "version": "4.1.0"
-            },
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge-ID-5.0.0-beta.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge-de_DE-5.0.0-beta.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge-en_US-5.0.0-beta.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge-en_x_pirate-5.0.0-beta.0.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge-es-5.0.0-beta.0.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge-fil-5.0.0-beta.0.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge-fr-5.0.0-beta.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge-it_IT-5.0.0-beta.0.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge-pl-5.0.0-beta.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge-pt_BR-5.0.0-beta.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge-zh_Latn_pinyin-5.0.0-beta.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
@@ -5044,91 +5284,97 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge_airlift-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge_airlift-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge_airlift-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge_airlift-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge_airlift-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge_airlift-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge_airlift-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge_airlift-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge_airlift-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge_airlift-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge_airlift-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge_airlift-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge_airlift-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge_airlift-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge_airlift-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge_airlift-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge_airlift-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge_airlift-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge_airlift-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge_airlift-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge_airlift-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pybadge_airlift-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge_airlift-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 9,
+        "downloads": 20,
         "id": "pyboard_v11",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyboard_v11-ID-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyboard_v11-ID-5.0.0-beta.1.bin"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyboard_v11-de_DE-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyboard_v11-de_DE-5.0.0-beta.1.bin"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyboard_v11-en_US-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyboard_v11-en_US-5.0.0-beta.1.bin"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyboard_v11-en_x_pirate-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyboard_v11-en_x_pirate-5.0.0-beta.1.bin"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyboard_v11-es-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyboard_v11-es-5.0.0-beta.1.bin"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyboard_v11-fil-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyboard_v11-fil-5.0.0-beta.1.bin"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyboard_v11-fr-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyboard_v11-fr-5.0.0-beta.1.bin"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyboard_v11-it_IT-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyboard_v11-it_IT-5.0.0-beta.1.bin"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyboard_v11-ko-5.0.0-beta.1.bin"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyboard_v11-pl-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyboard_v11-pl-5.0.0-beta.1.bin"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyboard_v11-pt_BR-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyboard_v11-pt_BR-5.0.0-beta.1.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyboard_v11-zh_Latn_pinyin-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyboard_v11-zh_Latn_pinyin-5.0.0-beta.1.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 551,
+        "downloads": 606,
         "id": "pygamer",
         "versions": [
             {
@@ -5173,46 +5419,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pygamer-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pygamer-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pygamer-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pygamer-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pygamer-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pygamer-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pygamer-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pygamer-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pygamer-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pygamer-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pygamer-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 35,
+        "downloads": 41,
         "id": "pygamer_advance",
         "versions": [
             {
@@ -5257,46 +5506,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pygamer_advance-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer_advance-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pygamer_advance-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer_advance-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pygamer_advance-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer_advance-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pygamer_advance-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer_advance-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pygamer_advance-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer_advance-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pygamer_advance-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer_advance-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pygamer_advance-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer_advance-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pygamer_advance-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer_advance-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer_advance-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pygamer_advance-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer_advance-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pygamer_advance-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer_advance-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pygamer_advance-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer_advance-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 1095,
+        "downloads": 1302,
         "id": "pyportal",
         "versions": [
             {
@@ -5341,91 +5593,97 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyportal-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyportal-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyportal-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyportal-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyportal-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyportal-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyportal-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyportal-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyportal-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyportal-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyportal-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 2,
         "id": "pyportal_titano",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyportal_titano-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal_titano-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyportal_titano-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal_titano-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyportal_titano-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal_titano-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyportal_titano-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal_titano-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyportal_titano-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal_titano-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyportal_titano-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal_titano-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyportal_titano-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal_titano-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyportal_titano-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal_titano-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal_titano-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyportal_titano-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal_titano-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyportal_titano-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal_titano-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyportal_titano-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal_titano-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 195,
+        "downloads": 221,
         "id": "pyruler",
         "versions": [
             {
@@ -5470,91 +5728,97 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyruler-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyruler-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyruler-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyruler-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyruler-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyruler-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyruler-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyruler-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyruler-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyruler-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyruler-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyruler-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyruler-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyruler-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyruler-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyruler-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyruler-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyruler-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyruler-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyruler-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyruler-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-pyruler-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyruler-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 2,
         "id": "robohatmm1_m4",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-robohatmm1_m4-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-robohatmm1_m4-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-robohatmm1_m4-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-robohatmm1_m4-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-robohatmm1_m4-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-robohatmm1_m4-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-robohatmm1_m4-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-robohatmm1_m4-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-robohatmm1_m4-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-robohatmm1_m4-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-robohatmm1_m4-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-robohatmm1_m4-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-robohatmm1_m4-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-robohatmm1_m4-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-robohatmm1_m4-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-robohatmm1_m4-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-robohatmm1_m4-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-robohatmm1_m4-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-robohatmm1_m4-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-robohatmm1_m4-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-robohatmm1_m4-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-robohatmm1_m4-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-robohatmm1_m4-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 44,
+        "downloads": 48,
         "id": "sam32",
         "versions": [
             {
@@ -5599,136 +5863,193 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sam32-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sam32-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sam32-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sam32-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sam32-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sam32-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sam32-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sam32-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sam32-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sam32-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sam32-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sam32-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sam32-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sam32-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sam32-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sam32-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sam32-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sam32-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sam32-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sam32-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sam32-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sam32-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sam32-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 8,
+        "downloads": 10,
         "id": "serpente",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-serpente-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-serpente-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-serpente-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-serpente-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-serpente-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-serpente-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-serpente-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-serpente-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-serpente-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-serpente-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-serpente-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-serpente-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-serpente-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-serpente-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-serpente-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-serpente-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-serpente-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-serpente-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-serpente-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-serpente-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-serpente-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-serpente-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-serpente-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 1,
+        "downloads": 0,
+        "id": "shirtty",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-shirtty-ID-5.0.0-beta.1.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-shirtty-de_DE-5.0.0-beta.1.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-shirtty-en_US-5.0.0-beta.1.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-shirtty-en_x_pirate-5.0.0-beta.1.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-shirtty-es-5.0.0-beta.1.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-shirtty-fil-5.0.0-beta.1.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-shirtty-fr-5.0.0-beta.1.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-shirtty-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-shirtty-ko-5.0.0-beta.1.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-shirtty-pl-5.0.0-beta.1.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-shirtty-pt_BR-5.0.0-beta.1.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-shirtty-zh_Latn_pinyin-5.0.0-beta.1.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.1"
+            }
+        ]
+    },
+    {
+        "downloads": 0,
         "id": "snekboard",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-snekboard-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-snekboard-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-snekboard-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-snekboard-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-snekboard-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-snekboard-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-snekboard-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-snekboard-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-snekboard-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-snekboard-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-snekboard-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-snekboard-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-snekboard-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-snekboard-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-snekboard-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-snekboard-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-snekboard-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-snekboard-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-snekboard-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-snekboard-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-snekboard-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-snekboard-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-snekboard-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 17,
+        "downloads": 18,
         "id": "sparkfun_lumidrive",
         "versions": [
             {
@@ -5773,46 +6094,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_lumidrive-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_lumidrive-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_lumidrive-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_lumidrive-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_lumidrive-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_lumidrive-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_lumidrive-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_lumidrive-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_lumidrive-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_lumidrive-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_lumidrive-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_lumidrive-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_lumidrive-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_lumidrive-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_lumidrive-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_lumidrive-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_lumidrive-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_lumidrive-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_lumidrive-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_lumidrive-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_lumidrive-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_lumidrive-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_lumidrive-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 45,
+        "downloads": 53,
         "id": "sparkfun_nrf52840_mini",
         "versions": [
             {
@@ -5857,41 +6181,44 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_nrf52840_mini-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_nrf52840_mini-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_nrf52840_mini-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_nrf52840_mini-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_nrf52840_mini-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_nrf52840_mini-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_nrf52840_mini-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_nrf52840_mini-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_nrf52840_mini-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_nrf52840_mini-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_nrf52840_mini-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_nrf52840_mini-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_nrf52840_mini-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_nrf52840_mini-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_nrf52840_mini-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_nrf52840_mini-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_nrf52840_mini-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_nrf52840_mini-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_nrf52840_mini-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_nrf52840_mini-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_nrf52840_mini-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_nrf52840_mini-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_nrf52840_mini-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
@@ -5902,41 +6229,44 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
@@ -5947,46 +6277,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 44,
+        "downloads": 48,
         "id": "sparkfun_redboard_turbo",
         "versions": [
             {
@@ -6031,46 +6364,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_redboard_turbo-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_redboard_turbo-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_redboard_turbo-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_redboard_turbo-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_redboard_turbo-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_redboard_turbo-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_redboard_turbo-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_redboard_turbo-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_redboard_turbo-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_redboard_turbo-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_redboard_turbo-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_redboard_turbo-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_redboard_turbo-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_redboard_turbo-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_redboard_turbo-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_redboard_turbo-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_redboard_turbo-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_redboard_turbo-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_redboard_turbo-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_redboard_turbo-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_redboard_turbo-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_redboard_turbo-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_redboard_turbo-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 34,
+        "downloads": 36,
         "id": "sparkfun_samd21_dev",
         "versions": [
             {
@@ -6115,46 +6451,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_samd21_dev-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_dev-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_samd21_dev-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_dev-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_samd21_dev-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_dev-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_samd21_dev-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_dev-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_samd21_dev-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_dev-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_samd21_dev-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_dev-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_samd21_dev-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_dev-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_samd21_dev-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_dev-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_dev-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_samd21_dev-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_dev-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_samd21_dev-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_dev-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_samd21_dev-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_dev-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 33,
+        "downloads": 39,
         "id": "sparkfun_samd21_mini",
         "versions": [
             {
@@ -6199,176 +6538,188 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_samd21_mini-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_mini-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_samd21_mini-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_mini-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_samd21_mini-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_mini-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_samd21_mini-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_mini-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_samd21_mini-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_mini-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_samd21_mini-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_mini-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_samd21_mini-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_mini-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_samd21_mini-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_mini-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_mini-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_samd21_mini-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_mini-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_samd21_mini-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_mini-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-sparkfun_samd21_mini-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_mini-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
-            }
-        ]
-    },
-    {
-        "downloads": 1,
-        "id": "spresense",
-        "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-spresense-ID-5.0.0-beta.0.spk"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-spresense-de_DE-5.0.0-beta.0.spk"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-spresense-en_US-5.0.0-beta.0.spk"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-spresense-en_x_pirate-5.0.0-beta.0.spk"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-spresense-es-5.0.0-beta.0.spk"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-spresense-fil-5.0.0-beta.0.spk"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-spresense-fr-5.0.0-beta.0.spk"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-spresense-it_IT-5.0.0-beta.0.spk"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-spresense-pl-5.0.0-beta.0.spk"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-spresense-pt_BR-5.0.0-beta.0.spk"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-spresense-zh_Latn_pinyin-5.0.0-beta.0.spk"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
         "downloads": 3,
+        "id": "spresense",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-spresense-ID-5.0.0-beta.1.spk"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-spresense-de_DE-5.0.0-beta.1.spk"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-spresense-en_US-5.0.0-beta.1.spk"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-spresense-en_x_pirate-5.0.0-beta.1.spk"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-spresense-es-5.0.0-beta.1.spk"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-spresense-fil-5.0.0-beta.1.spk"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-spresense-fr-5.0.0-beta.1.spk"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-spresense-it_IT-5.0.0-beta.1.spk"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-spresense-ko-5.0.0-beta.1.spk"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-spresense-pl-5.0.0-beta.1.spk"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-spresense-pt_BR-5.0.0-beta.1.spk"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-spresense-zh_Latn_pinyin-5.0.0-beta.1.spk"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.1"
+            }
+        ]
+    },
+    {
+        "downloads": 4,
         "id": "stm32f411ve_discovery",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stm32f411ve_discovery-ID-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f411ve_discovery-ID-5.0.0-beta.1.bin"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stm32f411ve_discovery-de_DE-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f411ve_discovery-de_DE-5.0.0-beta.1.bin"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stm32f411ve_discovery-en_US-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f411ve_discovery-en_US-5.0.0-beta.1.bin"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stm32f411ve_discovery-en_x_pirate-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f411ve_discovery-en_x_pirate-5.0.0-beta.1.bin"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stm32f411ve_discovery-es-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f411ve_discovery-es-5.0.0-beta.1.bin"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stm32f411ve_discovery-fil-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f411ve_discovery-fil-5.0.0-beta.1.bin"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stm32f411ve_discovery-fr-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f411ve_discovery-fr-5.0.0-beta.1.bin"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stm32f411ve_discovery-it_IT-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f411ve_discovery-it_IT-5.0.0-beta.1.bin"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f411ve_discovery-ko-5.0.0-beta.1.bin"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stm32f411ve_discovery-pl-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f411ve_discovery-pl-5.0.0-beta.1.bin"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stm32f411ve_discovery-pt_BR-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f411ve_discovery-pt_BR-5.0.0-beta.1.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stm32f411ve_discovery-zh_Latn_pinyin-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f411ve_discovery-zh_Latn_pinyin-5.0.0-beta.1.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 20,
+        "downloads": 3,
         "id": "stm32f412zg_discovery",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stm32f412zg_discovery-ID-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f412zg_discovery-ID-5.0.0-beta.1.bin"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stm32f412zg_discovery-de_DE-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f412zg_discovery-de_DE-5.0.0-beta.1.bin"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stm32f412zg_discovery-en_US-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f412zg_discovery-en_US-5.0.0-beta.1.bin"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stm32f412zg_discovery-en_x_pirate-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f412zg_discovery-en_x_pirate-5.0.0-beta.1.bin"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stm32f412zg_discovery-es-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f412zg_discovery-es-5.0.0-beta.1.bin"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stm32f412zg_discovery-fil-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f412zg_discovery-fil-5.0.0-beta.1.bin"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stm32f412zg_discovery-fr-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f412zg_discovery-fr-5.0.0-beta.1.bin"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stm32f412zg_discovery-it_IT-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f412zg_discovery-it_IT-5.0.0-beta.1.bin"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f412zg_discovery-ko-5.0.0-beta.1.bin"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stm32f412zg_discovery-pl-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f412zg_discovery-pl-5.0.0-beta.1.bin"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stm32f412zg_discovery-pt_BR-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f412zg_discovery-pt_BR-5.0.0-beta.1.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stm32f412zg_discovery-zh_Latn_pinyin-5.0.0-beta.0.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f412zg_discovery-zh_Latn_pinyin-5.0.0-beta.1.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
@@ -6379,46 +6730,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stringcar_m0_express-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stringcar_m0_express-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stringcar_m0_express-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stringcar_m0_express-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stringcar_m0_express-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stringcar_m0_express-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stringcar_m0_express-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stringcar_m0_express-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stringcar_m0_express-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stringcar_m0_express-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stringcar_m0_express-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stringcar_m0_express-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stringcar_m0_express-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stringcar_m0_express-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stringcar_m0_express-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stringcar_m0_express-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stringcar_m0_express-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stringcar_m0_express-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stringcar_m0_express-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stringcar_m0_express-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stringcar_m0_express-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-stringcar_m0_express-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stringcar_m0_express-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 304,
+        "downloads": 413,
         "id": "trellis_m4_express",
         "versions": [
             {
@@ -6463,46 +6817,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trellis_m4_express-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trellis_m4_express-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trellis_m4_express-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trellis_m4_express-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trellis_m4_express-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trellis_m4_express-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trellis_m4_express-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trellis_m4_express-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trellis_m4_express-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trellis_m4_express-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trellis_m4_express-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trellis_m4_express-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trellis_m4_express-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trellis_m4_express-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trellis_m4_express-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trellis_m4_express-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trellis_m4_express-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trellis_m4_express-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trellis_m4_express-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trellis_m4_express-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trellis_m4_express-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trellis_m4_express-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trellis_m4_express-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 1888,
+        "downloads": 2201,
         "id": "trinket_m0",
         "versions": [
             {
@@ -6547,41 +6904,44 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trinket_m0-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trinket_m0-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trinket_m0-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trinket_m0-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trinket_m0-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trinket_m0-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trinket_m0-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trinket_m0-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trinket_m0-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trinket_m0-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trinket_m0-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
@@ -6631,46 +6991,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trinket_m0_haxpress-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0_haxpress-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trinket_m0_haxpress-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0_haxpress-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trinket_m0_haxpress-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0_haxpress-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trinket_m0_haxpress-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0_haxpress-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trinket_m0_haxpress-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0_haxpress-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trinket_m0_haxpress-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0_haxpress-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trinket_m0_haxpress-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0_haxpress-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trinket_m0_haxpress-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0_haxpress-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0_haxpress-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trinket_m0_haxpress-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0_haxpress-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trinket_m0_haxpress-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0_haxpress-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-trinket_m0_haxpress-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0_haxpress-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 19,
+        "downloads": 20,
         "id": "uchip",
         "versions": [
             {
@@ -6715,41 +7078,44 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-uchip-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-uchip-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-uchip-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-uchip-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-uchip-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-uchip-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-uchip-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-uchip-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-uchip-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-uchip-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-uchip-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-uchip-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-uchip-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-uchip-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-uchip-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-uchip-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-uchip-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-uchip-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-uchip-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-uchip-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-uchip-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-uchip-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-uchip-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
@@ -6799,41 +7165,44 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-ugame10-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-ugame10-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-ugame10-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-ugame10-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-ugame10-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-ugame10-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-ugame10-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-ugame10-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-ugame10-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-ugame10-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-ugame10-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-ugame10-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-ugame10-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-ugame10-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-ugame10-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-ugame10-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-ugame10-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-ugame10-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-ugame10-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-ugame10-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-ugame10-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-ugame10-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-ugame10-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     },
@@ -6844,41 +7213,44 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-winterbloom_sol-ID-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-winterbloom_sol-ID-5.0.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-winterbloom_sol-de_DE-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-winterbloom_sol-de_DE-5.0.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-winterbloom_sol-en_US-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-winterbloom_sol-en_US-5.0.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-winterbloom_sol-en_x_pirate-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-winterbloom_sol-en_x_pirate-5.0.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-winterbloom_sol-es-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-winterbloom_sol-es-5.0.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-winterbloom_sol-fil-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-winterbloom_sol-fil-5.0.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-winterbloom_sol-fr-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-winterbloom_sol-fr-5.0.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-winterbloom_sol-it_IT-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-winterbloom_sol-it_IT-5.0.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-winterbloom_sol-ko-5.0.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-winterbloom_sol-pl-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-winterbloom_sol-pl-5.0.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-winterbloom_sol-pt_BR-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-winterbloom_sol-pt_BR-5.0.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.0/adafruit-circuitpython-winterbloom_sol-zh_Latn_pinyin-5.0.0-beta.0.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-winterbloom_sol-zh_Latn_pinyin-5.0.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.0"
+                "version": "5.0.0-beta.1"
             }
         ]
     }


### PR DESCRIPTION
Automated website update for release 5.0.0-beta.1 by Blinka.

New boards:
* shirtty
* pyb_nano_v2

New languages:
* ko
