### PR TITLE
Update Absolute Newest and Past Releases download info

### DIFF
--- a/_includes/download/board.html
+++ b/_includes/download/board.html
@@ -86,11 +86,10 @@
     But we have discontinued including binaries as assets on newer release pages
     because of the large number of files for each release.
   </p>
+  <p>
+    <a class="download-button-unrecommended" href="https://github.com/adafruit/circuitpython/releases">BROWSE GITHUB<i class="fab fa-github" aria-hidden="true"></i></a>
+  </p>
   <div>
-      <a class="download-button-unrecommended" href="https://github.com/adafruit/circuitpython/releases">BROWSE GITHUB<i class="fab fa-github" aria-hidden="true"></i></a>
-    <div class="clear"></div>
-  <div>
-      <a class="download-button-unrecommended" href="https://adafruit-circuit-python.s3.amazonaws.com/index.html?prefix=bin/{{ page.board_id }}/">BROWSE S3<i class="fas fa-arrow-circle-right" aria-hidden="true"></i></a>
-    <div class="clear"></div>
+    <a class="download-button-unrecommended" href="https://adafruit-circuit-python.s3.amazonaws.com/index.html?prefix=bin/{{ page.board_id }}/">BROWSE S3<i class="fas fa-arrow-circle-right" aria-hidden="true"></i></a>
   </div>
 </div>

--- a/_includes/download/board.html
+++ b/_includes/download/board.html
@@ -67,9 +67,9 @@
 <div class="section unrecommended">
   <h3>Absolute Newest</h3>
   <p>
-    Every time we commit new code to CircuitPython we automatically build binaries for it. They
-    are stored on Amazon S3 by language (some which may be unreleased.) Try them if you want
-    the absolute latest and are feeling risky.
+    Every time we commit new code to CircuitPython we automatically build binaries for each board and language.
+    The binaries are stored on Amazon S3, organized by board, and then by language. Try them if you want
+    the absolute latest and are feeling daring or want to see if a problem has been fixed.
   </p>
   <div>
       <a class="download-button-unrecommended" href="https://adafruit-circuit-python.s3.amazonaws.com/index.html?prefix=bin/{{ page.board_id }}/">BROWSE S3<i class="fas fa-arrow-circle-right" aria-hidden="true"></i></a>
@@ -79,11 +79,18 @@
 <div class="section unrecommended">
   <h3>Past Releases</h3>
   <p>
-    All previous releases are available on GitHub. They are handy for testing but we recommend
-    the latest stable otherwise.
+    All previous releases are listed on GitHub, with release notes,
+    and are available for download from Amazon S3.
+    They are handy for testing, but otherwise we recommend using the latest stable release.
+    Some older GitHub release pages include the same binaries for downloading.
+    But we have discontinued including binaries as assets on newer release pages
+    because of the large number of files for each release.
   </p>
   <div>
       <a class="download-button-unrecommended" href="https://github.com/adafruit/circuitpython/releases">BROWSE GITHUB<i class="fab fa-github" aria-hidden="true"></i></a>
+    <div class="clear"></div>
+  <div>
+      <a class="download-button-unrecommended" href="https://adafruit-circuit-python.s3.amazonaws.com/index.html?prefix=bin/{{ page.board_id }}/">BROWSE S3<i class="fas fa-arrow-circle-right" aria-hidden="true"></i></a>
     <div class="clear"></div>
   </div>
 </div>


### PR DESCRIPTION
- Add S3 download button for Past Releases, since future releases will only have assets on S3.
- Update download blurbs.