### PR TITLE
Automated website update for release 5.0.0-beta.2

### DIFF
--- a/_data/files.json
+++ b/_data/files.json
@@ -1,50 +1,8 @@
 [
     {
-        "downloads": 139,
+        "downloads": 1,
         "id": "arduino_mkr1300",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkr1300-ID-5.0.0-beta.1.bin"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkr1300-de_DE-5.0.0-beta.1.bin"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkr1300-en_US-5.0.0-beta.1.bin"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkr1300-en_x_pirate-5.0.0-beta.1.bin"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkr1300-es-5.0.0-beta.1.bin"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkr1300-fil-5.0.0-beta.1.bin"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkr1300-fr-5.0.0-beta.1.bin"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkr1300-it_IT-5.0.0-beta.1.bin"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkr1300-ko-5.0.0-beta.1.bin"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkr1300-pl-5.0.0-beta.1.bin"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkr1300-pt_BR-5.0.0-beta.1.bin"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkr1300-zh_Latn_pinyin-5.0.0-beta.1.bin"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -83,55 +41,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_mkr1300-ID-5.0.0-beta.2.bin"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_mkr1300-de_DE-5.0.0-beta.2.bin"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_mkr1300-en_US-5.0.0-beta.2.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_mkr1300-en_x_pirate-5.0.0-beta.2.bin"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_mkr1300-es-5.0.0-beta.2.bin"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_mkr1300-fil-5.0.0-beta.2.bin"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_mkr1300-fr-5.0.0-beta.2.bin"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_mkr1300-it_IT-5.0.0-beta.2.bin"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_mkr1300-ko-5.0.0-beta.2.bin"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_mkr1300-pl-5.0.0-beta.2.bin"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_mkr1300-pt_BR-5.0.0-beta.2.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_mkr1300-zh_Latn_pinyin-5.0.0-beta.2.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 92,
+        "downloads": 0,
         "id": "arduino_mkrzero",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkrzero-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkrzero-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkrzero-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkrzero-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkrzero-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkrzero-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkrzero-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkrzero-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkrzero-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkrzero-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkrzero-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_mkrzero-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -170,103 +128,103 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_mkrzero-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_mkrzero-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_mkrzero-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_mkrzero-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_mkrzero-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_mkrzero-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_mkrzero-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_mkrzero-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_mkrzero-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_mkrzero-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_mkrzero-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_mkrzero-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 21,
+        "downloads": 4,
         "id": "arduino_nano_33_ble",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_nano_33_ble-ID-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_nano_33_ble-ID-5.0.0-beta.2.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_nano_33_ble-de_DE-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_nano_33_ble-de_DE-5.0.0-beta.2.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_nano_33_ble-en_US-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_nano_33_ble-en_US-5.0.0-beta.2.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_nano_33_ble-en_x_pirate-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_nano_33_ble-en_x_pirate-5.0.0-beta.2.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_nano_33_ble-es-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_nano_33_ble-es-5.0.0-beta.2.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_nano_33_ble-fil-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_nano_33_ble-fil-5.0.0-beta.2.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_nano_33_ble-fr-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_nano_33_ble-fr-5.0.0-beta.2.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_nano_33_ble-it_IT-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_nano_33_ble-it_IT-5.0.0-beta.2.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_nano_33_ble-ko-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_nano_33_ble-ko-5.0.0-beta.2.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_nano_33_ble-pl-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_nano_33_ble-pl-5.0.0-beta.2.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_nano_33_ble-pt_BR-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_nano_33_ble-pt_BR-5.0.0-beta.2.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_nano_33_ble-zh_Latn_pinyin-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_nano_33_ble-zh_Latn_pinyin-5.0.0-beta.2.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.1"
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 207,
+        "downloads": 5,
         "id": "arduino_zero",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_zero-ID-5.0.0-beta.1.bin"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_zero-de_DE-5.0.0-beta.1.bin"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_zero-en_US-5.0.0-beta.1.bin"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_zero-en_x_pirate-5.0.0-beta.1.bin"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_zero-es-5.0.0-beta.1.bin"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_zero-fil-5.0.0-beta.1.bin"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_zero-fr-5.0.0-beta.1.bin"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_zero-it_IT-5.0.0-beta.1.bin"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_zero-ko-5.0.0-beta.1.bin"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_zero-pl-5.0.0-beta.1.bin"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_zero-pt_BR-5.0.0-beta.1.bin"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-arduino_zero-zh_Latn_pinyin-5.0.0-beta.1.bin"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -305,55 +263,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_zero-ID-5.0.0-beta.2.bin"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_zero-de_DE-5.0.0-beta.2.bin"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_zero-en_US-5.0.0-beta.2.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_zero-en_x_pirate-5.0.0-beta.2.bin"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_zero-es-5.0.0-beta.2.bin"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_zero-fil-5.0.0-beta.2.bin"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_zero-fr-5.0.0-beta.2.bin"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_zero-it_IT-5.0.0-beta.2.bin"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_zero-ko-5.0.0-beta.2.bin"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_zero-pl-5.0.0-beta.2.bin"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_zero-pt_BR-5.0.0-beta.2.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-arduino_zero-zh_Latn_pinyin-5.0.0-beta.2.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 25,
+        "downloads": 0,
         "id": "bast_pro_mini_m0",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-bast_pro_mini_m0-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-bast_pro_mini_m0-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-bast_pro_mini_m0-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-bast_pro_mini_m0-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-bast_pro_mini_m0-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-bast_pro_mini_m0-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-bast_pro_mini_m0-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-bast_pro_mini_m0-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-bast_pro_mini_m0-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-bast_pro_mini_m0-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-bast_pro_mini_m0-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-bast_pro_mini_m0-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -392,55 +350,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-bast_pro_mini_m0-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-bast_pro_mini_m0-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-bast_pro_mini_m0-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-bast_pro_mini_m0-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-bast_pro_mini_m0-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-bast_pro_mini_m0-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-bast_pro_mini_m0-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-bast_pro_mini_m0-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-bast_pro_mini_m0-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-bast_pro_mini_m0-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-bast_pro_mini_m0-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-bast_pro_mini_m0-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 20,
+        "downloads": 0,
         "id": "capablerobot_usbhub",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-capablerobot_usbhub-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-capablerobot_usbhub-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-capablerobot_usbhub-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-capablerobot_usbhub-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-capablerobot_usbhub-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-capablerobot_usbhub-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-capablerobot_usbhub-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-capablerobot_usbhub-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-capablerobot_usbhub-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-capablerobot_usbhub-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-capablerobot_usbhub-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-capablerobot_usbhub-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -479,55 +437,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-capablerobot_usbhub-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-capablerobot_usbhub-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-capablerobot_usbhub-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-capablerobot_usbhub-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-capablerobot_usbhub-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-capablerobot_usbhub-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-capablerobot_usbhub-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-capablerobot_usbhub-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-capablerobot_usbhub-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-capablerobot_usbhub-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-capablerobot_usbhub-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-capablerobot_usbhub-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 23,
+        "downloads": 0,
         "id": "catwan_usbstick",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-catwan_usbstick-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-catwan_usbstick-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-catwan_usbstick-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-catwan_usbstick-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-catwan_usbstick-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-catwan_usbstick-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-catwan_usbstick-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-catwan_usbstick-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-catwan_usbstick-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-catwan_usbstick-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-catwan_usbstick-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-catwan_usbstick-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -566,103 +524,103 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-catwan_usbstick-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-catwan_usbstick-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-catwan_usbstick-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-catwan_usbstick-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-catwan_usbstick-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-catwan_usbstick-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-catwan_usbstick-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-catwan_usbstick-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-catwan_usbstick-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-catwan_usbstick-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-catwan_usbstick-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-catwan_usbstick-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 339,
+        "downloads": 754,
         "id": "circuitplayground_bluefruit",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_bluefruit-ID-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_bluefruit-ID-5.0.0-beta.2.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_bluefruit-de_DE-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_bluefruit-de_DE-5.0.0-beta.2.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_bluefruit-en_US-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_bluefruit-en_US-5.0.0-beta.2.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_bluefruit-en_x_pirate-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_bluefruit-en_x_pirate-5.0.0-beta.2.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_bluefruit-es-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_bluefruit-es-5.0.0-beta.2.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_bluefruit-fil-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_bluefruit-fil-5.0.0-beta.2.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_bluefruit-fr-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_bluefruit-fr-5.0.0-beta.2.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_bluefruit-it_IT-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_bluefruit-it_IT-5.0.0-beta.2.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_bluefruit-ko-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_bluefruit-ko-5.0.0-beta.2.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_bluefruit-pl-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_bluefruit-pl-5.0.0-beta.2.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_bluefruit-pt_BR-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_bluefruit-pt_BR-5.0.0-beta.2.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_bluefruit-zh_Latn_pinyin-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_bluefruit-zh_Latn_pinyin-5.0.0-beta.2.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.1"
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 7266,
+        "downloads": 67,
         "id": "circuitplayground_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -701,55 +659,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 51,
+        "downloads": 1,
         "id": "circuitplayground_express_4h",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_4h-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_4h-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_4h-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_4h-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_4h-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_4h-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_4h-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_4h-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_4h-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_4h-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_4h-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_4h-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -788,55 +746,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_4h-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_4h-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_4h-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_4h-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_4h-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_4h-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_4h-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_4h-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_4h-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_4h-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_4h-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_4h-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 355,
+        "downloads": 7,
         "id": "circuitplayground_express_crickit",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_crickit-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_crickit-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_crickit-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_crickit-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_crickit-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_crickit-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_crickit-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_crickit-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_crickit-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_crickit-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_crickit-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_crickit-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -875,55 +833,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_crickit-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_crickit-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_crickit-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_crickit-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_crickit-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_crickit-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_crickit-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_crickit-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_crickit-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_crickit-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_crickit-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_crickit-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 29,
+        "downloads": 0,
         "id": "circuitplayground_express_digikey_pycon2019",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -962,54 +920,96 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 12,
+        "downloads": 22,
         "id": "circuitplayground_express_displayio",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_displayio-ID-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_displayio-ID-5.0.0-beta.2.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_displayio-de_DE-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_displayio-de_DE-5.0.0-beta.2.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_displayio-en_US-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_displayio-en_US-5.0.0-beta.2.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_displayio-en_x_pirate-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_displayio-en_x_pirate-5.0.0-beta.2.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_displayio-es-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_displayio-es-5.0.0-beta.2.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_displayio-fil-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_displayio-fil-5.0.0-beta.2.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_displayio-fr-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_displayio-fr-5.0.0-beta.2.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_displayio-it_IT-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_displayio-it_IT-5.0.0-beta.2.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_displayio-ko-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_displayio-ko-5.0.0-beta.2.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_displayio-pl-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_displayio-pl-5.0.0-beta.2.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_displayio-pt_BR-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_displayio-pt_BR-5.0.0-beta.2.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-circuitplayground_express_displayio-zh_Latn_pinyin-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-circuitplayground_express_displayio-zh_Latn_pinyin-5.0.0-beta.2.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.1"
+                "version": "5.0.0-beta.2"
             }
         ]
     },
