### PR TITLE
Automated website update for release 5.0.0-rc.0

### DIFF
--- a/_data/files.json
+++ b/_data/files.json
@@ -1,54 +1,54 @@
 [
     {
-        "downloads": 4,
+        "downloads": 1,
         "id": "aramcon_badge_2019",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-aramcon_badge_2019-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-aramcon_badge_2019-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-aramcon_badge_2019-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-aramcon_badge_2019-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-aramcon_badge_2019-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-aramcon_badge_2019-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-aramcon_badge_2019-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-aramcon_badge_2019-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-aramcon_badge_2019-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-aramcon_badge_2019-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-aramcon_badge_2019-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-aramcon_badge_2019-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-aramcon_badge_2019-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-aramcon_badge_2019-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-aramcon_badge_2019-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-aramcon_badge_2019-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-aramcon_badge_2019-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-aramcon_badge_2019-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-aramcon_badge_2019-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-aramcon_badge_2019-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-aramcon_badge_2019-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-aramcon_badge_2019-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-aramcon_badge_2019-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-aramcon_badge_2019-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 43,
+        "downloads": 62,
         "id": "arduino_mkr1300",
         "versions": [
             {
@@ -93,49 +93,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_mkr1300-ID-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_mkr1300-ID-5.0.0-rc.0.bin"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_mkr1300-de_DE-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_mkr1300-de_DE-5.0.0-rc.0.bin"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_mkr1300-en_US-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_mkr1300-en_US-5.0.0-rc.0.bin"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_mkr1300-en_x_pirate-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_mkr1300-en_x_pirate-5.0.0-rc.0.bin"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_mkr1300-es-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_mkr1300-es-5.0.0-rc.0.bin"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_mkr1300-fil-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_mkr1300-fil-5.0.0-rc.0.bin"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_mkr1300-fr-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_mkr1300-fr-5.0.0-rc.0.bin"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_mkr1300-it_IT-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_mkr1300-it_IT-5.0.0-rc.0.bin"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_mkr1300-ko-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_mkr1300-ko-5.0.0-rc.0.bin"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_mkr1300-pl-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_mkr1300-pl-5.0.0-rc.0.bin"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_mkr1300-pt_BR-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_mkr1300-pt_BR-5.0.0-rc.0.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_mkr1300-zh_Latn_pinyin-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_mkr1300-zh_Latn_pinyin-5.0.0-rc.0.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 26,
+        "downloads": 45,
         "id": "arduino_mkrzero",
         "versions": [
             {
@@ -180,97 +180,145 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_mkrzero-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_mkrzero-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_mkrzero-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_mkrzero-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_mkrzero-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_mkrzero-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_mkrzero-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_mkrzero-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_mkrzero-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_mkrzero-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_mkrzero-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_mkrzero-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_mkrzero-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_mkrzero-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_mkrzero-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_mkrzero-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_mkrzero-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_mkrzero-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_mkrzero-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_mkrzero-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_mkrzero-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_mkrzero-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_mkrzero-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_mkrzero-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 7,
+        "downloads": 23,
         "id": "arduino_nano_33_ble",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_nano_33_ble-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_nano_33_ble-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_nano_33_ble-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_nano_33_ble-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_nano_33_ble-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_nano_33_ble-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_nano_33_ble-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_nano_33_ble-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_nano_33_ble-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_nano_33_ble-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_nano_33_ble-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_nano_33_ble-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_nano_33_ble-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_nano_33_ble-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_nano_33_ble-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_nano_33_ble-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_nano_33_ble-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_nano_33_ble-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_nano_33_ble-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_nano_33_ble-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_nano_33_ble-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_nano_33_ble-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_nano_33_ble-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_nano_33_ble-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 68,
+        "downloads": 0,
+        "id": "arduino_nano_33_iot",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_nano_33_iot-ID-5.0.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_nano_33_iot-de_DE-5.0.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_nano_33_iot-en_US-5.0.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_nano_33_iot-en_x_pirate-5.0.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_nano_33_iot-es-5.0.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_nano_33_iot-fil-5.0.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_nano_33_iot-fr-5.0.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_nano_33_iot-it_IT-5.0.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_nano_33_iot-ko-5.0.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_nano_33_iot-pl-5.0.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_nano_33_iot-pt_BR-5.0.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_nano_33_iot-zh_Latn_pinyin-5.0.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-rc.0"
+            }
+        ]
+    },
+    {
+        "downloads": 94,
         "id": "arduino_zero",
         "versions": [
             {
@@ -315,49 +363,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_zero-ID-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_zero-ID-5.0.0-rc.0.bin"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_zero-de_DE-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_zero-de_DE-5.0.0-rc.0.bin"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_zero-en_US-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_zero-en_US-5.0.0-rc.0.bin"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_zero-en_x_pirate-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_zero-en_x_pirate-5.0.0-rc.0.bin"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_zero-es-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_zero-es-5.0.0-rc.0.bin"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_zero-fil-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_zero-fil-5.0.0-rc.0.bin"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_zero-fr-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_zero-fr-5.0.0-rc.0.bin"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_zero-it_IT-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_zero-it_IT-5.0.0-rc.0.bin"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_zero-ko-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_zero-ko-5.0.0-rc.0.bin"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_zero-pl-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_zero-pl-5.0.0-rc.0.bin"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_zero-pt_BR-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_zero-pt_BR-5.0.0-rc.0.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-arduino_zero-zh_Latn_pinyin-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-arduino_zero-zh_Latn_pinyin-5.0.0-rc.0.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 12,
+        "downloads": 14,
         "id": "bast_pro_mini_m0",
         "versions": [
             {
@@ -402,49 +450,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-bast_pro_mini_m0-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-bast_pro_mini_m0-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-bast_pro_mini_m0-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-bast_pro_mini_m0-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-bast_pro_mini_m0-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-bast_pro_mini_m0-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-bast_pro_mini_m0-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-bast_pro_mini_m0-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-bast_pro_mini_m0-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-bast_pro_mini_m0-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-bast_pro_mini_m0-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-bast_pro_mini_m0-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-bast_pro_mini_m0-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-bast_pro_mini_m0-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-bast_pro_mini_m0-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-bast_pro_mini_m0-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-bast_pro_mini_m0-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-bast_pro_mini_m0-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-bast_pro_mini_m0-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-bast_pro_mini_m0-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-bast_pro_mini_m0-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-bast_pro_mini_m0-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-bast_pro_mini_m0-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-bast_pro_mini_m0-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 22,
+        "downloads": 23,
         "id": "capablerobot_usbhub",
         "versions": [
             {
@@ -489,49 +537,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-capablerobot_usbhub-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-capablerobot_usbhub-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-capablerobot_usbhub-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-capablerobot_usbhub-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-capablerobot_usbhub-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-capablerobot_usbhub-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-capablerobot_usbhub-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-capablerobot_usbhub-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-capablerobot_usbhub-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-capablerobot_usbhub-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-capablerobot_usbhub-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-capablerobot_usbhub-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-capablerobot_usbhub-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-capablerobot_usbhub-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-capablerobot_usbhub-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-capablerobot_usbhub-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-capablerobot_usbhub-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-capablerobot_usbhub-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-capablerobot_usbhub-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-capablerobot_usbhub-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-capablerobot_usbhub-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-capablerobot_usbhub-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-capablerobot_usbhub-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-capablerobot_usbhub-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 16,
+        "downloads": 17,
         "id": "catwan_usbstick",
         "versions": [
             {
@@ -576,97 +624,193 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-catwan_usbstick-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-catwan_usbstick-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-catwan_usbstick-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-catwan_usbstick-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-catwan_usbstick-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-catwan_usbstick-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-catwan_usbstick-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-catwan_usbstick-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-catwan_usbstick-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-catwan_usbstick-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-catwan_usbstick-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-catwan_usbstick-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-catwan_usbstick-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-catwan_usbstick-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-catwan_usbstick-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-catwan_usbstick-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-catwan_usbstick-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-catwan_usbstick-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-catwan_usbstick-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-catwan_usbstick-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-catwan_usbstick-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-catwan_usbstick-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-catwan_usbstick-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-catwan_usbstick-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 285,
+        "downloads": 0,
+        "id": "circuitbrains_basic_m0",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitbrains_basic_m0-ID-5.0.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitbrains_basic_m0-de_DE-5.0.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitbrains_basic_m0-en_US-5.0.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitbrains_basic_m0-en_x_pirate-5.0.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitbrains_basic_m0-es-5.0.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitbrains_basic_m0-fil-5.0.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitbrains_basic_m0-fr-5.0.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitbrains_basic_m0-it_IT-5.0.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitbrains_basic_m0-ko-5.0.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitbrains_basic_m0-pl-5.0.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitbrains_basic_m0-pt_BR-5.0.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitbrains_basic_m0-zh_Latn_pinyin-5.0.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-rc.0"
+            }
+        ]
+    },
+    {
+        "downloads": 0,
+        "id": "circuitbrains_deluxe_m4",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitbrains_deluxe_m4-ID-5.0.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitbrains_deluxe_m4-de_DE-5.0.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitbrains_deluxe_m4-en_US-5.0.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitbrains_deluxe_m4-en_x_pirate-5.0.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitbrains_deluxe_m4-es-5.0.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitbrains_deluxe_m4-fil-5.0.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitbrains_deluxe_m4-fr-5.0.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitbrains_deluxe_m4-it_IT-5.0.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitbrains_deluxe_m4-ko-5.0.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitbrains_deluxe_m4-pl-5.0.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitbrains_deluxe_m4-pt_BR-5.0.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitbrains_deluxe_m4-zh_Latn_pinyin-5.0.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-rc.0"
+            }
+        ]
+    },
+    {
+        "downloads": 364,
         "id": "circuitplayground_bluefruit",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_bluefruit-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_bluefruit-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_bluefruit-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_bluefruit-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_bluefruit-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_bluefruit-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_bluefruit-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_bluefruit-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_bluefruit-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_bluefruit-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_bluefruit-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_bluefruit-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_bluefruit-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_bluefruit-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_bluefruit-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_bluefruit-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_bluefruit-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_bluefruit-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_bluefruit-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_bluefruit-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_bluefruit-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_bluefruit-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_bluefruit-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_bluefruit-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 2699,
+        "downloads": 3706,
         "id": "circuitplayground_express",
         "versions": [
             {
@@ -711,49 +855,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 44,
+        "downloads": 47,
         "id": "circuitplayground_express_4h",
         "versions": [
             {
@@ -798,49 +942,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_4h-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_4h-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_4h-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_4h-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_4h-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_4h-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_4h-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_4h-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_4h-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_4h-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_4h-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_4h-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_4h-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_4h-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_4h-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_4h-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_4h-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_4h-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_4h-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_4h-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_4h-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_4h-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_4h-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_4h-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 167,
+        "downloads": 229,
         "id": "circuitplayground_express_crickit",
         "versions": [
             {
@@ -885,49 +1029,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_crickit-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_crickit-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_crickit-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_crickit-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_crickit-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_crickit-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_crickit-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_crickit-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_crickit-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_crickit-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_crickit-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_crickit-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_crickit-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_crickit-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_crickit-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_crickit-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_crickit-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_crickit-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_crickit-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_crickit-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_crickit-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_crickit-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_crickit-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_crickit-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 33,
+        "downloads": 36,
         "id": "circuitplayground_express_digikey_pycon2019",
         "versions": [
             {
@@ -972,140 +1116,140 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 12,
+        "downloads": 29,
         "id": "circuitplayground_express_displayio",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_displayio-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_displayio-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_displayio-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_displayio-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_displayio-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_displayio-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_displayio-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_displayio-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_displayio-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_displayio-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_displayio-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_displayio-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_displayio-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_displayio-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_displayio-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_displayio-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_displayio-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_displayio-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_displayio-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_displayio-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_displayio-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_displayio-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-circuitplayground_express_displayio-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-circuitplayground_express_displayio-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 37,
+        "downloads": 238,
         "id": "clue_nrf52840_express",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-clue_nrf52840_express-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-clue_nrf52840_express-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-clue_nrf52840_express-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-clue_nrf52840_express-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-clue_nrf52840_express-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-clue_nrf52840_express-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-clue_nrf52840_express-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-clue_nrf52840_express-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-clue_nrf52840_express-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-clue_nrf52840_express-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-clue_nrf52840_express-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-clue_nrf52840_express-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-clue_nrf52840_express-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-clue_nrf52840_express-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-clue_nrf52840_express-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-clue_nrf52840_express-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-clue_nrf52840_express-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-clue_nrf52840_express-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-clue_nrf52840_express-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-clue_nrf52840_express-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-clue_nrf52840_express-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-clue_nrf52840_express-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-clue_nrf52840_express-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-clue_nrf52840_express-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
@@ -1155,44 +1299,44 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-cp32-m4-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-cp32-m4-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-cp32-m4-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-cp32-m4-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-cp32-m4-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-cp32-m4-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-cp32-m4-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-cp32-m4-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-cp32-m4-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-cp32-m4-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-cp32-m4-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-cp32-m4-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-cp32-m4-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-cp32-m4-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-cp32-m4-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-cp32-m4-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-cp32-m4-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-cp32-m4-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-cp32-m4-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-cp32-m4-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-cp32-m4-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-cp32-m4-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-cp32-m4-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-cp32-m4-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
@@ -1242,49 +1386,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datalore_ip_m4-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datalore_ip_m4-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datalore_ip_m4-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datalore_ip_m4-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datalore_ip_m4-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datalore_ip_m4-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datalore_ip_m4-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datalore_ip_m4-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datalore_ip_m4-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datalore_ip_m4-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datalore_ip_m4-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datalore_ip_m4-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datalore_ip_m4-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datalore_ip_m4-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datalore_ip_m4-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datalore_ip_m4-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datalore_ip_m4-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datalore_ip_m4-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datalore_ip_m4-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datalore_ip_m4-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datalore_ip_m4-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datalore_ip_m4-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datalore_ip_m4-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datalore_ip_m4-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 17,
+        "downloads": 18,
         "id": "datum_distance",
         "versions": [
             {
@@ -1329,49 +1473,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_distance-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_distance-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_distance-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_distance-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_distance-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_distance-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_distance-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_distance-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_distance-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_distance-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_distance-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_distance-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_distance-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_distance-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_distance-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_distance-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_distance-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_distance-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_distance-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_distance-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_distance-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_distance-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_distance-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_distance-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 19,
+        "downloads": 20,
         "id": "datum_imu",
         "versions": [
             {
@@ -1416,49 +1560,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_imu-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_imu-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_imu-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_imu-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_imu-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_imu-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_imu-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_imu-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_imu-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_imu-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_imu-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_imu-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_imu-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_imu-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_imu-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_imu-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_imu-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_imu-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_imu-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_imu-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_imu-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_imu-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_imu-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_imu-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 13,
+        "downloads": 14,
         "id": "datum_light",
         "versions": [
             {
@@ -1503,49 +1647,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_light-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_light-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_light-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_light-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_light-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_light-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_light-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_light-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_light-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_light-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_light-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_light-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_light-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_light-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_light-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_light-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_light-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_light-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_light-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_light-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_light-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_light-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_light-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_light-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 15,
+        "downloads": 16,
         "id": "datum_weather",
         "versions": [
             {
@@ -1590,97 +1734,97 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_weather-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_weather-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_weather-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_weather-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_weather-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_weather-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_weather-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_weather-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_weather-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_weather-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_weather-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_weather-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_weather-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_weather-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_weather-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_weather-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_weather-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_weather-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_weather-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_weather-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_weather-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_weather-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-datum_weather-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-datum_weather-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 12,
+        "downloads": 20,
         "id": "edgebadge",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-edgebadge-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-edgebadge-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-edgebadge-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-edgebadge-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-edgebadge-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-edgebadge-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-edgebadge-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-edgebadge-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-edgebadge-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-edgebadge-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-edgebadge-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-edgebadge-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-edgebadge-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-edgebadge-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-edgebadge-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-edgebadge-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-edgebadge-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-edgebadge-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-edgebadge-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-edgebadge-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-edgebadge-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-edgebadge-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-edgebadge-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-edgebadge-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 16,
+        "downloads": 17,
         "id": "electronut_labs_blip",
         "versions": [
             {
@@ -1725,49 +1869,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-electronut_labs_blip-ID-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-electronut_labs_blip-ID-5.0.0-rc.0.hex"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-electronut_labs_blip-de_DE-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-electronut_labs_blip-de_DE-5.0.0-rc.0.hex"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-electronut_labs_blip-en_US-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-electronut_labs_blip-en_US-5.0.0-rc.0.hex"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-electronut_labs_blip-en_x_pirate-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-electronut_labs_blip-en_x_pirate-5.0.0-rc.0.hex"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-electronut_labs_blip-es-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-electronut_labs_blip-es-5.0.0-rc.0.hex"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-electronut_labs_blip-fil-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-electronut_labs_blip-fil-5.0.0-rc.0.hex"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-electronut_labs_blip-fr-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-electronut_labs_blip-fr-5.0.0-rc.0.hex"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-electronut_labs_blip-it_IT-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-electronut_labs_blip-it_IT-5.0.0-rc.0.hex"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-electronut_labs_blip-ko-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-electronut_labs_blip-ko-5.0.0-rc.0.hex"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-electronut_labs_blip-pl-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-electronut_labs_blip-pl-5.0.0-rc.0.hex"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-electronut_labs_blip-pt_BR-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-electronut_labs_blip-pt_BR-5.0.0-rc.0.hex"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-electronut_labs_blip-zh_Latn_pinyin-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-electronut_labs_blip-zh_Latn_pinyin-5.0.0-rc.0.hex"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 22,
+        "downloads": 24,
         "id": "electronut_labs_papyr",
         "versions": [
             {
@@ -1812,44 +1956,44 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-electronut_labs_papyr-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-electronut_labs_papyr-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-electronut_labs_papyr-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-electronut_labs_papyr-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-electronut_labs_papyr-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-electronut_labs_papyr-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-electronut_labs_papyr-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-electronut_labs_papyr-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-electronut_labs_papyr-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-electronut_labs_papyr-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-electronut_labs_papyr-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-electronut_labs_papyr-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-electronut_labs_papyr-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-electronut_labs_papyr-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-electronut_labs_papyr-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-electronut_labs_papyr-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-electronut_labs_papyr-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-electronut_labs_papyr-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-electronut_labs_papyr-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-electronut_labs_papyr-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-electronut_labs_papyr-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-electronut_labs_papyr-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-electronut_labs_papyr-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-electronut_labs_papyr-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
@@ -1899,97 +2043,193 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-escornabot_makech-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-escornabot_makech-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-escornabot_makech-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-escornabot_makech-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-escornabot_makech-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-escornabot_makech-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-escornabot_makech-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-escornabot_makech-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-escornabot_makech-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-escornabot_makech-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-escornabot_makech-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-escornabot_makech-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-escornabot_makech-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-escornabot_makech-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-escornabot_makech-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-escornabot_makech-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-escornabot_makech-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-escornabot_makech-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-escornabot_makech-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-escornabot_makech-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-escornabot_makech-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-escornabot_makech-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-escornabot_makech-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-escornabot_makech-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
         "downloads": 0,
+        "id": "espruino_pico",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-espruino_pico-ID-5.0.0-rc.0.bin"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-espruino_pico-de_DE-5.0.0-rc.0.bin"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-espruino_pico-en_US-5.0.0-rc.0.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-espruino_pico-en_x_pirate-5.0.0-rc.0.bin"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-espruino_pico-es-5.0.0-rc.0.bin"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-espruino_pico-fil-5.0.0-rc.0.bin"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-espruino_pico-fr-5.0.0-rc.0.bin"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-espruino_pico-it_IT-5.0.0-rc.0.bin"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-espruino_pico-ko-5.0.0-rc.0.bin"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-espruino_pico-pl-5.0.0-rc.0.bin"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-espruino_pico-pt_BR-5.0.0-rc.0.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-espruino_pico-zh_Latn_pinyin-5.0.0-rc.0.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-rc.0"
+            }
+        ]
+    },
+    {
+        "downloads": 0,
+        "id": "espruino_wifi",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-espruino_wifi-ID-5.0.0-rc.0.bin"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-espruino_wifi-de_DE-5.0.0-rc.0.bin"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-espruino_wifi-en_US-5.0.0-rc.0.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-espruino_wifi-en_x_pirate-5.0.0-rc.0.bin"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-espruino_wifi-es-5.0.0-rc.0.bin"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-espruino_wifi-fil-5.0.0-rc.0.bin"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-espruino_wifi-fr-5.0.0-rc.0.bin"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-espruino_wifi-it_IT-5.0.0-rc.0.bin"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-espruino_wifi-ko-5.0.0-rc.0.bin"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-espruino_wifi-pl-5.0.0-rc.0.bin"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-espruino_wifi-pt_BR-5.0.0-rc.0.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-espruino_wifi-zh_Latn_pinyin-5.0.0-rc.0.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-rc.0"
+            }
+        ]
+    },
+    {
+        "downloads": 12,
         "id": "feather_bluefruit_sense",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_bluefruit_sense-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_bluefruit_sense-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_bluefruit_sense-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_bluefruit_sense-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_bluefruit_sense-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_bluefruit_sense-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_bluefruit_sense-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_bluefruit_sense-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_bluefruit_sense-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_bluefruit_sense-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_bluefruit_sense-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_bluefruit_sense-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_bluefruit_sense-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_bluefruit_sense-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_bluefruit_sense-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_bluefruit_sense-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_bluefruit_sense-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_bluefruit_sense-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_bluefruit_sense-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_bluefruit_sense-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_bluefruit_sense-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_bluefruit_sense-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_bluefruit_sense-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_bluefruit_sense-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 145,
+        "downloads": 208,
         "id": "feather_m0_adalogger",
         "versions": [
             {
@@ -2045,61 +2285,61 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-ID-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_adalogger-ID-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_adalogger-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-de_DE-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_adalogger-de_DE-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_adalogger-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-en_US-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_adalogger-en_US-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_adalogger-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-es-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_adalogger-es-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_adalogger-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-fil-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_adalogger-fil-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_adalogger-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-fr-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_adalogger-fr-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_adalogger-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-it_IT-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_adalogger-it_IT-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_adalogger-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-ko-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_adalogger-ko-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_adalogger-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-pl-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_adalogger-pl-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_adalogger-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-pt_BR-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_adalogger-pt_BR-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_adalogger-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-zh_Latn_pinyin-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_adalogger-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_adalogger-zh_Latn_pinyin-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_adalogger-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 166,
+        "downloads": 218,
         "id": "feather_m0_basic",
         "versions": [
             {
@@ -2155,61 +2395,61 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-ID-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_basic-ID-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_basic-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-de_DE-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_basic-de_DE-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_basic-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-en_US-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_basic-en_US-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_basic-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-en_x_pirate-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_basic-en_x_pirate-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_basic-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-es-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_basic-es-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_basic-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-fil-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_basic-fil-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_basic-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-fr-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_basic-fr-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_basic-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-it_IT-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_basic-it_IT-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_basic-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-ko-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_basic-ko-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_basic-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-pl-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_basic-pl-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_basic-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-pt_BR-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_basic-pt_BR-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_basic-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-zh_Latn_pinyin-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_basic-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_basic-zh_Latn_pinyin-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_basic-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 359,
+        "downloads": 523,
         "id": "feather_m0_express",
         "versions": [
             {
@@ -2254,49 +2494,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_express-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_express-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_express-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_express-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_express-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_express-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_express-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_express-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_express-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_express-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_express-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_express-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_express-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_express-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_express-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_express-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_express-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_express-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_express-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_express-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_express-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_express-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_express-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_express-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 34,
+        "downloads": 36,
         "id": "feather_m0_express_crickit",
         "versions": [
             {
@@ -2341,49 +2581,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_express_crickit-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_express_crickit-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_express_crickit-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_express_crickit-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_express_crickit-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_express_crickit-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_express_crickit-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_express_crickit-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_express_crickit-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_express_crickit-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_express_crickit-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_express_crickit-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_express_crickit-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_express_crickit-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_express_crickit-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_express_crickit-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_express_crickit-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_express_crickit-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_express_crickit-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_express_crickit-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_express_crickit-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_express_crickit-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_express_crickit-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_express_crickit-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 77,
+        "downloads": 105,
         "id": "feather_m0_rfm69",
         "versions": [
             {
@@ -2439,61 +2679,61 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-ID-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm69-ID-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm69-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-de_DE-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm69-de_DE-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm69-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-en_US-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm69-en_US-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm69-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-es-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm69-es-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm69-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-fil-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm69-fil-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm69-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-fr-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm69-fr-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm69-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-it_IT-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm69-it_IT-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm69-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-ko-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm69-ko-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm69-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-pl-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm69-pl-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm69-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-pt_BR-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm69-pt_BR-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm69-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-zh_Latn_pinyin-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm69-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm69-zh_Latn_pinyin-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm69-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 148,
+        "downloads": 211,
         "id": "feather_m0_rfm9x",
         "versions": [
             {
@@ -2549,61 +2789,61 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-ID-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm9x-ID-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm9x-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-de_DE-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm9x-de_DE-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm9x-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-en_US-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm9x-en_US-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm9x-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-es-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm9x-es-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm9x-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-fil-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm9x-fil-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm9x-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-fr-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm9x-fr-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm9x-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-it_IT-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm9x-it_IT-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm9x-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-ko-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm9x-ko-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm9x-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-pl-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm9x-pl-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm9x-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-zh_Latn_pinyin-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_rfm9x-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm9x-zh_Latn_pinyin-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_rfm9x-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 2,
+        "downloads": 0,
         "id": "feather_m0_supersized",
         "versions": [
             {
@@ -2648,49 +2888,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_supersized-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_supersized-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_supersized-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_supersized-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_supersized-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_supersized-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_supersized-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_supersized-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_supersized-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_supersized-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_supersized-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_supersized-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_supersized-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_supersized-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_supersized-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_supersized-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_supersized-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_supersized-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_supersized-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_supersized-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_supersized-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_supersized-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m0_supersized-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m0_supersized-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 722,
+        "downloads": 1223,
         "id": "feather_m4_express",
         "versions": [
             {
@@ -2735,169 +2975,229 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m4_express-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m4_express-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m4_express-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m4_express-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m4_express-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m4_express-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m4_express-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m4_express-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m4_express-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m4_express-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m4_express-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m4_express-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m4_express-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m4_express-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m4_express-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m4_express-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m4_express-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m4_express-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m4_express-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m4_express-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m4_express-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m4_express-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_m4_express-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m4_express-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 1,
-        "id": "feather_mimxrt1011",
+        "downloads": 0,
+        "id": "feather_m7_1011",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1011-ID-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1011-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m7_1011-ID-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m7_1011-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1011-de_DE-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1011-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m7_1011-de_DE-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m7_1011-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1011-en_US-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1011-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m7_1011-en_US-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m7_1011-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1011-en_x_pirate-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1011-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m7_1011-en_x_pirate-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m7_1011-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1011-es-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1011-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m7_1011-es-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m7_1011-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1011-fil-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1011-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m7_1011-fil-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m7_1011-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1011-fr-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1011-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m7_1011-fr-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m7_1011-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1011-it_IT-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1011-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m7_1011-it_IT-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m7_1011-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1011-ko-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1011-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m7_1011-ko-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m7_1011-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1011-pl-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1011-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m7_1011-pl-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m7_1011-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1011-pt_BR-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1011-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m7_1011-pt_BR-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m7_1011-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1011-zh_Latn_pinyin-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1011-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m7_1011-zh_Latn_pinyin-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_m7_1011-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
         "downloads": 6,
+        "id": "feather_mimxrt1011",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1011-ID-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1011-ID-5.0.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1011-de_DE-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1011-de_DE-5.0.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1011-en_US-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1011-en_US-5.0.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1011-en_x_pirate-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1011-en_x_pirate-5.0.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1011-es-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1011-es-5.0.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1011-fil-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1011-fil-5.0.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1011-fr-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1011-fr-5.0.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1011-it_IT-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1011-it_IT-5.0.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1011-ko-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1011-ko-5.0.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1011-pl-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1011-pl-5.0.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1011-pt_BR-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1011-pt_BR-5.0.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1011-zh_Latn_pinyin-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1011-zh_Latn_pinyin-5.0.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-rc.0"
+            }
+        ]
+    },
+    {
+        "downloads": 8,
         "id": "feather_mimxrt1062",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1062-ID-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1062-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1062-ID-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1062-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1062-de_DE-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1062-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1062-de_DE-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1062-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1062-en_US-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1062-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1062-en_US-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1062-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1062-en_x_pirate-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1062-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1062-en_x_pirate-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1062-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1062-es-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1062-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1062-es-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1062-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1062-fil-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1062-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1062-fil-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1062-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1062-fr-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1062-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1062-fr-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1062-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1062-it_IT-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1062-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1062-it_IT-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1062-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1062-ko-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1062-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1062-ko-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1062-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1062-pl-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1062-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1062-pl-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1062-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1062-pt_BR-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1062-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1062-pt_BR-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1062-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1062-zh_Latn_pinyin-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_mimxrt1062-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1062-zh_Latn_pinyin-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_mimxrt1062-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 218,
+        "downloads": 346,
         "id": "feather_nrf52840_express",
         "versions": [
             {
@@ -2942,49 +3242,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_nrf52840_express-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_nrf52840_express-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_nrf52840_express-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_nrf52840_express-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_nrf52840_express-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_nrf52840_express-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_nrf52840_express-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_nrf52840_express-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_nrf52840_express-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_nrf52840_express-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_nrf52840_express-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_nrf52840_express-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_nrf52840_express-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_nrf52840_express-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_nrf52840_express-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_nrf52840_express-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_nrf52840_express-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_nrf52840_express-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_nrf52840_express-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_nrf52840_express-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_nrf52840_express-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_nrf52840_express-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_nrf52840_express-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_nrf52840_express-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 28,
+        "downloads": 29,
         "id": "feather_radiofruit_zigbee",
         "versions": [
             {
@@ -3029,92 +3329,92 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_radiofruit_zigbee-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_radiofruit_zigbee-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_radiofruit_zigbee-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_radiofruit_zigbee-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_radiofruit_zigbee-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_radiofruit_zigbee-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_radiofruit_zigbee-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_radiofruit_zigbee-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_radiofruit_zigbee-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_radiofruit_zigbee-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_radiofruit_zigbee-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_radiofruit_zigbee-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_radiofruit_zigbee-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_radiofruit_zigbee-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_radiofruit_zigbee-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_radiofruit_zigbee-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_radiofruit_zigbee-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_radiofruit_zigbee-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_radiofruit_zigbee-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_radiofruit_zigbee-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_radiofruit_zigbee-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_radiofruit_zigbee-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_radiofruit_zigbee-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_radiofruit_zigbee-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 53,
+        "downloads": 49,
         "id": "feather_stm32f405_express",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_stm32f405_express-ID-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_stm32f405_express-ID-5.0.0-rc.0.bin"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_stm32f405_express-de_DE-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_stm32f405_express-de_DE-5.0.0-rc.0.bin"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_stm32f405_express-en_US-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_stm32f405_express-en_US-5.0.0-rc.0.bin"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_stm32f405_express-en_x_pirate-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_stm32f405_express-en_x_pirate-5.0.0-rc.0.bin"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_stm32f405_express-es-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_stm32f405_express-es-5.0.0-rc.0.bin"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_stm32f405_express-fil-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_stm32f405_express-fil-5.0.0-rc.0.bin"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_stm32f405_express-fr-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_stm32f405_express-fr-5.0.0-rc.0.bin"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_stm32f405_express-it_IT-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_stm32f405_express-it_IT-5.0.0-rc.0.bin"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_stm32f405_express-ko-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_stm32f405_express-ko-5.0.0-rc.0.bin"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_stm32f405_express-pl-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_stm32f405_express-pl-5.0.0-rc.0.bin"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_stm32f405_express-pt_BR-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_stm32f405_express-pt_BR-5.0.0-rc.0.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-feather_stm32f405_express-zh_Latn_pinyin-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-feather_stm32f405_express-zh_Latn_pinyin-5.0.0-rc.0.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
@@ -3124,7 +3424,7 @@
         "versions": []
     },
     {
-        "downloads": 290,
+        "downloads": 390,
         "id": "gemma_m0",
         "versions": [
             {
@@ -3169,49 +3469,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-gemma_m0-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-gemma_m0-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-gemma_m0-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-gemma_m0-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-gemma_m0-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-gemma_m0-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-gemma_m0-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-gemma_m0-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-gemma_m0-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-gemma_m0-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-gemma_m0-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-gemma_m0-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-gemma_m0-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-gemma_m0-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-gemma_m0-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-gemma_m0-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-gemma_m0-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-gemma_m0-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-gemma_m0-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-gemma_m0-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-gemma_m0-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-gemma_m0-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-gemma_m0-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-gemma_m0-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 41,
+        "downloads": 44,
         "id": "gemma_m0_pycon2018",
         "versions": [
             {
@@ -3256,49 +3556,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-gemma_m0_pycon2018-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-gemma_m0_pycon2018-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-gemma_m0_pycon2018-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-gemma_m0_pycon2018-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-gemma_m0_pycon2018-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-gemma_m0_pycon2018-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-gemma_m0_pycon2018-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-gemma_m0_pycon2018-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-gemma_m0_pycon2018-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-gemma_m0_pycon2018-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-gemma_m0_pycon2018-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-gemma_m0_pycon2018-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-gemma_m0_pycon2018-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-gemma_m0_pycon2018-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-gemma_m0_pycon2018-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-gemma_m0_pycon2018-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-gemma_m0_pycon2018-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-gemma_m0_pycon2018-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-gemma_m0_pycon2018-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-gemma_m0_pycon2018-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-gemma_m0_pycon2018-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-gemma_m0_pycon2018-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-gemma_m0_pycon2018-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-gemma_m0_pycon2018-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 150,
+        "downloads": 202,
         "id": "grandcentral_m4_express",
         "versions": [
             {
@@ -3343,49 +3643,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-grandcentral_m4_express-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-grandcentral_m4_express-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-grandcentral_m4_express-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-grandcentral_m4_express-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-grandcentral_m4_express-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-grandcentral_m4_express-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-grandcentral_m4_express-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-grandcentral_m4_express-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-grandcentral_m4_express-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-grandcentral_m4_express-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-grandcentral_m4_express-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-grandcentral_m4_express-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-grandcentral_m4_express-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-grandcentral_m4_express-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-grandcentral_m4_express-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-grandcentral_m4_express-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-grandcentral_m4_express-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-grandcentral_m4_express-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-grandcentral_m4_express-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-grandcentral_m4_express-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-grandcentral_m4_express-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-grandcentral_m4_express-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-grandcentral_m4_express-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-grandcentral_m4_express-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 93,
+        "downloads": 107,
         "id": "hallowing_m0_express",
         "versions": [
             {
@@ -3430,49 +3730,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-hallowing_m0_express-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-hallowing_m0_express-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-hallowing_m0_express-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-hallowing_m0_express-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-hallowing_m0_express-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-hallowing_m0_express-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-hallowing_m0_express-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-hallowing_m0_express-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-hallowing_m0_express-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-hallowing_m0_express-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-hallowing_m0_express-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-hallowing_m0_express-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-hallowing_m0_express-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-hallowing_m0_express-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-hallowing_m0_express-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-hallowing_m0_express-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-hallowing_m0_express-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-hallowing_m0_express-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-hallowing_m0_express-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-hallowing_m0_express-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-hallowing_m0_express-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-hallowing_m0_express-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-hallowing_m0_express-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-hallowing_m0_express-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 51,
+        "downloads": 56,
         "id": "hallowing_m4_express",
         "versions": [
             {
@@ -3517,164 +3817,164 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-hallowing_m4_express-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-hallowing_m4_express-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-hallowing_m4_express-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-hallowing_m4_express-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-hallowing_m4_express-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-hallowing_m4_express-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-hallowing_m4_express-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-hallowing_m4_express-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-hallowing_m4_express-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-hallowing_m4_express-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-hallowing_m4_express-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-hallowing_m4_express-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-hallowing_m4_express-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-hallowing_m4_express-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-hallowing_m4_express-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-hallowing_m4_express-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-hallowing_m4_express-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-hallowing_m4_express-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-hallowing_m4_express-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-hallowing_m4_express-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-hallowing_m4_express-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-hallowing_m4_express-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-hallowing_m4_express-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-hallowing_m4_express-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 3,
+        "downloads": 6,
         "id": "imxrt1010_evk",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1010_evk-ID-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1010_evk-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1010_evk-ID-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1010_evk-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1010_evk-de_DE-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1010_evk-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1010_evk-de_DE-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1010_evk-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1010_evk-en_US-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1010_evk-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1010_evk-en_US-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1010_evk-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1010_evk-en_x_pirate-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1010_evk-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1010_evk-en_x_pirate-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1010_evk-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1010_evk-es-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1010_evk-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1010_evk-es-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1010_evk-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1010_evk-fil-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1010_evk-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1010_evk-fil-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1010_evk-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1010_evk-fr-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1010_evk-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1010_evk-fr-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1010_evk-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1010_evk-it_IT-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1010_evk-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1010_evk-it_IT-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1010_evk-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1010_evk-ko-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1010_evk-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1010_evk-ko-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1010_evk-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1010_evk-pl-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1010_evk-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1010_evk-pl-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1010_evk-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1010_evk-pt_BR-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1010_evk-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1010_evk-pt_BR-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1010_evk-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1010_evk-zh_Latn_pinyin-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1010_evk-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1010_evk-zh_Latn_pinyin-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1010_evk-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 1,
         "id": "imxrt1020_evk",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1020_evk-ID-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1020_evk-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1020_evk-ID-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1020_evk-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1020_evk-de_DE-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1020_evk-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1020_evk-de_DE-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1020_evk-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1020_evk-en_US-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1020_evk-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1020_evk-en_US-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1020_evk-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1020_evk-en_x_pirate-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1020_evk-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1020_evk-en_x_pirate-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1020_evk-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1020_evk-es-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1020_evk-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1020_evk-es-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1020_evk-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1020_evk-fil-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1020_evk-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1020_evk-fil-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1020_evk-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1020_evk-fr-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1020_evk-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1020_evk-fr-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1020_evk-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1020_evk-it_IT-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1020_evk-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1020_evk-it_IT-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1020_evk-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1020_evk-ko-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1020_evk-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1020_evk-ko-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1020_evk-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1020_evk-pl-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1020_evk-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1020_evk-pl-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1020_evk-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1020_evk-pt_BR-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1020_evk-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1020_evk-pt_BR-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1020_evk-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1020_evk-zh_Latn_pinyin-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1020_evk-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1020_evk-zh_Latn_pinyin-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1020_evk-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
@@ -3685,61 +3985,61 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1060_evk-ID-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1060_evk-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1060_evk-ID-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1060_evk-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1060_evk-de_DE-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1060_evk-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1060_evk-de_DE-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1060_evk-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1060_evk-en_US-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1060_evk-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1060_evk-en_US-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1060_evk-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1060_evk-en_x_pirate-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1060_evk-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1060_evk-en_x_pirate-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1060_evk-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1060_evk-es-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1060_evk-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1060_evk-es-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1060_evk-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1060_evk-fil-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1060_evk-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1060_evk-fil-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1060_evk-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1060_evk-fr-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1060_evk-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1060_evk-fr-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1060_evk-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1060_evk-it_IT-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1060_evk-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1060_evk-it_IT-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1060_evk-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1060_evk-ko-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1060_evk-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1060_evk-ko-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1060_evk-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1060_evk-pl-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1060_evk-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1060_evk-pl-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1060_evk-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1060_evk-pt_BR-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1060_evk-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1060_evk-pt_BR-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1060_evk-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1060_evk-zh_Latn_pinyin-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-imxrt1060_evk-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1060_evk-zh_Latn_pinyin-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-imxrt1060_evk-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 180,
+        "downloads": 256,
         "id": "itsybitsy_m0_express",
         "versions": [
             {
@@ -3784,49 +4084,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_m0_express-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_m0_express-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_m0_express-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_m0_express-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_m0_express-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_m0_express-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_m0_express-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_m0_express-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_m0_express-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_m0_express-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_m0_express-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_m0_express-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_m0_express-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_m0_express-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_m0_express-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_m0_express-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_m0_express-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_m0_express-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_m0_express-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_m0_express-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_m0_express-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_m0_express-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_m0_express-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_m0_express-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 331,
+        "downloads": 515,
         "id": "itsybitsy_m4_express",
         "versions": [
             {
@@ -3871,92 +4171,92 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_m4_express-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_m4_express-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_m4_express-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_m4_express-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_m4_express-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_m4_express-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_m4_express-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_m4_express-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_m4_express-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_m4_express-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_m4_express-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_m4_express-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_m4_express-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_m4_express-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_m4_express-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_m4_express-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_m4_express-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_m4_express-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_m4_express-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_m4_express-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_m4_express-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_m4_express-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_m4_express-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_m4_express-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 29,
+        "downloads": 31,
         "id": "itsybitsy_nrf52840_express",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_nrf52840_express-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_nrf52840_express-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_nrf52840_express-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_nrf52840_express-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_nrf52840_express-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_nrf52840_express-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_nrf52840_express-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_nrf52840_express-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_nrf52840_express-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_nrf52840_express-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_nrf52840_express-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_nrf52840_express-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_nrf52840_express-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_nrf52840_express-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_nrf52840_express-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_nrf52840_express-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_nrf52840_express-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_nrf52840_express-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_nrf52840_express-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_nrf52840_express-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_nrf52840_express-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_nrf52840_express-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-itsybitsy_nrf52840_express-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-itsybitsy_nrf52840_express-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
@@ -4006,49 +4306,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-kicksat-sprite-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-kicksat-sprite-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-kicksat-sprite-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-kicksat-sprite-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-kicksat-sprite-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-kicksat-sprite-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-kicksat-sprite-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-kicksat-sprite-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-kicksat-sprite-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-kicksat-sprite-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-kicksat-sprite-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-kicksat-sprite-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-kicksat-sprite-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-kicksat-sprite-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-kicksat-sprite-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-kicksat-sprite-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-kicksat-sprite-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-kicksat-sprite-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-kicksat-sprite-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-kicksat-sprite-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-kicksat-sprite-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-kicksat-sprite-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-kicksat-sprite-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-kicksat-sprite-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 28,
+        "downloads": 33,
         "id": "makerdiary_nrf52840_mdk",
         "versions": [
             {
@@ -4093,49 +4393,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk-ID-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-makerdiary_nrf52840_mdk-ID-5.0.0-rc.0.hex"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk-de_DE-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-makerdiary_nrf52840_mdk-de_DE-5.0.0-rc.0.hex"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_US-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_US-5.0.0-rc.0.hex"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_x_pirate-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_x_pirate-5.0.0-rc.0.hex"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk-es-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-makerdiary_nrf52840_mdk-es-5.0.0-rc.0.hex"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk-fil-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-makerdiary_nrf52840_mdk-fil-5.0.0-rc.0.hex"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk-fr-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-makerdiary_nrf52840_mdk-fr-5.0.0-rc.0.hex"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk-it_IT-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-makerdiary_nrf52840_mdk-it_IT-5.0.0-rc.0.hex"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk-ko-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-makerdiary_nrf52840_mdk-ko-5.0.0-rc.0.hex"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk-pl-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-makerdiary_nrf52840_mdk-pl-5.0.0-rc.0.hex"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk-pt_BR-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-makerdiary_nrf52840_mdk-pt_BR-5.0.0-rc.0.hex"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk-zh_Latn_pinyin-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-makerdiary_nrf52840_mdk-zh_Latn_pinyin-5.0.0-rc.0.hex"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 41,
+        "downloads": 62,
         "id": "makerdiary_nrf52840_mdk_usb_dongle",
         "versions": [
             {
@@ -4180,97 +4480,97 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-ID-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-ID-5.0.0-rc.0.hex"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-de_DE-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-de_DE-5.0.0-rc.0.hex"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_US-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_US-5.0.0-rc.0.hex"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_x_pirate-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_x_pirate-5.0.0-rc.0.hex"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-es-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-es-5.0.0-rc.0.hex"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fil-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fil-5.0.0-rc.0.hex"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fr-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fr-5.0.0-rc.0.hex"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-it_IT-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-it_IT-5.0.0-rc.0.hex"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-ko-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-ko-5.0.0-rc.0.hex"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pl-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pl-5.0.0-rc.0.hex"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pt_BR-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pt_BR-5.0.0-rc.0.hex"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-zh_Latn_pinyin-5.0.0-beta.5.hex"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-zh_Latn_pinyin-5.0.0-rc.0.hex"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 16,
         "id": "meowbit_v121",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-meowbit_v121-ID-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-meowbit_v121-ID-5.0.0-rc.0.bin"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-meowbit_v121-de_DE-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-meowbit_v121-de_DE-5.0.0-rc.0.bin"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-meowbit_v121-en_US-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-meowbit_v121-en_US-5.0.0-rc.0.bin"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-meowbit_v121-en_x_pirate-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-meowbit_v121-en_x_pirate-5.0.0-rc.0.bin"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-meowbit_v121-es-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-meowbit_v121-es-5.0.0-rc.0.bin"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-meowbit_v121-fil-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-meowbit_v121-fil-5.0.0-rc.0.bin"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-meowbit_v121-fr-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-meowbit_v121-fr-5.0.0-rc.0.bin"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-meowbit_v121-it_IT-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-meowbit_v121-it_IT-5.0.0-rc.0.bin"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-meowbit_v121-ko-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-meowbit_v121-ko-5.0.0-rc.0.bin"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-meowbit_v121-pl-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-meowbit_v121-pl-5.0.0-rc.0.bin"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-meowbit_v121-pt_BR-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-meowbit_v121-pt_BR-5.0.0-rc.0.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-meowbit_v121-zh_Latn_pinyin-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-meowbit_v121-zh_Latn_pinyin-5.0.0-rc.0.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 25,
+        "downloads": 30,
         "id": "meowmeow",
         "versions": [
             {
@@ -4315,49 +4615,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-meowmeow-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-meowmeow-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-meowmeow-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-meowmeow-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-meowmeow-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-meowmeow-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-meowmeow-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-meowmeow-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-meowmeow-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-meowmeow-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-meowmeow-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-meowmeow-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-meowmeow-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-meowmeow-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-meowmeow-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-meowmeow-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-meowmeow-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-meowmeow-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-meowmeow-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-meowmeow-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-meowmeow-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-meowmeow-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-meowmeow-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-meowmeow-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 260,
+        "downloads": 703,
         "id": "metro_m0_express",
         "versions": [
             {
@@ -4402,49 +4702,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m0_express-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m0_express-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m0_express-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m0_express-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m0_express-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m0_express-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m0_express-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m0_express-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m0_express-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m0_express-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m0_express-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m0_express-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m0_express-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m0_express-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m0_express-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m0_express-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m0_express-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m0_express-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m0_express-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m0_express-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m0_express-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m0_express-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m0_express-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m0_express-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 122,
+        "downloads": 160,
         "id": "metro_m4_airlift_lite",
         "versions": [
             {
@@ -4489,49 +4789,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m4_airlift_lite-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m4_airlift_lite-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m4_airlift_lite-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m4_airlift_lite-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m4_airlift_lite-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m4_airlift_lite-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m4_airlift_lite-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m4_airlift_lite-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m4_airlift_lite-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m4_airlift_lite-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m4_airlift_lite-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m4_airlift_lite-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m4_airlift_lite-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m4_airlift_lite-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m4_airlift_lite-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m4_airlift_lite-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m4_airlift_lite-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m4_airlift_lite-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m4_airlift_lite-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m4_airlift_lite-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m4_airlift_lite-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m4_airlift_lite-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m4_airlift_lite-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m4_airlift_lite-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 159,
+        "downloads": 232,
         "id": "metro_m4_express",
         "versions": [
             {
@@ -4576,44 +4876,44 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m4_express-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m4_express-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m4_express-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m4_express-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m4_express-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m4_express-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m4_express-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m4_express-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m4_express-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m4_express-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m4_express-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m4_express-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m4_express-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m4_express-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m4_express-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m4_express-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m4_express-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m4_express-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m4_express-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m4_express-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m4_express-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m4_express-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_m4_express-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_m4_express-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
@@ -4624,49 +4924,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_nrf52840_express-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_nrf52840_express-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_nrf52840_express-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_nrf52840_express-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_nrf52840_express-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_nrf52840_express-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_nrf52840_express-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_nrf52840_express-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_nrf52840_express-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_nrf52840_express-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_nrf52840_express-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_nrf52840_express-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_nrf52840_express-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_nrf52840_express-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_nrf52840_express-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_nrf52840_express-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_nrf52840_express-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_nrf52840_express-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_nrf52840_express-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_nrf52840_express-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_nrf52840_express-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_nrf52840_express-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-metro_nrf52840_express-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-metro_nrf52840_express-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 26,
+        "downloads": 28,
         "id": "mini_sam_m4",
         "versions": [
             {
@@ -4711,92 +5011,92 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-mini_sam_m4-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-mini_sam_m4-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-mini_sam_m4-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-mini_sam_m4-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-mini_sam_m4-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-mini_sam_m4-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-mini_sam_m4-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-mini_sam_m4-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-mini_sam_m4-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-mini_sam_m4-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-mini_sam_m4-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-mini_sam_m4-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-mini_sam_m4-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-mini_sam_m4-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-mini_sam_m4-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-mini_sam_m4-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-mini_sam_m4-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-mini_sam_m4-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-mini_sam_m4-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-mini_sam_m4-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-mini_sam_m4-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-mini_sam_m4-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-mini_sam_m4-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-mini_sam_m4-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 18,
+        "downloads": 30,
         "id": "monster_m4sk",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-monster_m4sk-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-monster_m4sk-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-monster_m4sk-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-monster_m4sk-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-monster_m4sk-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-monster_m4sk-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-monster_m4sk-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-monster_m4sk-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-monster_m4sk-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-monster_m4sk-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-monster_m4sk-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-monster_m4sk-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-monster_m4sk-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-monster_m4sk-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-monster_m4sk-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-monster_m4sk-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-monster_m4sk-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-monster_m4sk-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-monster_m4sk-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-monster_m4sk-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-monster_m4sk-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-monster_m4sk-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-monster_m4sk-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-monster_m4sk-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
@@ -4807,145 +5107,145 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ndgarage_ndbit6-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ndgarage_ndbit6-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ndgarage_ndbit6-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ndgarage_ndbit6-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ndgarage_ndbit6-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ndgarage_ndbit6-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ndgarage_ndbit6-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ndgarage_ndbit6-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ndgarage_ndbit6-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ndgarage_ndbit6-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ndgarage_ndbit6-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ndgarage_ndbit6-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ndgarage_ndbit6-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ndgarage_ndbit6-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ndgarage_ndbit6-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ndgarage_ndbit6-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ndgarage_ndbit6-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ndgarage_ndbit6-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ndgarage_ndbit6-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ndgarage_ndbit6-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ndgarage_ndbit6-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ndgarage_ndbit6-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ndgarage_ndbit6-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ndgarage_ndbit6-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 8,
+        "downloads": 7,
         "id": "ohs2020_badge",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ohs2020_badge-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ohs2020_badge-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ohs2020_badge-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ohs2020_badge-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ohs2020_badge-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ohs2020_badge-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ohs2020_badge-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ohs2020_badge-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ohs2020_badge-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ohs2020_badge-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ohs2020_badge-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ohs2020_badge-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ohs2020_badge-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ohs2020_badge-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ohs2020_badge-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ohs2020_badge-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ohs2020_badge-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ohs2020_badge-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ohs2020_badge-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ohs2020_badge-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ohs2020_badge-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ohs2020_badge-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ohs2020_badge-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ohs2020_badge-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 2,
+        "downloads": 5,
         "id": "openbook_m4",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-openbook_m4-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-openbook_m4-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-openbook_m4-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-openbook_m4-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-openbook_m4-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-openbook_m4-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-openbook_m4-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-openbook_m4-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-openbook_m4-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-openbook_m4-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-openbook_m4-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-openbook_m4-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-openbook_m4-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-openbook_m4-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-openbook_m4-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-openbook_m4-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-openbook_m4-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-openbook_m4-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-openbook_m4-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-openbook_m4-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-openbook_m4-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-openbook_m4-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-openbook_m4-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-openbook_m4-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 33,
+        "downloads": 44,
         "id": "particle_argon",
         "versions": [
             {
@@ -4990,49 +5290,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_argon-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_argon-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_argon-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_argon-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_argon-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_argon-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_argon-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_argon-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_argon-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_argon-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_argon-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_argon-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_argon-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_argon-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_argon-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_argon-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_argon-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_argon-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_argon-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_argon-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_argon-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_argon-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_argon-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_argon-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 28,
+        "downloads": 31,
         "id": "particle_boron",
         "versions": [
             {
@@ -5077,49 +5377,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_boron-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_boron-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_boron-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_boron-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_boron-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_boron-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_boron-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_boron-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_boron-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_boron-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_boron-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_boron-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_boron-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_boron-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_boron-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_boron-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_boron-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_boron-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_boron-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_boron-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_boron-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_boron-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_boron-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_boron-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 59,
+        "downloads": 105,
         "id": "particle_xenon",
         "versions": [
             {
@@ -5164,44 +5464,44 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_xenon-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_xenon-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_xenon-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_xenon-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_xenon-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_xenon-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_xenon-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_xenon-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_xenon-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_xenon-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_xenon-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_xenon-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_xenon-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_xenon-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_xenon-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_xenon-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_xenon-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_xenon-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_xenon-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_xenon-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_xenon-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_xenon-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-particle_xenon-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-particle_xenon-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
@@ -5211,7 +5511,7 @@
         "versions": []
     },
     {
-        "downloads": 74,
+        "downloads": 84,
         "id": "pca10056",
         "versions": [
             {
@@ -5267,61 +5567,61 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10056-ID-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10056-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10056-ID-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10056-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10056-de_DE-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10056-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10056-de_DE-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10056-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10056-en_US-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10056-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10056-en_US-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10056-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10056-en_x_pirate-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10056-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10056-en_x_pirate-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10056-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10056-es-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10056-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10056-es-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10056-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10056-fil-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10056-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10056-fil-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10056-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10056-fr-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10056-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10056-fr-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10056-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10056-it_IT-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10056-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10056-it_IT-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10056-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10056-ko-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10056-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10056-ko-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10056-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10056-pl-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10056-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10056-pl-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10056-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10056-pt_BR-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10056-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10056-pt_BR-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10056-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10056-zh_Latn_pinyin-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10056-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10056-zh_Latn_pinyin-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10056-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 121,
+        "downloads": 137,
         "id": "pca10059",
         "versions": [
             {
@@ -5377,61 +5677,61 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10059-ID-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10059-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10059-ID-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10059-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10059-de_DE-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10059-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10059-de_DE-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10059-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10059-en_US-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10059-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10059-en_US-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10059-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10059-en_x_pirate-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10059-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10059-en_x_pirate-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10059-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10059-es-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10059-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10059-es-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10059-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10059-fil-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10059-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10059-fil-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10059-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10059-fr-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10059-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10059-fr-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10059-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10059-it_IT-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10059-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10059-it_IT-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10059-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10059-ko-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10059-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10059-ko-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10059-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10059-pl-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10059-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10059-pl-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10059-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10059-pt_BR-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10059-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10059-pt_BR-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10059-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10059-zh_Latn_pinyin-5.0.0-beta.5.bin",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pca10059-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10059-zh_Latn_pinyin-5.0.0-rc.0.bin",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pca10059-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 41,
+        "downloads": 45,
         "id": "pewpew10",
         "versions": [
             {
@@ -5476,49 +5776,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew10-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew10-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew10-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew10-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew10-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew10-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew10-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew10-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew10-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew10-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew10-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew10-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew10-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew10-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew10-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew10-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew10-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew10-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew10-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew10-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew10-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew10-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew10-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew10-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 23,
+        "downloads": 25,
         "id": "pewpew13",
         "versions": [
             {
@@ -5563,97 +5863,97 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew13-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew13-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew13-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew13-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew13-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew13-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew13-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew13-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew13-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew13-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew13-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew13-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew13-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew13-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew13-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew13-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew13-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew13-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew13-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew13-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew13-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew13-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew13-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew13-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 2,
+        "downloads": 1,
         "id": "pewpew_m4",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew_m4-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew_m4-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew_m4-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew_m4-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew_m4-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew_m4-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew_m4-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew_m4-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew_m4-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew_m4-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew_m4-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew_m4-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew_m4-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew_m4-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew_m4-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew_m4-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew_m4-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew_m4-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew_m4-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew_m4-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew_m4-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew_m4-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pewpew_m4-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pewpew_m4-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 23,
+        "downloads": 26,
         "id": "pirkey_m0",
         "versions": [
             {
@@ -5698,97 +5998,97 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pirkey_m0-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pirkey_m0-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pirkey_m0-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pirkey_m0-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pirkey_m0-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pirkey_m0-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pirkey_m0-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pirkey_m0-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pirkey_m0-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pirkey_m0-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pirkey_m0-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pirkey_m0-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pirkey_m0-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pirkey_m0-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pirkey_m0-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pirkey_m0-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pirkey_m0-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pirkey_m0-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pirkey_m0-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pirkey_m0-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pirkey_m0-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pirkey_m0-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pirkey_m0-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pirkey_m0-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 2,
+        "downloads": 1,
         "id": "pyb_nano_v2",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyb_nano_v2-ID-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyb_nano_v2-ID-5.0.0-rc.0.bin"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyb_nano_v2-de_DE-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyb_nano_v2-de_DE-5.0.0-rc.0.bin"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyb_nano_v2-en_US-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyb_nano_v2-en_US-5.0.0-rc.0.bin"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyb_nano_v2-en_x_pirate-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyb_nano_v2-en_x_pirate-5.0.0-rc.0.bin"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyb_nano_v2-es-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyb_nano_v2-es-5.0.0-rc.0.bin"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyb_nano_v2-fil-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyb_nano_v2-fil-5.0.0-rc.0.bin"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyb_nano_v2-fr-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyb_nano_v2-fr-5.0.0-rc.0.bin"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyb_nano_v2-it_IT-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyb_nano_v2-it_IT-5.0.0-rc.0.bin"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyb_nano_v2-ko-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyb_nano_v2-ko-5.0.0-rc.0.bin"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyb_nano_v2-pl-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyb_nano_v2-pl-5.0.0-rc.0.bin"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyb_nano_v2-pt_BR-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyb_nano_v2-pt_BR-5.0.0-rc.0.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyb_nano_v2-zh_Latn_pinyin-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyb_nano_v2-zh_Latn_pinyin-5.0.0-rc.0.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 199,
+        "downloads": 256,
         "id": "pybadge",
         "versions": [
             {
@@ -5833,49 +6133,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pybadge-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pybadge-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pybadge-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pybadge-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pybadge-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pybadge-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pybadge-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pybadge-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pybadge-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pybadge-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pybadge-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pybadge-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pybadge-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pybadge-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pybadge-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pybadge-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pybadge-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pybadge-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pybadge-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pybadge-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pybadge-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pybadge-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pybadge-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pybadge-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 27,
+        "downloads": 28,
         "id": "pybadge_airlift",
         "versions": [
             {
@@ -5920,97 +6220,145 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pybadge_airlift-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pybadge_airlift-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pybadge_airlift-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pybadge_airlift-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pybadge_airlift-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pybadge_airlift-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pybadge_airlift-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pybadge_airlift-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pybadge_airlift-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pybadge_airlift-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pybadge_airlift-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pybadge_airlift-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pybadge_airlift-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pybadge_airlift-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pybadge_airlift-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pybadge_airlift-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pybadge_airlift-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pybadge_airlift-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pybadge_airlift-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pybadge_airlift-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pybadge_airlift-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pybadge_airlift-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pybadge_airlift-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pybadge_airlift-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 14,
+        "downloads": 6,
         "id": "pyboard_v11",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyboard_v11-ID-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyboard_v11-ID-5.0.0-rc.0.bin"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyboard_v11-de_DE-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyboard_v11-de_DE-5.0.0-rc.0.bin"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyboard_v11-en_US-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyboard_v11-en_US-5.0.0-rc.0.bin"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyboard_v11-en_x_pirate-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyboard_v11-en_x_pirate-5.0.0-rc.0.bin"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyboard_v11-es-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyboard_v11-es-5.0.0-rc.0.bin"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyboard_v11-fil-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyboard_v11-fil-5.0.0-rc.0.bin"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyboard_v11-fr-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyboard_v11-fr-5.0.0-rc.0.bin"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyboard_v11-it_IT-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyboard_v11-it_IT-5.0.0-rc.0.bin"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyboard_v11-ko-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyboard_v11-ko-5.0.0-rc.0.bin"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyboard_v11-pl-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyboard_v11-pl-5.0.0-rc.0.bin"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyboard_v11-pt_BR-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyboard_v11-pt_BR-5.0.0-rc.0.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyboard_v11-zh_Latn_pinyin-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyboard_v11-zh_Latn_pinyin-5.0.0-rc.0.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 155,
+        "downloads": 0,
+        "id": "pycubed",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pycubed-ID-5.0.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pycubed-de_DE-5.0.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pycubed-en_US-5.0.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pycubed-en_x_pirate-5.0.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pycubed-es-5.0.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pycubed-fil-5.0.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pycubed-fr-5.0.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pycubed-it_IT-5.0.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pycubed-ko-5.0.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pycubed-pl-5.0.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pycubed-pt_BR-5.0.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pycubed-zh_Latn_pinyin-5.0.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-rc.0"
+            }
+        ]
+    },
+    {
+        "downloads": 226,
         "id": "pygamer",
         "versions": [
             {
@@ -6055,49 +6403,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pygamer-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pygamer-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pygamer-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pygamer-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pygamer-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pygamer-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pygamer-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pygamer-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pygamer-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pygamer-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pygamer-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pygamer-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pygamer-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pygamer-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pygamer-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pygamer-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pygamer-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pygamer-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pygamer-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pygamer-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pygamer-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pygamer-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pygamer-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pygamer-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 30,
+        "downloads": 31,
         "id": "pygamer_advance",
         "versions": [
             {
@@ -6142,49 +6490,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pygamer_advance-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pygamer_advance-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pygamer_advance-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pygamer_advance-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pygamer_advance-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pygamer_advance-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pygamer_advance-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pygamer_advance-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pygamer_advance-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pygamer_advance-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pygamer_advance-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pygamer_advance-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pygamer_advance-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pygamer_advance-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pygamer_advance-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pygamer_advance-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pygamer_advance-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pygamer_advance-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pygamer_advance-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pygamer_advance-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pygamer_advance-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pygamer_advance-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pygamer_advance-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pygamer_advance-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 627,
+        "downloads": 847,
         "id": "pyportal",
         "versions": [
             {
@@ -6229,145 +6577,145 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 14,
+        "downloads": 15,
         "id": "pyportal_pynt",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal_pynt-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal_pynt-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal_pynt-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal_pynt-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal_pynt-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal_pynt-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal_pynt-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal_pynt-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal_pynt-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal_pynt-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal_pynt-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal_pynt-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal_pynt-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal_pynt-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal_pynt-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal_pynt-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal_pynt-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal_pynt-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal_pynt-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal_pynt-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal_pynt-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal_pynt-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal_pynt-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal_pynt-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 35,
+        "downloads": 66,
         "id": "pyportal_titano",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal_titano-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal_titano-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal_titano-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal_titano-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal_titano-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal_titano-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal_titano-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal_titano-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal_titano-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal_titano-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal_titano-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal_titano-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal_titano-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal_titano-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal_titano-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal_titano-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal_titano-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal_titano-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal_titano-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal_titano-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal_titano-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal_titano-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyportal_titano-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyportal_titano-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 79,
+        "downloads": 105,
         "id": "pyruler",
         "versions": [
             {
@@ -6412,97 +6760,97 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyruler-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyruler-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyruler-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyruler-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyruler-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyruler-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyruler-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyruler-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyruler-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyruler-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyruler-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyruler-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyruler-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyruler-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyruler-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyruler-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyruler-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyruler-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyruler-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyruler-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyruler-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyruler-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-pyruler-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-pyruler-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 2,
+        "downloads": 3,
         "id": "robohatmm1_m4",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-robohatmm1_m4-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-robohatmm1_m4-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-robohatmm1_m4-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-robohatmm1_m4-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-robohatmm1_m4-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-robohatmm1_m4-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-robohatmm1_m4-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-robohatmm1_m4-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-robohatmm1_m4-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-robohatmm1_m4-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-robohatmm1_m4-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-robohatmm1_m4-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-robohatmm1_m4-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-robohatmm1_m4-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-robohatmm1_m4-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-robohatmm1_m4-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-robohatmm1_m4-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-robohatmm1_m4-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-robohatmm1_m4-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-robohatmm1_m4-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-robohatmm1_m4-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-robohatmm1_m4-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-robohatmm1_m4-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-robohatmm1_m4-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 34,
+        "downloads": 38,
         "id": "sam32",
         "versions": [
             {
@@ -6547,188 +6895,188 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sam32-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sam32-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sam32-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sam32-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sam32-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sam32-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sam32-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sam32-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sam32-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sam32-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sam32-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sam32-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sam32-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sam32-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sam32-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sam32-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sam32-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sam32-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sam32-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sam32-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sam32-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sam32-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sam32-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sam32-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 4,
+        "downloads": 6,
         "id": "seeeduino_xiao",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-seeeduino_xiao-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-seeeduino_xiao-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-seeeduino_xiao-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-seeeduino_xiao-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-seeeduino_xiao-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-seeeduino_xiao-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-seeeduino_xiao-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-seeeduino_xiao-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-seeeduino_xiao-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-seeeduino_xiao-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-seeeduino_xiao-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-seeeduino_xiao-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-seeeduino_xiao-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-seeeduino_xiao-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-seeeduino_xiao-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-seeeduino_xiao-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-seeeduino_xiao-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-seeeduino_xiao-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-seeeduino_xiao-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-seeeduino_xiao-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-seeeduino_xiao-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-seeeduino_xiao-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-seeeduino_xiao-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-seeeduino_xiao-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 9,
+        "downloads": 16,
         "id": "serpente",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-serpente-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-serpente-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-serpente-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-serpente-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-serpente-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-serpente-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-serpente-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-serpente-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-serpente-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-serpente-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-serpente-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-serpente-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-serpente-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-serpente-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-serpente-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-serpente-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-serpente-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-serpente-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-serpente-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-serpente-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-serpente-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-serpente-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-serpente-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-serpente-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 1,
+        "downloads": 0,
         "id": "shirtty",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-shirtty-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-shirtty-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-shirtty-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-shirtty-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-shirtty-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-shirtty-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-shirtty-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-shirtty-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-shirtty-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-shirtty-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-shirtty-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-shirtty-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-shirtty-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-shirtty-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-shirtty-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-shirtty-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-shirtty-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-shirtty-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-shirtty-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-shirtty-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-shirtty-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-shirtty-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-shirtty-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-shirtty-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
@@ -6739,49 +7087,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-snekboard-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-snekboard-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-snekboard-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-snekboard-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-snekboard-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-snekboard-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-snekboard-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-snekboard-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-snekboard-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-snekboard-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-snekboard-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-snekboard-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-snekboard-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-snekboard-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-snekboard-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-snekboard-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-snekboard-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-snekboard-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-snekboard-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-snekboard-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-snekboard-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-snekboard-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-snekboard-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-snekboard-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 28,
+        "downloads": 30,
         "id": "sparkfun_lumidrive",
         "versions": [
             {
@@ -6826,49 +7174,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_lumidrive-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_lumidrive-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_lumidrive-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_lumidrive-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_lumidrive-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_lumidrive-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_lumidrive-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_lumidrive-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_lumidrive-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_lumidrive-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_lumidrive-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_lumidrive-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_lumidrive-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_lumidrive-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_lumidrive-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_lumidrive-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_lumidrive-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_lumidrive-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_lumidrive-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_lumidrive-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_lumidrive-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_lumidrive-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_lumidrive-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_lumidrive-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 30,
+        "downloads": 36,
         "id": "sparkfun_nrf52840_mini",
         "versions": [
             {
@@ -6913,44 +7261,44 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_nrf52840_mini-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_nrf52840_mini-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_nrf52840_mini-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_nrf52840_mini-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_nrf52840_mini-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_nrf52840_mini-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_nrf52840_mini-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_nrf52840_mini-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_nrf52840_mini-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_nrf52840_mini-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_nrf52840_mini-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_nrf52840_mini-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_nrf52840_mini-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_nrf52840_mini-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_nrf52840_mini-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_nrf52840_mini-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_nrf52840_mini-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_nrf52840_mini-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_nrf52840_mini-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_nrf52840_mini-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_nrf52840_mini-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_nrf52840_mini-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_nrf52840_mini-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_nrf52840_mini-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
@@ -6961,97 +7309,97 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 1,
+        "downloads": 0,
         "id": "sparkfun_qwiic_micro_with_flash",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 38,
+        "downloads": 42,
         "id": "sparkfun_redboard_turbo",
         "versions": [
             {
@@ -7096,49 +7444,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_redboard_turbo-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_redboard_turbo-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_redboard_turbo-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_redboard_turbo-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_redboard_turbo-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_redboard_turbo-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_redboard_turbo-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_redboard_turbo-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_redboard_turbo-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_redboard_turbo-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_redboard_turbo-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_redboard_turbo-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_redboard_turbo-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_redboard_turbo-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_redboard_turbo-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_redboard_turbo-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_redboard_turbo-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_redboard_turbo-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_redboard_turbo-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_redboard_turbo-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_redboard_turbo-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_redboard_turbo-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_redboard_turbo-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_redboard_turbo-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 33,
+        "downloads": 37,
         "id": "sparkfun_samd21_dev",
         "versions": [
             {
@@ -7183,49 +7531,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_dev-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd21_dev-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_dev-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd21_dev-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_dev-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd21_dev-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_dev-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd21_dev-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_dev-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd21_dev-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_dev-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd21_dev-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_dev-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd21_dev-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_dev-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd21_dev-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_dev-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd21_dev-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_dev-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd21_dev-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_dev-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd21_dev-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_dev-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd21_dev-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 37,
+        "downloads": 50,
         "id": "sparkfun_samd21_mini",
         "versions": [
             {
@@ -7270,188 +7618,236 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_mini-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd21_mini-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_mini-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd21_mini-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_mini-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd21_mini-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_mini-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd21_mini-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_mini-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd21_mini-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_mini-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd21_mini-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_mini-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd21_mini-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_mini-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd21_mini-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_mini-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd21_mini-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_mini-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd21_mini-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_mini-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd21_mini-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-sparkfun_samd21_mini-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd21_mini-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 1,
-        "id": "spresense",
+        "downloads": 0,
+        "id": "sparkfun_samd51_thing_plus",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-spresense-ID-5.0.0-beta.5.spk"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd51_thing_plus-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-spresense-de_DE-5.0.0-beta.5.spk"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd51_thing_plus-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-spresense-en_US-5.0.0-beta.5.spk"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd51_thing_plus-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-spresense-en_x_pirate-5.0.0-beta.5.spk"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd51_thing_plus-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-spresense-es-5.0.0-beta.5.spk"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd51_thing_plus-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-spresense-fil-5.0.0-beta.5.spk"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd51_thing_plus-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-spresense-fr-5.0.0-beta.5.spk"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd51_thing_plus-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-spresense-it_IT-5.0.0-beta.5.spk"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd51_thing_plus-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-spresense-ko-5.0.0-beta.5.spk"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd51_thing_plus-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-spresense-pl-5.0.0-beta.5.spk"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd51_thing_plus-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-spresense-pt_BR-5.0.0-beta.5.spk"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd51_thing_plus-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-spresense-zh_Latn_pinyin-5.0.0-beta.5.spk"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-sparkfun_samd51_thing_plus-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
-            }
-        ]
-    },
-    {
-        "downloads": 15,
-        "id": "stm32f411ce_blackpill",
-        "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f411ce_blackpill-ID-5.0.0-beta.5.bin"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f411ce_blackpill-de_DE-5.0.0-beta.5.bin"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f411ce_blackpill-en_US-5.0.0-beta.5.bin"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f411ce_blackpill-en_x_pirate-5.0.0-beta.5.bin"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f411ce_blackpill-es-5.0.0-beta.5.bin"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f411ce_blackpill-fil-5.0.0-beta.5.bin"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f411ce_blackpill-fr-5.0.0-beta.5.bin"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f411ce_blackpill-it_IT-5.0.0-beta.5.bin"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f411ce_blackpill-ko-5.0.0-beta.5.bin"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f411ce_blackpill-pl-5.0.0-beta.5.bin"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f411ce_blackpill-pt_BR-5.0.0-beta.5.bin"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f411ce_blackpill-zh_Latn_pinyin-5.0.0-beta.5.bin"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
         "downloads": 3,
+        "id": "spresense",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-spresense-ID-5.0.0-rc.0.spk"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-spresense-de_DE-5.0.0-rc.0.spk"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-spresense-en_US-5.0.0-rc.0.spk"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-spresense-en_x_pirate-5.0.0-rc.0.spk"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-spresense-es-5.0.0-rc.0.spk"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-spresense-fil-5.0.0-rc.0.spk"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-spresense-fr-5.0.0-rc.0.spk"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-spresense-it_IT-5.0.0-rc.0.spk"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-spresense-ko-5.0.0-rc.0.spk"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-spresense-pl-5.0.0-rc.0.spk"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-spresense-pt_BR-5.0.0-rc.0.spk"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-spresense-zh_Latn_pinyin-5.0.0-rc.0.spk"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-rc.0"
+            }
+        ]
+    },
+    {
+        "downloads": 22,
+        "id": "stm32f411ce_blackpill",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f411ce_blackpill-ID-5.0.0-rc.0.bin"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f411ce_blackpill-de_DE-5.0.0-rc.0.bin"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f411ce_blackpill-en_US-5.0.0-rc.0.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f411ce_blackpill-en_x_pirate-5.0.0-rc.0.bin"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f411ce_blackpill-es-5.0.0-rc.0.bin"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f411ce_blackpill-fil-5.0.0-rc.0.bin"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f411ce_blackpill-fr-5.0.0-rc.0.bin"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f411ce_blackpill-it_IT-5.0.0-rc.0.bin"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f411ce_blackpill-ko-5.0.0-rc.0.bin"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f411ce_blackpill-pl-5.0.0-rc.0.bin"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f411ce_blackpill-pt_BR-5.0.0-rc.0.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f411ce_blackpill-zh_Latn_pinyin-5.0.0-rc.0.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-rc.0"
+            }
+        ]
+    },
+    {
+        "downloads": 1,
         "id": "stm32f411ve_discovery",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f411ve_discovery-ID-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f411ve_discovery-ID-5.0.0-rc.0.bin"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f411ve_discovery-de_DE-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f411ve_discovery-de_DE-5.0.0-rc.0.bin"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f411ve_discovery-en_US-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f411ve_discovery-en_US-5.0.0-rc.0.bin"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f411ve_discovery-en_x_pirate-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f411ve_discovery-en_x_pirate-5.0.0-rc.0.bin"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f411ve_discovery-es-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f411ve_discovery-es-5.0.0-rc.0.bin"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f411ve_discovery-fil-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f411ve_discovery-fil-5.0.0-rc.0.bin"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f411ve_discovery-fr-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f411ve_discovery-fr-5.0.0-rc.0.bin"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f411ve_discovery-it_IT-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f411ve_discovery-it_IT-5.0.0-rc.0.bin"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f411ve_discovery-ko-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f411ve_discovery-ko-5.0.0-rc.0.bin"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f411ve_discovery-pl-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f411ve_discovery-pl-5.0.0-rc.0.bin"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f411ve_discovery-pt_BR-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f411ve_discovery-pt_BR-5.0.0-rc.0.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f411ve_discovery-zh_Latn_pinyin-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f411ve_discovery-zh_Latn_pinyin-5.0.0-rc.0.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
@@ -7462,205 +7858,253 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f412zg_discovery-ID-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f412zg_discovery-ID-5.0.0-rc.0.bin"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f412zg_discovery-de_DE-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f412zg_discovery-de_DE-5.0.0-rc.0.bin"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f412zg_discovery-en_US-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f412zg_discovery-en_US-5.0.0-rc.0.bin"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f412zg_discovery-en_x_pirate-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f412zg_discovery-en_x_pirate-5.0.0-rc.0.bin"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f412zg_discovery-es-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f412zg_discovery-es-5.0.0-rc.0.bin"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f412zg_discovery-fil-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f412zg_discovery-fil-5.0.0-rc.0.bin"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f412zg_discovery-fr-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f412zg_discovery-fr-5.0.0-rc.0.bin"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f412zg_discovery-it_IT-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f412zg_discovery-it_IT-5.0.0-rc.0.bin"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f412zg_discovery-ko-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f412zg_discovery-ko-5.0.0-rc.0.bin"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f412zg_discovery-pl-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f412zg_discovery-pl-5.0.0-rc.0.bin"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f412zg_discovery-pt_BR-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f412zg_discovery-pt_BR-5.0.0-rc.0.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stm32f412zg_discovery-zh_Latn_pinyin-5.0.0-beta.5.bin"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f412zg_discovery-zh_Latn_pinyin-5.0.0-rc.0.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
-            }
-        ]
-    },
-    {
-        "downloads": 3,
-        "id": "stringcar_m0_express",
-        "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stringcar_m0_express-ID-5.0.0-beta.5.uf2"
-                    ],
-                    "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stringcar_m0_express-de_DE-5.0.0-beta.5.uf2"
-                    ],
-                    "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stringcar_m0_express-en_US-5.0.0-beta.5.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stringcar_m0_express-en_x_pirate-5.0.0-beta.5.uf2"
-                    ],
-                    "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stringcar_m0_express-es-5.0.0-beta.5.uf2"
-                    ],
-                    "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stringcar_m0_express-fil-5.0.0-beta.5.uf2"
-                    ],
-                    "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stringcar_m0_express-fr-5.0.0-beta.5.uf2"
-                    ],
-                    "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stringcar_m0_express-it_IT-5.0.0-beta.5.uf2"
-                    ],
-                    "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stringcar_m0_express-ko-5.0.0-beta.5.uf2"
-                    ],
-                    "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stringcar_m0_express-pl-5.0.0-beta.5.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stringcar_m0_express-pt_BR-5.0.0-beta.5.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-stringcar_m0_express-zh_Latn_pinyin-5.0.0-beta.5.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
         "downloads": 0,
-        "id": "teensy40",
+        "id": "stm32f4_discovery",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teensy40-ID-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teensy40-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f4_discovery-ID-5.0.0-rc.0.bin"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teensy40-de_DE-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teensy40-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f4_discovery-de_DE-5.0.0-rc.0.bin"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teensy40-en_US-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teensy40-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f4_discovery-en_US-5.0.0-rc.0.bin"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teensy40-en_x_pirate-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teensy40-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f4_discovery-en_x_pirate-5.0.0-rc.0.bin"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teensy40-es-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teensy40-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f4_discovery-es-5.0.0-rc.0.bin"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teensy40-fil-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teensy40-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f4_discovery-fil-5.0.0-rc.0.bin"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teensy40-fr-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teensy40-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f4_discovery-fr-5.0.0-rc.0.bin"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teensy40-it_IT-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teensy40-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f4_discovery-it_IT-5.0.0-rc.0.bin"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teensy40-ko-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teensy40-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f4_discovery-ko-5.0.0-rc.0.bin"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teensy40-pl-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teensy40-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f4_discovery-pl-5.0.0-rc.0.bin"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teensy40-pt_BR-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teensy40-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f4_discovery-pt_BR-5.0.0-rc.0.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teensy40-zh_Latn_pinyin-5.0.0-beta.5.hex",
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teensy40-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stm32f4_discovery-zh_Latn_pinyin-5.0.0-rc.0.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
         "downloads": 1,
+        "id": "stringcar_m0_express",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stringcar_m0_express-ID-5.0.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stringcar_m0_express-de_DE-5.0.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stringcar_m0_express-en_US-5.0.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stringcar_m0_express-en_x_pirate-5.0.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stringcar_m0_express-es-5.0.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stringcar_m0_express-fil-5.0.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stringcar_m0_express-fr-5.0.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stringcar_m0_express-it_IT-5.0.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stringcar_m0_express-ko-5.0.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stringcar_m0_express-pl-5.0.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stringcar_m0_express-pt_BR-5.0.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-stringcar_m0_express-zh_Latn_pinyin-5.0.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-rc.0"
+            }
+        ]
+    },
+    {
+        "downloads": 76,
+        "id": "teensy40",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teensy40-ID-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teensy40-ID-5.0.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teensy40-de_DE-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teensy40-de_DE-5.0.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teensy40-en_US-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teensy40-en_US-5.0.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teensy40-en_x_pirate-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teensy40-en_x_pirate-5.0.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teensy40-es-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teensy40-es-5.0.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teensy40-fil-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teensy40-fil-5.0.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teensy40-fr-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teensy40-fr-5.0.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teensy40-it_IT-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teensy40-it_IT-5.0.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teensy40-ko-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teensy40-ko-5.0.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teensy40-pl-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teensy40-pl-5.0.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teensy40-pt_BR-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teensy40-pt_BR-5.0.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teensy40-zh_Latn_pinyin-5.0.0-rc.0.hex",
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teensy40-zh_Latn_pinyin-5.0.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.0.0-rc.0"
+            }
+        ]
+    },
+    {
+        "downloads": 0,
         "id": "teknikio_bluebird",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teknikio_bluebird-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teknikio_bluebird-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teknikio_bluebird-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teknikio_bluebird-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teknikio_bluebird-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teknikio_bluebird-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teknikio_bluebird-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teknikio_bluebird-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teknikio_bluebird-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teknikio_bluebird-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teknikio_bluebird-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teknikio_bluebird-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teknikio_bluebird-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teknikio_bluebird-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teknikio_bluebird-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teknikio_bluebird-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teknikio_bluebird-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teknikio_bluebird-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teknikio_bluebird-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teknikio_bluebird-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teknikio_bluebird-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teknikio_bluebird-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-teknikio_bluebird-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-teknikio_bluebird-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 163,
+        "downloads": 269,
         "id": "trellis_m4_express",
         "versions": [
             {
@@ -7705,49 +8149,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trellis_m4_express-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trellis_m4_express-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trellis_m4_express-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trellis_m4_express-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trellis_m4_express-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trellis_m4_express-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trellis_m4_express-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trellis_m4_express-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trellis_m4_express-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trellis_m4_express-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trellis_m4_express-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trellis_m4_express-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trellis_m4_express-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trellis_m4_express-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trellis_m4_express-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trellis_m4_express-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trellis_m4_express-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trellis_m4_express-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trellis_m4_express-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trellis_m4_express-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trellis_m4_express-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trellis_m4_express-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trellis_m4_express-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trellis_m4_express-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 909,
+        "downloads": 1282,
         "id": "trinket_m0",
         "versions": [
             {
@@ -7792,49 +8236,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trinket_m0-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trinket_m0-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trinket_m0-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trinket_m0-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trinket_m0-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trinket_m0-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trinket_m0-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trinket_m0-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trinket_m0-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trinket_m0-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trinket_m0-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trinket_m0-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trinket_m0-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trinket_m0-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trinket_m0-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trinket_m0-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trinket_m0-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trinket_m0-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trinket_m0-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trinket_m0-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trinket_m0-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trinket_m0-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trinket_m0-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trinket_m0-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 2,
+        "downloads": 1,
         "id": "trinket_m0_haxpress",
         "versions": [
             {
@@ -7879,49 +8323,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trinket_m0_haxpress-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trinket_m0_haxpress-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trinket_m0_haxpress-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trinket_m0_haxpress-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trinket_m0_haxpress-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trinket_m0_haxpress-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trinket_m0_haxpress-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trinket_m0_haxpress-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trinket_m0_haxpress-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trinket_m0_haxpress-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trinket_m0_haxpress-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trinket_m0_haxpress-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trinket_m0_haxpress-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trinket_m0_haxpress-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trinket_m0_haxpress-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trinket_m0_haxpress-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trinket_m0_haxpress-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trinket_m0_haxpress-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trinket_m0_haxpress-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trinket_m0_haxpress-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trinket_m0_haxpress-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trinket_m0_haxpress-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-trinket_m0_haxpress-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-trinket_m0_haxpress-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 23,
+        "downloads": 24,
         "id": "uchip",
         "versions": [
             {
@@ -7966,49 +8410,49 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-uchip-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-uchip-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-uchip-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-uchip-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-uchip-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-uchip-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-uchip-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-uchip-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-uchip-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-uchip-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-uchip-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-uchip-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-uchip-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-uchip-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-uchip-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-uchip-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-uchip-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-uchip-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-uchip-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-uchip-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-uchip-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-uchip-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-uchip-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-uchip-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 30,
+        "downloads": 32,
         "id": "ugame10",
         "versions": [
             {
@@ -8053,188 +8497,188 @@
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ugame10-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ugame10-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ugame10-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ugame10-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ugame10-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ugame10-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ugame10-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ugame10-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ugame10-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ugame10-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ugame10-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ugame10-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ugame10-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ugame10-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ugame10-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ugame10-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ugame10-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ugame10-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ugame10-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ugame10-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ugame10-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ugame10-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-ugame10-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-ugame10-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 2,
+        "downloads": 1,
         "id": "winterbloom_sol",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-winterbloom_sol-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-winterbloom_sol-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-winterbloom_sol-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-winterbloom_sol-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-winterbloom_sol-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-winterbloom_sol-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-winterbloom_sol-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-winterbloom_sol-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-winterbloom_sol-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-winterbloom_sol-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-winterbloom_sol-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-winterbloom_sol-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-winterbloom_sol-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-winterbloom_sol-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-winterbloom_sol-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-winterbloom_sol-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-winterbloom_sol-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-winterbloom_sol-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-winterbloom_sol-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-winterbloom_sol-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-winterbloom_sol-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-winterbloom_sol-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-winterbloom_sol-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-winterbloom_sol-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 1,
+        "downloads": 0,
         "id": "xinabox_cc03",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-xinabox_cc03-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-xinabox_cc03-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-xinabox_cc03-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-xinabox_cc03-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-xinabox_cc03-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-xinabox_cc03-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-xinabox_cc03-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-xinabox_cc03-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-xinabox_cc03-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-xinabox_cc03-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-xinabox_cc03-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-xinabox_cc03-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-xinabox_cc03-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-xinabox_cc03-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-xinabox_cc03-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-xinabox_cc03-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-xinabox_cc03-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-xinabox_cc03-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-xinabox_cc03-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-xinabox_cc03-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-xinabox_cc03-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-xinabox_cc03-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-xinabox_cc03-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-xinabox_cc03-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 1,
+        "downloads": 0,
         "id": "xinabox_cs11",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-xinabox_cs11-ID-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-xinabox_cs11-ID-5.0.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-xinabox_cs11-de_DE-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-xinabox_cs11-de_DE-5.0.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-xinabox_cs11-en_US-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-xinabox_cs11-en_US-5.0.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-xinabox_cs11-en_x_pirate-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-xinabox_cs11-en_x_pirate-5.0.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-xinabox_cs11-es-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-xinabox_cs11-es-5.0.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-xinabox_cs11-fil-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-xinabox_cs11-fil-5.0.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-xinabox_cs11-fr-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-xinabox_cs11-fr-5.0.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-xinabox_cs11-it_IT-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-xinabox_cs11-it_IT-5.0.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-xinabox_cs11-ko-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-xinabox_cs11-ko-5.0.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-xinabox_cs11-pl-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-xinabox_cs11-pl-5.0.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-xinabox_cs11-pt_BR-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-xinabox_cs11-pt_BR-5.0.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-beta.5/adafruit-circuitpython-xinabox_cs11-zh_Latn_pinyin-5.0.0-beta.5.uf2"
+                        "https://github.com/adafruit/circuitpython/releases/download/5.0.0-rc.0/adafruit-circuitpython-xinabox_cs11-zh_Latn_pinyin-5.0.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-beta.5"
+                "version": "5.0.0-rc.0"
             }
         ]
     }


### PR DESCRIPTION
Automated website update for release 5.0.0-rc.0 by Blinka.

New boards:
* arduino_nano_33_iot
* pycubed
* circuitbrains_basic_m0
* circuitbrains_deluxe_m4
* sparkfun_samd51_thing_plus
* espruino_wifi
* stm32f4_discovery
* espruino_pico
* feather_m7_1011


