### PR TITLE
fix feature list for open book

### DIFF
--- a/_board/openbook_m4.md
+++ b/_board/openbook_m4.md
@@ -7,11 +7,9 @@ manufacturer: "Oddly Specific Objects"
 board_url: "https://github.com/joeycastillo/The-Open-Book"
 board_image: "openbook_m4.jpg"
 features:
-  - 400x300 e-paper display
-  - Feather & STEMMA compatible
-  - MicroSD card slot
-  - Audio jack for stereo audio + mic input
-  - Detailed explanatory silkscreen
+  - Feather-Compatible
+  - Battery Charging
+  - Display
 ---
 
 The Open Book is an open-hardware device for reading books in all the languages of the world. It includes a large screen and buttons for navigation, as well as audio options for accessibility and ports to extend its functionality. Its detailed silkscreen, with the all the manic energy and quixotic ambition of a Dr. Bronner's bottle, aims to demystify the Open Book's own design, breaking down for the curious reader both how the book works, and how they can build one for themselves.


### PR DESCRIPTION
This was an oversight on my part; I didn't realize that the feature list was intended for tags and not freeform text. 

We could also add all the defined tags to template.md with a comment, which would clarify this for folks submitting new boards.