@@ -1017,48 +1017,6 @@
         "downloads": 0,
         "id": "cp32-m4",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-cp32-m4-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-cp32-m4-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-cp32-m4-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-cp32-m4-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-cp32-m4-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-cp32-m4-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-cp32-m4-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-cp32-m4-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-cp32-m4-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-cp32-m4-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-cp32-m4-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-cp32-m4-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -1097,6 +1055,48 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-cp32-m4-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-cp32-m4-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-cp32-m4-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-cp32-m4-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-cp32-m4-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-cp32-m4-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-cp32-m4-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-cp32-m4-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-cp32-m4-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-cp32-m4-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-cp32-m4-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-cp32-m4-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
@@ -1104,48 +1104,6 @@
         "downloads": 0,
         "id": "datalore_ip_m4",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datalore_ip_m4-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datalore_ip_m4-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datalore_ip_m4-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datalore_ip_m4-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datalore_ip_m4-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datalore_ip_m4-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datalore_ip_m4-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datalore_ip_m4-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datalore_ip_m4-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datalore_ip_m4-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datalore_ip_m4-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datalore_ip_m4-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -1184,55 +1142,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datalore_ip_m4-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datalore_ip_m4-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datalore_ip_m4-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datalore_ip_m4-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datalore_ip_m4-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datalore_ip_m4-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datalore_ip_m4-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datalore_ip_m4-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datalore_ip_m4-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datalore_ip_m4-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datalore_ip_m4-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datalore_ip_m4-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 22,
+        "downloads": 0,
         "id": "datum_distance",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_distance-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_distance-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_distance-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_distance-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_distance-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_distance-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_distance-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_distance-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_distance-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_distance-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_distance-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_distance-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -1271,55 +1229,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_distance-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_distance-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_distance-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_distance-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_distance-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_distance-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_distance-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_distance-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_distance-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_distance-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_distance-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_distance-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 25,
+        "downloads": 0,
         "id": "datum_imu",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_imu-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_imu-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_imu-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_imu-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_imu-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_imu-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_imu-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_imu-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_imu-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_imu-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_imu-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_imu-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -1358,55 +1316,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_imu-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_imu-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_imu-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_imu-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_imu-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_imu-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_imu-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_imu-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_imu-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_imu-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_imu-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_imu-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 19,
+        "downloads": 0,
         "id": "datum_light",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_light-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_light-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_light-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_light-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_light-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_light-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_light-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_light-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_light-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_light-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_light-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_light-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -1445,55 +1403,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_light-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_light-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_light-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_light-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_light-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_light-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_light-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_light-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_light-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_light-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_light-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_light-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 23,
+        "downloads": 0,
         "id": "datum_weather",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_weather-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_weather-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_weather-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_weather-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_weather-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_weather-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_weather-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_weather-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_weather-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_weather-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_weather-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-datum_weather-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -1532,103 +1490,103 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_weather-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_weather-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_weather-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_weather-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_weather-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_weather-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_weather-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_weather-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_weather-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_weather-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_weather-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-datum_weather-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 4,
         "id": "edgebadge",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-edgebadge-ID-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-edgebadge-ID-5.0.0-beta.2.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-edgebadge-de_DE-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-edgebadge-de_DE-5.0.0-beta.2.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-edgebadge-en_US-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-edgebadge-en_US-5.0.0-beta.2.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-edgebadge-en_x_pirate-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-edgebadge-en_x_pirate-5.0.0-beta.2.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-edgebadge-es-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-edgebadge-es-5.0.0-beta.2.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-edgebadge-fil-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-edgebadge-fil-5.0.0-beta.2.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-edgebadge-fr-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-edgebadge-fr-5.0.0-beta.2.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-edgebadge-it_IT-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-edgebadge-it_IT-5.0.0-beta.2.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-edgebadge-ko-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-edgebadge-ko-5.0.0-beta.2.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-edgebadge-pl-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-edgebadge-pl-5.0.0-beta.2.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-edgebadge-pt_BR-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-edgebadge-pt_BR-5.0.0-beta.2.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-edgebadge-zh_Latn_pinyin-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-edgebadge-zh_Latn_pinyin-5.0.0-beta.2.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.1"
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 23,
+        "downloads": 0,
         "id": "electronut_labs_blip",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_blip-ID-5.0.0-beta.1.hex"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_blip-de_DE-5.0.0-beta.1.hex"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_blip-en_US-5.0.0-beta.1.hex"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_blip-en_x_pirate-5.0.0-beta.1.hex"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_blip-es-5.0.0-beta.1.hex"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_blip-fil-5.0.0-beta.1.hex"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_blip-fr-5.0.0-beta.1.hex"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_blip-it_IT-5.0.0-beta.1.hex"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_blip-ko-5.0.0-beta.1.hex"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_blip-pl-5.0.0-beta.1.hex"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_blip-pt_BR-5.0.0-beta.1.hex"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_blip-zh_Latn_pinyin-5.0.0-beta.1.hex"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -1667,55 +1625,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-electronut_labs_blip-ID-5.0.0-beta.2.hex"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-electronut_labs_blip-de_DE-5.0.0-beta.2.hex"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-electronut_labs_blip-en_US-5.0.0-beta.2.hex"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-electronut_labs_blip-en_x_pirate-5.0.0-beta.2.hex"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-electronut_labs_blip-es-5.0.0-beta.2.hex"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-electronut_labs_blip-fil-5.0.0-beta.2.hex"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-electronut_labs_blip-fr-5.0.0-beta.2.hex"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-electronut_labs_blip-it_IT-5.0.0-beta.2.hex"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-electronut_labs_blip-ko-5.0.0-beta.2.hex"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-electronut_labs_blip-pl-5.0.0-beta.2.hex"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-electronut_labs_blip-pt_BR-5.0.0-beta.2.hex"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-electronut_labs_blip-zh_Latn_pinyin-5.0.0-beta.2.hex"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 19,
+        "downloads": 0,
         "id": "electronut_labs_papyr",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_papyr-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_papyr-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_papyr-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_papyr-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_papyr-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_papyr-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_papyr-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_papyr-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_papyr-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_papyr-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_papyr-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-electronut_labs_papyr-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -1754,55 +1712,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-electronut_labs_papyr-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-electronut_labs_papyr-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-electronut_labs_papyr-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-electronut_labs_papyr-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-electronut_labs_papyr-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-electronut_labs_papyr-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-electronut_labs_papyr-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-electronut_labs_papyr-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-electronut_labs_papyr-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-electronut_labs_papyr-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-electronut_labs_papyr-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-electronut_labs_papyr-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 22,
+        "downloads": 0,
         "id": "escornabot_makech",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-escornabot_makech-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-escornabot_makech-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-escornabot_makech-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-escornabot_makech-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-escornabot_makech-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-escornabot_makech-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-escornabot_makech-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-escornabot_makech-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-escornabot_makech-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-escornabot_makech-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-escornabot_makech-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-escornabot_makech-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -1841,67 +1799,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-escornabot_makech-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-escornabot_makech-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-escornabot_makech-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-escornabot_makech-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-escornabot_makech-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-escornabot_makech-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-escornabot_makech-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-escornabot_makech-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-escornabot_makech-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-escornabot_makech-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-escornabot_makech-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-escornabot_makech-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 404,
+        "downloads": 0,
         "id": "feather_m0_adalogger",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-ID-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-de_DE-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-en_US-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-es-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-fil-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-fr-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-it_IT-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-ko-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-pl-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-pt_BR-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-zh_Latn_pinyin-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_adalogger-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -1951,67 +1897,67 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_adalogger-ID-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_adalogger-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_adalogger-de_DE-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_adalogger-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_adalogger-en_US-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_adalogger-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_adalogger-es-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_adalogger-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_adalogger-fil-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_adalogger-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_adalogger-fr-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_adalogger-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_adalogger-it_IT-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_adalogger-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_adalogger-ko-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_adalogger-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_adalogger-pl-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_adalogger-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_adalogger-pt_BR-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_adalogger-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_adalogger-zh_Latn_pinyin-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_adalogger-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 308,
+        "downloads": 3,
         "id": "feather_m0_basic",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-ID-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-de_DE-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-en_US-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-en_x_pirate-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-es-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-fil-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-fr-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-it_IT-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-ko-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-pl-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-pt_BR-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-zh_Latn_pinyin-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_basic-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -2061,55 +2007,67 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_basic-ID-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_basic-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_basic-de_DE-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_basic-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_basic-en_US-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_basic-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_basic-en_x_pirate-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_basic-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_basic-es-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_basic-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_basic-fil-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_basic-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_basic-fr-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_basic-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_basic-it_IT-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_basic-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_basic-ko-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_basic-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_basic-pl-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_basic-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_basic-pt_BR-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_basic-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_basic-zh_Latn_pinyin-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_basic-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 932,
