### PR TITLE
Fixing Orange Pi Malformed files

### DIFF
--- a/_blinka/orange_pi_lite.md
+++ b/_blinka/orange_pi_lite.md
@@ -1,6 +1,6 @@
 ---
 layout: download
-board_id: "orange_pi_lite
+board_id: "orange_pi_lite"
 title: "Orange Pi Lite Download"
 name: "Orange Pi Lite"
 manufacturer: "Shenzhen Xunlong Software CO.,Limited"

--- a/_blinka/orange_pi_one.md
+++ b/_blinka/orange_pi_one.md
@@ -5,7 +5,7 @@ title: "Orange Pi One Download"
 name: "Orange Pi One"
 manufacturer: "Shenzhen Xunlong Software CO.,Limited"
 board_url: "http://www.orangepi.org/orangepione/"
-board_image: "orange_pi_one.jpg"
+board_image: "orange_pi_one.png"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-orangepi-linux/circuitpython-orangepi"
 downloads_display: true
 blinka: true


### PR DESCRIPTION
Found missing quote mark in one and other referred to jpg instead of png.