### PR TITLE
Clarify the features list

### DIFF
--- a/template.md
+++ b/template.md
@@ -9,10 +9,19 @@ board_image: "unknown.jpg"
 downloads_display: true
 blinka: false
 download_instructions: "BLINKA ONLY - url"
+# Features are tags; they should be limited to the items in this list and spelled exactly the same.
+# Include only the features your board supports, and remove these comment lines before committing.
 features:
-  - ~5 interesting
-  - features
-  - such as bluetooth
+  - Speaker
+  - Solder-Free Alligator Clip
+  - Feather-Compatible
+  - Battery Charging
+  - Display
+  - Wi-Fi
+  - Bluetooth/BTLE
+  - Robotics
+  - LoRa/Radio
+  - GPS
 ---
 
 This board hasn't been fully documented yet. Please make a pull request adding more info to this file.


### PR DESCRIPTION
@makermelissa asked me to open an issue for a suggestion I made in #380; I figured it would be easier to just make it a pull request. The learn guide for adding a board mentions the constraints on tags, but the README doesn't; I think adding instructions and the official tags to the template file would streamline this process for people adding new boards.