+        "downloads": 18,
         "id": "feather_m0_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -2148,55 +2106,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_express-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_express-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_express-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_express-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_express-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_express-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_express-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_express-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_express-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_express-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_express-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_express-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 46,
+        "downloads": 0,
         "id": "feather_m0_express_crickit",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express_crickit-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express_crickit-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express_crickit-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express_crickit-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express_crickit-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express_crickit-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express_crickit-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express_crickit-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express_crickit-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express_crickit-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express_crickit-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_express_crickit-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -2235,67 +2193,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_express_crickit-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_express_crickit-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_express_crickit-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_express_crickit-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_express_crickit-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_express_crickit-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_express_crickit-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_express_crickit-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_express_crickit-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_express_crickit-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_express_crickit-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_express_crickit-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 161,
+        "downloads": 2,
         "id": "feather_m0_rfm69",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-ID-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-de_DE-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-en_US-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-es-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-fil-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-fr-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-it_IT-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-ko-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-pl-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-pt_BR-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-zh_Latn_pinyin-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm69-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -2345,67 +2291,67 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm69-ID-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm69-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm69-de_DE-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm69-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm69-en_US-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm69-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm69-es-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm69-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm69-fil-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm69-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm69-fr-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm69-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm69-it_IT-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm69-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm69-ko-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm69-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm69-pl-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm69-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm69-pt_BR-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm69-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm69-zh_Latn_pinyin-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm69-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 285,
+        "downloads": 4,
         "id": "feather_m0_rfm9x",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-ID-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-de_DE-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-en_US-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-es-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-fil-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-fr-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-it_IT-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-ko-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-pl-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-zh_Latn_pinyin-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_rfm9x-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -2455,6 +2401,60 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm9x-ID-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm9x-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm9x-de_DE-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm9x-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm9x-en_US-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm9x-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm9x-es-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm9x-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm9x-fil-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm9x-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm9x-fr-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm9x-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm9x-it_IT-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm9x-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm9x-ko-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm9x-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm9x-pl-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm9x-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm9x-zh_Latn_pinyin-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_rfm9x-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
@@ -2462,48 +2462,6 @@
         "downloads": 0,
         "id": "feather_m0_supersized",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_supersized-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_supersized-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_supersized-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_supersized-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_supersized-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_supersized-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_supersized-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_supersized-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_supersized-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_supersized-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_supersized-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m0_supersized-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -2542,55 +2500,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_supersized-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_supersized-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_supersized-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_supersized-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_supersized-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_supersized-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_supersized-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_supersized-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_supersized-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_supersized-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_supersized-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m0_supersized-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 1469,
+        "downloads": 55,
         "id": "feather_m4_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m4_express-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m4_express-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m4_express-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m4_express-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m4_express-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m4_express-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m4_express-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m4_express-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m4_express-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m4_express-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m4_express-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_m4_express-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -2629,55 +2587,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m4_express-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m4_express-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m4_express-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m4_express-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m4_express-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m4_express-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m4_express-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m4_express-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m4_express-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m4_express-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m4_express-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_m4_express-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 354,
+        "downloads": 34,
         "id": "feather_nrf52840_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_nrf52840_express-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_nrf52840_express-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_nrf52840_express-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_nrf52840_express-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_nrf52840_express-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_nrf52840_express-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_nrf52840_express-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_nrf52840_express-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_nrf52840_express-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_nrf52840_express-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_nrf52840_express-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_nrf52840_express-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -2716,55 +2674,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_nrf52840_express-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_nrf52840_express-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_nrf52840_express-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_nrf52840_express-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_nrf52840_express-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_nrf52840_express-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_nrf52840_express-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_nrf52840_express-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_nrf52840_express-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_nrf52840_express-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_nrf52840_express-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_nrf52840_express-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 21,
+        "downloads": 0,
         "id": "feather_radiofruit_zigbee",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_radiofruit_zigbee-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_radiofruit_zigbee-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_radiofruit_zigbee-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_radiofruit_zigbee-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_radiofruit_zigbee-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_radiofruit_zigbee-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_radiofruit_zigbee-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_radiofruit_zigbee-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_radiofruit_zigbee-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_radiofruit_zigbee-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_radiofruit_zigbee-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_radiofruit_zigbee-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -2803,54 +2761,96 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_radiofruit_zigbee-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_radiofruit_zigbee-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_radiofruit_zigbee-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_radiofruit_zigbee-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_radiofruit_zigbee-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_radiofruit_zigbee-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_radiofruit_zigbee-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_radiofruit_zigbee-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_radiofruit_zigbee-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_radiofruit_zigbee-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_radiofruit_zigbee-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_radiofruit_zigbee-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 69,
+        "downloads": 29,
         "id": "feather_stm32f405_express",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_stm32f405_express-ID-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_stm32f405_express-ID-5.0.0-beta.2.bin"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_stm32f405_express-de_DE-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_stm32f405_express-de_DE-5.0.0-beta.2.bin"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_stm32f405_express-en_US-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_stm32f405_express-en_US-5.0.0-beta.2.bin"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_stm32f405_express-en_x_pirate-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_stm32f405_express-en_x_pirate-5.0.0-beta.2.bin"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_stm32f405_express-es-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_stm32f405_express-es-5.0.0-beta.2.bin"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_stm32f405_express-fil-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_stm32f405_express-fil-5.0.0-beta.2.bin"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_stm32f405_express-fr-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_stm32f405_express-fr-5.0.0-beta.2.bin"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_stm32f405_express-it_IT-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_stm32f405_express-it_IT-5.0.0-beta.2.bin"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_stm32f405_express-ko-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_stm32f405_express-ko-5.0.0-beta.2.bin"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_stm32f405_express-pl-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_stm32f405_express-pl-5.0.0-beta.2.bin"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_stm32f405_express-pt_BR-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_stm32f405_express-pt_BR-5.0.0-beta.2.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-feather_stm32f405_express-zh_Latn_pinyin-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-feather_stm32f405_express-zh_Latn_pinyin-5.0.0-beta.2.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.1"
+                "version": "5.0.0-beta.2"
             }
         ]
     },
@@ -2860,51 +2860,9 @@
         "versions": []
     },
     {
-        "downloads": 810,
+        "downloads": 5,
         "id": "gemma_m0",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -2943,55 +2901,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-gemma_m0-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-gemma_m0-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-gemma_m0-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-gemma_m0-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-gemma_m0-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-gemma_m0-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-gemma_m0-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-gemma_m0-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-gemma_m0-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-gemma_m0-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-gemma_m0-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-gemma_m0-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 28,
+        "downloads": 1,
         "id": "gemma_m0_pycon2018",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0_pycon2018-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0_pycon2018-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0_pycon2018-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0_pycon2018-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0_pycon2018-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0_pycon2018-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0_pycon2018-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0_pycon2018-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0_pycon2018-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0_pycon2018-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0_pycon2018-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-gemma_m0_pycon2018-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -3030,55 +2988,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-gemma_m0_pycon2018-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-gemma_m0_pycon2018-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-gemma_m0_pycon2018-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-gemma_m0_pycon2018-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-gemma_m0_pycon2018-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-gemma_m0_pycon2018-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-gemma_m0_pycon2018-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-gemma_m0_pycon2018-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-gemma_m0_pycon2018-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-gemma_m0_pycon2018-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-gemma_m0_pycon2018-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-gemma_m0_pycon2018-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 324,
+        "downloads": 9,
         "id": "grandcentral_m4_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-grandcentral_m4_express-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-grandcentral_m4_express-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-grandcentral_m4_express-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-grandcentral_m4_express-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-grandcentral_m4_express-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-grandcentral_m4_express-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-grandcentral_m4_express-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-grandcentral_m4_express-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-grandcentral_m4_express-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-grandcentral_m4_express-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-grandcentral_m4_express-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-grandcentral_m4_express-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -3117,55 +3075,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-grandcentral_m4_express-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-grandcentral_m4_express-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-grandcentral_m4_express-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-grandcentral_m4_express-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-grandcentral_m4_express-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-grandcentral_m4_express-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-grandcentral_m4_express-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-grandcentral_m4_express-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-grandcentral_m4_express-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-grandcentral_m4_express-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-grandcentral_m4_express-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-grandcentral_m4_express-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 400,
+        "downloads": 4,
         "id": "hallowing_m0_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m0_express-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m0_express-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m0_express-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m0_express-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m0_express-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m0_express-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m0_express-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m0_express-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m0_express-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m0_express-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m0_express-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m0_express-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -3204,55 +3162,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-hallowing_m0_express-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-hallowing_m0_express-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-hallowing_m0_express-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-hallowing_m0_express-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-hallowing_m0_express-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-hallowing_m0_express-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-hallowing_m0_express-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-hallowing_m0_express-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-hallowing_m0_express-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-hallowing_m0_express-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-hallowing_m0_express-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-hallowing_m0_express-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 6,
+        "downloads": 7,
         "id": "hallowing_m4_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m4_express-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m4_express-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m4_express-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m4_express-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m4_express-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m4_express-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m4_express-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m4_express-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m4_express-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m4_express-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m4_express-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-hallowing_m4_express-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -3291,55 +3249,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-hallowing_m4_express-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-hallowing_m4_express-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-hallowing_m4_express-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-hallowing_m4_express-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-hallowing_m4_express-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-hallowing_m4_express-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-hallowing_m4_express-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-hallowing_m4_express-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-hallowing_m4_express-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-hallowing_m4_express-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-hallowing_m4_express-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-hallowing_m4_express-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 471,
+        "downloads": 5,
         "id": "itsybitsy_m0_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m0_express-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m0_express-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m0_express-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m0_express-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m0_express-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m0_express-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m0_express-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m0_express-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m0_express-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m0_express-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m0_express-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m0_express-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -3378,55 +3336,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_m0_express-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_m0_express-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_m0_express-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_m0_express-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_m0_express-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_m0_express-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_m0_express-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_m0_express-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_m0_express-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_m0_express-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_m0_express-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_m0_express-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 952,
+        "downloads": 18,
         "id": "itsybitsy_m4_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m4_express-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m4_express-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m4_express-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m4_express-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m4_express-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m4_express-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m4_express-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m4_express-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m4_express-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m4_express-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m4_express-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_m4_express-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -3465,54 +3423,96 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_m4_express-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_m4_express-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_m4_express-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_m4_express-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_m4_express-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_m4_express-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_m4_express-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_m4_express-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_m4_express-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_m4_express-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_m4_express-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_m4_express-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 2,
+        "downloads": 0,
         "id": "itsybitsy_nrf52840_express",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_nrf52840_express-ID-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_nrf52840_express-ID-5.0.0-beta.2.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_nrf52840_express-de_DE-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_nrf52840_express-de_DE-5.0.0-beta.2.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_nrf52840_express-en_US-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_nrf52840_express-en_US-5.0.0-beta.2.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_nrf52840_express-en_x_pirate-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_nrf52840_express-en_x_pirate-5.0.0-beta.2.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_nrf52840_express-es-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_nrf52840_express-es-5.0.0-beta.2.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_nrf52840_express-fil-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_nrf52840_express-fil-5.0.0-beta.2.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_nrf52840_express-fr-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_nrf52840_express-fr-5.0.0-beta.2.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_nrf52840_express-it_IT-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_nrf52840_express-it_IT-5.0.0-beta.2.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_nrf52840_express-ko-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_nrf52840_express-ko-5.0.0-beta.2.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_nrf52840_express-pl-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_nrf52840_express-pl-5.0.0-beta.2.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_nrf52840_express-pt_BR-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_nrf52840_express-pt_BR-5.0.0-beta.2.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-itsybitsy_nrf52840_express-zh_Latn_pinyin-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-itsybitsy_nrf52840_express-zh_Latn_pinyin-5.0.0-beta.2.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.1"
+                "version": "5.0.0-beta.2"
             }
         ]
     },
