### PR TITLE
Added board counter for downloads

### DIFF
--- a/assets/javascript/downloads.js
+++ b/assets/javascript/downloads.js
@@ -255,14 +255,16 @@ function filterResults() {
   setFeaturesChecked();
 
   var downloads = document.querySelectorAll('.download');
-
+  var board_count = 0
   downloads.forEach(function(download) {
     if (!shouldDisplayDownload(download, displayedManufacturers, displayedFeatures)) {
       download.style.display = 'none';
     } else {
       download.style.display = 'block';
+      board_count++;
     }
   });
+  document.getElementById("board_count").innerHTML = board_count;
 }
 
 function handleSortResults(event) {

--- a/downloads.html
+++ b/downloads.html
@@ -47,6 +47,32 @@ permalink: /downloads
       </div>
     </div>
   </div>
+  <div class="download-count">
+      {% comment %}
+        Get a total number of boards by running through both loops
+        to get an accurate total.
+      {% endcomment %}
+      {% assign board_count = 0 %}
+      {% assign boards = site.data.files %}
+      {% for board in boards %}
+        {% assign info = site.board | where: 'board_id', board.id %}
+        {% if info.size == 0 %}
+          {% assign info = site.board | where: 'board_id', 'unknown' %}
+        {% endif %}
+        {% assign info = info[0] %}
+        {% if info.downloads_display == false %}
+          {% continue %}
+        {% endif %}
+        {% assign board_count = board_count | plus: 1 %}
+      {% endfor %}
+      {% for board in site.board %}
+        {% assign info = site.data.files | where: 'id', board.board_id | first %}
+        {% if info == nil and board.board_id != 'unknown' %}
+          {% assign board_count = board_count | plus: 1 %}
+        {% endif %}
+      {% endfor %}
+      Displaying <span id="board_count">{{ board_count }}</span> boards.
+  </div>
   <div class="downloads-section">
     {% comment %}
       The following are boards that are in the _data/files.json build


### PR DESCRIPTION
As suggested in #347, this adds a board counter for the downloads. Tested on my system locally with Jekyll. If it all looks good, I'll add the same to the Blinka page.