@@ -3520,48 +3520,6 @@
         "downloads": 0,
         "id": "kicksat-sprite",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-kicksat-sprite-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-kicksat-sprite-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-kicksat-sprite-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-kicksat-sprite-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-kicksat-sprite-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-kicksat-sprite-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-kicksat-sprite-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-kicksat-sprite-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-kicksat-sprite-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-kicksat-sprite-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-kicksat-sprite-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-kicksat-sprite-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -3600,55 +3558,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-kicksat-sprite-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-kicksat-sprite-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-kicksat-sprite-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-kicksat-sprite-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-kicksat-sprite-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-kicksat-sprite-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-kicksat-sprite-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-kicksat-sprite-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-kicksat-sprite-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-kicksat-sprite-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-kicksat-sprite-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-kicksat-sprite-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 37,
+        "downloads": 0,
         "id": "makerdiary_nrf52840_mdk",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk-ID-5.0.0-beta.1.hex"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk-de_DE-5.0.0-beta.1.hex"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_US-5.0.0-beta.1.hex"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_x_pirate-5.0.0-beta.1.hex"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk-es-5.0.0-beta.1.hex"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk-fil-5.0.0-beta.1.hex"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk-fr-5.0.0-beta.1.hex"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk-it_IT-5.0.0-beta.1.hex"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk-ko-5.0.0-beta.1.hex"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk-pl-5.0.0-beta.1.hex"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk-pt_BR-5.0.0-beta.1.hex"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk-zh_Latn_pinyin-5.0.0-beta.1.hex"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -3687,55 +3645,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-makerdiary_nrf52840_mdk-ID-5.0.0-beta.2.hex"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-makerdiary_nrf52840_mdk-de_DE-5.0.0-beta.2.hex"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_US-5.0.0-beta.2.hex"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_x_pirate-5.0.0-beta.2.hex"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-makerdiary_nrf52840_mdk-es-5.0.0-beta.2.hex"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-makerdiary_nrf52840_mdk-fil-5.0.0-beta.2.hex"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-makerdiary_nrf52840_mdk-fr-5.0.0-beta.2.hex"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-makerdiary_nrf52840_mdk-it_IT-5.0.0-beta.2.hex"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-makerdiary_nrf52840_mdk-ko-5.0.0-beta.2.hex"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-makerdiary_nrf52840_mdk-pl-5.0.0-beta.2.hex"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-makerdiary_nrf52840_mdk-pt_BR-5.0.0-beta.2.hex"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-makerdiary_nrf52840_mdk-zh_Latn_pinyin-5.0.0-beta.2.hex"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 76,
+        "downloads": 3,
         "id": "makerdiary_nrf52840_mdk_usb_dongle",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-ID-5.0.0-beta.1.hex"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-de_DE-5.0.0-beta.1.hex"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_US-5.0.0-beta.1.hex"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_x_pirate-5.0.0-beta.1.hex"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-es-5.0.0-beta.1.hex"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fil-5.0.0-beta.1.hex"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fr-5.0.0-beta.1.hex"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-it_IT-5.0.0-beta.1.hex"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-ko-5.0.0-beta.1.hex"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pl-5.0.0-beta.1.hex"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pt_BR-5.0.0-beta.1.hex"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-zh_Latn_pinyin-5.0.0-beta.1.hex"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -3774,55 +3732,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-ID-5.0.0-beta.2.hex"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-de_DE-5.0.0-beta.2.hex"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_US-5.0.0-beta.2.hex"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_x_pirate-5.0.0-beta.2.hex"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-es-5.0.0-beta.2.hex"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fil-5.0.0-beta.2.hex"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fr-5.0.0-beta.2.hex"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-it_IT-5.0.0-beta.2.hex"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-ko-5.0.0-beta.2.hex"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pl-5.0.0-beta.2.hex"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pt_BR-5.0.0-beta.2.hex"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-zh_Latn_pinyin-5.0.0-beta.2.hex"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 22,
+        "downloads": 0,
         "id": "meowmeow",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-meowmeow-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-meowmeow-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-meowmeow-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-meowmeow-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-meowmeow-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-meowmeow-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-meowmeow-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-meowmeow-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-meowmeow-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-meowmeow-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-meowmeow-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-meowmeow-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -3861,55 +3819,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-meowmeow-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-meowmeow-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-meowmeow-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-meowmeow-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-meowmeow-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-meowmeow-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-meowmeow-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-meowmeow-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-meowmeow-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-meowmeow-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-meowmeow-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-meowmeow-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 861,
+        "downloads": 12,
         "id": "metro_m0_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m0_express-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m0_express-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m0_express-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m0_express-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m0_express-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m0_express-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m0_express-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m0_express-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m0_express-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m0_express-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m0_express-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m0_express-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -3948,55 +3906,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m0_express-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m0_express-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m0_express-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m0_express-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m0_express-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m0_express-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m0_express-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m0_express-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m0_express-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m0_express-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m0_express-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m0_express-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 202,
+        "downloads": 3,
         "id": "metro_m4_airlift_lite",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_airlift_lite-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_airlift_lite-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_airlift_lite-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_airlift_lite-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_airlift_lite-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_airlift_lite-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_airlift_lite-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_airlift_lite-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_airlift_lite-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_airlift_lite-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_airlift_lite-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_airlift_lite-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -4035,55 +3993,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m4_airlift_lite-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m4_airlift_lite-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m4_airlift_lite-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m4_airlift_lite-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m4_airlift_lite-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m4_airlift_lite-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m4_airlift_lite-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m4_airlift_lite-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m4_airlift_lite-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m4_airlift_lite-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m4_airlift_lite-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m4_airlift_lite-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 452,
+        "downloads": 7,
         "id": "metro_m4_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_express-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_express-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_express-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_express-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_express-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_express-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_express-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_express-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_express-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_express-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_express-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_m4_express-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -4122,103 +4080,103 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m4_express-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m4_express-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m4_express-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m4_express-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m4_express-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m4_express-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m4_express-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m4_express-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m4_express-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m4_express-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m4_express-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_m4_express-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 3,
+        "downloads": 0,
         "id": "metro_nrf52840_express",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_nrf52840_express-ID-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_nrf52840_express-ID-5.0.0-beta.2.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_nrf52840_express-de_DE-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_nrf52840_express-de_DE-5.0.0-beta.2.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_nrf52840_express-en_US-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_nrf52840_express-en_US-5.0.0-beta.2.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_nrf52840_express-en_x_pirate-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_nrf52840_express-en_x_pirate-5.0.0-beta.2.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_nrf52840_express-es-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_nrf52840_express-es-5.0.0-beta.2.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_nrf52840_express-fil-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_nrf52840_express-fil-5.0.0-beta.2.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_nrf52840_express-fr-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_nrf52840_express-fr-5.0.0-beta.2.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_nrf52840_express-it_IT-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_nrf52840_express-it_IT-5.0.0-beta.2.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_nrf52840_express-ko-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_nrf52840_express-ko-5.0.0-beta.2.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_nrf52840_express-pl-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_nrf52840_express-pl-5.0.0-beta.2.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_nrf52840_express-pt_BR-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_nrf52840_express-pt_BR-5.0.0-beta.2.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-metro_nrf52840_express-zh_Latn_pinyin-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-metro_nrf52840_express-zh_Latn_pinyin-5.0.0-beta.2.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.1"
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 40,
+        "downloads": 0,
         "id": "mini_sam_m4",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-mini_sam_m4-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-mini_sam_m4-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-mini_sam_m4-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-mini_sam_m4-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-mini_sam_m4-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-mini_sam_m4-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-mini_sam_m4-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-mini_sam_m4-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-mini_sam_m4-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-mini_sam_m4-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-mini_sam_m4-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-mini_sam_m4-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -4257,103 +4215,103 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-mini_sam_m4-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-mini_sam_m4-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-mini_sam_m4-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-mini_sam_m4-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-mini_sam_m4-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-mini_sam_m4-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-mini_sam_m4-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-mini_sam_m4-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-mini_sam_m4-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-mini_sam_m4-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-mini_sam_m4-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-mini_sam_m4-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 26,
+        "downloads": 19,
         "id": "monster_m4sk",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-monster_m4sk-ID-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-monster_m4sk-ID-5.0.0-beta.2.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-monster_m4sk-de_DE-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-monster_m4sk-de_DE-5.0.0-beta.2.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-monster_m4sk-en_US-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-monster_m4sk-en_US-5.0.0-beta.2.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-monster_m4sk-en_x_pirate-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-monster_m4sk-en_x_pirate-5.0.0-beta.2.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-monster_m4sk-es-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-monster_m4sk-es-5.0.0-beta.2.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-monster_m4sk-fil-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-monster_m4sk-fil-5.0.0-beta.2.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-monster_m4sk-fr-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-monster_m4sk-fr-5.0.0-beta.2.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-monster_m4sk-it_IT-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-monster_m4sk-it_IT-5.0.0-beta.2.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-monster_m4sk-ko-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-monster_m4sk-ko-5.0.0-beta.2.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-monster_m4sk-pl-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-monster_m4sk-pl-5.0.0-beta.2.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-monster_m4sk-pt_BR-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-monster_m4sk-pt_BR-5.0.0-beta.2.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-monster_m4sk-zh_Latn_pinyin-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-monster_m4sk-zh_Latn_pinyin-5.0.0-beta.2.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.1"
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 53,
+        "downloads": 1,
         "id": "particle_argon",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_argon-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_argon-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_argon-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_argon-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_argon-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_argon-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_argon-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_argon-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_argon-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_argon-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_argon-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_argon-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -4392,55 +4350,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_argon-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_argon-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_argon-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_argon-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_argon-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_argon-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_argon-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_argon-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_argon-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_argon-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_argon-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_argon-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 30,
+        "downloads": 0,
         "id": "particle_boron",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_boron-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_boron-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_boron-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_boron-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_boron-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_boron-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_boron-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_boron-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_boron-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_boron-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_boron-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_boron-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -4479,55 +4437,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_boron-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_boron-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_boron-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_boron-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_boron-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_boron-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_boron-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_boron-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_boron-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_boron-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_boron-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_boron-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 57,
+        "downloads": 0,
         "id": "particle_xenon",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_xenon-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_xenon-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_xenon-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_xenon-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_xenon-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_xenon-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_xenon-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_xenon-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_xenon-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_xenon-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_xenon-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-particle_xenon-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -4566,6 +4524,48 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_xenon-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_xenon-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_xenon-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_xenon-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_xenon-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_xenon-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_xenon-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_xenon-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_xenon-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_xenon-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_xenon-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-particle_xenon-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
@@ -4575,63 +4575,9 @@
         "versions": []
     },
     {
-        "downloads": 133,
+        "downloads": 11,
         "id": "pca10056",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-ID-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-de_DE-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-en_US-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-en_x_pirate-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-es-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-fil-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-fr-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-it_IT-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-ko-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-pl-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-pt_BR-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-zh_Latn_pinyin-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10056-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -4681,67 +4627,67 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10056-ID-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10056-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10056-de_DE-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10056-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10056-en_US-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10056-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10056-en_x_pirate-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10056-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10056-es-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10056-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10056-fil-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10056-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10056-fr-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10056-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10056-it_IT-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10056-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10056-ko-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10056-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10056-pl-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10056-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10056-pt_BR-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10056-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10056-zh_Latn_pinyin-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10056-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 229,
+        "downloads": 8,
         "id": "pca10059",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-ID-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-de_DE-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-en_US-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-en_x_pirate-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-es-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-fil-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-fr-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-it_IT-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-ko-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-pl-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-pt_BR-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-zh_Latn_pinyin-5.0.0-beta.1.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pca10059-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -4791,55 +4737,67 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10059-ID-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10059-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10059-de_DE-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10059-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10059-en_US-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10059-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10059-en_x_pirate-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10059-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10059-es-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10059-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10059-fil-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10059-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10059-fr-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10059-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10059-it_IT-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10059-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10059-ko-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10059-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10059-pl-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10059-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10059-pt_BR-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10059-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10059-zh_Latn_pinyin-5.0.0-beta.2.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pca10059-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 52,
+        "downloads": 0,
         "id": "pewpew10",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew10-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew10-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew10-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew10-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew10-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew10-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew10-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew10-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew10-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew10-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew10-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew10-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -4878,55 +4836,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew10-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew10-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew10-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew10-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew10-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew10-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew10-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew10-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew10-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew10-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew10-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew10-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 19,
+        "downloads": 0,
         "id": "pewpew13",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew13-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew13-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew13-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew13-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew13-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew13-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew13-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew13-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew13-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew13-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew13-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew13-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -4965,103 +4923,103 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew13-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew13-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew13-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew13-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew13-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew13-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew13-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew13-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew13-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew13-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew13-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew13-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 1,
         "id": "pewpew_m4",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew_m4-ID-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew_m4-ID-5.0.0-beta.2.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew_m4-de_DE-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew_m4-de_DE-5.0.0-beta.2.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew_m4-en_US-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew_m4-en_US-5.0.0-beta.2.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew_m4-en_x_pirate-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew_m4-en_x_pirate-5.0.0-beta.2.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew_m4-es-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew_m4-es-5.0.0-beta.2.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew_m4-fil-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew_m4-fil-5.0.0-beta.2.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew_m4-fr-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew_m4-fr-5.0.0-beta.2.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew_m4-it_IT-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew_m4-it_IT-5.0.0-beta.2.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew_m4-ko-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew_m4-ko-5.0.0-beta.2.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew_m4-pl-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew_m4-pl-5.0.0-beta.2.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew_m4-pt_BR-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew_m4-pt_BR-5.0.0-beta.2.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pewpew_m4-zh_Latn_pinyin-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pewpew_m4-zh_Latn_pinyin-5.0.0-beta.2.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.1"
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 20,
+        "downloads": 0,
         "id": "pirkey_m0",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pirkey_m0-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pirkey_m0-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pirkey_m0-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pirkey_m0-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pirkey_m0-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pirkey_m0-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pirkey_m0-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pirkey_m0-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pirkey_m0-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pirkey_m0-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pirkey_m0-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pirkey_m0-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -5100,103 +5058,103 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pirkey_m0-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pirkey_m0-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pirkey_m0-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pirkey_m0-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pirkey_m0-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pirkey_m0-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pirkey_m0-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pirkey_m0-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pirkey_m0-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pirkey_m0-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pirkey_m0-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pirkey_m0-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 3,
         "id": "pyb_nano_v2",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyb_nano_v2-ID-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyb_nano_v2-ID-5.0.0-beta.2.bin"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyb_nano_v2-de_DE-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyb_nano_v2-de_DE-5.0.0-beta.2.bin"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyb_nano_v2-en_US-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyb_nano_v2-en_US-5.0.0-beta.2.bin"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyb_nano_v2-en_x_pirate-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyb_nano_v2-en_x_pirate-5.0.0-beta.2.bin"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyb_nano_v2-es-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyb_nano_v2-es-5.0.0-beta.2.bin"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyb_nano_v2-fil-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyb_nano_v2-fil-5.0.0-beta.2.bin"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyb_nano_v2-fr-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyb_nano_v2-fr-5.0.0-beta.2.bin"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyb_nano_v2-it_IT-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyb_nano_v2-it_IT-5.0.0-beta.2.bin"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyb_nano_v2-ko-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyb_nano_v2-ko-5.0.0-beta.2.bin"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyb_nano_v2-pl-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyb_nano_v2-pl-5.0.0-beta.2.bin"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyb_nano_v2-pt_BR-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyb_nano_v2-pt_BR-5.0.0-beta.2.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyb_nano_v2-zh_Latn_pinyin-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyb_nano_v2-zh_Latn_pinyin-5.0.0-beta.2.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.1"
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 519,
+        "downloads": 4,
         "id": "pybadge",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -5235,55 +5193,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pybadge-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pybadge-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pybadge-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pybadge-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pybadge-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pybadge-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pybadge-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pybadge-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pybadge-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pybadge-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pybadge-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pybadge-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 24,
+        "downloads": 0,
         "id": "pybadge_airlift",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge_airlift-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge_airlift-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge_airlift-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge_airlift-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge_airlift-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge_airlift-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge_airlift-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge_airlift-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge_airlift-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge_airlift-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge_airlift-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pybadge_airlift-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -5322,103 +5280,103 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pybadge_airlift-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pybadge_airlift-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pybadge_airlift-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pybadge_airlift-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pybadge_airlift-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pybadge_airlift-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pybadge_airlift-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pybadge_airlift-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pybadge_airlift-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pybadge_airlift-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pybadge_airlift-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pybadge_airlift-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 20,
+        "downloads": 10,
         "id": "pyboard_v11",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyboard_v11-ID-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyboard_v11-ID-5.0.0-beta.2.bin"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyboard_v11-de_DE-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyboard_v11-de_DE-5.0.0-beta.2.bin"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyboard_v11-en_US-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyboard_v11-en_US-5.0.0-beta.2.bin"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyboard_v11-en_x_pirate-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyboard_v11-en_x_pirate-5.0.0-beta.2.bin"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyboard_v11-es-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyboard_v11-es-5.0.0-beta.2.bin"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyboard_v11-fil-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyboard_v11-fil-5.0.0-beta.2.bin"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyboard_v11-fr-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyboard_v11-fr-5.0.0-beta.2.bin"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyboard_v11-it_IT-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyboard_v11-it_IT-5.0.0-beta.2.bin"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyboard_v11-ko-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyboard_v11-ko-5.0.0-beta.2.bin"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyboard_v11-pl-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyboard_v11-pl-5.0.0-beta.2.bin"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyboard_v11-pt_BR-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyboard_v11-pt_BR-5.0.0-beta.2.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyboard_v11-zh_Latn_pinyin-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyboard_v11-zh_Latn_pinyin-5.0.0-beta.2.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.1"
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 639,
+        "downloads": 12,
         "id": "pygamer",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -5457,55 +5415,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pygamer-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pygamer-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pygamer-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pygamer-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pygamer-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pygamer-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pygamer-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pygamer-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pygamer-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pygamer-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pygamer-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pygamer-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 45,
+        "downloads": 1,
         "id": "pygamer_advance",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer_advance-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer_advance-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer_advance-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer_advance-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer_advance-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer_advance-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer_advance-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer_advance-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer_advance-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer_advance-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer_advance-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pygamer_advance-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -5544,55 +5502,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pygamer_advance-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pygamer_advance-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pygamer_advance-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pygamer_advance-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pygamer_advance-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pygamer_advance-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pygamer_advance-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pygamer_advance-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pygamer_advance-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pygamer_advance-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pygamer_advance-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pygamer_advance-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 1394,
+        "downloads": 47,
         "id": "pyportal",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -5631,6 +5589,48 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
@@ -5641,141 +5641,99 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-ID-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal_pynt-ID-5.0.0-beta.2.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-de_DE-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal_pynt-de_DE-5.0.0-beta.2.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-en_US-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal_pynt-en_US-5.0.0-beta.2.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-en_x_pirate-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal_pynt-en_x_pirate-5.0.0-beta.2.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-es-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal_pynt-es-5.0.0-beta.2.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-fil-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal_pynt-fil-5.0.0-beta.2.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-fr-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal_pynt-fr-5.0.0-beta.2.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-it_IT-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal_pynt-it_IT-5.0.0-beta.2.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-ko-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal_pynt-ko-5.0.0-beta.2.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-pl-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal_pynt-pl-5.0.0-beta.2.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-pt_BR-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal_pynt-pt_BR-5.0.0-beta.2.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal-zh_Latn_pinyin-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal_pynt-zh_Latn_pinyin-5.0.0-beta.2.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.1"
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 2,
+        "downloads": 8,
         "id": "pyportal_titano",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal_titano-ID-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal_titano-ID-5.0.0-beta.2.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal_titano-de_DE-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal_titano-de_DE-5.0.0-beta.2.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal_titano-en_US-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal_titano-en_US-5.0.0-beta.2.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal_titano-en_x_pirate-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal_titano-en_x_pirate-5.0.0-beta.2.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal_titano-es-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal_titano-es-5.0.0-beta.2.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal_titano-fil-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal_titano-fil-5.0.0-beta.2.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal_titano-fr-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal_titano-fr-5.0.0-beta.2.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal_titano-it_IT-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal_titano-it_IT-5.0.0-beta.2.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal_titano-ko-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal_titano-ko-5.0.0-beta.2.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal_titano-pl-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal_titano-pl-5.0.0-beta.2.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal_titano-pt_BR-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal_titano-pt_BR-5.0.0-beta.2.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyportal_titano-zh_Latn_pinyin-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyportal_titano-zh_Latn_pinyin-5.0.0-beta.2.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.1"
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 237,
+        "downloads": 4,
         "id": "pyruler",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyruler-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyruler-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyruler-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyruler-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyruler-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyruler-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyruler-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyruler-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyruler-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyruler-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyruler-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-pyruler-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -5814,148 +5772,103 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
-            }
-        ]
-    },
-    {
-        "downloads": 20,
-        "id": "robohatmm1_m4",
-        "versions": [
+            },
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.1.2/adafruit-circuitpython-robohatmm1-ID-4.1.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyruler-ID-5.0.0-beta.2.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.1.2/adafruit-circuitpython-robohatmm1-de_DE-4.1.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyruler-de_DE-5.0.0-beta.2.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.1.2/adafruit-circuitpython-robohatmm1-en_US-4.1.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyruler-en_US-5.0.0-beta.2.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.1.2/adafruit-circuitpython-robohatmm1-en_x_pirate-4.1.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyruler-en_x_pirate-5.0.0-beta.2.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.1.2/adafruit-circuitpython-robohatmm1-es-4.1.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyruler-es-5.0.0-beta.2.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.1.2/adafruit-circuitpython-robohatmm1-fil-4.1.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyruler-fil-5.0.0-beta.2.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.1.2/adafruit-circuitpython-robohatmm1-fr-4.1.2.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyruler-fr-5.0.0-beta.2.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.1.2/adafruit-circuitpython-robohatmm1-it_IT-4.1.2.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.1.2/adafruit-circuitpython-robohatmm1-pl-4.1.2.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.1.2/adafruit-circuitpython-robohatmm1-pt_BR-4.1.2.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/4.1.2/adafruit-circuitpython-robohatmm1-zh_Latn_pinyin-4.1.2.uf2"
-                    ]
-                },
-                "stable": true,
-                "version": "4.1.2"
-            }
-        ]
-    },
-    {
-        "downloads": 2,
-        "id": "robohatmm1_m4",
-        "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-robohatmm1_m4-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-robohatmm1_m4-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-robohatmm1_m4-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-robohatmm1_m4-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-robohatmm1_m4-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-robohatmm1_m4-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-robohatmm1_m4-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-robohatmm1_m4-it_IT-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyruler-it_IT-5.0.0-beta.2.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-robohatmm1_m4-ko-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyruler-ko-5.0.0-beta.2.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-robohatmm1_m4-pl-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyruler-pl-5.0.0-beta.2.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-robohatmm1_m4-pt_BR-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyruler-pt_BR-5.0.0-beta.2.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-robohatmm1_m4-zh_Latn_pinyin-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-pyruler-zh_Latn_pinyin-5.0.0-beta.2.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.1"
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 53,
+        "downloads": 1,
+        "id": "robohatmm1_m4",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-robohatmm1_m4-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-robohatmm1_m4-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-robohatmm1_m4-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-robohatmm1_m4-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-robohatmm1_m4-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-robohatmm1_m4-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-robohatmm1_m4-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-robohatmm1_m4-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-robohatmm1_m4-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-robohatmm1_m4-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-robohatmm1_m4-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-robohatmm1_m4-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
+            }
+        ]
+    },
+    {
+        "downloads": 0,
         "id": "sam32",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sam32-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sam32-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sam32-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sam32-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sam32-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sam32-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sam32-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sam32-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sam32-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sam32-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sam32-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sam32-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -5994,54 +5907,96 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sam32-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sam32-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sam32-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sam32-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sam32-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sam32-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sam32-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sam32-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sam32-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sam32-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sam32-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sam32-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 10,
+        "downloads": 12,
         "id": "serpente",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-serpente-ID-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-serpente-ID-5.0.0-beta.2.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-serpente-de_DE-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-serpente-de_DE-5.0.0-beta.2.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-serpente-en_US-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-serpente-en_US-5.0.0-beta.2.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-serpente-en_x_pirate-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-serpente-en_x_pirate-5.0.0-beta.2.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-serpente-es-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-serpente-es-5.0.0-beta.2.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-serpente-fil-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-serpente-fil-5.0.0-beta.2.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-serpente-fr-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-serpente-fr-5.0.0-beta.2.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-serpente-it_IT-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-serpente-it_IT-5.0.0-beta.2.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-serpente-ko-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-serpente-ko-5.0.0-beta.2.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-serpente-pl-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-serpente-pl-5.0.0-beta.2.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-serpente-pt_BR-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-serpente-pt_BR-5.0.0-beta.2.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-serpente-zh_Latn_pinyin-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-serpente-zh_Latn_pinyin-5.0.0-beta.2.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.1"
+                "version": "5.0.0-beta.2"
             }
         ]
     },
@@ -6052,44 +6007,44 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-shirtty-ID-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-shirtty-ID-5.0.0-beta.2.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-shirtty-de_DE-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-shirtty-de_DE-5.0.0-beta.2.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-shirtty-en_US-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-shirtty-en_US-5.0.0-beta.2.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-shirtty-en_x_pirate-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-shirtty-en_x_pirate-5.0.0-beta.2.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-shirtty-es-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-shirtty-es-5.0.0-beta.2.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-shirtty-fil-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-shirtty-fil-5.0.0-beta.2.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-shirtty-fr-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-shirtty-fr-5.0.0-beta.2.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-shirtty-it_IT-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-shirtty-it_IT-5.0.0-beta.2.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-shirtty-ko-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-shirtty-ko-5.0.0-beta.2.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-shirtty-pl-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-shirtty-pl-5.0.0-beta.2.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-shirtty-pt_BR-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-shirtty-pt_BR-5.0.0-beta.2.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-shirtty-zh_Latn_pinyin-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-shirtty-zh_Latn_pinyin-5.0.0-beta.2.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.1"
+                "version": "5.0.0-beta.2"
             }
         ]
     },
@@ -6100,93 +6055,51 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-snekboard-ID-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-snekboard-ID-5.0.0-beta.2.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-snekboard-de_DE-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-snekboard-de_DE-5.0.0-beta.2.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-snekboard-en_US-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-snekboard-en_US-5.0.0-beta.2.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-snekboard-en_x_pirate-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-snekboard-en_x_pirate-5.0.0-beta.2.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-snekboard-es-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-snekboard-es-5.0.0-beta.2.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-snekboard-fil-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-snekboard-fil-5.0.0-beta.2.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-snekboard-fr-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-snekboard-fr-5.0.0-beta.2.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-snekboard-it_IT-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-snekboard-it_IT-5.0.0-beta.2.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-snekboard-ko-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-snekboard-ko-5.0.0-beta.2.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-snekboard-pl-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-snekboard-pl-5.0.0-beta.2.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-snekboard-pt_BR-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-snekboard-pt_BR-5.0.0-beta.2.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-snekboard-zh_Latn_pinyin-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-snekboard-zh_Latn_pinyin-5.0.0-beta.2.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.1"
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 23,
+        "downloads": 0,
         "id": "sparkfun_lumidrive",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_lumidrive-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_lumidrive-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_lumidrive-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_lumidrive-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_lumidrive-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_lumidrive-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_lumidrive-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_lumidrive-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_lumidrive-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_lumidrive-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_lumidrive-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_lumidrive-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -6225,55 +6138,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_lumidrive-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_lumidrive-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_lumidrive-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_lumidrive-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_lumidrive-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_lumidrive-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_lumidrive-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_lumidrive-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_lumidrive-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_lumidrive-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_lumidrive-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_lumidrive-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 56,
+        "downloads": 2,
         "id": "sparkfun_nrf52840_mini",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_nrf52840_mini-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_nrf52840_mini-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_nrf52840_mini-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_nrf52840_mini-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_nrf52840_mini-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_nrf52840_mini-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_nrf52840_mini-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_nrf52840_mini-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_nrf52840_mini-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_nrf52840_mini-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_nrf52840_mini-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_nrf52840_mini-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -6312,6 +6225,48 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_nrf52840_mini-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_nrf52840_mini-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_nrf52840_mini-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_nrf52840_mini-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_nrf52840_mini-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_nrf52840_mini-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_nrf52840_mini-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_nrf52840_mini-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_nrf52840_mini-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_nrf52840_mini-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_nrf52840_mini-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_nrf52840_mini-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
@@ -6322,141 +6277,99 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-ID-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-ID-5.0.0-beta.2.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-de_DE-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-de_DE-5.0.0-beta.2.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-en_US-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-en_US-5.0.0-beta.2.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-en_x_pirate-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-en_x_pirate-5.0.0-beta.2.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-es-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-es-5.0.0-beta.2.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-fil-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-fil-5.0.0-beta.2.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-fr-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-fr-5.0.0-beta.2.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-it_IT-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-it_IT-5.0.0-beta.2.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-ko-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-ko-5.0.0-beta.2.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-pl-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-pl-5.0.0-beta.2.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-pt_BR-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-pt_BR-5.0.0-beta.2.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-zh_Latn_pinyin-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-zh_Latn_pinyin-5.0.0-beta.2.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.1"
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 1,
         "id": "sparkfun_qwiic_micro_with_flash",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-ID-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-ID-5.0.0-beta.2.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-de_DE-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-de_DE-5.0.0-beta.2.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-en_US-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-en_US-5.0.0-beta.2.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-en_x_pirate-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-en_x_pirate-5.0.0-beta.2.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-es-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-es-5.0.0-beta.2.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-fil-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-fil-5.0.0-beta.2.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-fr-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-fr-5.0.0-beta.2.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-it_IT-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-it_IT-5.0.0-beta.2.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-ko-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-ko-5.0.0-beta.2.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-pl-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-pl-5.0.0-beta.2.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-pt_BR-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-pt_BR-5.0.0-beta.2.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-zh_Latn_pinyin-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-zh_Latn_pinyin-5.0.0-beta.2.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.1"
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 58,
+        "downloads": 1,
         "id": "sparkfun_redboard_turbo",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_redboard_turbo-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_redboard_turbo-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_redboard_turbo-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_redboard_turbo-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_redboard_turbo-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_redboard_turbo-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_redboard_turbo-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_redboard_turbo-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_redboard_turbo-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_redboard_turbo-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_redboard_turbo-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_redboard_turbo-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -6495,55 +6408,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_redboard_turbo-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_redboard_turbo-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_redboard_turbo-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_redboard_turbo-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_redboard_turbo-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_redboard_turbo-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_redboard_turbo-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_redboard_turbo-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_redboard_turbo-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_redboard_turbo-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_redboard_turbo-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_redboard_turbo-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 42,
+        "downloads": 0,
         "id": "sparkfun_samd21_dev",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_dev-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_dev-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_dev-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_dev-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_dev-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_dev-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_dev-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_dev-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_dev-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_dev-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_dev-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_dev-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -6582,55 +6495,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_samd21_dev-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_samd21_dev-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_samd21_dev-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_samd21_dev-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_samd21_dev-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_samd21_dev-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_samd21_dev-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_samd21_dev-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_samd21_dev-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_samd21_dev-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_samd21_dev-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_samd21_dev-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 50,
+        "downloads": 1,
         "id": "sparkfun_samd21_mini",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_mini-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_mini-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_mini-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_mini-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_mini-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_mini-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_mini-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_mini-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_mini-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_mini-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_mini-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-sparkfun_samd21_mini-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -6669,247 +6582,343 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
-            }
-        ]
-    },
-    {
-        "downloads": 3,
-        "id": "spresense",
-        "versions": [
+            },
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-spresense-ID-5.0.0-beta.1.spk"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_samd21_mini-ID-5.0.0-beta.2.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-spresense-de_DE-5.0.0-beta.1.spk"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_samd21_mini-de_DE-5.0.0-beta.2.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-spresense-en_US-5.0.0-beta.1.spk"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_samd21_mini-en_US-5.0.0-beta.2.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-spresense-en_x_pirate-5.0.0-beta.1.spk"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_samd21_mini-en_x_pirate-5.0.0-beta.2.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-spresense-es-5.0.0-beta.1.spk"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_samd21_mini-es-5.0.0-beta.2.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-spresense-fil-5.0.0-beta.1.spk"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_samd21_mini-fil-5.0.0-beta.2.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-spresense-fr-5.0.0-beta.1.spk"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_samd21_mini-fr-5.0.0-beta.2.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-spresense-it_IT-5.0.0-beta.1.spk"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_samd21_mini-it_IT-5.0.0-beta.2.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-spresense-ko-5.0.0-beta.1.spk"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_samd21_mini-ko-5.0.0-beta.2.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-spresense-pl-5.0.0-beta.1.spk"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_samd21_mini-pl-5.0.0-beta.2.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-spresense-pt_BR-5.0.0-beta.1.spk"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_samd21_mini-pt_BR-5.0.0-beta.2.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-spresense-zh_Latn_pinyin-5.0.0-beta.1.spk"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-sparkfun_samd21_mini-zh_Latn_pinyin-5.0.0-beta.2.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.1"
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
         "downloads": 4,
+        "id": "spresense",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-spresense-ID-5.0.0-beta.2.spk"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-spresense-de_DE-5.0.0-beta.2.spk"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-spresense-en_US-5.0.0-beta.2.spk"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-spresense-en_x_pirate-5.0.0-beta.2.spk"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-spresense-es-5.0.0-beta.2.spk"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-spresense-fil-5.0.0-beta.2.spk"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-spresense-fr-5.0.0-beta.2.spk"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-spresense-it_IT-5.0.0-beta.2.spk"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-spresense-ko-5.0.0-beta.2.spk"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-spresense-pl-5.0.0-beta.2.spk"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-spresense-pt_BR-5.0.0-beta.2.spk"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-spresense-zh_Latn_pinyin-5.0.0-beta.2.spk"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
+            }
+        ]
+    },
+    {
+        "downloads": 0,
+        "id": "stm32f411ce_blackpill",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f411ce_blackpill-ID-5.0.0-beta.2.bin"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f411ce_blackpill-de_DE-5.0.0-beta.2.bin"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f411ce_blackpill-en_US-5.0.0-beta.2.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f411ce_blackpill-en_x_pirate-5.0.0-beta.2.bin"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f411ce_blackpill-es-5.0.0-beta.2.bin"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f411ce_blackpill-fil-5.0.0-beta.2.bin"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f411ce_blackpill-fr-5.0.0-beta.2.bin"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f411ce_blackpill-it_IT-5.0.0-beta.2.bin"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f411ce_blackpill-ko-5.0.0-beta.2.bin"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f411ce_blackpill-pl-5.0.0-beta.2.bin"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f411ce_blackpill-pt_BR-5.0.0-beta.2.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f411ce_blackpill-zh_Latn_pinyin-5.0.0-beta.2.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
+            }
+        ]
+    },
+    {
+        "downloads": 2,
         "id": "stm32f411ve_discovery",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f411ve_discovery-ID-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f411ve_discovery-ID-5.0.0-beta.2.bin"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f411ve_discovery-de_DE-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f411ve_discovery-de_DE-5.0.0-beta.2.bin"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f411ve_discovery-en_US-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f411ve_discovery-en_US-5.0.0-beta.2.bin"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f411ve_discovery-en_x_pirate-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f411ve_discovery-en_x_pirate-5.0.0-beta.2.bin"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f411ve_discovery-es-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f411ve_discovery-es-5.0.0-beta.2.bin"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f411ve_discovery-fil-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f411ve_discovery-fil-5.0.0-beta.2.bin"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f411ve_discovery-fr-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f411ve_discovery-fr-5.0.0-beta.2.bin"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f411ve_discovery-it_IT-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f411ve_discovery-it_IT-5.0.0-beta.2.bin"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f411ve_discovery-ko-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f411ve_discovery-ko-5.0.0-beta.2.bin"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f411ve_discovery-pl-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f411ve_discovery-pl-5.0.0-beta.2.bin"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f411ve_discovery-pt_BR-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f411ve_discovery-pt_BR-5.0.0-beta.2.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f411ve_discovery-zh_Latn_pinyin-5.0.0-beta.1.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f411ve_discovery-zh_Latn_pinyin-5.0.0-beta.2.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.1"
-            }
-        ]
-    },
-    {
-        "downloads": 3,
-        "id": "stm32f412zg_discovery",
-        "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f412zg_discovery-ID-5.0.0-beta.1.bin"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f412zg_discovery-de_DE-5.0.0-beta.1.bin"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f412zg_discovery-en_US-5.0.0-beta.1.bin"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f412zg_discovery-en_x_pirate-5.0.0-beta.1.bin"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f412zg_discovery-es-5.0.0-beta.1.bin"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f412zg_discovery-fil-5.0.0-beta.1.bin"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f412zg_discovery-fr-5.0.0-beta.1.bin"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f412zg_discovery-it_IT-5.0.0-beta.1.bin"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f412zg_discovery-ko-5.0.0-beta.1.bin"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f412zg_discovery-pl-5.0.0-beta.1.bin"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f412zg_discovery-pt_BR-5.0.0-beta.1.bin"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stm32f412zg_discovery-zh_Latn_pinyin-5.0.0-beta.1.bin"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
         "downloads": 1,
+        "id": "stm32f412zg_discovery",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f412zg_discovery-ID-5.0.0-beta.2.bin"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f412zg_discovery-de_DE-5.0.0-beta.2.bin"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f412zg_discovery-en_US-5.0.0-beta.2.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f412zg_discovery-en_x_pirate-5.0.0-beta.2.bin"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f412zg_discovery-es-5.0.0-beta.2.bin"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f412zg_discovery-fil-5.0.0-beta.2.bin"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f412zg_discovery-fr-5.0.0-beta.2.bin"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f412zg_discovery-it_IT-5.0.0-beta.2.bin"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f412zg_discovery-ko-5.0.0-beta.2.bin"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f412zg_discovery-pl-5.0.0-beta.2.bin"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f412zg_discovery-pt_BR-5.0.0-beta.2.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stm32f412zg_discovery-zh_Latn_pinyin-5.0.0-beta.2.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
+            }
+        ]
+    },
+    {
+        "downloads": 0,
         "id": "stringcar_m0_express",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stringcar_m0_express-ID-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stringcar_m0_express-ID-5.0.0-beta.2.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stringcar_m0_express-de_DE-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stringcar_m0_express-de_DE-5.0.0-beta.2.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stringcar_m0_express-en_US-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stringcar_m0_express-en_US-5.0.0-beta.2.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stringcar_m0_express-en_x_pirate-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stringcar_m0_express-en_x_pirate-5.0.0-beta.2.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stringcar_m0_express-es-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stringcar_m0_express-es-5.0.0-beta.2.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stringcar_m0_express-fil-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stringcar_m0_express-fil-5.0.0-beta.2.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stringcar_m0_express-fr-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stringcar_m0_express-fr-5.0.0-beta.2.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stringcar_m0_express-it_IT-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stringcar_m0_express-it_IT-5.0.0-beta.2.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stringcar_m0_express-ko-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stringcar_m0_express-ko-5.0.0-beta.2.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stringcar_m0_express-pl-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stringcar_m0_express-pl-5.0.0-beta.2.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stringcar_m0_express-pt_BR-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stringcar_m0_express-pt_BR-5.0.0-beta.2.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-stringcar_m0_express-zh_Latn_pinyin-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-stringcar_m0_express-zh_Latn_pinyin-5.0.0-beta.2.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.1"
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 446,
-        "id": "trellis_m4_express",
+        "downloads": 0,
+        "id": "teknikio_bluebird",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trellis_m4_express-ID-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-teknikio_bluebird-ID-5.0.0-beta.2.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trellis_m4_express-de_DE-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-teknikio_bluebird-de_DE-5.0.0-beta.2.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trellis_m4_express-en_US-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-teknikio_bluebird-en_US-5.0.0-beta.2.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trellis_m4_express-en_x_pirate-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-teknikio_bluebird-en_x_pirate-5.0.0-beta.2.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trellis_m4_express-es-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-teknikio_bluebird-es-5.0.0-beta.2.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trellis_m4_express-fil-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-teknikio_bluebird-fil-5.0.0-beta.2.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trellis_m4_express-fr-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-teknikio_bluebird-fr-5.0.0-beta.2.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trellis_m4_express-it_IT-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-teknikio_bluebird-it_IT-5.0.0-beta.2.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trellis_m4_express-ko-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-teknikio_bluebird-ko-5.0.0-beta.2.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trellis_m4_express-pl-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-teknikio_bluebird-pl-5.0.0-beta.2.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trellis_m4_express-pt_BR-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-teknikio_bluebird-pt_BR-5.0.0-beta.2.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trellis_m4_express-zh_Latn_pinyin-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-teknikio_bluebird-zh_Latn_pinyin-5.0.0-beta.2.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.1"
-            },
+                "version": "5.0.0-beta.2"
+            }
+        ]
+    },
+    {
+        "downloads": 4,
+        "id": "trellis_m4_express",
+        "versions": [
             {
                 "files": {
                     "ID": [
@@ -6948,55 +6957,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trellis_m4_express-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trellis_m4_express-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trellis_m4_express-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trellis_m4_express-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trellis_m4_express-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trellis_m4_express-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trellis_m4_express-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trellis_m4_express-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trellis_m4_express-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trellis_m4_express-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trellis_m4_express-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trellis_m4_express-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 2321,
+        "downloads": 25,
         "id": "trinket_m0",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -7035,6 +7044,48 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trinket_m0-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trinket_m0-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trinket_m0-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trinket_m0-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trinket_m0-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trinket_m0-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trinket_m0-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trinket_m0-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trinket_m0-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trinket_m0-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trinket_m0-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trinket_m0-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
@@ -7042,48 +7093,6 @@
         "downloads": 1,
         "id": "trinket_m0_haxpress",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0_haxpress-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0_haxpress-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0_haxpress-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0_haxpress-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0_haxpress-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0_haxpress-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0_haxpress-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0_haxpress-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0_haxpress-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0_haxpress-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0_haxpress-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-trinket_m0_haxpress-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -7122,55 +7131,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trinket_m0_haxpress-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trinket_m0_haxpress-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trinket_m0_haxpress-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trinket_m0_haxpress-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trinket_m0_haxpress-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trinket_m0_haxpress-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trinket_m0_haxpress-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trinket_m0_haxpress-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trinket_m0_haxpress-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trinket_m0_haxpress-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trinket_m0_haxpress-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-trinket_m0_haxpress-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 25,
+        "downloads": 0,
         "id": "uchip",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-uchip-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-uchip-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-uchip-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-uchip-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-uchip-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-uchip-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-uchip-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-uchip-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-uchip-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-uchip-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-uchip-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-uchip-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -7209,55 +7218,55 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-uchip-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-uchip-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-uchip-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-uchip-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-uchip-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-uchip-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-uchip-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-uchip-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-uchip-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-uchip-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-uchip-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-uchip-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
     {
-        "downloads": 42,
+        "downloads": 2,
         "id": "ugame10",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-ugame10-ID-5.0.0-beta.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-ugame10-de_DE-5.0.0-beta.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-ugame10-en_US-5.0.0-beta.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-ugame10-en_x_pirate-5.0.0-beta.1.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-ugame10-es-5.0.0-beta.1.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-ugame10-fil-5.0.0-beta.1.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-ugame10-fr-5.0.0-beta.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-ugame10-it_IT-5.0.0-beta.1.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-ugame10-ko-5.0.0-beta.1.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-ugame10-pl-5.0.0-beta.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-ugame10-pt_BR-5.0.0-beta.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-ugame10-zh_Latn_pinyin-5.0.0-beta.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -7296,6 +7305,48 @@
                 },
                 "stable": true,
                 "version": "4.1.2"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-ugame10-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-ugame10-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-ugame10-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-ugame10-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-ugame10-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-ugame10-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-ugame10-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-ugame10-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-ugame10-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-ugame10-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-ugame10-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-ugame10-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     },
@@ -7306,44 +7357,140 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-winterbloom_sol-ID-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-winterbloom_sol-ID-5.0.0-beta.2.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-winterbloom_sol-de_DE-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-winterbloom_sol-de_DE-5.0.0-beta.2.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-winterbloom_sol-en_US-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-winterbloom_sol-en_US-5.0.0-beta.2.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-winterbloom_sol-en_x_pirate-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-winterbloom_sol-en_x_pirate-5.0.0-beta.2.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-winterbloom_sol-es-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-winterbloom_sol-es-5.0.0-beta.2.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-winterbloom_sol-fil-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-winterbloom_sol-fil-5.0.0-beta.2.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-winterbloom_sol-fr-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-winterbloom_sol-fr-5.0.0-beta.2.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-winterbloom_sol-it_IT-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-winterbloom_sol-it_IT-5.0.0-beta.2.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-winterbloom_sol-ko-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-winterbloom_sol-ko-5.0.0-beta.2.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-winterbloom_sol-pl-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-winterbloom_sol-pl-5.0.0-beta.2.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-winterbloom_sol-pt_BR-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-winterbloom_sol-pt_BR-5.0.0-beta.2.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.1/adafruit-circuitpython-winterbloom_sol-zh_Latn_pinyin-5.0.0-beta.1.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-winterbloom_sol-zh_Latn_pinyin-5.0.0-beta.2.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.1"
+                "version": "5.0.0-beta.2"
+            }
+        ]
+    },
+    {
+        "downloads": 0,
+        "id": "xinabox_cc03",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-xinabox_cc03-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-xinabox_cc03-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-xinabox_cc03-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-xinabox_cc03-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-xinabox_cc03-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-xinabox_cc03-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-xinabox_cc03-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-xinabox_cc03-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-xinabox_cc03-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-xinabox_cc03-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-xinabox_cc03-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-xinabox_cc03-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
+            }
+        ]
+    },
+    {
+        "downloads": 0,
+        "id": "xinabox_cs11",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-xinabox_cs11-ID-5.0.0-beta.2.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-xinabox_cs11-de_DE-5.0.0-beta.2.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-xinabox_cs11-en_US-5.0.0-beta.2.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-xinabox_cs11-en_x_pirate-5.0.0-beta.2.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-xinabox_cs11-es-5.0.0-beta.2.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-xinabox_cs11-fil-5.0.0-beta.2.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-xinabox_cs11-fr-5.0.0-beta.2.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-xinabox_cs11-it_IT-5.0.0-beta.2.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-xinabox_cs11-ko-5.0.0-beta.2.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-xinabox_cs11-pl-5.0.0-beta.2.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-xinabox_cs11-pt_BR-5.0.0-beta.2.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.2/adafruit-circuitpython-xinabox_cs11-zh_Latn_pinyin-5.0.0-beta.2.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-beta.2"
             }
         ]
     }


### PR DESCRIPTION
Automated website update for release 5.0.0-beta.2 by Blinka.

New boards:
* teknikio_bluebird
* xinabox_cc03
* xinabox_cs11
* stm32f411ce_blackpill


