### PR TITLE
Automated website update for release 5.1.0-rc.0

### DIFF
--- a/_data/files.json
+++ b/_data/files.json
@@ -1,50 +1,56 @@
 [
     {
         "downloads": 0,
-        "id": "aramcon_badge_2019",
+        "id": "TG-Watch02A",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/ID/adafruit-circuitpython-aramcon_badge_2019-ID-5.0.0-rc.1.uf2"
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/ID/adafruit-circuitpython-TG-Watch02A-ID-5.1.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/de_DE/adafruit-circuitpython-aramcon_badge_2019-de_DE-5.0.0-rc.1.uf2"
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/de_DE/adafruit-circuitpython-TG-Watch02A-de_DE-5.1.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/en_US/adafruit-circuitpython-aramcon_badge_2019-en_US-5.0.0-rc.1.uf2"
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/en_US/adafruit-circuitpython-TG-Watch02A-en_US-5.1.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/en_x_pirate/adafruit-circuitpython-aramcon_badge_2019-en_x_pirate-5.0.0-rc.1.uf2"
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/en_x_pirate/adafruit-circuitpython-TG-Watch02A-en_x_pirate-5.1.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/es/adafruit-circuitpython-aramcon_badge_2019-es-5.0.0-rc.1.uf2"
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/es/adafruit-circuitpython-TG-Watch02A-es-5.1.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/fil/adafruit-circuitpython-aramcon_badge_2019-fil-5.0.0-rc.1.uf2"
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/fil/adafruit-circuitpython-TG-Watch02A-fil-5.1.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/fr/adafruit-circuitpython-aramcon_badge_2019-fr-5.0.0-rc.1.uf2"
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/fr/adafruit-circuitpython-TG-Watch02A-fr-5.1.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/it_IT/adafruit-circuitpython-aramcon_badge_2019-it_IT-5.0.0-rc.1.uf2"
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/it_IT/adafruit-circuitpython-TG-Watch02A-it_IT-5.1.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/ko/adafruit-circuitpython-aramcon_badge_2019-ko-5.0.0-rc.1.uf2"
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/ko/adafruit-circuitpython-TG-Watch02A-ko-5.1.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/pl/adafruit-circuitpython-aramcon_badge_2019-pl-5.0.0-rc.1.uf2"
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/pl/adafruit-circuitpython-TG-Watch02A-pl-5.1.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/pt_BR/adafruit-circuitpython-aramcon_badge_2019-pt_BR-5.0.0-rc.1.uf2"
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/pt_BR/adafruit-circuitpython-TG-Watch02A-pt_BR-5.1.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/zh_Latn_pinyin/adafruit-circuitpython-aramcon_badge_2019-zh_Latn_pinyin-5.0.0-rc.1.uf2"
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/zh_Latn_pinyin/adafruit-circuitpython-TG-Watch02A-zh_Latn_pinyin-5.1.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-rc.1"
-            },
+                "version": "5.1.0-rc.0"
+            }
+        ]
+    },
+    {
+        "downloads": 0,
+        "id": "aramcon_badge_2019",
+        "versions": [
             {
                 "files": {
                     "ID": [
@@ -86,67 +92,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/ID/adafruit-circuitpython-aramcon_badge_2019-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/de_DE/adafruit-circuitpython-aramcon_badge_2019-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/en_US/adafruit-circuitpython-aramcon_badge_2019-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/en_x_pirate/adafruit-circuitpython-aramcon_badge_2019-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/es/adafruit-circuitpython-aramcon_badge_2019-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/fil/adafruit-circuitpython-aramcon_badge_2019-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/fr/adafruit-circuitpython-aramcon_badge_2019-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/it_IT/adafruit-circuitpython-aramcon_badge_2019-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/ko/adafruit-circuitpython-aramcon_badge_2019-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/pl/adafruit-circuitpython-aramcon_badge_2019-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/pt_BR/adafruit-circuitpython-aramcon_badge_2019-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/zh_Latn_pinyin/adafruit-circuitpython-aramcon_badge_2019-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 61,
+        "downloads": 0,
         "id": "arduino_mkr1300",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/ID/adafruit-circuitpython-arduino_mkr1300-ID-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/ID/adafruit-circuitpython-arduino_mkr1300-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/de_DE/adafruit-circuitpython-arduino_mkr1300-de_DE-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/de_DE/adafruit-circuitpython-arduino_mkr1300-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/en_US/adafruit-circuitpython-arduino_mkr1300-en_US-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/en_US/adafruit-circuitpython-arduino_mkr1300-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/en_x_pirate/adafruit-circuitpython-arduino_mkr1300-en_x_pirate-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/en_x_pirate/adafruit-circuitpython-arduino_mkr1300-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/es/adafruit-circuitpython-arduino_mkr1300-es-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/es/adafruit-circuitpython-arduino_mkr1300-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/fil/adafruit-circuitpython-arduino_mkr1300-fil-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/fil/adafruit-circuitpython-arduino_mkr1300-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/fr/adafruit-circuitpython-arduino_mkr1300-fr-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/fr/adafruit-circuitpython-arduino_mkr1300-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/it_IT/adafruit-circuitpython-arduino_mkr1300-it_IT-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/it_IT/adafruit-circuitpython-arduino_mkr1300-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/ko/adafruit-circuitpython-arduino_mkr1300-ko-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/ko/adafruit-circuitpython-arduino_mkr1300-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/pl/adafruit-circuitpython-arduino_mkr1300-pl-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/pl/adafruit-circuitpython-arduino_mkr1300-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/pt_BR/adafruit-circuitpython-arduino_mkr1300-pt_BR-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/pt_BR/adafruit-circuitpython-arduino_mkr1300-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/zh_Latn_pinyin/adafruit-circuitpython-arduino_mkr1300-zh_Latn_pinyin-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/zh_Latn_pinyin/adafruit-circuitpython-arduino_mkr1300-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -200,67 +194,67 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/ID/adafruit-circuitpython-arduino_mkr1300-ID-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/ID/adafruit-circuitpython-arduino_mkr1300-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/de_DE/adafruit-circuitpython-arduino_mkr1300-de_DE-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/de_DE/adafruit-circuitpython-arduino_mkr1300-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/en_US/adafruit-circuitpython-arduino_mkr1300-en_US-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/en_US/adafruit-circuitpython-arduino_mkr1300-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/en_x_pirate/adafruit-circuitpython-arduino_mkr1300-en_x_pirate-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/en_x_pirate/adafruit-circuitpython-arduino_mkr1300-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/es/adafruit-circuitpython-arduino_mkr1300-es-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/es/adafruit-circuitpython-arduino_mkr1300-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/fil/adafruit-circuitpython-arduino_mkr1300-fil-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/fil/adafruit-circuitpython-arduino_mkr1300-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/fr/adafruit-circuitpython-arduino_mkr1300-fr-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/fr/adafruit-circuitpython-arduino_mkr1300-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/it_IT/adafruit-circuitpython-arduino_mkr1300-it_IT-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/it_IT/adafruit-circuitpython-arduino_mkr1300-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/ko/adafruit-circuitpython-arduino_mkr1300-ko-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/ko/adafruit-circuitpython-arduino_mkr1300-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/pl/adafruit-circuitpython-arduino_mkr1300-pl-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/pl/adafruit-circuitpython-arduino_mkr1300-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/pt_BR/adafruit-circuitpython-arduino_mkr1300-pt_BR-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/pt_BR/adafruit-circuitpython-arduino_mkr1300-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/zh_Latn_pinyin/adafruit-circuitpython-arduino_mkr1300-zh_Latn_pinyin-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/zh_Latn_pinyin/adafruit-circuitpython-arduino_mkr1300-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 44,
+        "downloads": 0,
         "id": "arduino_mkrzero",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/ID/adafruit-circuitpython-arduino_mkrzero-ID-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/ID/adafruit-circuitpython-arduino_mkrzero-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/de_DE/adafruit-circuitpython-arduino_mkrzero-de_DE-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/de_DE/adafruit-circuitpython-arduino_mkrzero-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/en_US/adafruit-circuitpython-arduino_mkrzero-en_US-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/en_US/adafruit-circuitpython-arduino_mkrzero-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/en_x_pirate/adafruit-circuitpython-arduino_mkrzero-en_x_pirate-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/en_x_pirate/adafruit-circuitpython-arduino_mkrzero-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/es/adafruit-circuitpython-arduino_mkrzero-es-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/es/adafruit-circuitpython-arduino_mkrzero-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/fil/adafruit-circuitpython-arduino_mkrzero-fil-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/fil/adafruit-circuitpython-arduino_mkrzero-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/fr/adafruit-circuitpython-arduino_mkrzero-fr-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/fr/adafruit-circuitpython-arduino_mkrzero-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/it_IT/adafruit-circuitpython-arduino_mkrzero-it_IT-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/it_IT/adafruit-circuitpython-arduino_mkrzero-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/ko/adafruit-circuitpython-arduino_mkrzero-ko-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/ko/adafruit-circuitpython-arduino_mkrzero-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/pl/adafruit-circuitpython-arduino_mkrzero-pl-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/pl/adafruit-circuitpython-arduino_mkrzero-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/pt_BR/adafruit-circuitpython-arduino_mkrzero-pt_BR-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/pt_BR/adafruit-circuitpython-arduino_mkrzero-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/zh_Latn_pinyin/adafruit-circuitpython-arduino_mkrzero-zh_Latn_pinyin-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/zh_Latn_pinyin/adafruit-circuitpython-arduino_mkrzero-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -314,6 +308,60 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/ID/adafruit-circuitpython-arduino_mkrzero-ID-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/ID/adafruit-circuitpython-arduino_mkrzero-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/de_DE/adafruit-circuitpython-arduino_mkrzero-de_DE-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/de_DE/adafruit-circuitpython-arduino_mkrzero-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/en_US/adafruit-circuitpython-arduino_mkrzero-en_US-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/en_US/adafruit-circuitpython-arduino_mkrzero-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/en_x_pirate/adafruit-circuitpython-arduino_mkrzero-en_x_pirate-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/en_x_pirate/adafruit-circuitpython-arduino_mkrzero-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/es/adafruit-circuitpython-arduino_mkrzero-es-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/es/adafruit-circuitpython-arduino_mkrzero-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/fil/adafruit-circuitpython-arduino_mkrzero-fil-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/fil/adafruit-circuitpython-arduino_mkrzero-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/fr/adafruit-circuitpython-arduino_mkrzero-fr-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/fr/adafruit-circuitpython-arduino_mkrzero-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/it_IT/adafruit-circuitpython-arduino_mkrzero-it_IT-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/it_IT/adafruit-circuitpython-arduino_mkrzero-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/ko/adafruit-circuitpython-arduino_mkrzero-ko-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/ko/adafruit-circuitpython-arduino_mkrzero-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/pl/adafruit-circuitpython-arduino_mkrzero-pl-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/pl/adafruit-circuitpython-arduino_mkrzero-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/pt_BR/adafruit-circuitpython-arduino_mkrzero-pt_BR-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/pt_BR/adafruit-circuitpython-arduino_mkrzero-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/zh_Latn_pinyin/adafruit-circuitpython-arduino_mkrzero-zh_Latn_pinyin-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/zh_Latn_pinyin/adafruit-circuitpython-arduino_mkrzero-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -321,48 +369,6 @@
         "downloads": 0,
         "id": "arduino_nano_33_ble",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/ID/adafruit-circuitpython-arduino_nano_33_ble-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/de_DE/adafruit-circuitpython-arduino_nano_33_ble-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/en_US/adafruit-circuitpython-arduino_nano_33_ble-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/en_x_pirate/adafruit-circuitpython-arduino_nano_33_ble-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/es/adafruit-circuitpython-arduino_nano_33_ble-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/fil/adafruit-circuitpython-arduino_nano_33_ble-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/fr/adafruit-circuitpython-arduino_nano_33_ble-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/it_IT/adafruit-circuitpython-arduino_nano_33_ble-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/ko/adafruit-circuitpython-arduino_nano_33_ble-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/pl/adafruit-circuitpython-arduino_nano_33_ble-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/pt_BR/adafruit-circuitpython-arduino_nano_33_ble-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/zh_Latn_pinyin/adafruit-circuitpython-arduino_nano_33_ble-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -404,6 +410,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/ID/adafruit-circuitpython-arduino_nano_33_ble-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/de_DE/adafruit-circuitpython-arduino_nano_33_ble-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/en_US/adafruit-circuitpython-arduino_nano_33_ble-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/en_x_pirate/adafruit-circuitpython-arduino_nano_33_ble-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/es/adafruit-circuitpython-arduino_nano_33_ble-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/fil/adafruit-circuitpython-arduino_nano_33_ble-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/fr/adafruit-circuitpython-arduino_nano_33_ble-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/it_IT/adafruit-circuitpython-arduino_nano_33_ble-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/ko/adafruit-circuitpython-arduino_nano_33_ble-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/pl/adafruit-circuitpython-arduino_nano_33_ble-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/pt_BR/adafruit-circuitpython-arduino_nano_33_ble-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/zh_Latn_pinyin/adafruit-circuitpython-arduino_nano_33_ble-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -411,60 +459,6 @@
         "downloads": 0,
         "id": "arduino_nano_33_iot",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/ID/adafruit-circuitpython-arduino_nano_33_iot-ID-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/ID/adafruit-circuitpython-arduino_nano_33_iot-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/de_DE/adafruit-circuitpython-arduino_nano_33_iot-de_DE-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/de_DE/adafruit-circuitpython-arduino_nano_33_iot-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/en_US/adafruit-circuitpython-arduino_nano_33_iot-en_US-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/en_US/adafruit-circuitpython-arduino_nano_33_iot-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/en_x_pirate/adafruit-circuitpython-arduino_nano_33_iot-en_x_pirate-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/en_x_pirate/adafruit-circuitpython-arduino_nano_33_iot-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/es/adafruit-circuitpython-arduino_nano_33_iot-es-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/es/adafruit-circuitpython-arduino_nano_33_iot-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/fil/adafruit-circuitpython-arduino_nano_33_iot-fil-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/fil/adafruit-circuitpython-arduino_nano_33_iot-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/fr/adafruit-circuitpython-arduino_nano_33_iot-fr-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/fr/adafruit-circuitpython-arduino_nano_33_iot-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/it_IT/adafruit-circuitpython-arduino_nano_33_iot-it_IT-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/it_IT/adafruit-circuitpython-arduino_nano_33_iot-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/ko/adafruit-circuitpython-arduino_nano_33_iot-ko-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/ko/adafruit-circuitpython-arduino_nano_33_iot-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/pl/adafruit-circuitpython-arduino_nano_33_iot-pl-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/pl/adafruit-circuitpython-arduino_nano_33_iot-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/pt_BR/adafruit-circuitpython-arduino_nano_33_iot-pt_BR-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/pt_BR/adafruit-circuitpython-arduino_nano_33_iot-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/zh_Latn_pinyin/adafruit-circuitpython-arduino_nano_33_iot-zh_Latn_pinyin-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/zh_Latn_pinyin/adafruit-circuitpython-arduino_nano_33_iot-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -518,67 +512,67 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/ID/adafruit-circuitpython-arduino_nano_33_iot-ID-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/ID/adafruit-circuitpython-arduino_nano_33_iot-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/de_DE/adafruit-circuitpython-arduino_nano_33_iot-de_DE-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/de_DE/adafruit-circuitpython-arduino_nano_33_iot-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/en_US/adafruit-circuitpython-arduino_nano_33_iot-en_US-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/en_US/adafruit-circuitpython-arduino_nano_33_iot-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/en_x_pirate/adafruit-circuitpython-arduino_nano_33_iot-en_x_pirate-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/en_x_pirate/adafruit-circuitpython-arduino_nano_33_iot-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/es/adafruit-circuitpython-arduino_nano_33_iot-es-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/es/adafruit-circuitpython-arduino_nano_33_iot-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/fil/adafruit-circuitpython-arduino_nano_33_iot-fil-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/fil/adafruit-circuitpython-arduino_nano_33_iot-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/fr/adafruit-circuitpython-arduino_nano_33_iot-fr-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/fr/adafruit-circuitpython-arduino_nano_33_iot-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/it_IT/adafruit-circuitpython-arduino_nano_33_iot-it_IT-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/it_IT/adafruit-circuitpython-arduino_nano_33_iot-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/ko/adafruit-circuitpython-arduino_nano_33_iot-ko-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/ko/adafruit-circuitpython-arduino_nano_33_iot-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/pl/adafruit-circuitpython-arduino_nano_33_iot-pl-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/pl/adafruit-circuitpython-arduino_nano_33_iot-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/pt_BR/adafruit-circuitpython-arduino_nano_33_iot-pt_BR-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/pt_BR/adafruit-circuitpython-arduino_nano_33_iot-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/zh_Latn_pinyin/adafruit-circuitpython-arduino_nano_33_iot-zh_Latn_pinyin-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/zh_Latn_pinyin/adafruit-circuitpython-arduino_nano_33_iot-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 100,
+        "downloads": 0,
         "id": "arduino_zero",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/ID/adafruit-circuitpython-arduino_zero-ID-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/ID/adafruit-circuitpython-arduino_zero-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/de_DE/adafruit-circuitpython-arduino_zero-de_DE-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/de_DE/adafruit-circuitpython-arduino_zero-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/en_US/adafruit-circuitpython-arduino_zero-en_US-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/en_US/adafruit-circuitpython-arduino_zero-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/en_x_pirate/adafruit-circuitpython-arduino_zero-en_x_pirate-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/en_x_pirate/adafruit-circuitpython-arduino_zero-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/es/adafruit-circuitpython-arduino_zero-es-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/es/adafruit-circuitpython-arduino_zero-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/fil/adafruit-circuitpython-arduino_zero-fil-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/fil/adafruit-circuitpython-arduino_zero-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/fr/adafruit-circuitpython-arduino_zero-fr-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/fr/adafruit-circuitpython-arduino_zero-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/it_IT/adafruit-circuitpython-arduino_zero-it_IT-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/it_IT/adafruit-circuitpython-arduino_zero-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/ko/adafruit-circuitpython-arduino_zero-ko-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/ko/adafruit-circuitpython-arduino_zero-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/pl/adafruit-circuitpython-arduino_zero-pl-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/pl/adafruit-circuitpython-arduino_zero-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/pt_BR/adafruit-circuitpython-arduino_zero-pt_BR-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/pt_BR/adafruit-circuitpython-arduino_zero-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/zh_Latn_pinyin/adafruit-circuitpython-arduino_zero-zh_Latn_pinyin-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/zh_Latn_pinyin/adafruit-circuitpython-arduino_zero-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -632,55 +626,67 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/arduino_zero/ID/adafruit-circuitpython-arduino_zero-ID-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/ID/adafruit-circuitpython-arduino_zero-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/arduino_zero/de_DE/adafruit-circuitpython-arduino_zero-de_DE-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/de_DE/adafruit-circuitpython-arduino_zero-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/arduino_zero/en_US/adafruit-circuitpython-arduino_zero-en_US-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/en_US/adafruit-circuitpython-arduino_zero-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/arduino_zero/en_x_pirate/adafruit-circuitpython-arduino_zero-en_x_pirate-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/en_x_pirate/adafruit-circuitpython-arduino_zero-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/arduino_zero/es/adafruit-circuitpython-arduino_zero-es-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/es/adafruit-circuitpython-arduino_zero-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/arduino_zero/fil/adafruit-circuitpython-arduino_zero-fil-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/fil/adafruit-circuitpython-arduino_zero-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/arduino_zero/fr/adafruit-circuitpython-arduino_zero-fr-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/fr/adafruit-circuitpython-arduino_zero-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/arduino_zero/it_IT/adafruit-circuitpython-arduino_zero-it_IT-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/it_IT/adafruit-circuitpython-arduino_zero-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/arduino_zero/ko/adafruit-circuitpython-arduino_zero-ko-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/ko/adafruit-circuitpython-arduino_zero-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/arduino_zero/pl/adafruit-circuitpython-arduino_zero-pl-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/pl/adafruit-circuitpython-arduino_zero-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/arduino_zero/pt_BR/adafruit-circuitpython-arduino_zero-pt_BR-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/pt_BR/adafruit-circuitpython-arduino_zero-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/arduino_zero/zh_Latn_pinyin/adafruit-circuitpython-arduino_zero-zh_Latn_pinyin-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/zh_Latn_pinyin/adafruit-circuitpython-arduino_zero-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 14,
+        "downloads": 0,
         "id": "bast_pro_mini_m0",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/ID/adafruit-circuitpython-bast_pro_mini_m0-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/de_DE/adafruit-circuitpython-bast_pro_mini_m0-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/en_US/adafruit-circuitpython-bast_pro_mini_m0-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/en_x_pirate/adafruit-circuitpython-bast_pro_mini_m0-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/es/adafruit-circuitpython-bast_pro_mini_m0-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/fil/adafruit-circuitpython-bast_pro_mini_m0-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/fr/adafruit-circuitpython-bast_pro_mini_m0-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/it_IT/adafruit-circuitpython-bast_pro_mini_m0-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/ko/adafruit-circuitpython-bast_pro_mini_m0-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/pl/adafruit-circuitpython-bast_pro_mini_m0-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/pt_BR/adafruit-circuitpython-bast_pro_mini_m0-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/zh_Latn_pinyin/adafruit-circuitpython-bast_pro_mini_m0-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -722,55 +728,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/ID/adafruit-circuitpython-bast_pro_mini_m0-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/de_DE/adafruit-circuitpython-bast_pro_mini_m0-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/en_US/adafruit-circuitpython-bast_pro_mini_m0-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/en_x_pirate/adafruit-circuitpython-bast_pro_mini_m0-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/es/adafruit-circuitpython-bast_pro_mini_m0-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/fil/adafruit-circuitpython-bast_pro_mini_m0-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/fr/adafruit-circuitpython-bast_pro_mini_m0-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/it_IT/adafruit-circuitpython-bast_pro_mini_m0-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/ko/adafruit-circuitpython-bast_pro_mini_m0-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/pl/adafruit-circuitpython-bast_pro_mini_m0-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/pt_BR/adafruit-circuitpython-bast_pro_mini_m0-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/zh_Latn_pinyin/adafruit-circuitpython-bast_pro_mini_m0-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 24,
+        "downloads": 0,
         "id": "capablerobot_usbhub",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/ID/adafruit-circuitpython-capablerobot_usbhub-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/de_DE/adafruit-circuitpython-capablerobot_usbhub-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/en_US/adafruit-circuitpython-capablerobot_usbhub-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/en_x_pirate/adafruit-circuitpython-capablerobot_usbhub-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/es/adafruit-circuitpython-capablerobot_usbhub-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/fil/adafruit-circuitpython-capablerobot_usbhub-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/fr/adafruit-circuitpython-capablerobot_usbhub-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/it_IT/adafruit-circuitpython-capablerobot_usbhub-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/ko/adafruit-circuitpython-capablerobot_usbhub-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/pl/adafruit-circuitpython-capablerobot_usbhub-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/pt_BR/adafruit-circuitpython-capablerobot_usbhub-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/zh_Latn_pinyin/adafruit-circuitpython-capablerobot_usbhub-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -812,55 +818,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/ID/adafruit-circuitpython-capablerobot_usbhub-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/de_DE/adafruit-circuitpython-capablerobot_usbhub-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/en_US/adafruit-circuitpython-capablerobot_usbhub-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/en_x_pirate/adafruit-circuitpython-capablerobot_usbhub-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/es/adafruit-circuitpython-capablerobot_usbhub-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/fil/adafruit-circuitpython-capablerobot_usbhub-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/fr/adafruit-circuitpython-capablerobot_usbhub-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/it_IT/adafruit-circuitpython-capablerobot_usbhub-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/ko/adafruit-circuitpython-capablerobot_usbhub-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/pl/adafruit-circuitpython-capablerobot_usbhub-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/pt_BR/adafruit-circuitpython-capablerobot_usbhub-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/zh_Latn_pinyin/adafruit-circuitpython-capablerobot_usbhub-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 17,
+        "downloads": 0,
         "id": "catwan_usbstick",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/ID/adafruit-circuitpython-catwan_usbstick-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/de_DE/adafruit-circuitpython-catwan_usbstick-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/en_US/adafruit-circuitpython-catwan_usbstick-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/en_x_pirate/adafruit-circuitpython-catwan_usbstick-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/es/adafruit-circuitpython-catwan_usbstick-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/fil/adafruit-circuitpython-catwan_usbstick-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/fr/adafruit-circuitpython-catwan_usbstick-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/it_IT/adafruit-circuitpython-catwan_usbstick-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/ko/adafruit-circuitpython-catwan_usbstick-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/pl/adafruit-circuitpython-catwan_usbstick-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/pt_BR/adafruit-circuitpython-catwan_usbstick-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/zh_Latn_pinyin/adafruit-circuitpython-catwan_usbstick-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -902,6 +908,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/ID/adafruit-circuitpython-catwan_usbstick-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/de_DE/adafruit-circuitpython-catwan_usbstick-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/en_US/adafruit-circuitpython-catwan_usbstick-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/en_x_pirate/adafruit-circuitpython-catwan_usbstick-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/es/adafruit-circuitpython-catwan_usbstick-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/fil/adafruit-circuitpython-catwan_usbstick-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/fr/adafruit-circuitpython-catwan_usbstick-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/it_IT/adafruit-circuitpython-catwan_usbstick-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/ko/adafruit-circuitpython-catwan_usbstick-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/pl/adafruit-circuitpython-catwan_usbstick-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/pt_BR/adafruit-circuitpython-catwan_usbstick-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/zh_Latn_pinyin/adafruit-circuitpython-catwan_usbstick-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -909,48 +957,6 @@
         "downloads": 0,
         "id": "circuitbrains_basic_m0",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/ID/adafruit-circuitpython-circuitbrains_basic_m0-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/de_DE/adafruit-circuitpython-circuitbrains_basic_m0-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/en_US/adafruit-circuitpython-circuitbrains_basic_m0-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/en_x_pirate/adafruit-circuitpython-circuitbrains_basic_m0-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/es/adafruit-circuitpython-circuitbrains_basic_m0-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/fil/adafruit-circuitpython-circuitbrains_basic_m0-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/fr/adafruit-circuitpython-circuitbrains_basic_m0-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/it_IT/adafruit-circuitpython-circuitbrains_basic_m0-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/ko/adafruit-circuitpython-circuitbrains_basic_m0-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/pl/adafruit-circuitpython-circuitbrains_basic_m0-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/pt_BR/adafruit-circuitpython-circuitbrains_basic_m0-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/zh_Latn_pinyin/adafruit-circuitpython-circuitbrains_basic_m0-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -992,6 +998,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/ID/adafruit-circuitpython-circuitbrains_basic_m0-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/de_DE/adafruit-circuitpython-circuitbrains_basic_m0-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/en_US/adafruit-circuitpython-circuitbrains_basic_m0-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/en_x_pirate/adafruit-circuitpython-circuitbrains_basic_m0-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/es/adafruit-circuitpython-circuitbrains_basic_m0-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/fil/adafruit-circuitpython-circuitbrains_basic_m0-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/fr/adafruit-circuitpython-circuitbrains_basic_m0-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/it_IT/adafruit-circuitpython-circuitbrains_basic_m0-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/ko/adafruit-circuitpython-circuitbrains_basic_m0-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/pl/adafruit-circuitpython-circuitbrains_basic_m0-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/pt_BR/adafruit-circuitpython-circuitbrains_basic_m0-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/zh_Latn_pinyin/adafruit-circuitpython-circuitbrains_basic_m0-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -999,48 +1047,6 @@
         "downloads": 0,
         "id": "circuitbrains_deluxe_m4",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/ID/adafruit-circuitpython-circuitbrains_deluxe_m4-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/de_DE/adafruit-circuitpython-circuitbrains_deluxe_m4-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/en_US/adafruit-circuitpython-circuitbrains_deluxe_m4-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/en_x_pirate/adafruit-circuitpython-circuitbrains_deluxe_m4-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/es/adafruit-circuitpython-circuitbrains_deluxe_m4-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/fil/adafruit-circuitpython-circuitbrains_deluxe_m4-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/fr/adafruit-circuitpython-circuitbrains_deluxe_m4-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/it_IT/adafruit-circuitpython-circuitbrains_deluxe_m4-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/ko/adafruit-circuitpython-circuitbrains_deluxe_m4-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/pl/adafruit-circuitpython-circuitbrains_deluxe_m4-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/pt_BR/adafruit-circuitpython-circuitbrains_deluxe_m4-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/zh_Latn_pinyin/adafruit-circuitpython-circuitbrains_deluxe_m4-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -1082,6 +1088,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/ID/adafruit-circuitpython-circuitbrains_deluxe_m4-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/de_DE/adafruit-circuitpython-circuitbrains_deluxe_m4-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/en_US/adafruit-circuitpython-circuitbrains_deluxe_m4-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/en_x_pirate/adafruit-circuitpython-circuitbrains_deluxe_m4-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/es/adafruit-circuitpython-circuitbrains_deluxe_m4-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/fil/adafruit-circuitpython-circuitbrains_deluxe_m4-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/fr/adafruit-circuitpython-circuitbrains_deluxe_m4-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/it_IT/adafruit-circuitpython-circuitbrains_deluxe_m4-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/ko/adafruit-circuitpython-circuitbrains_deluxe_m4-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/pl/adafruit-circuitpython-circuitbrains_deluxe_m4-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/pt_BR/adafruit-circuitpython-circuitbrains_deluxe_m4-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/zh_Latn_pinyin/adafruit-circuitpython-circuitbrains_deluxe_m4-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -1089,48 +1137,6 @@
         "downloads": 0,
         "id": "circuitplayground_bluefruit",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/ID/adafruit-circuitpython-circuitplayground_bluefruit-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/de_DE/adafruit-circuitpython-circuitplayground_bluefruit-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/en_US/adafruit-circuitpython-circuitplayground_bluefruit-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/en_x_pirate/adafruit-circuitpython-circuitplayground_bluefruit-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/es/adafruit-circuitpython-circuitplayground_bluefruit-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/fil/adafruit-circuitpython-circuitplayground_bluefruit-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/fr/adafruit-circuitpython-circuitplayground_bluefruit-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/it_IT/adafruit-circuitpython-circuitplayground_bluefruit-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/ko/adafruit-circuitpython-circuitplayground_bluefruit-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/pl/adafruit-circuitpython-circuitplayground_bluefruit-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/pt_BR/adafruit-circuitpython-circuitplayground_bluefruit-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_bluefruit-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -1172,55 +1178,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/ID/adafruit-circuitpython-circuitplayground_bluefruit-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/de_DE/adafruit-circuitpython-circuitplayground_bluefruit-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/en_US/adafruit-circuitpython-circuitplayground_bluefruit-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/en_x_pirate/adafruit-circuitpython-circuitplayground_bluefruit-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/es/adafruit-circuitpython-circuitplayground_bluefruit-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/fil/adafruit-circuitpython-circuitplayground_bluefruit-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/fr/adafruit-circuitpython-circuitplayground_bluefruit-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/it_IT/adafruit-circuitpython-circuitplayground_bluefruit-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/ko/adafruit-circuitpython-circuitplayground_bluefruit-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/pl/adafruit-circuitpython-circuitplayground_bluefruit-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/pt_BR/adafruit-circuitpython-circuitplayground_bluefruit-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_bluefruit-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 3856,
+        "downloads": 0,
         "id": "circuitplayground_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/ID/adafruit-circuitpython-circuitplayground_express-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/de_DE/adafruit-circuitpython-circuitplayground_express-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/en_US/adafruit-circuitpython-circuitplayground_express-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/en_x_pirate/adafruit-circuitpython-circuitplayground_express-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/es/adafruit-circuitpython-circuitplayground_express-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/fil/adafruit-circuitpython-circuitplayground_express-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/fr/adafruit-circuitpython-circuitplayground_express-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/it_IT/adafruit-circuitpython-circuitplayground_express-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/ko/adafruit-circuitpython-circuitplayground_express-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/pl/adafruit-circuitpython-circuitplayground_express-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/pt_BR/adafruit-circuitpython-circuitplayground_express-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_express-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -1262,55 +1268,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/ID/adafruit-circuitpython-circuitplayground_express-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/de_DE/adafruit-circuitpython-circuitplayground_express-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/en_US/adafruit-circuitpython-circuitplayground_express-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/en_x_pirate/adafruit-circuitpython-circuitplayground_express-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/es/adafruit-circuitpython-circuitplayground_express-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/fil/adafruit-circuitpython-circuitplayground_express-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/fr/adafruit-circuitpython-circuitplayground_express-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/it_IT/adafruit-circuitpython-circuitplayground_express-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/ko/adafruit-circuitpython-circuitplayground_express-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/pl/adafruit-circuitpython-circuitplayground_express-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/pt_BR/adafruit-circuitpython-circuitplayground_express-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_express-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 47,
+        "downloads": 0,
         "id": "circuitplayground_express_4h",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/ID/adafruit-circuitpython-circuitplayground_express_4h-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/de_DE/adafruit-circuitpython-circuitplayground_express_4h-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/en_US/adafruit-circuitpython-circuitplayground_express_4h-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/en_x_pirate/adafruit-circuitpython-circuitplayground_express_4h-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/es/adafruit-circuitpython-circuitplayground_express_4h-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/fil/adafruit-circuitpython-circuitplayground_express_4h-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/fr/adafruit-circuitpython-circuitplayground_express_4h-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/it_IT/adafruit-circuitpython-circuitplayground_express_4h-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/ko/adafruit-circuitpython-circuitplayground_express_4h-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/pl/adafruit-circuitpython-circuitplayground_express_4h-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/pt_BR/adafruit-circuitpython-circuitplayground_express_4h-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_express_4h-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -1352,55 +1358,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/ID/adafruit-circuitpython-circuitplayground_express_4h-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/de_DE/adafruit-circuitpython-circuitplayground_express_4h-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/en_US/adafruit-circuitpython-circuitplayground_express_4h-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/en_x_pirate/adafruit-circuitpython-circuitplayground_express_4h-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/es/adafruit-circuitpython-circuitplayground_express_4h-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/fil/adafruit-circuitpython-circuitplayground_express_4h-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/fr/adafruit-circuitpython-circuitplayground_express_4h-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/it_IT/adafruit-circuitpython-circuitplayground_express_4h-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/ko/adafruit-circuitpython-circuitplayground_express_4h-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/pl/adafruit-circuitpython-circuitplayground_express_4h-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/pt_BR/adafruit-circuitpython-circuitplayground_express_4h-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_express_4h-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 222,
+        "downloads": 0,
         "id": "circuitplayground_express_crickit",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/ID/adafruit-circuitpython-circuitplayground_express_crickit-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/de_DE/adafruit-circuitpython-circuitplayground_express_crickit-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/en_US/adafruit-circuitpython-circuitplayground_express_crickit-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/en_x_pirate/adafruit-circuitpython-circuitplayground_express_crickit-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/es/adafruit-circuitpython-circuitplayground_express_crickit-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/fil/adafruit-circuitpython-circuitplayground_express_crickit-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/fr/adafruit-circuitpython-circuitplayground_express_crickit-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/it_IT/adafruit-circuitpython-circuitplayground_express_crickit-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/ko/adafruit-circuitpython-circuitplayground_express_crickit-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/pl/adafruit-circuitpython-circuitplayground_express_crickit-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/pt_BR/adafruit-circuitpython-circuitplayground_express_crickit-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_express_crickit-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -1442,55 +1448,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/ID/adafruit-circuitpython-circuitplayground_express_crickit-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/de_DE/adafruit-circuitpython-circuitplayground_express_crickit-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/en_US/adafruit-circuitpython-circuitplayground_express_crickit-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/en_x_pirate/adafruit-circuitpython-circuitplayground_express_crickit-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/es/adafruit-circuitpython-circuitplayground_express_crickit-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/fil/adafruit-circuitpython-circuitplayground_express_crickit-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/fr/adafruit-circuitpython-circuitplayground_express_crickit-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/it_IT/adafruit-circuitpython-circuitplayground_express_crickit-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/ko/adafruit-circuitpython-circuitplayground_express_crickit-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/pl/adafruit-circuitpython-circuitplayground_express_crickit-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/pt_BR/adafruit-circuitpython-circuitplayground_express_crickit-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_express_crickit-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 36,
+        "downloads": 0,
         "id": "circuitplayground_express_digikey_pycon2019",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/ID/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/de_DE/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/en_US/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/en_x_pirate/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/es/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/fil/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/fr/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/it_IT/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/ko/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/pl/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/pt_BR/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -1532,6 +1538,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/ID/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/de_DE/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/en_US/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/en_x_pirate/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/es/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/fil/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/fr/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/it_IT/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/ko/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/pl/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/pt_BR/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -1539,48 +1587,6 @@
         "downloads": 0,
         "id": "circuitplayground_express_displayio",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/ID/adafruit-circuitpython-circuitplayground_express_displayio-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/de_DE/adafruit-circuitpython-circuitplayground_express_displayio-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/en_US/adafruit-circuitpython-circuitplayground_express_displayio-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/en_x_pirate/adafruit-circuitpython-circuitplayground_express_displayio-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/es/adafruit-circuitpython-circuitplayground_express_displayio-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/fil/adafruit-circuitpython-circuitplayground_express_displayio-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/fr/adafruit-circuitpython-circuitplayground_express_displayio-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/it_IT/adafruit-circuitpython-circuitplayground_express_displayio-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/ko/adafruit-circuitpython-circuitplayground_express_displayio-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/pl/adafruit-circuitpython-circuitplayground_express_displayio-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/pt_BR/adafruit-circuitpython-circuitplayground_express_displayio-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_express_displayio-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -1622,6 +1628,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/ID/adafruit-circuitpython-circuitplayground_express_displayio-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/de_DE/adafruit-circuitpython-circuitplayground_express_displayio-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/en_US/adafruit-circuitpython-circuitplayground_express_displayio-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/en_x_pirate/adafruit-circuitpython-circuitplayground_express_displayio-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/es/adafruit-circuitpython-circuitplayground_express_displayio-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/fil/adafruit-circuitpython-circuitplayground_express_displayio-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/fr/adafruit-circuitpython-circuitplayground_express_displayio-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/it_IT/adafruit-circuitpython-circuitplayground_express_displayio-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/ko/adafruit-circuitpython-circuitplayground_express_displayio-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/pl/adafruit-circuitpython-circuitplayground_express_displayio-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/pt_BR/adafruit-circuitpython-circuitplayground_express_displayio-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_express_displayio-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -1629,48 +1677,6 @@
         "downloads": 0,
         "id": "clue_nrf52840_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/ID/adafruit-circuitpython-clue_nrf52840_express-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/de_DE/adafruit-circuitpython-clue_nrf52840_express-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/en_US/adafruit-circuitpython-clue_nrf52840_express-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/en_x_pirate/adafruit-circuitpython-clue_nrf52840_express-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/es/adafruit-circuitpython-clue_nrf52840_express-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/fil/adafruit-circuitpython-clue_nrf52840_express-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/fr/adafruit-circuitpython-clue_nrf52840_express-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/it_IT/adafruit-circuitpython-clue_nrf52840_express-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/ko/adafruit-circuitpython-clue_nrf52840_express-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/pl/adafruit-circuitpython-clue_nrf52840_express-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/pt_BR/adafruit-circuitpython-clue_nrf52840_express-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/zh_Latn_pinyin/adafruit-circuitpython-clue_nrf52840_express-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -1712,6 +1718,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/ID/adafruit-circuitpython-clue_nrf52840_express-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/de_DE/adafruit-circuitpython-clue_nrf52840_express-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/en_US/adafruit-circuitpython-clue_nrf52840_express-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/en_x_pirate/adafruit-circuitpython-clue_nrf52840_express-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/es/adafruit-circuitpython-clue_nrf52840_express-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/fil/adafruit-circuitpython-clue_nrf52840_express-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/fr/adafruit-circuitpython-clue_nrf52840_express-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/it_IT/adafruit-circuitpython-clue_nrf52840_express-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/ko/adafruit-circuitpython-clue_nrf52840_express-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/pl/adafruit-circuitpython-clue_nrf52840_express-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/pt_BR/adafruit-circuitpython-clue_nrf52840_express-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/zh_Latn_pinyin/adafruit-circuitpython-clue_nrf52840_express-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -1719,48 +1767,6 @@
         "downloads": 0,
         "id": "cp32-m4",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/ID/adafruit-circuitpython-cp32-m4-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/de_DE/adafruit-circuitpython-cp32-m4-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/en_US/adafruit-circuitpython-cp32-m4-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/en_x_pirate/adafruit-circuitpython-cp32-m4-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/es/adafruit-circuitpython-cp32-m4-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/fil/adafruit-circuitpython-cp32-m4-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/fr/adafruit-circuitpython-cp32-m4-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/it_IT/adafruit-circuitpython-cp32-m4-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/ko/adafruit-circuitpython-cp32-m4-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/pl/adafruit-circuitpython-cp32-m4-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/pt_BR/adafruit-circuitpython-cp32-m4-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/zh_Latn_pinyin/adafruit-circuitpython-cp32-m4-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -1802,6 +1808,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/cp32-m4/ID/adafruit-circuitpython-cp32-m4-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/cp32-m4/de_DE/adafruit-circuitpython-cp32-m4-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/cp32-m4/en_US/adafruit-circuitpython-cp32-m4-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/cp32-m4/en_x_pirate/adafruit-circuitpython-cp32-m4-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/cp32-m4/es/adafruit-circuitpython-cp32-m4-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/cp32-m4/fil/adafruit-circuitpython-cp32-m4-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/cp32-m4/fr/adafruit-circuitpython-cp32-m4-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/cp32-m4/it_IT/adafruit-circuitpython-cp32-m4-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/cp32-m4/ko/adafruit-circuitpython-cp32-m4-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/cp32-m4/pl/adafruit-circuitpython-cp32-m4-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/cp32-m4/pt_BR/adafruit-circuitpython-cp32-m4-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/cp32-m4/zh_Latn_pinyin/adafruit-circuitpython-cp32-m4-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -1809,48 +1857,6 @@
         "downloads": 0,
         "id": "datalore_ip_m4",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/ID/adafruit-circuitpython-datalore_ip_m4-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/de_DE/adafruit-circuitpython-datalore_ip_m4-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/en_US/adafruit-circuitpython-datalore_ip_m4-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/en_x_pirate/adafruit-circuitpython-datalore_ip_m4-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/es/adafruit-circuitpython-datalore_ip_m4-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/fil/adafruit-circuitpython-datalore_ip_m4-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/fr/adafruit-circuitpython-datalore_ip_m4-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/it_IT/adafruit-circuitpython-datalore_ip_m4-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/ko/adafruit-circuitpython-datalore_ip_m4-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/pl/adafruit-circuitpython-datalore_ip_m4-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/pt_BR/adafruit-circuitpython-datalore_ip_m4-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/zh_Latn_pinyin/adafruit-circuitpython-datalore_ip_m4-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -1892,55 +1898,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/ID/adafruit-circuitpython-datalore_ip_m4-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/de_DE/adafruit-circuitpython-datalore_ip_m4-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/en_US/adafruit-circuitpython-datalore_ip_m4-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/en_x_pirate/adafruit-circuitpython-datalore_ip_m4-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/es/adafruit-circuitpython-datalore_ip_m4-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/fil/adafruit-circuitpython-datalore_ip_m4-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/fr/adafruit-circuitpython-datalore_ip_m4-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/it_IT/adafruit-circuitpython-datalore_ip_m4-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/ko/adafruit-circuitpython-datalore_ip_m4-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/pl/adafruit-circuitpython-datalore_ip_m4-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/pt_BR/adafruit-circuitpython-datalore_ip_m4-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/zh_Latn_pinyin/adafruit-circuitpython-datalore_ip_m4-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 18,
+        "downloads": 0,
         "id": "datum_distance",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/ID/adafruit-circuitpython-datum_distance-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/de_DE/adafruit-circuitpython-datum_distance-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/en_US/adafruit-circuitpython-datum_distance-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/en_x_pirate/adafruit-circuitpython-datum_distance-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/es/adafruit-circuitpython-datum_distance-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/fil/adafruit-circuitpython-datum_distance-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/fr/adafruit-circuitpython-datum_distance-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/it_IT/adafruit-circuitpython-datum_distance-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/ko/adafruit-circuitpython-datum_distance-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/pl/adafruit-circuitpython-datum_distance-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/pt_BR/adafruit-circuitpython-datum_distance-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/zh_Latn_pinyin/adafruit-circuitpython-datum_distance-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -1982,55 +1988,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/datum_distance/ID/adafruit-circuitpython-datum_distance-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/datum_distance/de_DE/adafruit-circuitpython-datum_distance-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/datum_distance/en_US/adafruit-circuitpython-datum_distance-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/datum_distance/en_x_pirate/adafruit-circuitpython-datum_distance-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/datum_distance/es/adafruit-circuitpython-datum_distance-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/datum_distance/fil/adafruit-circuitpython-datum_distance-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/datum_distance/fr/adafruit-circuitpython-datum_distance-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/datum_distance/it_IT/adafruit-circuitpython-datum_distance-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/datum_distance/ko/adafruit-circuitpython-datum_distance-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/datum_distance/pl/adafruit-circuitpython-datum_distance-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/datum_distance/pt_BR/adafruit-circuitpython-datum_distance-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/datum_distance/zh_Latn_pinyin/adafruit-circuitpython-datum_distance-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 20,
+        "downloads": 0,
         "id": "datum_imu",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/ID/adafruit-circuitpython-datum_imu-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/de_DE/adafruit-circuitpython-datum_imu-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/en_US/adafruit-circuitpython-datum_imu-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/en_x_pirate/adafruit-circuitpython-datum_imu-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/es/adafruit-circuitpython-datum_imu-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/fil/adafruit-circuitpython-datum_imu-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/fr/adafruit-circuitpython-datum_imu-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/it_IT/adafruit-circuitpython-datum_imu-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/ko/adafruit-circuitpython-datum_imu-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/pl/adafruit-circuitpython-datum_imu-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/pt_BR/adafruit-circuitpython-datum_imu-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/zh_Latn_pinyin/adafruit-circuitpython-datum_imu-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -2072,55 +2078,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/datum_imu/ID/adafruit-circuitpython-datum_imu-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/datum_imu/de_DE/adafruit-circuitpython-datum_imu-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/datum_imu/en_US/adafruit-circuitpython-datum_imu-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/datum_imu/en_x_pirate/adafruit-circuitpython-datum_imu-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/datum_imu/es/adafruit-circuitpython-datum_imu-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/datum_imu/fil/adafruit-circuitpython-datum_imu-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/datum_imu/fr/adafruit-circuitpython-datum_imu-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/datum_imu/it_IT/adafruit-circuitpython-datum_imu-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/datum_imu/ko/adafruit-circuitpython-datum_imu-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/datum_imu/pl/adafruit-circuitpython-datum_imu-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/datum_imu/pt_BR/adafruit-circuitpython-datum_imu-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/datum_imu/zh_Latn_pinyin/adafruit-circuitpython-datum_imu-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 14,
+        "downloads": 0,
         "id": "datum_light",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/datum_light/ID/adafruit-circuitpython-datum_light-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/datum_light/de_DE/adafruit-circuitpython-datum_light-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/datum_light/en_US/adafruit-circuitpython-datum_light-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/datum_light/en_x_pirate/adafruit-circuitpython-datum_light-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/datum_light/es/adafruit-circuitpython-datum_light-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/datum_light/fil/adafruit-circuitpython-datum_light-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/datum_light/fr/adafruit-circuitpython-datum_light-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/datum_light/it_IT/adafruit-circuitpython-datum_light-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/datum_light/ko/adafruit-circuitpython-datum_light-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/datum_light/pl/adafruit-circuitpython-datum_light-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/datum_light/pt_BR/adafruit-circuitpython-datum_light-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/datum_light/zh_Latn_pinyin/adafruit-circuitpython-datum_light-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -2162,55 +2168,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/datum_light/ID/adafruit-circuitpython-datum_light-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/datum_light/de_DE/adafruit-circuitpython-datum_light-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/datum_light/en_US/adafruit-circuitpython-datum_light-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/datum_light/en_x_pirate/adafruit-circuitpython-datum_light-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/datum_light/es/adafruit-circuitpython-datum_light-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/datum_light/fil/adafruit-circuitpython-datum_light-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/datum_light/fr/adafruit-circuitpython-datum_light-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/datum_light/it_IT/adafruit-circuitpython-datum_light-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/datum_light/ko/adafruit-circuitpython-datum_light-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/datum_light/pl/adafruit-circuitpython-datum_light-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/datum_light/pt_BR/adafruit-circuitpython-datum_light-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/datum_light/zh_Latn_pinyin/adafruit-circuitpython-datum_light-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 16,
+        "downloads": 0,
         "id": "datum_weather",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/ID/adafruit-circuitpython-datum_weather-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/de_DE/adafruit-circuitpython-datum_weather-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/en_US/adafruit-circuitpython-datum_weather-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/en_x_pirate/adafruit-circuitpython-datum_weather-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/es/adafruit-circuitpython-datum_weather-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/fil/adafruit-circuitpython-datum_weather-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/fr/adafruit-circuitpython-datum_weather-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/it_IT/adafruit-circuitpython-datum_weather-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/ko/adafruit-circuitpython-datum_weather-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/pl/adafruit-circuitpython-datum_weather-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/pt_BR/adafruit-circuitpython-datum_weather-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/zh_Latn_pinyin/adafruit-circuitpython-datum_weather-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -2252,6 +2258,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/datum_weather/ID/adafruit-circuitpython-datum_weather-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/datum_weather/de_DE/adafruit-circuitpython-datum_weather-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/datum_weather/en_US/adafruit-circuitpython-datum_weather-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/datum_weather/en_x_pirate/adafruit-circuitpython-datum_weather-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/datum_weather/es/adafruit-circuitpython-datum_weather-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/datum_weather/fil/adafruit-circuitpython-datum_weather-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/datum_weather/fr/adafruit-circuitpython-datum_weather-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/datum_weather/it_IT/adafruit-circuitpython-datum_weather-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/datum_weather/ko/adafruit-circuitpython-datum_weather-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/datum_weather/pl/adafruit-circuitpython-datum_weather-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/datum_weather/pt_BR/adafruit-circuitpython-datum_weather-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/datum_weather/zh_Latn_pinyin/adafruit-circuitpython-datum_weather-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -2259,48 +2307,6 @@
         "downloads": 0,
         "id": "edgebadge",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/ID/adafruit-circuitpython-edgebadge-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/de_DE/adafruit-circuitpython-edgebadge-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/en_US/adafruit-circuitpython-edgebadge-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/en_x_pirate/adafruit-circuitpython-edgebadge-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/es/adafruit-circuitpython-edgebadge-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/fil/adafruit-circuitpython-edgebadge-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/fr/adafruit-circuitpython-edgebadge-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/it_IT/adafruit-circuitpython-edgebadge-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/ko/adafruit-circuitpython-edgebadge-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/pl/adafruit-circuitpython-edgebadge-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/pt_BR/adafruit-circuitpython-edgebadge-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/zh_Latn_pinyin/adafruit-circuitpython-edgebadge-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -2342,55 +2348,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/edgebadge/ID/adafruit-circuitpython-edgebadge-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/edgebadge/de_DE/adafruit-circuitpython-edgebadge-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/edgebadge/en_US/adafruit-circuitpython-edgebadge-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/edgebadge/en_x_pirate/adafruit-circuitpython-edgebadge-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/edgebadge/es/adafruit-circuitpython-edgebadge-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/edgebadge/fil/adafruit-circuitpython-edgebadge-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/edgebadge/fr/adafruit-circuitpython-edgebadge-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/edgebadge/it_IT/adafruit-circuitpython-edgebadge-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/edgebadge/ko/adafruit-circuitpython-edgebadge-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/edgebadge/pl/adafruit-circuitpython-edgebadge-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/edgebadge/pt_BR/adafruit-circuitpython-edgebadge-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/edgebadge/zh_Latn_pinyin/adafruit-circuitpython-edgebadge-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 18,
+        "downloads": 0,
         "id": "electronut_labs_blip",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/ID/adafruit-circuitpython-electronut_labs_blip-ID-5.0.0-rc.1.hex"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/de_DE/adafruit-circuitpython-electronut_labs_blip-de_DE-5.0.0-rc.1.hex"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/en_US/adafruit-circuitpython-electronut_labs_blip-en_US-5.0.0-rc.1.hex"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/en_x_pirate/adafruit-circuitpython-electronut_labs_blip-en_x_pirate-5.0.0-rc.1.hex"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/es/adafruit-circuitpython-electronut_labs_blip-es-5.0.0-rc.1.hex"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/fil/adafruit-circuitpython-electronut_labs_blip-fil-5.0.0-rc.1.hex"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/fr/adafruit-circuitpython-electronut_labs_blip-fr-5.0.0-rc.1.hex"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/it_IT/adafruit-circuitpython-electronut_labs_blip-it_IT-5.0.0-rc.1.hex"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/ko/adafruit-circuitpython-electronut_labs_blip-ko-5.0.0-rc.1.hex"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/pl/adafruit-circuitpython-electronut_labs_blip-pl-5.0.0-rc.1.hex"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/pt_BR/adafruit-circuitpython-electronut_labs_blip-pt_BR-5.0.0-rc.1.hex"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/zh_Latn_pinyin/adafruit-circuitpython-electronut_labs_blip-zh_Latn_pinyin-5.0.0-rc.1.hex"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -2432,55 +2438,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/ID/adafruit-circuitpython-electronut_labs_blip-ID-5.1.0-rc.0.hex"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/de_DE/adafruit-circuitpython-electronut_labs_blip-de_DE-5.1.0-rc.0.hex"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/en_US/adafruit-circuitpython-electronut_labs_blip-en_US-5.1.0-rc.0.hex"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/en_x_pirate/adafruit-circuitpython-electronut_labs_blip-en_x_pirate-5.1.0-rc.0.hex"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/es/adafruit-circuitpython-electronut_labs_blip-es-5.1.0-rc.0.hex"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/fil/adafruit-circuitpython-electronut_labs_blip-fil-5.1.0-rc.0.hex"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/fr/adafruit-circuitpython-electronut_labs_blip-fr-5.1.0-rc.0.hex"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/it_IT/adafruit-circuitpython-electronut_labs_blip-it_IT-5.1.0-rc.0.hex"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/ko/adafruit-circuitpython-electronut_labs_blip-ko-5.1.0-rc.0.hex"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/pl/adafruit-circuitpython-electronut_labs_blip-pl-5.1.0-rc.0.hex"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/pt_BR/adafruit-circuitpython-electronut_labs_blip-pt_BR-5.1.0-rc.0.hex"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/zh_Latn_pinyin/adafruit-circuitpython-electronut_labs_blip-zh_Latn_pinyin-5.1.0-rc.0.hex"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 25,
+        "downloads": 0,
         "id": "electronut_labs_papyr",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/ID/adafruit-circuitpython-electronut_labs_papyr-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/de_DE/adafruit-circuitpython-electronut_labs_papyr-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/en_US/adafruit-circuitpython-electronut_labs_papyr-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/en_x_pirate/adafruit-circuitpython-electronut_labs_papyr-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/es/adafruit-circuitpython-electronut_labs_papyr-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/fil/adafruit-circuitpython-electronut_labs_papyr-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/fr/adafruit-circuitpython-electronut_labs_papyr-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/it_IT/adafruit-circuitpython-electronut_labs_papyr-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/ko/adafruit-circuitpython-electronut_labs_papyr-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/pl/adafruit-circuitpython-electronut_labs_papyr-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/pt_BR/adafruit-circuitpython-electronut_labs_papyr-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/zh_Latn_pinyin/adafruit-circuitpython-electronut_labs_papyr-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -2522,55 +2528,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/ID/adafruit-circuitpython-electronut_labs_papyr-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/de_DE/adafruit-circuitpython-electronut_labs_papyr-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/en_US/adafruit-circuitpython-electronut_labs_papyr-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/en_x_pirate/adafruit-circuitpython-electronut_labs_papyr-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/es/adafruit-circuitpython-electronut_labs_papyr-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/fil/adafruit-circuitpython-electronut_labs_papyr-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/fr/adafruit-circuitpython-electronut_labs_papyr-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/it_IT/adafruit-circuitpython-electronut_labs_papyr-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/ko/adafruit-circuitpython-electronut_labs_papyr-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/pl/adafruit-circuitpython-electronut_labs_papyr-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/pt_BR/adafruit-circuitpython-electronut_labs_papyr-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/zh_Latn_pinyin/adafruit-circuitpython-electronut_labs_papyr-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 23,
+        "downloads": 0,
         "id": "escornabot_makech",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/ID/adafruit-circuitpython-escornabot_makech-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/de_DE/adafruit-circuitpython-escornabot_makech-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/en_US/adafruit-circuitpython-escornabot_makech-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/en_x_pirate/adafruit-circuitpython-escornabot_makech-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/es/adafruit-circuitpython-escornabot_makech-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/fil/adafruit-circuitpython-escornabot_makech-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/fr/adafruit-circuitpython-escornabot_makech-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/it_IT/adafruit-circuitpython-escornabot_makech-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/ko/adafruit-circuitpython-escornabot_makech-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/pl/adafruit-circuitpython-escornabot_makech-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/pt_BR/adafruit-circuitpython-escornabot_makech-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/zh_Latn_pinyin/adafruit-circuitpython-escornabot_makech-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -2612,6 +2618,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/ID/adafruit-circuitpython-escornabot_makech-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/de_DE/adafruit-circuitpython-escornabot_makech-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/en_US/adafruit-circuitpython-escornabot_makech-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/en_x_pirate/adafruit-circuitpython-escornabot_makech-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/es/adafruit-circuitpython-escornabot_makech-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/fil/adafruit-circuitpython-escornabot_makech-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/fr/adafruit-circuitpython-escornabot_makech-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/it_IT/adafruit-circuitpython-escornabot_makech-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/ko/adafruit-circuitpython-escornabot_makech-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/pl/adafruit-circuitpython-escornabot_makech-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/pt_BR/adafruit-circuitpython-escornabot_makech-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/zh_Latn_pinyin/adafruit-circuitpython-escornabot_makech-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -2619,48 +2667,6 @@
         "downloads": 0,
         "id": "espruino_pico",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/ID/adafruit-circuitpython-espruino_pico-ID-5.0.0-rc.1.bin"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/de_DE/adafruit-circuitpython-espruino_pico-de_DE-5.0.0-rc.1.bin"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/en_US/adafruit-circuitpython-espruino_pico-en_US-5.0.0-rc.1.bin"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/en_x_pirate/adafruit-circuitpython-espruino_pico-en_x_pirate-5.0.0-rc.1.bin"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/es/adafruit-circuitpython-espruino_pico-es-5.0.0-rc.1.bin"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/fil/adafruit-circuitpython-espruino_pico-fil-5.0.0-rc.1.bin"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/fr/adafruit-circuitpython-espruino_pico-fr-5.0.0-rc.1.bin"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/it_IT/adafruit-circuitpython-espruino_pico-it_IT-5.0.0-rc.1.bin"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/ko/adafruit-circuitpython-espruino_pico-ko-5.0.0-rc.1.bin"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/pl/adafruit-circuitpython-espruino_pico-pl-5.0.0-rc.1.bin"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/pt_BR/adafruit-circuitpython-espruino_pico-pt_BR-5.0.0-rc.1.bin"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/zh_Latn_pinyin/adafruit-circuitpython-espruino_pico-zh_Latn_pinyin-5.0.0-rc.1.bin"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -2702,6 +2708,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/espruino_pico/ID/adafruit-circuitpython-espruino_pico-ID-5.1.0-rc.0.bin"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/espruino_pico/de_DE/adafruit-circuitpython-espruino_pico-de_DE-5.1.0-rc.0.bin"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/espruino_pico/en_US/adafruit-circuitpython-espruino_pico-en_US-5.1.0-rc.0.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/espruino_pico/en_x_pirate/adafruit-circuitpython-espruino_pico-en_x_pirate-5.1.0-rc.0.bin"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/espruino_pico/es/adafruit-circuitpython-espruino_pico-es-5.1.0-rc.0.bin"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/espruino_pico/fil/adafruit-circuitpython-espruino_pico-fil-5.1.0-rc.0.bin"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/espruino_pico/fr/adafruit-circuitpython-espruino_pico-fr-5.1.0-rc.0.bin"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/espruino_pico/it_IT/adafruit-circuitpython-espruino_pico-it_IT-5.1.0-rc.0.bin"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/espruino_pico/ko/adafruit-circuitpython-espruino_pico-ko-5.1.0-rc.0.bin"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/espruino_pico/pl/adafruit-circuitpython-espruino_pico-pl-5.1.0-rc.0.bin"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/espruino_pico/pt_BR/adafruit-circuitpython-espruino_pico-pt_BR-5.1.0-rc.0.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/espruino_pico/zh_Latn_pinyin/adafruit-circuitpython-espruino_pico-zh_Latn_pinyin-5.1.0-rc.0.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -2709,48 +2757,6 @@
         "downloads": 0,
         "id": "espruino_wifi",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/ID/adafruit-circuitpython-espruino_wifi-ID-5.0.0-rc.1.bin"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/de_DE/adafruit-circuitpython-espruino_wifi-de_DE-5.0.0-rc.1.bin"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/en_US/adafruit-circuitpython-espruino_wifi-en_US-5.0.0-rc.1.bin"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/en_x_pirate/adafruit-circuitpython-espruino_wifi-en_x_pirate-5.0.0-rc.1.bin"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/es/adafruit-circuitpython-espruino_wifi-es-5.0.0-rc.1.bin"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/fil/adafruit-circuitpython-espruino_wifi-fil-5.0.0-rc.1.bin"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/fr/adafruit-circuitpython-espruino_wifi-fr-5.0.0-rc.1.bin"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/it_IT/adafruit-circuitpython-espruino_wifi-it_IT-5.0.0-rc.1.bin"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/ko/adafruit-circuitpython-espruino_wifi-ko-5.0.0-rc.1.bin"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/pl/adafruit-circuitpython-espruino_wifi-pl-5.0.0-rc.1.bin"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/pt_BR/adafruit-circuitpython-espruino_wifi-pt_BR-5.0.0-rc.1.bin"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/zh_Latn_pinyin/adafruit-circuitpython-espruino_wifi-zh_Latn_pinyin-5.0.0-rc.1.bin"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -2792,6 +2798,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/ID/adafruit-circuitpython-espruino_wifi-ID-5.1.0-rc.0.bin"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/de_DE/adafruit-circuitpython-espruino_wifi-de_DE-5.1.0-rc.0.bin"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/en_US/adafruit-circuitpython-espruino_wifi-en_US-5.1.0-rc.0.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/en_x_pirate/adafruit-circuitpython-espruino_wifi-en_x_pirate-5.1.0-rc.0.bin"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/es/adafruit-circuitpython-espruino_wifi-es-5.1.0-rc.0.bin"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/fil/adafruit-circuitpython-espruino_wifi-fil-5.1.0-rc.0.bin"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/fr/adafruit-circuitpython-espruino_wifi-fr-5.1.0-rc.0.bin"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/it_IT/adafruit-circuitpython-espruino_wifi-it_IT-5.1.0-rc.0.bin"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/ko/adafruit-circuitpython-espruino_wifi-ko-5.1.0-rc.0.bin"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/pl/adafruit-circuitpython-espruino_wifi-pl-5.1.0-rc.0.bin"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/pt_BR/adafruit-circuitpython-espruino_wifi-pt_BR-5.1.0-rc.0.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/zh_Latn_pinyin/adafruit-circuitpython-espruino_wifi-zh_Latn_pinyin-5.1.0-rc.0.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -2799,48 +2847,6 @@
         "downloads": 0,
         "id": "feather_bluefruit_sense",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/ID/adafruit-circuitpython-feather_bluefruit_sense-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/de_DE/adafruit-circuitpython-feather_bluefruit_sense-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/en_US/adafruit-circuitpython-feather_bluefruit_sense-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/en_x_pirate/adafruit-circuitpython-feather_bluefruit_sense-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/es/adafruit-circuitpython-feather_bluefruit_sense-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/fil/adafruit-circuitpython-feather_bluefruit_sense-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/fr/adafruit-circuitpython-feather_bluefruit_sense-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/it_IT/adafruit-circuitpython-feather_bluefruit_sense-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/ko/adafruit-circuitpython-feather_bluefruit_sense-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/pl/adafruit-circuitpython-feather_bluefruit_sense-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/pt_BR/adafruit-circuitpython-feather_bluefruit_sense-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/zh_Latn_pinyin/adafruit-circuitpython-feather_bluefruit_sense-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -2882,67 +2888,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/ID/adafruit-circuitpython-feather_bluefruit_sense-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/de_DE/adafruit-circuitpython-feather_bluefruit_sense-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/en_US/adafruit-circuitpython-feather_bluefruit_sense-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/en_x_pirate/adafruit-circuitpython-feather_bluefruit_sense-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/es/adafruit-circuitpython-feather_bluefruit_sense-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/fil/adafruit-circuitpython-feather_bluefruit_sense-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/fr/adafruit-circuitpython-feather_bluefruit_sense-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/it_IT/adafruit-circuitpython-feather_bluefruit_sense-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/ko/adafruit-circuitpython-feather_bluefruit_sense-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/pl/adafruit-circuitpython-feather_bluefruit_sense-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/pt_BR/adafruit-circuitpython-feather_bluefruit_sense-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/zh_Latn_pinyin/adafruit-circuitpython-feather_bluefruit_sense-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 205,
+        "downloads": 0,
         "id": "feather_m0_adalogger",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/ID/adafruit-circuitpython-feather_m0_adalogger-ID-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/ID/adafruit-circuitpython-feather_m0_adalogger-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/de_DE/adafruit-circuitpython-feather_m0_adalogger-de_DE-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/de_DE/adafruit-circuitpython-feather_m0_adalogger-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/en_US/adafruit-circuitpython-feather_m0_adalogger-en_US-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/en_US/adafruit-circuitpython-feather_m0_adalogger-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/en_x_pirate/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/en_x_pirate/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/es/adafruit-circuitpython-feather_m0_adalogger-es-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/es/adafruit-circuitpython-feather_m0_adalogger-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/fil/adafruit-circuitpython-feather_m0_adalogger-fil-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/fil/adafruit-circuitpython-feather_m0_adalogger-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/fr/adafruit-circuitpython-feather_m0_adalogger-fr-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/fr/adafruit-circuitpython-feather_m0_adalogger-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/it_IT/adafruit-circuitpython-feather_m0_adalogger-it_IT-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/it_IT/adafruit-circuitpython-feather_m0_adalogger-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/ko/adafruit-circuitpython-feather_m0_adalogger-ko-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/ko/adafruit-circuitpython-feather_m0_adalogger-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/pl/adafruit-circuitpython-feather_m0_adalogger-pl-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/pl/adafruit-circuitpython-feather_m0_adalogger-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/pt_BR/adafruit-circuitpython-feather_m0_adalogger-pt_BR-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/pt_BR/adafruit-circuitpython-feather_m0_adalogger-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_adalogger-zh_Latn_pinyin-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_adalogger-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -2996,67 +2990,67 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/ID/adafruit-circuitpython-feather_m0_adalogger-ID-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/ID/adafruit-circuitpython-feather_m0_adalogger-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/de_DE/adafruit-circuitpython-feather_m0_adalogger-de_DE-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/de_DE/adafruit-circuitpython-feather_m0_adalogger-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/en_US/adafruit-circuitpython-feather_m0_adalogger-en_US-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/en_US/adafruit-circuitpython-feather_m0_adalogger-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/en_x_pirate/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/en_x_pirate/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/es/adafruit-circuitpython-feather_m0_adalogger-es-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/es/adafruit-circuitpython-feather_m0_adalogger-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/fil/adafruit-circuitpython-feather_m0_adalogger-fil-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/fil/adafruit-circuitpython-feather_m0_adalogger-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/fr/adafruit-circuitpython-feather_m0_adalogger-fr-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/fr/adafruit-circuitpython-feather_m0_adalogger-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/it_IT/adafruit-circuitpython-feather_m0_adalogger-it_IT-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/it_IT/adafruit-circuitpython-feather_m0_adalogger-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/ko/adafruit-circuitpython-feather_m0_adalogger-ko-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/ko/adafruit-circuitpython-feather_m0_adalogger-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/pl/adafruit-circuitpython-feather_m0_adalogger-pl-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/pl/adafruit-circuitpython-feather_m0_adalogger-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/pt_BR/adafruit-circuitpython-feather_m0_adalogger-pt_BR-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/pt_BR/adafruit-circuitpython-feather_m0_adalogger-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_adalogger-zh_Latn_pinyin-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_adalogger-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 218,
+        "downloads": 0,
         "id": "feather_m0_basic",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/ID/adafruit-circuitpython-feather_m0_basic-ID-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/ID/adafruit-circuitpython-feather_m0_basic-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/de_DE/adafruit-circuitpython-feather_m0_basic-de_DE-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/de_DE/adafruit-circuitpython-feather_m0_basic-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/en_US/adafruit-circuitpython-feather_m0_basic-en_US-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/en_US/adafruit-circuitpython-feather_m0_basic-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/en_x_pirate/adafruit-circuitpython-feather_m0_basic-en_x_pirate-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/en_x_pirate/adafruit-circuitpython-feather_m0_basic-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/es/adafruit-circuitpython-feather_m0_basic-es-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/es/adafruit-circuitpython-feather_m0_basic-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/fil/adafruit-circuitpython-feather_m0_basic-fil-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/fil/adafruit-circuitpython-feather_m0_basic-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/fr/adafruit-circuitpython-feather_m0_basic-fr-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/fr/adafruit-circuitpython-feather_m0_basic-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/it_IT/adafruit-circuitpython-feather_m0_basic-it_IT-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/it_IT/adafruit-circuitpython-feather_m0_basic-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/ko/adafruit-circuitpython-feather_m0_basic-ko-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/ko/adafruit-circuitpython-feather_m0_basic-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/pl/adafruit-circuitpython-feather_m0_basic-pl-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/pl/adafruit-circuitpython-feather_m0_basic-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/pt_BR/adafruit-circuitpython-feather_m0_basic-pt_BR-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/pt_BR/adafruit-circuitpython-feather_m0_basic-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_basic-zh_Latn_pinyin-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_basic-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -3110,55 +3104,67 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/ID/adafruit-circuitpython-feather_m0_basic-ID-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/ID/adafruit-circuitpython-feather_m0_basic-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/de_DE/adafruit-circuitpython-feather_m0_basic-de_DE-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/de_DE/adafruit-circuitpython-feather_m0_basic-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/en_US/adafruit-circuitpython-feather_m0_basic-en_US-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/en_US/adafruit-circuitpython-feather_m0_basic-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/en_x_pirate/adafruit-circuitpython-feather_m0_basic-en_x_pirate-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/en_x_pirate/adafruit-circuitpython-feather_m0_basic-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/es/adafruit-circuitpython-feather_m0_basic-es-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/es/adafruit-circuitpython-feather_m0_basic-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/fil/adafruit-circuitpython-feather_m0_basic-fil-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/fil/adafruit-circuitpython-feather_m0_basic-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/fr/adafruit-circuitpython-feather_m0_basic-fr-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/fr/adafruit-circuitpython-feather_m0_basic-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/it_IT/adafruit-circuitpython-feather_m0_basic-it_IT-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/it_IT/adafruit-circuitpython-feather_m0_basic-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/ko/adafruit-circuitpython-feather_m0_basic-ko-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/ko/adafruit-circuitpython-feather_m0_basic-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/pl/adafruit-circuitpython-feather_m0_basic-pl-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/pl/adafruit-circuitpython-feather_m0_basic-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/pt_BR/adafruit-circuitpython-feather_m0_basic-pt_BR-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/pt_BR/adafruit-circuitpython-feather_m0_basic-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_basic-zh_Latn_pinyin-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_basic-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 522,
+        "downloads": 0,
         "id": "feather_m0_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/ID/adafruit-circuitpython-feather_m0_express-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/de_DE/adafruit-circuitpython-feather_m0_express-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/en_US/adafruit-circuitpython-feather_m0_express-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/en_x_pirate/adafruit-circuitpython-feather_m0_express-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/es/adafruit-circuitpython-feather_m0_express-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/fil/adafruit-circuitpython-feather_m0_express-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/fr/adafruit-circuitpython-feather_m0_express-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/it_IT/adafruit-circuitpython-feather_m0_express-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/ko/adafruit-circuitpython-feather_m0_express-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/pl/adafruit-circuitpython-feather_m0_express-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/pt_BR/adafruit-circuitpython-feather_m0_express-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_express-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -3200,55 +3206,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/ID/adafruit-circuitpython-feather_m0_express-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/de_DE/adafruit-circuitpython-feather_m0_express-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/en_US/adafruit-circuitpython-feather_m0_express-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/en_x_pirate/adafruit-circuitpython-feather_m0_express-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/es/adafruit-circuitpython-feather_m0_express-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/fil/adafruit-circuitpython-feather_m0_express-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/fr/adafruit-circuitpython-feather_m0_express-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/it_IT/adafruit-circuitpython-feather_m0_express-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/ko/adafruit-circuitpython-feather_m0_express-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/pl/adafruit-circuitpython-feather_m0_express-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/pt_BR/adafruit-circuitpython-feather_m0_express-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_express-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 36,
+        "downloads": 0,
         "id": "feather_m0_express_crickit",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/ID/adafruit-circuitpython-feather_m0_express_crickit-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/de_DE/adafruit-circuitpython-feather_m0_express_crickit-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/en_US/adafruit-circuitpython-feather_m0_express_crickit-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/en_x_pirate/adafruit-circuitpython-feather_m0_express_crickit-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/es/adafruit-circuitpython-feather_m0_express_crickit-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/fil/adafruit-circuitpython-feather_m0_express_crickit-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/fr/adafruit-circuitpython-feather_m0_express_crickit-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/it_IT/adafruit-circuitpython-feather_m0_express_crickit-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/ko/adafruit-circuitpython-feather_m0_express_crickit-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/pl/adafruit-circuitpython-feather_m0_express_crickit-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/pt_BR/adafruit-circuitpython-feather_m0_express_crickit-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_express_crickit-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -3290,67 +3296,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/ID/adafruit-circuitpython-feather_m0_express_crickit-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/de_DE/adafruit-circuitpython-feather_m0_express_crickit-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/en_US/adafruit-circuitpython-feather_m0_express_crickit-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/en_x_pirate/adafruit-circuitpython-feather_m0_express_crickit-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/es/adafruit-circuitpython-feather_m0_express_crickit-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/fil/adafruit-circuitpython-feather_m0_express_crickit-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/fr/adafruit-circuitpython-feather_m0_express_crickit-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/it_IT/adafruit-circuitpython-feather_m0_express_crickit-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/ko/adafruit-circuitpython-feather_m0_express_crickit-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/pl/adafruit-circuitpython-feather_m0_express_crickit-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/pt_BR/adafruit-circuitpython-feather_m0_express_crickit-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_express_crickit-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 106,
+        "downloads": 0,
         "id": "feather_m0_rfm69",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/ID/adafruit-circuitpython-feather_m0_rfm69-ID-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/ID/adafruit-circuitpython-feather_m0_rfm69-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/de_DE/adafruit-circuitpython-feather_m0_rfm69-de_DE-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/de_DE/adafruit-circuitpython-feather_m0_rfm69-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/en_US/adafruit-circuitpython-feather_m0_rfm69-en_US-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/en_US/adafruit-circuitpython-feather_m0_rfm69-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/en_x_pirate/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/en_x_pirate/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/es/adafruit-circuitpython-feather_m0_rfm69-es-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/es/adafruit-circuitpython-feather_m0_rfm69-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/fil/adafruit-circuitpython-feather_m0_rfm69-fil-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/fil/adafruit-circuitpython-feather_m0_rfm69-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/fr/adafruit-circuitpython-feather_m0_rfm69-fr-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/fr/adafruit-circuitpython-feather_m0_rfm69-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/it_IT/adafruit-circuitpython-feather_m0_rfm69-it_IT-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/it_IT/adafruit-circuitpython-feather_m0_rfm69-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/ko/adafruit-circuitpython-feather_m0_rfm69-ko-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/ko/adafruit-circuitpython-feather_m0_rfm69-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/pl/adafruit-circuitpython-feather_m0_rfm69-pl-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/pl/adafruit-circuitpython-feather_m0_rfm69-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/pt_BR/adafruit-circuitpython-feather_m0_rfm69-pt_BR-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/pt_BR/adafruit-circuitpython-feather_m0_rfm69-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_rfm69-zh_Latn_pinyin-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_rfm69-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -3404,67 +3398,67 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/ID/adafruit-circuitpython-feather_m0_rfm69-ID-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/ID/adafruit-circuitpython-feather_m0_rfm69-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/de_DE/adafruit-circuitpython-feather_m0_rfm69-de_DE-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/de_DE/adafruit-circuitpython-feather_m0_rfm69-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/en_US/adafruit-circuitpython-feather_m0_rfm69-en_US-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/en_US/adafruit-circuitpython-feather_m0_rfm69-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/en_x_pirate/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/en_x_pirate/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/es/adafruit-circuitpython-feather_m0_rfm69-es-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/es/adafruit-circuitpython-feather_m0_rfm69-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/fil/adafruit-circuitpython-feather_m0_rfm69-fil-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/fil/adafruit-circuitpython-feather_m0_rfm69-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/fr/adafruit-circuitpython-feather_m0_rfm69-fr-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/fr/adafruit-circuitpython-feather_m0_rfm69-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/it_IT/adafruit-circuitpython-feather_m0_rfm69-it_IT-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/it_IT/adafruit-circuitpython-feather_m0_rfm69-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/ko/adafruit-circuitpython-feather_m0_rfm69-ko-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/ko/adafruit-circuitpython-feather_m0_rfm69-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/pl/adafruit-circuitpython-feather_m0_rfm69-pl-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/pl/adafruit-circuitpython-feather_m0_rfm69-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/pt_BR/adafruit-circuitpython-feather_m0_rfm69-pt_BR-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/pt_BR/adafruit-circuitpython-feather_m0_rfm69-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_rfm69-zh_Latn_pinyin-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_rfm69-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 196,
+        "downloads": 0,
         "id": "feather_m0_rfm9x",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/ID/adafruit-circuitpython-feather_m0_rfm9x-ID-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/ID/adafruit-circuitpython-feather_m0_rfm9x-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/de_DE/adafruit-circuitpython-feather_m0_rfm9x-de_DE-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/de_DE/adafruit-circuitpython-feather_m0_rfm9x-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/en_US/adafruit-circuitpython-feather_m0_rfm9x-en_US-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/en_US/adafruit-circuitpython-feather_m0_rfm9x-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/en_x_pirate/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/en_x_pirate/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/es/adafruit-circuitpython-feather_m0_rfm9x-es-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/es/adafruit-circuitpython-feather_m0_rfm9x-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/fil/adafruit-circuitpython-feather_m0_rfm9x-fil-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/fil/adafruit-circuitpython-feather_m0_rfm9x-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/fr/adafruit-circuitpython-feather_m0_rfm9x-fr-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/fr/adafruit-circuitpython-feather_m0_rfm9x-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/it_IT/adafruit-circuitpython-feather_m0_rfm9x-it_IT-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/it_IT/adafruit-circuitpython-feather_m0_rfm9x-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/ko/adafruit-circuitpython-feather_m0_rfm9x-ko-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/ko/adafruit-circuitpython-feather_m0_rfm9x-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/pl/adafruit-circuitpython-feather_m0_rfm9x-pl-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/pl/adafruit-circuitpython-feather_m0_rfm9x-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/pt_BR/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/pt_BR/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_rfm9x-zh_Latn_pinyin-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_rfm9x-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -3518,6 +3512,60 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/ID/adafruit-circuitpython-feather_m0_rfm9x-ID-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/ID/adafruit-circuitpython-feather_m0_rfm9x-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/de_DE/adafruit-circuitpython-feather_m0_rfm9x-de_DE-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/de_DE/adafruit-circuitpython-feather_m0_rfm9x-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/en_US/adafruit-circuitpython-feather_m0_rfm9x-en_US-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/en_US/adafruit-circuitpython-feather_m0_rfm9x-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/en_x_pirate/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/en_x_pirate/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/es/adafruit-circuitpython-feather_m0_rfm9x-es-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/es/adafruit-circuitpython-feather_m0_rfm9x-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/fil/adafruit-circuitpython-feather_m0_rfm9x-fil-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/fil/adafruit-circuitpython-feather_m0_rfm9x-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/fr/adafruit-circuitpython-feather_m0_rfm9x-fr-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/fr/adafruit-circuitpython-feather_m0_rfm9x-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/it_IT/adafruit-circuitpython-feather_m0_rfm9x-it_IT-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/it_IT/adafruit-circuitpython-feather_m0_rfm9x-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/ko/adafruit-circuitpython-feather_m0_rfm9x-ko-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/ko/adafruit-circuitpython-feather_m0_rfm9x-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/pl/adafruit-circuitpython-feather_m0_rfm9x-pl-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/pl/adafruit-circuitpython-feather_m0_rfm9x-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/pt_BR/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/pt_BR/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_rfm9x-zh_Latn_pinyin-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_rfm9x-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -3525,48 +3573,6 @@
         "downloads": 0,
         "id": "feather_m0_supersized",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/ID/adafruit-circuitpython-feather_m0_supersized-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/de_DE/adafruit-circuitpython-feather_m0_supersized-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/en_US/adafruit-circuitpython-feather_m0_supersized-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/en_x_pirate/adafruit-circuitpython-feather_m0_supersized-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/es/adafruit-circuitpython-feather_m0_supersized-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/fil/adafruit-circuitpython-feather_m0_supersized-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/fr/adafruit-circuitpython-feather_m0_supersized-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/it_IT/adafruit-circuitpython-feather_m0_supersized-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/ko/adafruit-circuitpython-feather_m0_supersized-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/pl/adafruit-circuitpython-feather_m0_supersized-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/pt_BR/adafruit-circuitpython-feather_m0_supersized-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_supersized-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -3608,55 +3614,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/ID/adafruit-circuitpython-feather_m0_supersized-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/de_DE/adafruit-circuitpython-feather_m0_supersized-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/en_US/adafruit-circuitpython-feather_m0_supersized-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/en_x_pirate/adafruit-circuitpython-feather_m0_supersized-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/es/adafruit-circuitpython-feather_m0_supersized-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/fil/adafruit-circuitpython-feather_m0_supersized-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/fr/adafruit-circuitpython-feather_m0_supersized-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/it_IT/adafruit-circuitpython-feather_m0_supersized-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/ko/adafruit-circuitpython-feather_m0_supersized-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/pl/adafruit-circuitpython-feather_m0_supersized-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/pt_BR/adafruit-circuitpython-feather_m0_supersized-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_supersized-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 1189,
+        "downloads": 0,
         "id": "feather_m4_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/ID/adafruit-circuitpython-feather_m4_express-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/de_DE/adafruit-circuitpython-feather_m4_express-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/en_US/adafruit-circuitpython-feather_m4_express-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/en_x_pirate/adafruit-circuitpython-feather_m4_express-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/es/adafruit-circuitpython-feather_m4_express-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/fil/adafruit-circuitpython-feather_m4_express-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/fr/adafruit-circuitpython-feather_m4_express-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/it_IT/adafruit-circuitpython-feather_m4_express-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/ko/adafruit-circuitpython-feather_m4_express-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/pl/adafruit-circuitpython-feather_m4_express-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/pt_BR/adafruit-circuitpython-feather_m4_express-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/zh_Latn_pinyin/adafruit-circuitpython-feather_m4_express-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -3698,6 +3704,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/ID/adafruit-circuitpython-feather_m4_express-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/de_DE/adafruit-circuitpython-feather_m4_express-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/en_US/adafruit-circuitpython-feather_m4_express-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/en_x_pirate/adafruit-circuitpython-feather_m4_express-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/es/adafruit-circuitpython-feather_m4_express-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/fil/adafruit-circuitpython-feather_m4_express-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/fr/adafruit-circuitpython-feather_m4_express-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/it_IT/adafruit-circuitpython-feather_m4_express-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/ko/adafruit-circuitpython-feather_m4_express-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/pl/adafruit-circuitpython-feather_m4_express-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/pt_BR/adafruit-circuitpython-feather_m4_express-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/zh_Latn_pinyin/adafruit-circuitpython-feather_m4_express-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -3705,60 +3753,6 @@
         "downloads": 0,
         "id": "feather_m7_1011",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/ID/adafruit-circuitpython-feather_m7_1011-ID-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/ID/adafruit-circuitpython-feather_m7_1011-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/de_DE/adafruit-circuitpython-feather_m7_1011-de_DE-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/de_DE/adafruit-circuitpython-feather_m7_1011-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/en_US/adafruit-circuitpython-feather_m7_1011-en_US-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/en_US/adafruit-circuitpython-feather_m7_1011-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/en_x_pirate/adafruit-circuitpython-feather_m7_1011-en_x_pirate-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/en_x_pirate/adafruit-circuitpython-feather_m7_1011-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/es/adafruit-circuitpython-feather_m7_1011-es-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/es/adafruit-circuitpython-feather_m7_1011-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/fil/adafruit-circuitpython-feather_m7_1011-fil-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/fil/adafruit-circuitpython-feather_m7_1011-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/fr/adafruit-circuitpython-feather_m7_1011-fr-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/fr/adafruit-circuitpython-feather_m7_1011-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/it_IT/adafruit-circuitpython-feather_m7_1011-it_IT-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/it_IT/adafruit-circuitpython-feather_m7_1011-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/ko/adafruit-circuitpython-feather_m7_1011-ko-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/ko/adafruit-circuitpython-feather_m7_1011-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/pl/adafruit-circuitpython-feather_m7_1011-pl-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/pl/adafruit-circuitpython-feather_m7_1011-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/pt_BR/adafruit-circuitpython-feather_m7_1011-pt_BR-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/pt_BR/adafruit-circuitpython-feather_m7_1011-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/zh_Latn_pinyin/adafruit-circuitpython-feather_m7_1011-zh_Latn_pinyin-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/zh_Latn_pinyin/adafruit-circuitpython-feather_m7_1011-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -3812,6 +3806,60 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/ID/adafruit-circuitpython-feather_m7_1011-ID-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/ID/adafruit-circuitpython-feather_m7_1011-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/de_DE/adafruit-circuitpython-feather_m7_1011-de_DE-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/de_DE/adafruit-circuitpython-feather_m7_1011-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/en_US/adafruit-circuitpython-feather_m7_1011-en_US-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/en_US/adafruit-circuitpython-feather_m7_1011-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/en_x_pirate/adafruit-circuitpython-feather_m7_1011-en_x_pirate-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/en_x_pirate/adafruit-circuitpython-feather_m7_1011-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/es/adafruit-circuitpython-feather_m7_1011-es-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/es/adafruit-circuitpython-feather_m7_1011-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/fil/adafruit-circuitpython-feather_m7_1011-fil-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/fil/adafruit-circuitpython-feather_m7_1011-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/fr/adafruit-circuitpython-feather_m7_1011-fr-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/fr/adafruit-circuitpython-feather_m7_1011-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/it_IT/adafruit-circuitpython-feather_m7_1011-it_IT-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/it_IT/adafruit-circuitpython-feather_m7_1011-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/ko/adafruit-circuitpython-feather_m7_1011-ko-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/ko/adafruit-circuitpython-feather_m7_1011-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/pl/adafruit-circuitpython-feather_m7_1011-pl-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/pl/adafruit-circuitpython-feather_m7_1011-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/pt_BR/adafruit-circuitpython-feather_m7_1011-pt_BR-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/pt_BR/adafruit-circuitpython-feather_m7_1011-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/zh_Latn_pinyin/adafruit-circuitpython-feather_m7_1011-zh_Latn_pinyin-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/zh_Latn_pinyin/adafruit-circuitpython-feather_m7_1011-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -3819,60 +3867,6 @@
         "downloads": 0,
         "id": "feather_mimxrt1011",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/ID/adafruit-circuitpython-feather_mimxrt1011-ID-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/ID/adafruit-circuitpython-feather_mimxrt1011-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/de_DE/adafruit-circuitpython-feather_mimxrt1011-de_DE-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/de_DE/adafruit-circuitpython-feather_mimxrt1011-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/en_US/adafruit-circuitpython-feather_mimxrt1011-en_US-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/en_US/adafruit-circuitpython-feather_mimxrt1011-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/en_x_pirate/adafruit-circuitpython-feather_mimxrt1011-en_x_pirate-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/en_x_pirate/adafruit-circuitpython-feather_mimxrt1011-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/es/adafruit-circuitpython-feather_mimxrt1011-es-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/es/adafruit-circuitpython-feather_mimxrt1011-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/fil/adafruit-circuitpython-feather_mimxrt1011-fil-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/fil/adafruit-circuitpython-feather_mimxrt1011-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/fr/adafruit-circuitpython-feather_mimxrt1011-fr-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/fr/adafruit-circuitpython-feather_mimxrt1011-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/it_IT/adafruit-circuitpython-feather_mimxrt1011-it_IT-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/it_IT/adafruit-circuitpython-feather_mimxrt1011-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/ko/adafruit-circuitpython-feather_mimxrt1011-ko-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/ko/adafruit-circuitpython-feather_mimxrt1011-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/pl/adafruit-circuitpython-feather_mimxrt1011-pl-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/pl/adafruit-circuitpython-feather_mimxrt1011-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/pt_BR/adafruit-circuitpython-feather_mimxrt1011-pt_BR-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/pt_BR/adafruit-circuitpython-feather_mimxrt1011-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/zh_Latn_pinyin/adafruit-circuitpython-feather_mimxrt1011-zh_Latn_pinyin-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/zh_Latn_pinyin/adafruit-circuitpython-feather_mimxrt1011-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -3926,6 +3920,60 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/ID/adafruit-circuitpython-feather_mimxrt1011-ID-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/ID/adafruit-circuitpython-feather_mimxrt1011-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/de_DE/adafruit-circuitpython-feather_mimxrt1011-de_DE-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/de_DE/adafruit-circuitpython-feather_mimxrt1011-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/en_US/adafruit-circuitpython-feather_mimxrt1011-en_US-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/en_US/adafruit-circuitpython-feather_mimxrt1011-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/en_x_pirate/adafruit-circuitpython-feather_mimxrt1011-en_x_pirate-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/en_x_pirate/adafruit-circuitpython-feather_mimxrt1011-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/es/adafruit-circuitpython-feather_mimxrt1011-es-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/es/adafruit-circuitpython-feather_mimxrt1011-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/fil/adafruit-circuitpython-feather_mimxrt1011-fil-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/fil/adafruit-circuitpython-feather_mimxrt1011-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/fr/adafruit-circuitpython-feather_mimxrt1011-fr-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/fr/adafruit-circuitpython-feather_mimxrt1011-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/it_IT/adafruit-circuitpython-feather_mimxrt1011-it_IT-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/it_IT/adafruit-circuitpython-feather_mimxrt1011-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/ko/adafruit-circuitpython-feather_mimxrt1011-ko-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/ko/adafruit-circuitpython-feather_mimxrt1011-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/pl/adafruit-circuitpython-feather_mimxrt1011-pl-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/pl/adafruit-circuitpython-feather_mimxrt1011-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/pt_BR/adafruit-circuitpython-feather_mimxrt1011-pt_BR-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/pt_BR/adafruit-circuitpython-feather_mimxrt1011-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/zh_Latn_pinyin/adafruit-circuitpython-feather_mimxrt1011-zh_Latn_pinyin-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/zh_Latn_pinyin/adafruit-circuitpython-feather_mimxrt1011-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -3933,60 +3981,6 @@
         "downloads": 0,
         "id": "feather_mimxrt1062",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/ID/adafruit-circuitpython-feather_mimxrt1062-ID-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/ID/adafruit-circuitpython-feather_mimxrt1062-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/de_DE/adafruit-circuitpython-feather_mimxrt1062-de_DE-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/de_DE/adafruit-circuitpython-feather_mimxrt1062-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/en_US/adafruit-circuitpython-feather_mimxrt1062-en_US-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/en_US/adafruit-circuitpython-feather_mimxrt1062-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/en_x_pirate/adafruit-circuitpython-feather_mimxrt1062-en_x_pirate-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/en_x_pirate/adafruit-circuitpython-feather_mimxrt1062-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/es/adafruit-circuitpython-feather_mimxrt1062-es-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/es/adafruit-circuitpython-feather_mimxrt1062-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/fil/adafruit-circuitpython-feather_mimxrt1062-fil-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/fil/adafruit-circuitpython-feather_mimxrt1062-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/fr/adafruit-circuitpython-feather_mimxrt1062-fr-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/fr/adafruit-circuitpython-feather_mimxrt1062-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/it_IT/adafruit-circuitpython-feather_mimxrt1062-it_IT-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/it_IT/adafruit-circuitpython-feather_mimxrt1062-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/ko/adafruit-circuitpython-feather_mimxrt1062-ko-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/ko/adafruit-circuitpython-feather_mimxrt1062-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/pl/adafruit-circuitpython-feather_mimxrt1062-pl-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/pl/adafruit-circuitpython-feather_mimxrt1062-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/pt_BR/adafruit-circuitpython-feather_mimxrt1062-pt_BR-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/pt_BR/adafruit-circuitpython-feather_mimxrt1062-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/zh_Latn_pinyin/adafruit-circuitpython-feather_mimxrt1062-zh_Latn_pinyin-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/zh_Latn_pinyin/adafruit-circuitpython-feather_mimxrt1062-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -4040,55 +4034,67 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/ID/adafruit-circuitpython-feather_mimxrt1062-ID-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/ID/adafruit-circuitpython-feather_mimxrt1062-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/de_DE/adafruit-circuitpython-feather_mimxrt1062-de_DE-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/de_DE/adafruit-circuitpython-feather_mimxrt1062-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/en_US/adafruit-circuitpython-feather_mimxrt1062-en_US-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/en_US/adafruit-circuitpython-feather_mimxrt1062-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/en_x_pirate/adafruit-circuitpython-feather_mimxrt1062-en_x_pirate-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/en_x_pirate/adafruit-circuitpython-feather_mimxrt1062-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/es/adafruit-circuitpython-feather_mimxrt1062-es-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/es/adafruit-circuitpython-feather_mimxrt1062-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/fil/adafruit-circuitpython-feather_mimxrt1062-fil-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/fil/adafruit-circuitpython-feather_mimxrt1062-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/fr/adafruit-circuitpython-feather_mimxrt1062-fr-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/fr/adafruit-circuitpython-feather_mimxrt1062-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/it_IT/adafruit-circuitpython-feather_mimxrt1062-it_IT-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/it_IT/adafruit-circuitpython-feather_mimxrt1062-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/ko/adafruit-circuitpython-feather_mimxrt1062-ko-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/ko/adafruit-circuitpython-feather_mimxrt1062-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/pl/adafruit-circuitpython-feather_mimxrt1062-pl-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/pl/adafruit-circuitpython-feather_mimxrt1062-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/pt_BR/adafruit-circuitpython-feather_mimxrt1062-pt_BR-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/pt_BR/adafruit-circuitpython-feather_mimxrt1062-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/zh_Latn_pinyin/adafruit-circuitpython-feather_mimxrt1062-zh_Latn_pinyin-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/zh_Latn_pinyin/adafruit-circuitpython-feather_mimxrt1062-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 294,
+        "downloads": 0,
         "id": "feather_nrf52840_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/ID/adafruit-circuitpython-feather_nrf52840_express-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/de_DE/adafruit-circuitpython-feather_nrf52840_express-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/en_US/adafruit-circuitpython-feather_nrf52840_express-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/en_x_pirate/adafruit-circuitpython-feather_nrf52840_express-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/es/adafruit-circuitpython-feather_nrf52840_express-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/fil/adafruit-circuitpython-feather_nrf52840_express-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/fr/adafruit-circuitpython-feather_nrf52840_express-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/it_IT/adafruit-circuitpython-feather_nrf52840_express-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/ko/adafruit-circuitpython-feather_nrf52840_express-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/pl/adafruit-circuitpython-feather_nrf52840_express-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/pt_BR/adafruit-circuitpython-feather_nrf52840_express-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/zh_Latn_pinyin/adafruit-circuitpython-feather_nrf52840_express-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -4130,55 +4136,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/ID/adafruit-circuitpython-feather_nrf52840_express-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/de_DE/adafruit-circuitpython-feather_nrf52840_express-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/en_US/adafruit-circuitpython-feather_nrf52840_express-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/en_x_pirate/adafruit-circuitpython-feather_nrf52840_express-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/es/adafruit-circuitpython-feather_nrf52840_express-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/fil/adafruit-circuitpython-feather_nrf52840_express-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/fr/adafruit-circuitpython-feather_nrf52840_express-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/it_IT/adafruit-circuitpython-feather_nrf52840_express-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/ko/adafruit-circuitpython-feather_nrf52840_express-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/pl/adafruit-circuitpython-feather_nrf52840_express-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/pt_BR/adafruit-circuitpython-feather_nrf52840_express-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/zh_Latn_pinyin/adafruit-circuitpython-feather_nrf52840_express-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 29,
+        "downloads": 0,
         "id": "feather_radiofruit_zigbee",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/ID/adafruit-circuitpython-feather_radiofruit_zigbee-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/de_DE/adafruit-circuitpython-feather_radiofruit_zigbee-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/en_US/adafruit-circuitpython-feather_radiofruit_zigbee-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/en_x_pirate/adafruit-circuitpython-feather_radiofruit_zigbee-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/es/adafruit-circuitpython-feather_radiofruit_zigbee-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/fil/adafruit-circuitpython-feather_radiofruit_zigbee-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/fr/adafruit-circuitpython-feather_radiofruit_zigbee-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/it_IT/adafruit-circuitpython-feather_radiofruit_zigbee-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/ko/adafruit-circuitpython-feather_radiofruit_zigbee-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/pl/adafruit-circuitpython-feather_radiofruit_zigbee-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/pt_BR/adafruit-circuitpython-feather_radiofruit_zigbee-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/zh_Latn_pinyin/adafruit-circuitpython-feather_radiofruit_zigbee-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -4220,6 +4226,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/ID/adafruit-circuitpython-feather_radiofruit_zigbee-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/de_DE/adafruit-circuitpython-feather_radiofruit_zigbee-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/en_US/adafruit-circuitpython-feather_radiofruit_zigbee-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/en_x_pirate/adafruit-circuitpython-feather_radiofruit_zigbee-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/es/adafruit-circuitpython-feather_radiofruit_zigbee-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/fil/adafruit-circuitpython-feather_radiofruit_zigbee-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/fr/adafruit-circuitpython-feather_radiofruit_zigbee-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/it_IT/adafruit-circuitpython-feather_radiofruit_zigbee-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/ko/adafruit-circuitpython-feather_radiofruit_zigbee-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/pl/adafruit-circuitpython-feather_radiofruit_zigbee-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/pt_BR/adafruit-circuitpython-feather_radiofruit_zigbee-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/zh_Latn_pinyin/adafruit-circuitpython-feather_radiofruit_zigbee-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -4227,48 +4275,6 @@
         "downloads": 0,
         "id": "feather_stm32f405_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/ID/adafruit-circuitpython-feather_stm32f405_express-ID-5.0.0-rc.1.bin"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/de_DE/adafruit-circuitpython-feather_stm32f405_express-de_DE-5.0.0-rc.1.bin"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/en_US/adafruit-circuitpython-feather_stm32f405_express-en_US-5.0.0-rc.1.bin"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/en_x_pirate/adafruit-circuitpython-feather_stm32f405_express-en_x_pirate-5.0.0-rc.1.bin"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/es/adafruit-circuitpython-feather_stm32f405_express-es-5.0.0-rc.1.bin"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/fil/adafruit-circuitpython-feather_stm32f405_express-fil-5.0.0-rc.1.bin"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/fr/adafruit-circuitpython-feather_stm32f405_express-fr-5.0.0-rc.1.bin"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/it_IT/adafruit-circuitpython-feather_stm32f405_express-it_IT-5.0.0-rc.1.bin"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/ko/adafruit-circuitpython-feather_stm32f405_express-ko-5.0.0-rc.1.bin"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/pl/adafruit-circuitpython-feather_stm32f405_express-pl-5.0.0-rc.1.bin"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/pt_BR/adafruit-circuitpython-feather_stm32f405_express-pt_BR-5.0.0-rc.1.bin"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/zh_Latn_pinyin/adafruit-circuitpython-feather_stm32f405_express-zh_Latn_pinyin-5.0.0-rc.1.bin"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -4310,6 +4316,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/ID/adafruit-circuitpython-feather_stm32f405_express-ID-5.1.0-rc.0.bin"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/de_DE/adafruit-circuitpython-feather_stm32f405_express-de_DE-5.1.0-rc.0.bin"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/en_US/adafruit-circuitpython-feather_stm32f405_express-en_US-5.1.0-rc.0.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/en_x_pirate/adafruit-circuitpython-feather_stm32f405_express-en_x_pirate-5.1.0-rc.0.bin"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/es/adafruit-circuitpython-feather_stm32f405_express-es-5.1.0-rc.0.bin"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/fil/adafruit-circuitpython-feather_stm32f405_express-fil-5.1.0-rc.0.bin"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/fr/adafruit-circuitpython-feather_stm32f405_express-fr-5.1.0-rc.0.bin"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/it_IT/adafruit-circuitpython-feather_stm32f405_express-it_IT-5.1.0-rc.0.bin"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/ko/adafruit-circuitpython-feather_stm32f405_express-ko-5.1.0-rc.0.bin"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/pl/adafruit-circuitpython-feather_stm32f405_express-pl-5.1.0-rc.0.bin"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/pt_BR/adafruit-circuitpython-feather_stm32f405_express-pt_BR-5.1.0-rc.0.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/zh_Latn_pinyin/adafruit-circuitpython-feather_stm32f405_express-zh_Latn_pinyin-5.1.0-rc.0.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -4319,51 +4367,9 @@
         "versions": []
     },
     {
-        "downloads": 394,
+        "downloads": 0,
         "id": "gemma_m0",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/ID/adafruit-circuitpython-gemma_m0-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/de_DE/adafruit-circuitpython-gemma_m0-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/en_US/adafruit-circuitpython-gemma_m0-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/en_x_pirate/adafruit-circuitpython-gemma_m0-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/es/adafruit-circuitpython-gemma_m0-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/fil/adafruit-circuitpython-gemma_m0-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/fr/adafruit-circuitpython-gemma_m0-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/it_IT/adafruit-circuitpython-gemma_m0-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/ko/adafruit-circuitpython-gemma_m0-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/pl/adafruit-circuitpython-gemma_m0-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/pt_BR/adafruit-circuitpython-gemma_m0-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/zh_Latn_pinyin/adafruit-circuitpython-gemma_m0-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -4405,55 +4411,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0/ID/adafruit-circuitpython-gemma_m0-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0/de_DE/adafruit-circuitpython-gemma_m0-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0/en_US/adafruit-circuitpython-gemma_m0-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0/en_x_pirate/adafruit-circuitpython-gemma_m0-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0/es/adafruit-circuitpython-gemma_m0-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0/fil/adafruit-circuitpython-gemma_m0-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0/fr/adafruit-circuitpython-gemma_m0-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0/it_IT/adafruit-circuitpython-gemma_m0-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0/ko/adafruit-circuitpython-gemma_m0-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0/pl/adafruit-circuitpython-gemma_m0-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0/pt_BR/adafruit-circuitpython-gemma_m0-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0/zh_Latn_pinyin/adafruit-circuitpython-gemma_m0-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 44,
+        "downloads": 0,
         "id": "gemma_m0_pycon2018",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/ID/adafruit-circuitpython-gemma_m0_pycon2018-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/de_DE/adafruit-circuitpython-gemma_m0_pycon2018-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/en_US/adafruit-circuitpython-gemma_m0_pycon2018-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/en_x_pirate/adafruit-circuitpython-gemma_m0_pycon2018-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/es/adafruit-circuitpython-gemma_m0_pycon2018-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/fil/adafruit-circuitpython-gemma_m0_pycon2018-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/fr/adafruit-circuitpython-gemma_m0_pycon2018-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/it_IT/adafruit-circuitpython-gemma_m0_pycon2018-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/ko/adafruit-circuitpython-gemma_m0_pycon2018-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/pl/adafruit-circuitpython-gemma_m0_pycon2018-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/pt_BR/adafruit-circuitpython-gemma_m0_pycon2018-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/zh_Latn_pinyin/adafruit-circuitpython-gemma_m0_pycon2018-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -4495,55 +4501,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/ID/adafruit-circuitpython-gemma_m0_pycon2018-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/de_DE/adafruit-circuitpython-gemma_m0_pycon2018-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/en_US/adafruit-circuitpython-gemma_m0_pycon2018-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/en_x_pirate/adafruit-circuitpython-gemma_m0_pycon2018-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/es/adafruit-circuitpython-gemma_m0_pycon2018-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/fil/adafruit-circuitpython-gemma_m0_pycon2018-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/fr/adafruit-circuitpython-gemma_m0_pycon2018-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/it_IT/adafruit-circuitpython-gemma_m0_pycon2018-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/ko/adafruit-circuitpython-gemma_m0_pycon2018-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/pl/adafruit-circuitpython-gemma_m0_pycon2018-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/pt_BR/adafruit-circuitpython-gemma_m0_pycon2018-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/zh_Latn_pinyin/adafruit-circuitpython-gemma_m0_pycon2018-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 195,
+        "downloads": 0,
         "id": "grandcentral_m4_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/ID/adafruit-circuitpython-grandcentral_m4_express-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/de_DE/adafruit-circuitpython-grandcentral_m4_express-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/en_US/adafruit-circuitpython-grandcentral_m4_express-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/en_x_pirate/adafruit-circuitpython-grandcentral_m4_express-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/es/adafruit-circuitpython-grandcentral_m4_express-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/fil/adafruit-circuitpython-grandcentral_m4_express-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/fr/adafruit-circuitpython-grandcentral_m4_express-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/it_IT/adafruit-circuitpython-grandcentral_m4_express-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/ko/adafruit-circuitpython-grandcentral_m4_express-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/pl/adafruit-circuitpython-grandcentral_m4_express-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/pt_BR/adafruit-circuitpython-grandcentral_m4_express-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/zh_Latn_pinyin/adafruit-circuitpython-grandcentral_m4_express-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -4585,55 +4591,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/ID/adafruit-circuitpython-grandcentral_m4_express-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/de_DE/adafruit-circuitpython-grandcentral_m4_express-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/en_US/adafruit-circuitpython-grandcentral_m4_express-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/en_x_pirate/adafruit-circuitpython-grandcentral_m4_express-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/es/adafruit-circuitpython-grandcentral_m4_express-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/fil/adafruit-circuitpython-grandcentral_m4_express-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/fr/adafruit-circuitpython-grandcentral_m4_express-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/it_IT/adafruit-circuitpython-grandcentral_m4_express-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/ko/adafruit-circuitpython-grandcentral_m4_express-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/pl/adafruit-circuitpython-grandcentral_m4_express-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/pt_BR/adafruit-circuitpython-grandcentral_m4_express-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/zh_Latn_pinyin/adafruit-circuitpython-grandcentral_m4_express-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 109,
+        "downloads": 0,
         "id": "hallowing_m0_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/ID/adafruit-circuitpython-hallowing_m0_express-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/de_DE/adafruit-circuitpython-hallowing_m0_express-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/en_US/adafruit-circuitpython-hallowing_m0_express-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/en_x_pirate/adafruit-circuitpython-hallowing_m0_express-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/es/adafruit-circuitpython-hallowing_m0_express-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/fil/adafruit-circuitpython-hallowing_m0_express-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/fr/adafruit-circuitpython-hallowing_m0_express-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/it_IT/adafruit-circuitpython-hallowing_m0_express-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/ko/adafruit-circuitpython-hallowing_m0_express-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/pl/adafruit-circuitpython-hallowing_m0_express-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/pt_BR/adafruit-circuitpython-hallowing_m0_express-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/zh_Latn_pinyin/adafruit-circuitpython-hallowing_m0_express-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -4675,55 +4681,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/ID/adafruit-circuitpython-hallowing_m0_express-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/de_DE/adafruit-circuitpython-hallowing_m0_express-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/en_US/adafruit-circuitpython-hallowing_m0_express-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/en_x_pirate/adafruit-circuitpython-hallowing_m0_express-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/es/adafruit-circuitpython-hallowing_m0_express-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/fil/adafruit-circuitpython-hallowing_m0_express-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/fr/adafruit-circuitpython-hallowing_m0_express-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/it_IT/adafruit-circuitpython-hallowing_m0_express-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/ko/adafruit-circuitpython-hallowing_m0_express-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/pl/adafruit-circuitpython-hallowing_m0_express-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/pt_BR/adafruit-circuitpython-hallowing_m0_express-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/zh_Latn_pinyin/adafruit-circuitpython-hallowing_m0_express-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 56,
+        "downloads": 0,
         "id": "hallowing_m4_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/ID/adafruit-circuitpython-hallowing_m4_express-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/de_DE/adafruit-circuitpython-hallowing_m4_express-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/en_US/adafruit-circuitpython-hallowing_m4_express-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/en_x_pirate/adafruit-circuitpython-hallowing_m4_express-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/es/adafruit-circuitpython-hallowing_m4_express-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/fil/adafruit-circuitpython-hallowing_m4_express-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/fr/adafruit-circuitpython-hallowing_m4_express-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/it_IT/adafruit-circuitpython-hallowing_m4_express-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/ko/adafruit-circuitpython-hallowing_m4_express-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/pl/adafruit-circuitpython-hallowing_m4_express-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/pt_BR/adafruit-circuitpython-hallowing_m4_express-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/zh_Latn_pinyin/adafruit-circuitpython-hallowing_m4_express-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -4765,6 +4771,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/ID/adafruit-circuitpython-hallowing_m4_express-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/de_DE/adafruit-circuitpython-hallowing_m4_express-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/en_US/adafruit-circuitpython-hallowing_m4_express-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/en_x_pirate/adafruit-circuitpython-hallowing_m4_express-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/es/adafruit-circuitpython-hallowing_m4_express-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/fil/adafruit-circuitpython-hallowing_m4_express-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/fr/adafruit-circuitpython-hallowing_m4_express-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/it_IT/adafruit-circuitpython-hallowing_m4_express-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/ko/adafruit-circuitpython-hallowing_m4_express-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/pl/adafruit-circuitpython-hallowing_m4_express-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/pt_BR/adafruit-circuitpython-hallowing_m4_express-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/zh_Latn_pinyin/adafruit-circuitpython-hallowing_m4_express-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -4772,60 +4820,6 @@
         "downloads": 0,
         "id": "imxrt1010_evk",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/ID/adafruit-circuitpython-imxrt1010_evk-ID-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/ID/adafruit-circuitpython-imxrt1010_evk-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/de_DE/adafruit-circuitpython-imxrt1010_evk-de_DE-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/de_DE/adafruit-circuitpython-imxrt1010_evk-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/en_US/adafruit-circuitpython-imxrt1010_evk-en_US-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/en_US/adafruit-circuitpython-imxrt1010_evk-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/en_x_pirate/adafruit-circuitpython-imxrt1010_evk-en_x_pirate-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/en_x_pirate/adafruit-circuitpython-imxrt1010_evk-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/es/adafruit-circuitpython-imxrt1010_evk-es-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/es/adafruit-circuitpython-imxrt1010_evk-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/fil/adafruit-circuitpython-imxrt1010_evk-fil-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/fil/adafruit-circuitpython-imxrt1010_evk-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/fr/adafruit-circuitpython-imxrt1010_evk-fr-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/fr/adafruit-circuitpython-imxrt1010_evk-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/it_IT/adafruit-circuitpython-imxrt1010_evk-it_IT-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/it_IT/adafruit-circuitpython-imxrt1010_evk-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/ko/adafruit-circuitpython-imxrt1010_evk-ko-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/ko/adafruit-circuitpython-imxrt1010_evk-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/pl/adafruit-circuitpython-imxrt1010_evk-pl-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/pl/adafruit-circuitpython-imxrt1010_evk-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/pt_BR/adafruit-circuitpython-imxrt1010_evk-pt_BR-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/pt_BR/adafruit-circuitpython-imxrt1010_evk-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1010_evk-zh_Latn_pinyin-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1010_evk-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -4879,6 +4873,60 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/ID/adafruit-circuitpython-imxrt1010_evk-ID-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/ID/adafruit-circuitpython-imxrt1010_evk-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/de_DE/adafruit-circuitpython-imxrt1010_evk-de_DE-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/de_DE/adafruit-circuitpython-imxrt1010_evk-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/en_US/adafruit-circuitpython-imxrt1010_evk-en_US-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/en_US/adafruit-circuitpython-imxrt1010_evk-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/en_x_pirate/adafruit-circuitpython-imxrt1010_evk-en_x_pirate-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/en_x_pirate/adafruit-circuitpython-imxrt1010_evk-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/es/adafruit-circuitpython-imxrt1010_evk-es-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/es/adafruit-circuitpython-imxrt1010_evk-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/fil/adafruit-circuitpython-imxrt1010_evk-fil-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/fil/adafruit-circuitpython-imxrt1010_evk-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/fr/adafruit-circuitpython-imxrt1010_evk-fr-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/fr/adafruit-circuitpython-imxrt1010_evk-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/it_IT/adafruit-circuitpython-imxrt1010_evk-it_IT-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/it_IT/adafruit-circuitpython-imxrt1010_evk-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/ko/adafruit-circuitpython-imxrt1010_evk-ko-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/ko/adafruit-circuitpython-imxrt1010_evk-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/pl/adafruit-circuitpython-imxrt1010_evk-pl-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/pl/adafruit-circuitpython-imxrt1010_evk-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/pt_BR/adafruit-circuitpython-imxrt1010_evk-pt_BR-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/pt_BR/adafruit-circuitpython-imxrt1010_evk-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1010_evk-zh_Latn_pinyin-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1010_evk-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -4886,60 +4934,6 @@
         "downloads": 0,
         "id": "imxrt1020_evk",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/ID/adafruit-circuitpython-imxrt1020_evk-ID-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/ID/adafruit-circuitpython-imxrt1020_evk-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/de_DE/adafruit-circuitpython-imxrt1020_evk-de_DE-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/de_DE/adafruit-circuitpython-imxrt1020_evk-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/en_US/adafruit-circuitpython-imxrt1020_evk-en_US-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/en_US/adafruit-circuitpython-imxrt1020_evk-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/en_x_pirate/adafruit-circuitpython-imxrt1020_evk-en_x_pirate-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/en_x_pirate/adafruit-circuitpython-imxrt1020_evk-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/es/adafruit-circuitpython-imxrt1020_evk-es-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/es/adafruit-circuitpython-imxrt1020_evk-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/fil/adafruit-circuitpython-imxrt1020_evk-fil-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/fil/adafruit-circuitpython-imxrt1020_evk-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/fr/adafruit-circuitpython-imxrt1020_evk-fr-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/fr/adafruit-circuitpython-imxrt1020_evk-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/it_IT/adafruit-circuitpython-imxrt1020_evk-it_IT-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/it_IT/adafruit-circuitpython-imxrt1020_evk-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/ko/adafruit-circuitpython-imxrt1020_evk-ko-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/ko/adafruit-circuitpython-imxrt1020_evk-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/pl/adafruit-circuitpython-imxrt1020_evk-pl-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/pl/adafruit-circuitpython-imxrt1020_evk-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/pt_BR/adafruit-circuitpython-imxrt1020_evk-pt_BR-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/pt_BR/adafruit-circuitpython-imxrt1020_evk-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1020_evk-zh_Latn_pinyin-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1020_evk-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -4993,6 +4987,60 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/ID/adafruit-circuitpython-imxrt1020_evk-ID-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/ID/adafruit-circuitpython-imxrt1020_evk-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/de_DE/adafruit-circuitpython-imxrt1020_evk-de_DE-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/de_DE/adafruit-circuitpython-imxrt1020_evk-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/en_US/adafruit-circuitpython-imxrt1020_evk-en_US-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/en_US/adafruit-circuitpython-imxrt1020_evk-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/en_x_pirate/adafruit-circuitpython-imxrt1020_evk-en_x_pirate-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/en_x_pirate/adafruit-circuitpython-imxrt1020_evk-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/es/adafruit-circuitpython-imxrt1020_evk-es-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/es/adafruit-circuitpython-imxrt1020_evk-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/fil/adafruit-circuitpython-imxrt1020_evk-fil-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/fil/adafruit-circuitpython-imxrt1020_evk-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/fr/adafruit-circuitpython-imxrt1020_evk-fr-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/fr/adafruit-circuitpython-imxrt1020_evk-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/it_IT/adafruit-circuitpython-imxrt1020_evk-it_IT-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/it_IT/adafruit-circuitpython-imxrt1020_evk-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/ko/adafruit-circuitpython-imxrt1020_evk-ko-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/ko/adafruit-circuitpython-imxrt1020_evk-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/pl/adafruit-circuitpython-imxrt1020_evk-pl-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/pl/adafruit-circuitpython-imxrt1020_evk-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/pt_BR/adafruit-circuitpython-imxrt1020_evk-pt_BR-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/pt_BR/adafruit-circuitpython-imxrt1020_evk-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1020_evk-zh_Latn_pinyin-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1020_evk-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -5000,60 +5048,6 @@
         "downloads": 0,
         "id": "imxrt1060_evk",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/ID/adafruit-circuitpython-imxrt1060_evk-ID-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/ID/adafruit-circuitpython-imxrt1060_evk-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/de_DE/adafruit-circuitpython-imxrt1060_evk-de_DE-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/de_DE/adafruit-circuitpython-imxrt1060_evk-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/en_US/adafruit-circuitpython-imxrt1060_evk-en_US-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/en_US/adafruit-circuitpython-imxrt1060_evk-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/en_x_pirate/adafruit-circuitpython-imxrt1060_evk-en_x_pirate-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/en_x_pirate/adafruit-circuitpython-imxrt1060_evk-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/es/adafruit-circuitpython-imxrt1060_evk-es-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/es/adafruit-circuitpython-imxrt1060_evk-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/fil/adafruit-circuitpython-imxrt1060_evk-fil-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/fil/adafruit-circuitpython-imxrt1060_evk-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/fr/adafruit-circuitpython-imxrt1060_evk-fr-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/fr/adafruit-circuitpython-imxrt1060_evk-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/it_IT/adafruit-circuitpython-imxrt1060_evk-it_IT-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/it_IT/adafruit-circuitpython-imxrt1060_evk-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/ko/adafruit-circuitpython-imxrt1060_evk-ko-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/ko/adafruit-circuitpython-imxrt1060_evk-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/pl/adafruit-circuitpython-imxrt1060_evk-pl-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/pl/adafruit-circuitpython-imxrt1060_evk-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/pt_BR/adafruit-circuitpython-imxrt1060_evk-pt_BR-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/pt_BR/adafruit-circuitpython-imxrt1060_evk-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1060_evk-zh_Latn_pinyin-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1060_evk-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -5107,55 +5101,67 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/ID/adafruit-circuitpython-imxrt1060_evk-ID-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/ID/adafruit-circuitpython-imxrt1060_evk-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/de_DE/adafruit-circuitpython-imxrt1060_evk-de_DE-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/de_DE/adafruit-circuitpython-imxrt1060_evk-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/en_US/adafruit-circuitpython-imxrt1060_evk-en_US-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/en_US/adafruit-circuitpython-imxrt1060_evk-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/en_x_pirate/adafruit-circuitpython-imxrt1060_evk-en_x_pirate-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/en_x_pirate/adafruit-circuitpython-imxrt1060_evk-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/es/adafruit-circuitpython-imxrt1060_evk-es-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/es/adafruit-circuitpython-imxrt1060_evk-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/fil/adafruit-circuitpython-imxrt1060_evk-fil-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/fil/adafruit-circuitpython-imxrt1060_evk-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/fr/adafruit-circuitpython-imxrt1060_evk-fr-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/fr/adafruit-circuitpython-imxrt1060_evk-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/it_IT/adafruit-circuitpython-imxrt1060_evk-it_IT-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/it_IT/adafruit-circuitpython-imxrt1060_evk-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/ko/adafruit-circuitpython-imxrt1060_evk-ko-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/ko/adafruit-circuitpython-imxrt1060_evk-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/pl/adafruit-circuitpython-imxrt1060_evk-pl-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/pl/adafruit-circuitpython-imxrt1060_evk-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/pt_BR/adafruit-circuitpython-imxrt1060_evk-pt_BR-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/pt_BR/adafruit-circuitpython-imxrt1060_evk-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1060_evk-zh_Latn_pinyin-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1060_evk-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 255,
+        "downloads": 0,
         "id": "itsybitsy_m0_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/ID/adafruit-circuitpython-itsybitsy_m0_express-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/de_DE/adafruit-circuitpython-itsybitsy_m0_express-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/en_US/adafruit-circuitpython-itsybitsy_m0_express-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/en_x_pirate/adafruit-circuitpython-itsybitsy_m0_express-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/es/adafruit-circuitpython-itsybitsy_m0_express-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/fil/adafruit-circuitpython-itsybitsy_m0_express-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/fr/adafruit-circuitpython-itsybitsy_m0_express-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/it_IT/adafruit-circuitpython-itsybitsy_m0_express-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/ko/adafruit-circuitpython-itsybitsy_m0_express-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/pl/adafruit-circuitpython-itsybitsy_m0_express-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/pt_BR/adafruit-circuitpython-itsybitsy_m0_express-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/zh_Latn_pinyin/adafruit-circuitpython-itsybitsy_m0_express-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -5197,55 +5203,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/ID/adafruit-circuitpython-itsybitsy_m0_express-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/de_DE/adafruit-circuitpython-itsybitsy_m0_express-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/en_US/adafruit-circuitpython-itsybitsy_m0_express-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/en_x_pirate/adafruit-circuitpython-itsybitsy_m0_express-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/es/adafruit-circuitpython-itsybitsy_m0_express-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/fil/adafruit-circuitpython-itsybitsy_m0_express-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/fr/adafruit-circuitpython-itsybitsy_m0_express-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/it_IT/adafruit-circuitpython-itsybitsy_m0_express-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/ko/adafruit-circuitpython-itsybitsy_m0_express-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/pl/adafruit-circuitpython-itsybitsy_m0_express-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/pt_BR/adafruit-circuitpython-itsybitsy_m0_express-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/zh_Latn_pinyin/adafruit-circuitpython-itsybitsy_m0_express-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 502,
+        "downloads": 0,
         "id": "itsybitsy_m4_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/ID/adafruit-circuitpython-itsybitsy_m4_express-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/de_DE/adafruit-circuitpython-itsybitsy_m4_express-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/en_US/adafruit-circuitpython-itsybitsy_m4_express-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/en_x_pirate/adafruit-circuitpython-itsybitsy_m4_express-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/es/adafruit-circuitpython-itsybitsy_m4_express-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/fil/adafruit-circuitpython-itsybitsy_m4_express-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/fr/adafruit-circuitpython-itsybitsy_m4_express-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/it_IT/adafruit-circuitpython-itsybitsy_m4_express-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/ko/adafruit-circuitpython-itsybitsy_m4_express-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/pl/adafruit-circuitpython-itsybitsy_m4_express-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/pt_BR/adafruit-circuitpython-itsybitsy_m4_express-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/zh_Latn_pinyin/adafruit-circuitpython-itsybitsy_m4_express-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -5287,6 +5293,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/ID/adafruit-circuitpython-itsybitsy_m4_express-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/de_DE/adafruit-circuitpython-itsybitsy_m4_express-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/en_US/adafruit-circuitpython-itsybitsy_m4_express-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/en_x_pirate/adafruit-circuitpython-itsybitsy_m4_express-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/es/adafruit-circuitpython-itsybitsy_m4_express-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/fil/adafruit-circuitpython-itsybitsy_m4_express-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/fr/adafruit-circuitpython-itsybitsy_m4_express-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/it_IT/adafruit-circuitpython-itsybitsy_m4_express-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/ko/adafruit-circuitpython-itsybitsy_m4_express-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/pl/adafruit-circuitpython-itsybitsy_m4_express-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/pt_BR/adafruit-circuitpython-itsybitsy_m4_express-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/zh_Latn_pinyin/adafruit-circuitpython-itsybitsy_m4_express-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -5294,48 +5342,6 @@
         "downloads": 0,
         "id": "itsybitsy_nrf52840_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/ID/adafruit-circuitpython-itsybitsy_nrf52840_express-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/de_DE/adafruit-circuitpython-itsybitsy_nrf52840_express-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/en_US/adafruit-circuitpython-itsybitsy_nrf52840_express-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/en_x_pirate/adafruit-circuitpython-itsybitsy_nrf52840_express-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/es/adafruit-circuitpython-itsybitsy_nrf52840_express-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/fil/adafruit-circuitpython-itsybitsy_nrf52840_express-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/fr/adafruit-circuitpython-itsybitsy_nrf52840_express-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/it_IT/adafruit-circuitpython-itsybitsy_nrf52840_express-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/ko/adafruit-circuitpython-itsybitsy_nrf52840_express-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/pl/adafruit-circuitpython-itsybitsy_nrf52840_express-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/pt_BR/adafruit-circuitpython-itsybitsy_nrf52840_express-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/zh_Latn_pinyin/adafruit-circuitpython-itsybitsy_nrf52840_express-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -5377,6 +5383,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/ID/adafruit-circuitpython-itsybitsy_nrf52840_express-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/de_DE/adafruit-circuitpython-itsybitsy_nrf52840_express-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/en_US/adafruit-circuitpython-itsybitsy_nrf52840_express-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/en_x_pirate/adafruit-circuitpython-itsybitsy_nrf52840_express-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/es/adafruit-circuitpython-itsybitsy_nrf52840_express-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/fil/adafruit-circuitpython-itsybitsy_nrf52840_express-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/fr/adafruit-circuitpython-itsybitsy_nrf52840_express-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/it_IT/adafruit-circuitpython-itsybitsy_nrf52840_express-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/ko/adafruit-circuitpython-itsybitsy_nrf52840_express-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/pl/adafruit-circuitpython-itsybitsy_nrf52840_express-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/pt_BR/adafruit-circuitpython-itsybitsy_nrf52840_express-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/zh_Latn_pinyin/adafruit-circuitpython-itsybitsy_nrf52840_express-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -5384,48 +5432,6 @@
         "downloads": 0,
         "id": "kicksat-sprite",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/ID/adafruit-circuitpython-kicksat-sprite-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/de_DE/adafruit-circuitpython-kicksat-sprite-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/en_US/adafruit-circuitpython-kicksat-sprite-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/en_x_pirate/adafruit-circuitpython-kicksat-sprite-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/es/adafruit-circuitpython-kicksat-sprite-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/fil/adafruit-circuitpython-kicksat-sprite-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/fr/adafruit-circuitpython-kicksat-sprite-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/it_IT/adafruit-circuitpython-kicksat-sprite-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/ko/adafruit-circuitpython-kicksat-sprite-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/pl/adafruit-circuitpython-kicksat-sprite-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/pt_BR/adafruit-circuitpython-kicksat-sprite-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/zh_Latn_pinyin/adafruit-circuitpython-kicksat-sprite-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -5467,55 +5473,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/ID/adafruit-circuitpython-kicksat-sprite-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/de_DE/adafruit-circuitpython-kicksat-sprite-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/en_US/adafruit-circuitpython-kicksat-sprite-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/en_x_pirate/adafruit-circuitpython-kicksat-sprite-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/es/adafruit-circuitpython-kicksat-sprite-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/fil/adafruit-circuitpython-kicksat-sprite-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/fr/adafruit-circuitpython-kicksat-sprite-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/it_IT/adafruit-circuitpython-kicksat-sprite-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/ko/adafruit-circuitpython-kicksat-sprite-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/pl/adafruit-circuitpython-kicksat-sprite-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/pt_BR/adafruit-circuitpython-kicksat-sprite-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/zh_Latn_pinyin/adafruit-circuitpython-kicksat-sprite-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 33,
+        "downloads": 0,
         "id": "makerdiary_nrf52840_mdk",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/ID/adafruit-circuitpython-makerdiary_nrf52840_mdk-ID-5.0.0-rc.1.hex"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/de_DE/adafruit-circuitpython-makerdiary_nrf52840_mdk-de_DE-5.0.0-rc.1.hex"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/en_US/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_US-5.0.0-rc.1.hex"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/en_x_pirate/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_x_pirate-5.0.0-rc.1.hex"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/es/adafruit-circuitpython-makerdiary_nrf52840_mdk-es-5.0.0-rc.1.hex"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/fil/adafruit-circuitpython-makerdiary_nrf52840_mdk-fil-5.0.0-rc.1.hex"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/fr/adafruit-circuitpython-makerdiary_nrf52840_mdk-fr-5.0.0-rc.1.hex"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/it_IT/adafruit-circuitpython-makerdiary_nrf52840_mdk-it_IT-5.0.0-rc.1.hex"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/ko/adafruit-circuitpython-makerdiary_nrf52840_mdk-ko-5.0.0-rc.1.hex"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/pl/adafruit-circuitpython-makerdiary_nrf52840_mdk-pl-5.0.0-rc.1.hex"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/pt_BR/adafruit-circuitpython-makerdiary_nrf52840_mdk-pt_BR-5.0.0-rc.1.hex"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/zh_Latn_pinyin/adafruit-circuitpython-makerdiary_nrf52840_mdk-zh_Latn_pinyin-5.0.0-rc.1.hex"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -5557,55 +5563,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/ID/adafruit-circuitpython-makerdiary_nrf52840_mdk-ID-5.1.0-rc.0.hex"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/de_DE/adafruit-circuitpython-makerdiary_nrf52840_mdk-de_DE-5.1.0-rc.0.hex"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/en_US/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_US-5.1.0-rc.0.hex"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/en_x_pirate/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_x_pirate-5.1.0-rc.0.hex"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/es/adafruit-circuitpython-makerdiary_nrf52840_mdk-es-5.1.0-rc.0.hex"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/fil/adafruit-circuitpython-makerdiary_nrf52840_mdk-fil-5.1.0-rc.0.hex"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/fr/adafruit-circuitpython-makerdiary_nrf52840_mdk-fr-5.1.0-rc.0.hex"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/it_IT/adafruit-circuitpython-makerdiary_nrf52840_mdk-it_IT-5.1.0-rc.0.hex"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/ko/adafruit-circuitpython-makerdiary_nrf52840_mdk-ko-5.1.0-rc.0.hex"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/pl/adafruit-circuitpython-makerdiary_nrf52840_mdk-pl-5.1.0-rc.0.hex"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/pt_BR/adafruit-circuitpython-makerdiary_nrf52840_mdk-pt_BR-5.1.0-rc.0.hex"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/zh_Latn_pinyin/adafruit-circuitpython-makerdiary_nrf52840_mdk-zh_Latn_pinyin-5.1.0-rc.0.hex"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 56,
+        "downloads": 0,
         "id": "makerdiary_nrf52840_mdk_usb_dongle",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/ID/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-ID-5.0.0-rc.1.hex"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/de_DE/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-de_DE-5.0.0-rc.1.hex"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/en_US/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_US-5.0.0-rc.1.hex"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/en_x_pirate/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_x_pirate-5.0.0-rc.1.hex"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/es/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-es-5.0.0-rc.1.hex"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/fil/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fil-5.0.0-rc.1.hex"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/fr/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fr-5.0.0-rc.1.hex"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/it_IT/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-it_IT-5.0.0-rc.1.hex"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/ko/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-ko-5.0.0-rc.1.hex"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/pl/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pl-5.0.0-rc.1.hex"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/pt_BR/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pt_BR-5.0.0-rc.1.hex"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/zh_Latn_pinyin/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-zh_Latn_pinyin-5.0.0-rc.1.hex"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -5647,6 +5653,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/ID/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-ID-5.1.0-rc.0.hex"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/de_DE/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-de_DE-5.1.0-rc.0.hex"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/en_US/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_US-5.1.0-rc.0.hex"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/en_x_pirate/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_x_pirate-5.1.0-rc.0.hex"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/es/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-es-5.1.0-rc.0.hex"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/fil/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fil-5.1.0-rc.0.hex"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/fr/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fr-5.1.0-rc.0.hex"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/it_IT/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-it_IT-5.1.0-rc.0.hex"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/ko/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-ko-5.1.0-rc.0.hex"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/pl/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pl-5.1.0-rc.0.hex"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/pt_BR/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pt_BR-5.1.0-rc.0.hex"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/zh_Latn_pinyin/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-zh_Latn_pinyin-5.1.0-rc.0.hex"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -5654,48 +5702,6 @@
         "downloads": 0,
         "id": "meowbit_v121",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/ID/adafruit-circuitpython-meowbit_v121-ID-5.0.0-rc.1.bin"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/de_DE/adafruit-circuitpython-meowbit_v121-de_DE-5.0.0-rc.1.bin"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/en_US/adafruit-circuitpython-meowbit_v121-en_US-5.0.0-rc.1.bin"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/en_x_pirate/adafruit-circuitpython-meowbit_v121-en_x_pirate-5.0.0-rc.1.bin"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/es/adafruit-circuitpython-meowbit_v121-es-5.0.0-rc.1.bin"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/fil/adafruit-circuitpython-meowbit_v121-fil-5.0.0-rc.1.bin"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/fr/adafruit-circuitpython-meowbit_v121-fr-5.0.0-rc.1.bin"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/it_IT/adafruit-circuitpython-meowbit_v121-it_IT-5.0.0-rc.1.bin"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/ko/adafruit-circuitpython-meowbit_v121-ko-5.0.0-rc.1.bin"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/pl/adafruit-circuitpython-meowbit_v121-pl-5.0.0-rc.1.bin"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/pt_BR/adafruit-circuitpython-meowbit_v121-pt_BR-5.0.0-rc.1.bin"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/zh_Latn_pinyin/adafruit-circuitpython-meowbit_v121-zh_Latn_pinyin-5.0.0-rc.1.bin"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -5737,55 +5743,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/ID/adafruit-circuitpython-meowbit_v121-ID-5.1.0-rc.0.bin"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/de_DE/adafruit-circuitpython-meowbit_v121-de_DE-5.1.0-rc.0.bin"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/en_US/adafruit-circuitpython-meowbit_v121-en_US-5.1.0-rc.0.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/en_x_pirate/adafruit-circuitpython-meowbit_v121-en_x_pirate-5.1.0-rc.0.bin"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/es/adafruit-circuitpython-meowbit_v121-es-5.1.0-rc.0.bin"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/fil/adafruit-circuitpython-meowbit_v121-fil-5.1.0-rc.0.bin"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/fr/adafruit-circuitpython-meowbit_v121-fr-5.1.0-rc.0.bin"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/it_IT/adafruit-circuitpython-meowbit_v121-it_IT-5.1.0-rc.0.bin"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/ko/adafruit-circuitpython-meowbit_v121-ko-5.1.0-rc.0.bin"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/pl/adafruit-circuitpython-meowbit_v121-pl-5.1.0-rc.0.bin"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/pt_BR/adafruit-circuitpython-meowbit_v121-pt_BR-5.1.0-rc.0.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/zh_Latn_pinyin/adafruit-circuitpython-meowbit_v121-zh_Latn_pinyin-5.1.0-rc.0.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 33,
+        "downloads": 0,
         "id": "meowmeow",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/ID/adafruit-circuitpython-meowmeow-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/de_DE/adafruit-circuitpython-meowmeow-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/en_US/adafruit-circuitpython-meowmeow-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/en_x_pirate/adafruit-circuitpython-meowmeow-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/es/adafruit-circuitpython-meowmeow-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/fil/adafruit-circuitpython-meowmeow-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/fr/adafruit-circuitpython-meowmeow-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/it_IT/adafruit-circuitpython-meowmeow-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/ko/adafruit-circuitpython-meowmeow-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/pl/adafruit-circuitpython-meowmeow-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/pt_BR/adafruit-circuitpython-meowmeow-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/zh_Latn_pinyin/adafruit-circuitpython-meowmeow-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -5827,55 +5833,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/meowmeow/ID/adafruit-circuitpython-meowmeow-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/meowmeow/de_DE/adafruit-circuitpython-meowmeow-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/meowmeow/en_US/adafruit-circuitpython-meowmeow-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/meowmeow/en_x_pirate/adafruit-circuitpython-meowmeow-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/meowmeow/es/adafruit-circuitpython-meowmeow-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/meowmeow/fil/adafruit-circuitpython-meowmeow-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/meowmeow/fr/adafruit-circuitpython-meowmeow-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/meowmeow/it_IT/adafruit-circuitpython-meowmeow-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/meowmeow/ko/adafruit-circuitpython-meowmeow-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/meowmeow/pl/adafruit-circuitpython-meowmeow-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/meowmeow/pt_BR/adafruit-circuitpython-meowmeow-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/meowmeow/zh_Latn_pinyin/adafruit-circuitpython-meowmeow-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 715,
+        "downloads": 0,
         "id": "metro_m0_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/ID/adafruit-circuitpython-metro_m0_express-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/de_DE/adafruit-circuitpython-metro_m0_express-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/en_US/adafruit-circuitpython-metro_m0_express-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/en_x_pirate/adafruit-circuitpython-metro_m0_express-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/es/adafruit-circuitpython-metro_m0_express-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/fil/adafruit-circuitpython-metro_m0_express-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/fr/adafruit-circuitpython-metro_m0_express-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/it_IT/adafruit-circuitpython-metro_m0_express-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/ko/adafruit-circuitpython-metro_m0_express-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/pl/adafruit-circuitpython-metro_m0_express-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/pt_BR/adafruit-circuitpython-metro_m0_express-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/zh_Latn_pinyin/adafruit-circuitpython-metro_m0_express-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -5917,55 +5923,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/ID/adafruit-circuitpython-metro_m0_express-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/de_DE/adafruit-circuitpython-metro_m0_express-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/en_US/adafruit-circuitpython-metro_m0_express-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/en_x_pirate/adafruit-circuitpython-metro_m0_express-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/es/adafruit-circuitpython-metro_m0_express-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/fil/adafruit-circuitpython-metro_m0_express-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/fr/adafruit-circuitpython-metro_m0_express-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/it_IT/adafruit-circuitpython-metro_m0_express-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/ko/adafruit-circuitpython-metro_m0_express-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/pl/adafruit-circuitpython-metro_m0_express-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/pt_BR/adafruit-circuitpython-metro_m0_express-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/zh_Latn_pinyin/adafruit-circuitpython-metro_m0_express-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 153,
+        "downloads": 0,
         "id": "metro_m4_airlift_lite",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/ID/adafruit-circuitpython-metro_m4_airlift_lite-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/de_DE/adafruit-circuitpython-metro_m4_airlift_lite-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/en_US/adafruit-circuitpython-metro_m4_airlift_lite-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/en_x_pirate/adafruit-circuitpython-metro_m4_airlift_lite-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/es/adafruit-circuitpython-metro_m4_airlift_lite-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/fil/adafruit-circuitpython-metro_m4_airlift_lite-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/fr/adafruit-circuitpython-metro_m4_airlift_lite-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/it_IT/adafruit-circuitpython-metro_m4_airlift_lite-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/ko/adafruit-circuitpython-metro_m4_airlift_lite-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/pl/adafruit-circuitpython-metro_m4_airlift_lite-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/pt_BR/adafruit-circuitpython-metro_m4_airlift_lite-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/zh_Latn_pinyin/adafruit-circuitpython-metro_m4_airlift_lite-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -6007,55 +6013,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/ID/adafruit-circuitpython-metro_m4_airlift_lite-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/de_DE/adafruit-circuitpython-metro_m4_airlift_lite-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/en_US/adafruit-circuitpython-metro_m4_airlift_lite-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/en_x_pirate/adafruit-circuitpython-metro_m4_airlift_lite-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/es/adafruit-circuitpython-metro_m4_airlift_lite-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/fil/adafruit-circuitpython-metro_m4_airlift_lite-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/fr/adafruit-circuitpython-metro_m4_airlift_lite-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/it_IT/adafruit-circuitpython-metro_m4_airlift_lite-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/ko/adafruit-circuitpython-metro_m4_airlift_lite-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/pl/adafruit-circuitpython-metro_m4_airlift_lite-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/pt_BR/adafruit-circuitpython-metro_m4_airlift_lite-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/zh_Latn_pinyin/adafruit-circuitpython-metro_m4_airlift_lite-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 215,
+        "downloads": 0,
         "id": "metro_m4_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/ID/adafruit-circuitpython-metro_m4_express-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/de_DE/adafruit-circuitpython-metro_m4_express-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/en_US/adafruit-circuitpython-metro_m4_express-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/en_x_pirate/adafruit-circuitpython-metro_m4_express-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/es/adafruit-circuitpython-metro_m4_express-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/fil/adafruit-circuitpython-metro_m4_express-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/fr/adafruit-circuitpython-metro_m4_express-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/it_IT/adafruit-circuitpython-metro_m4_express-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/ko/adafruit-circuitpython-metro_m4_express-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/pl/adafruit-circuitpython-metro_m4_express-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/pt_BR/adafruit-circuitpython-metro_m4_express-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/zh_Latn_pinyin/adafruit-circuitpython-metro_m4_express-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -6097,6 +6103,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/ID/adafruit-circuitpython-metro_m4_express-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/de_DE/adafruit-circuitpython-metro_m4_express-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/en_US/adafruit-circuitpython-metro_m4_express-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/en_x_pirate/adafruit-circuitpython-metro_m4_express-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/es/adafruit-circuitpython-metro_m4_express-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/fil/adafruit-circuitpython-metro_m4_express-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/fr/adafruit-circuitpython-metro_m4_express-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/it_IT/adafruit-circuitpython-metro_m4_express-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/ko/adafruit-circuitpython-metro_m4_express-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/pl/adafruit-circuitpython-metro_m4_express-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/pt_BR/adafruit-circuitpython-metro_m4_express-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/zh_Latn_pinyin/adafruit-circuitpython-metro_m4_express-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -6104,48 +6152,6 @@
         "downloads": 0,
         "id": "metro_nrf52840_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/ID/adafruit-circuitpython-metro_nrf52840_express-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/de_DE/adafruit-circuitpython-metro_nrf52840_express-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/en_US/adafruit-circuitpython-metro_nrf52840_express-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/en_x_pirate/adafruit-circuitpython-metro_nrf52840_express-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/es/adafruit-circuitpython-metro_nrf52840_express-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/fil/adafruit-circuitpython-metro_nrf52840_express-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/fr/adafruit-circuitpython-metro_nrf52840_express-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/it_IT/adafruit-circuitpython-metro_nrf52840_express-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/ko/adafruit-circuitpython-metro_nrf52840_express-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/pl/adafruit-circuitpython-metro_nrf52840_express-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/pt_BR/adafruit-circuitpython-metro_nrf52840_express-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/zh_Latn_pinyin/adafruit-circuitpython-metro_nrf52840_express-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -6187,55 +6193,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/ID/adafruit-circuitpython-metro_nrf52840_express-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/de_DE/adafruit-circuitpython-metro_nrf52840_express-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/en_US/adafruit-circuitpython-metro_nrf52840_express-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/en_x_pirate/adafruit-circuitpython-metro_nrf52840_express-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/es/adafruit-circuitpython-metro_nrf52840_express-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/fil/adafruit-circuitpython-metro_nrf52840_express-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/fr/adafruit-circuitpython-metro_nrf52840_express-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/it_IT/adafruit-circuitpython-metro_nrf52840_express-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/ko/adafruit-circuitpython-metro_nrf52840_express-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/pl/adafruit-circuitpython-metro_nrf52840_express-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/pt_BR/adafruit-circuitpython-metro_nrf52840_express-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/zh_Latn_pinyin/adafruit-circuitpython-metro_nrf52840_express-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 28,
+        "downloads": 0,
         "id": "mini_sam_m4",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/ID/adafruit-circuitpython-mini_sam_m4-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/de_DE/adafruit-circuitpython-mini_sam_m4-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/en_US/adafruit-circuitpython-mini_sam_m4-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/en_x_pirate/adafruit-circuitpython-mini_sam_m4-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/es/adafruit-circuitpython-mini_sam_m4-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/fil/adafruit-circuitpython-mini_sam_m4-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/fr/adafruit-circuitpython-mini_sam_m4-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/it_IT/adafruit-circuitpython-mini_sam_m4-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/ko/adafruit-circuitpython-mini_sam_m4-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/pl/adafruit-circuitpython-mini_sam_m4-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/pt_BR/adafruit-circuitpython-mini_sam_m4-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/zh_Latn_pinyin/adafruit-circuitpython-mini_sam_m4-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -6277,6 +6283,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/ID/adafruit-circuitpython-mini_sam_m4-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/de_DE/adafruit-circuitpython-mini_sam_m4-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/en_US/adafruit-circuitpython-mini_sam_m4-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/en_x_pirate/adafruit-circuitpython-mini_sam_m4-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/es/adafruit-circuitpython-mini_sam_m4-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/fil/adafruit-circuitpython-mini_sam_m4-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/fr/adafruit-circuitpython-mini_sam_m4-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/it_IT/adafruit-circuitpython-mini_sam_m4-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/ko/adafruit-circuitpython-mini_sam_m4-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/pl/adafruit-circuitpython-mini_sam_m4-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/pt_BR/adafruit-circuitpython-mini_sam_m4-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/zh_Latn_pinyin/adafruit-circuitpython-mini_sam_m4-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -6284,48 +6332,6 @@
         "downloads": 0,
         "id": "monster_m4sk",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/ID/adafruit-circuitpython-monster_m4sk-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/de_DE/adafruit-circuitpython-monster_m4sk-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/en_US/adafruit-circuitpython-monster_m4sk-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/en_x_pirate/adafruit-circuitpython-monster_m4sk-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/es/adafruit-circuitpython-monster_m4sk-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/fil/adafruit-circuitpython-monster_m4sk-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/fr/adafruit-circuitpython-monster_m4sk-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/it_IT/adafruit-circuitpython-monster_m4sk-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/ko/adafruit-circuitpython-monster_m4sk-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/pl/adafruit-circuitpython-monster_m4sk-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/pt_BR/adafruit-circuitpython-monster_m4sk-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/zh_Latn_pinyin/adafruit-circuitpython-monster_m4sk-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -6367,6 +6373,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/ID/adafruit-circuitpython-monster_m4sk-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/de_DE/adafruit-circuitpython-monster_m4sk-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/en_US/adafruit-circuitpython-monster_m4sk-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/en_x_pirate/adafruit-circuitpython-monster_m4sk-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/es/adafruit-circuitpython-monster_m4sk-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/fil/adafruit-circuitpython-monster_m4sk-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/fr/adafruit-circuitpython-monster_m4sk-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/it_IT/adafruit-circuitpython-monster_m4sk-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/ko/adafruit-circuitpython-monster_m4sk-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/pl/adafruit-circuitpython-monster_m4sk-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/pt_BR/adafruit-circuitpython-monster_m4sk-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/zh_Latn_pinyin/adafruit-circuitpython-monster_m4sk-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -6374,48 +6422,6 @@
         "downloads": 0,
         "id": "ndgarage_ndbit6",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/ID/adafruit-circuitpython-ndgarage_ndbit6-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/de_DE/adafruit-circuitpython-ndgarage_ndbit6-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/en_US/adafruit-circuitpython-ndgarage_ndbit6-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/en_x_pirate/adafruit-circuitpython-ndgarage_ndbit6-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/es/adafruit-circuitpython-ndgarage_ndbit6-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/fil/adafruit-circuitpython-ndgarage_ndbit6-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/fr/adafruit-circuitpython-ndgarage_ndbit6-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/it_IT/adafruit-circuitpython-ndgarage_ndbit6-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/ko/adafruit-circuitpython-ndgarage_ndbit6-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/pl/adafruit-circuitpython-ndgarage_ndbit6-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/pt_BR/adafruit-circuitpython-ndgarage_ndbit6-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/zh_Latn_pinyin/adafruit-circuitpython-ndgarage_ndbit6-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -6457,6 +6463,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/ID/adafruit-circuitpython-ndgarage_ndbit6-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/de_DE/adafruit-circuitpython-ndgarage_ndbit6-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/en_US/adafruit-circuitpython-ndgarage_ndbit6-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/en_x_pirate/adafruit-circuitpython-ndgarage_ndbit6-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/es/adafruit-circuitpython-ndgarage_ndbit6-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/fil/adafruit-circuitpython-ndgarage_ndbit6-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/fr/adafruit-circuitpython-ndgarage_ndbit6-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/it_IT/adafruit-circuitpython-ndgarage_ndbit6-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/ko/adafruit-circuitpython-ndgarage_ndbit6-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/pl/adafruit-circuitpython-ndgarage_ndbit6-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/pt_BR/adafruit-circuitpython-ndgarage_ndbit6-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/zh_Latn_pinyin/adafruit-circuitpython-ndgarage_ndbit6-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -6464,48 +6512,6 @@
         "downloads": 0,
         "id": "ohs2020_badge",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/ID/adafruit-circuitpython-ohs2020_badge-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/de_DE/adafruit-circuitpython-ohs2020_badge-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/en_US/adafruit-circuitpython-ohs2020_badge-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/en_x_pirate/adafruit-circuitpython-ohs2020_badge-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/es/adafruit-circuitpython-ohs2020_badge-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/fil/adafruit-circuitpython-ohs2020_badge-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/fr/adafruit-circuitpython-ohs2020_badge-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/it_IT/adafruit-circuitpython-ohs2020_badge-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/ko/adafruit-circuitpython-ohs2020_badge-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/pl/adafruit-circuitpython-ohs2020_badge-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/pt_BR/adafruit-circuitpython-ohs2020_badge-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/zh_Latn_pinyin/adafruit-circuitpython-ohs2020_badge-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -6547,6 +6553,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/ID/adafruit-circuitpython-ohs2020_badge-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/de_DE/adafruit-circuitpython-ohs2020_badge-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/en_US/adafruit-circuitpython-ohs2020_badge-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/en_x_pirate/adafruit-circuitpython-ohs2020_badge-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/es/adafruit-circuitpython-ohs2020_badge-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/fil/adafruit-circuitpython-ohs2020_badge-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/fr/adafruit-circuitpython-ohs2020_badge-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/it_IT/adafruit-circuitpython-ohs2020_badge-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/ko/adafruit-circuitpython-ohs2020_badge-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/pl/adafruit-circuitpython-ohs2020_badge-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/pt_BR/adafruit-circuitpython-ohs2020_badge-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/zh_Latn_pinyin/adafruit-circuitpython-ohs2020_badge-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -6554,48 +6602,6 @@
         "downloads": 0,
         "id": "openbook_m4",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/ID/adafruit-circuitpython-openbook_m4-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/de_DE/adafruit-circuitpython-openbook_m4-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/en_US/adafruit-circuitpython-openbook_m4-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/en_x_pirate/adafruit-circuitpython-openbook_m4-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/es/adafruit-circuitpython-openbook_m4-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/fil/adafruit-circuitpython-openbook_m4-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/fr/adafruit-circuitpython-openbook_m4-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/it_IT/adafruit-circuitpython-openbook_m4-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/ko/adafruit-circuitpython-openbook_m4-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/pl/adafruit-circuitpython-openbook_m4-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/pt_BR/adafruit-circuitpython-openbook_m4-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/zh_Latn_pinyin/adafruit-circuitpython-openbook_m4-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -6637,55 +6643,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/openbook_m4/ID/adafruit-circuitpython-openbook_m4-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/openbook_m4/de_DE/adafruit-circuitpython-openbook_m4-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/openbook_m4/en_US/adafruit-circuitpython-openbook_m4-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/openbook_m4/en_x_pirate/adafruit-circuitpython-openbook_m4-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/openbook_m4/es/adafruit-circuitpython-openbook_m4-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/openbook_m4/fil/adafruit-circuitpython-openbook_m4-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/openbook_m4/fr/adafruit-circuitpython-openbook_m4-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/openbook_m4/it_IT/adafruit-circuitpython-openbook_m4-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/openbook_m4/ko/adafruit-circuitpython-openbook_m4-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/openbook_m4/pl/adafruit-circuitpython-openbook_m4-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/openbook_m4/pt_BR/adafruit-circuitpython-openbook_m4-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/openbook_m4/zh_Latn_pinyin/adafruit-circuitpython-openbook_m4-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 43,
+        "downloads": 0,
         "id": "particle_argon",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/ID/adafruit-circuitpython-particle_argon-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/de_DE/adafruit-circuitpython-particle_argon-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/en_US/adafruit-circuitpython-particle_argon-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/en_x_pirate/adafruit-circuitpython-particle_argon-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/es/adafruit-circuitpython-particle_argon-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/fil/adafruit-circuitpython-particle_argon-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/fr/adafruit-circuitpython-particle_argon-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/it_IT/adafruit-circuitpython-particle_argon-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/ko/adafruit-circuitpython-particle_argon-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/pl/adafruit-circuitpython-particle_argon-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/pt_BR/adafruit-circuitpython-particle_argon-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/zh_Latn_pinyin/adafruit-circuitpython-particle_argon-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -6727,55 +6733,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/particle_argon/ID/adafruit-circuitpython-particle_argon-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/particle_argon/de_DE/adafruit-circuitpython-particle_argon-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/particle_argon/en_US/adafruit-circuitpython-particle_argon-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/particle_argon/en_x_pirate/adafruit-circuitpython-particle_argon-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/particle_argon/es/adafruit-circuitpython-particle_argon-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/particle_argon/fil/adafruit-circuitpython-particle_argon-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/particle_argon/fr/adafruit-circuitpython-particle_argon-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/particle_argon/it_IT/adafruit-circuitpython-particle_argon-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/particle_argon/ko/adafruit-circuitpython-particle_argon-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/particle_argon/pl/adafruit-circuitpython-particle_argon-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/particle_argon/pt_BR/adafruit-circuitpython-particle_argon-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/particle_argon/zh_Latn_pinyin/adafruit-circuitpython-particle_argon-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 31,
+        "downloads": 0,
         "id": "particle_boron",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/ID/adafruit-circuitpython-particle_boron-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/de_DE/adafruit-circuitpython-particle_boron-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/en_US/adafruit-circuitpython-particle_boron-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/en_x_pirate/adafruit-circuitpython-particle_boron-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/es/adafruit-circuitpython-particle_boron-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/fil/adafruit-circuitpython-particle_boron-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/fr/adafruit-circuitpython-particle_boron-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/it_IT/adafruit-circuitpython-particle_boron-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/ko/adafruit-circuitpython-particle_boron-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/pl/adafruit-circuitpython-particle_boron-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/pt_BR/adafruit-circuitpython-particle_boron-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/zh_Latn_pinyin/adafruit-circuitpython-particle_boron-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -6817,55 +6823,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/particle_boron/ID/adafruit-circuitpython-particle_boron-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/particle_boron/de_DE/adafruit-circuitpython-particle_boron-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/particle_boron/en_US/adafruit-circuitpython-particle_boron-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/particle_boron/en_x_pirate/adafruit-circuitpython-particle_boron-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/particle_boron/es/adafruit-circuitpython-particle_boron-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/particle_boron/fil/adafruit-circuitpython-particle_boron-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/particle_boron/fr/adafruit-circuitpython-particle_boron-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/particle_boron/it_IT/adafruit-circuitpython-particle_boron-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/particle_boron/ko/adafruit-circuitpython-particle_boron-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/particle_boron/pl/adafruit-circuitpython-particle_boron-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/particle_boron/pt_BR/adafruit-circuitpython-particle_boron-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/particle_boron/zh_Latn_pinyin/adafruit-circuitpython-particle_boron-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 98,
+        "downloads": 0,
         "id": "particle_xenon",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/ID/adafruit-circuitpython-particle_xenon-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/de_DE/adafruit-circuitpython-particle_xenon-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/en_US/adafruit-circuitpython-particle_xenon-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/en_x_pirate/adafruit-circuitpython-particle_xenon-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/es/adafruit-circuitpython-particle_xenon-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/fil/adafruit-circuitpython-particle_xenon-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/fr/adafruit-circuitpython-particle_xenon-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/it_IT/adafruit-circuitpython-particle_xenon-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/ko/adafruit-circuitpython-particle_xenon-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/pl/adafruit-circuitpython-particle_xenon-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/pt_BR/adafruit-circuitpython-particle_xenon-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/zh_Latn_pinyin/adafruit-circuitpython-particle_xenon-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -6907,6 +6913,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/particle_xenon/ID/adafruit-circuitpython-particle_xenon-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/particle_xenon/de_DE/adafruit-circuitpython-particle_xenon-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/particle_xenon/en_US/adafruit-circuitpython-particle_xenon-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/particle_xenon/en_x_pirate/adafruit-circuitpython-particle_xenon-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/particle_xenon/es/adafruit-circuitpython-particle_xenon-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/particle_xenon/fil/adafruit-circuitpython-particle_xenon-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/particle_xenon/fr/adafruit-circuitpython-particle_xenon-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/particle_xenon/it_IT/adafruit-circuitpython-particle_xenon-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/particle_xenon/ko/adafruit-circuitpython-particle_xenon-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/particle_xenon/pl/adafruit-circuitpython-particle_xenon-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/particle_xenon/pt_BR/adafruit-circuitpython-particle_xenon-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/particle_xenon/zh_Latn_pinyin/adafruit-circuitpython-particle_xenon-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -6916,63 +6964,9 @@
         "versions": []
     },
     {
-        "downloads": 81,
+        "downloads": 0,
         "id": "pca10056",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pca10056/ID/adafruit-circuitpython-pca10056-ID-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/ID/adafruit-circuitpython-pca10056-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pca10056/de_DE/adafruit-circuitpython-pca10056-de_DE-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/de_DE/adafruit-circuitpython-pca10056-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pca10056/en_US/adafruit-circuitpython-pca10056-en_US-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/en_US/adafruit-circuitpython-pca10056-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pca10056/en_x_pirate/adafruit-circuitpython-pca10056-en_x_pirate-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/en_x_pirate/adafruit-circuitpython-pca10056-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pca10056/es/adafruit-circuitpython-pca10056-es-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/es/adafruit-circuitpython-pca10056-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pca10056/fil/adafruit-circuitpython-pca10056-fil-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/fil/adafruit-circuitpython-pca10056-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pca10056/fr/adafruit-circuitpython-pca10056-fr-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/fr/adafruit-circuitpython-pca10056-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pca10056/it_IT/adafruit-circuitpython-pca10056-it_IT-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/it_IT/adafruit-circuitpython-pca10056-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pca10056/ko/adafruit-circuitpython-pca10056-ko-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/ko/adafruit-circuitpython-pca10056-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pca10056/pl/adafruit-circuitpython-pca10056-pl-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/pl/adafruit-circuitpython-pca10056-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pca10056/pt_BR/adafruit-circuitpython-pca10056-pt_BR-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/pt_BR/adafruit-circuitpython-pca10056-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pca10056/zh_Latn_pinyin/adafruit-circuitpython-pca10056-zh_Latn_pinyin-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/zh_Latn_pinyin/adafruit-circuitpython-pca10056-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -7026,67 +7020,67 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pca10056/ID/adafruit-circuitpython-pca10056-ID-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/ID/adafruit-circuitpython-pca10056-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pca10056/de_DE/adafruit-circuitpython-pca10056-de_DE-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/de_DE/adafruit-circuitpython-pca10056-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pca10056/en_US/adafruit-circuitpython-pca10056-en_US-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/en_US/adafruit-circuitpython-pca10056-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pca10056/en_x_pirate/adafruit-circuitpython-pca10056-en_x_pirate-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/en_x_pirate/adafruit-circuitpython-pca10056-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pca10056/es/adafruit-circuitpython-pca10056-es-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/es/adafruit-circuitpython-pca10056-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pca10056/fil/adafruit-circuitpython-pca10056-fil-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/fil/adafruit-circuitpython-pca10056-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pca10056/fr/adafruit-circuitpython-pca10056-fr-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/fr/adafruit-circuitpython-pca10056-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pca10056/it_IT/adafruit-circuitpython-pca10056-it_IT-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/it_IT/adafruit-circuitpython-pca10056-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pca10056/ko/adafruit-circuitpython-pca10056-ko-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/ko/adafruit-circuitpython-pca10056-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pca10056/pl/adafruit-circuitpython-pca10056-pl-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/pl/adafruit-circuitpython-pca10056-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pca10056/pt_BR/adafruit-circuitpython-pca10056-pt_BR-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/pt_BR/adafruit-circuitpython-pca10056-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pca10056/zh_Latn_pinyin/adafruit-circuitpython-pca10056-zh_Latn_pinyin-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/zh_Latn_pinyin/adafruit-circuitpython-pca10056-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 130,
+        "downloads": 0,
         "id": "pca10059",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pca10059/ID/adafruit-circuitpython-pca10059-ID-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/ID/adafruit-circuitpython-pca10059-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pca10059/de_DE/adafruit-circuitpython-pca10059-de_DE-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/de_DE/adafruit-circuitpython-pca10059-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pca10059/en_US/adafruit-circuitpython-pca10059-en_US-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/en_US/adafruit-circuitpython-pca10059-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pca10059/en_x_pirate/adafruit-circuitpython-pca10059-en_x_pirate-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/en_x_pirate/adafruit-circuitpython-pca10059-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pca10059/es/adafruit-circuitpython-pca10059-es-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/es/adafruit-circuitpython-pca10059-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pca10059/fil/adafruit-circuitpython-pca10059-fil-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/fil/adafruit-circuitpython-pca10059-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pca10059/fr/adafruit-circuitpython-pca10059-fr-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/fr/adafruit-circuitpython-pca10059-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pca10059/it_IT/adafruit-circuitpython-pca10059-it_IT-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/it_IT/adafruit-circuitpython-pca10059-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pca10059/ko/adafruit-circuitpython-pca10059-ko-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/ko/adafruit-circuitpython-pca10059-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pca10059/pl/adafruit-circuitpython-pca10059-pl-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/pl/adafruit-circuitpython-pca10059-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pca10059/pt_BR/adafruit-circuitpython-pca10059-pt_BR-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/pt_BR/adafruit-circuitpython-pca10059-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pca10059/zh_Latn_pinyin/adafruit-circuitpython-pca10059-zh_Latn_pinyin-5.0.0-rc.1.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/zh_Latn_pinyin/adafruit-circuitpython-pca10059-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -7140,55 +7134,67 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pca10059/ID/adafruit-circuitpython-pca10059-ID-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/ID/adafruit-circuitpython-pca10059-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pca10059/de_DE/adafruit-circuitpython-pca10059-de_DE-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/de_DE/adafruit-circuitpython-pca10059-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pca10059/en_US/adafruit-circuitpython-pca10059-en_US-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/en_US/adafruit-circuitpython-pca10059-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pca10059/en_x_pirate/adafruit-circuitpython-pca10059-en_x_pirate-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/en_x_pirate/adafruit-circuitpython-pca10059-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pca10059/es/adafruit-circuitpython-pca10059-es-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/es/adafruit-circuitpython-pca10059-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pca10059/fil/adafruit-circuitpython-pca10059-fil-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/fil/adafruit-circuitpython-pca10059-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pca10059/fr/adafruit-circuitpython-pca10059-fr-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/fr/adafruit-circuitpython-pca10059-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pca10059/it_IT/adafruit-circuitpython-pca10059-it_IT-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/it_IT/adafruit-circuitpython-pca10059-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pca10059/ko/adafruit-circuitpython-pca10059-ko-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/ko/adafruit-circuitpython-pca10059-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pca10059/pl/adafruit-circuitpython-pca10059-pl-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/pl/adafruit-circuitpython-pca10059-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pca10059/pt_BR/adafruit-circuitpython-pca10059-pt_BR-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/pt_BR/adafruit-circuitpython-pca10059-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pca10059/zh_Latn_pinyin/adafruit-circuitpython-pca10059-zh_Latn_pinyin-5.1.0-rc.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/zh_Latn_pinyin/adafruit-circuitpython-pca10059-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 46,
+        "downloads": 0,
         "id": "pewpew10",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/ID/adafruit-circuitpython-pewpew10-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/de_DE/adafruit-circuitpython-pewpew10-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/en_US/adafruit-circuitpython-pewpew10-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/en_x_pirate/adafruit-circuitpython-pewpew10-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/es/adafruit-circuitpython-pewpew10-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/fil/adafruit-circuitpython-pewpew10-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/fr/adafruit-circuitpython-pewpew10-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/it_IT/adafruit-circuitpython-pewpew10-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/ko/adafruit-circuitpython-pewpew10-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/pl/adafruit-circuitpython-pewpew10-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/pt_BR/adafruit-circuitpython-pewpew10-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/zh_Latn_pinyin/adafruit-circuitpython-pewpew10-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -7230,55 +7236,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pewpew10/ID/adafruit-circuitpython-pewpew10-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pewpew10/de_DE/adafruit-circuitpython-pewpew10-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pewpew10/en_US/adafruit-circuitpython-pewpew10-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pewpew10/en_x_pirate/adafruit-circuitpython-pewpew10-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pewpew10/es/adafruit-circuitpython-pewpew10-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pewpew10/fil/adafruit-circuitpython-pewpew10-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pewpew10/fr/adafruit-circuitpython-pewpew10-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pewpew10/it_IT/adafruit-circuitpython-pewpew10-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pewpew10/ko/adafruit-circuitpython-pewpew10-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pewpew10/pl/adafruit-circuitpython-pewpew10-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pewpew10/pt_BR/adafruit-circuitpython-pewpew10-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pewpew10/zh_Latn_pinyin/adafruit-circuitpython-pewpew10-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 25,
+        "downloads": 0,
         "id": "pewpew13",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/ID/adafruit-circuitpython-pewpew13-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/de_DE/adafruit-circuitpython-pewpew13-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/en_US/adafruit-circuitpython-pewpew13-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/en_x_pirate/adafruit-circuitpython-pewpew13-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/es/adafruit-circuitpython-pewpew13-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/fil/adafruit-circuitpython-pewpew13-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/fr/adafruit-circuitpython-pewpew13-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/it_IT/adafruit-circuitpython-pewpew13-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/ko/adafruit-circuitpython-pewpew13-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/pl/adafruit-circuitpython-pewpew13-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/pt_BR/adafruit-circuitpython-pewpew13-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/zh_Latn_pinyin/adafruit-circuitpython-pewpew13-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -7320,6 +7326,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pewpew13/ID/adafruit-circuitpython-pewpew13-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pewpew13/de_DE/adafruit-circuitpython-pewpew13-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pewpew13/en_US/adafruit-circuitpython-pewpew13-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pewpew13/en_x_pirate/adafruit-circuitpython-pewpew13-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pewpew13/es/adafruit-circuitpython-pewpew13-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pewpew13/fil/adafruit-circuitpython-pewpew13-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pewpew13/fr/adafruit-circuitpython-pewpew13-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pewpew13/it_IT/adafruit-circuitpython-pewpew13-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pewpew13/ko/adafruit-circuitpython-pewpew13-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pewpew13/pl/adafruit-circuitpython-pewpew13-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pewpew13/pt_BR/adafruit-circuitpython-pewpew13-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pewpew13/zh_Latn_pinyin/adafruit-circuitpython-pewpew13-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -7327,48 +7375,6 @@
         "downloads": 0,
         "id": "pewpew_m4",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/ID/adafruit-circuitpython-pewpew_m4-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/de_DE/adafruit-circuitpython-pewpew_m4-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/en_US/adafruit-circuitpython-pewpew_m4-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/en_x_pirate/adafruit-circuitpython-pewpew_m4-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/es/adafruit-circuitpython-pewpew_m4-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/fil/adafruit-circuitpython-pewpew_m4-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/fr/adafruit-circuitpython-pewpew_m4-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/it_IT/adafruit-circuitpython-pewpew_m4-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/ko/adafruit-circuitpython-pewpew_m4-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/pl/adafruit-circuitpython-pewpew_m4-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/pt_BR/adafruit-circuitpython-pewpew_m4-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/zh_Latn_pinyin/adafruit-circuitpython-pewpew_m4-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -7410,55 +7416,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/ID/adafruit-circuitpython-pewpew_m4-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/de_DE/adafruit-circuitpython-pewpew_m4-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/en_US/adafruit-circuitpython-pewpew_m4-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/en_x_pirate/adafruit-circuitpython-pewpew_m4-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/es/adafruit-circuitpython-pewpew_m4-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/fil/adafruit-circuitpython-pewpew_m4-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/fr/adafruit-circuitpython-pewpew_m4-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/it_IT/adafruit-circuitpython-pewpew_m4-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/ko/adafruit-circuitpython-pewpew_m4-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/pl/adafruit-circuitpython-pewpew_m4-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/pt_BR/adafruit-circuitpython-pewpew_m4-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/zh_Latn_pinyin/adafruit-circuitpython-pewpew_m4-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 27,
+        "downloads": 0,
         "id": "pirkey_m0",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/ID/adafruit-circuitpython-pirkey_m0-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/de_DE/adafruit-circuitpython-pirkey_m0-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/en_US/adafruit-circuitpython-pirkey_m0-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/en_x_pirate/adafruit-circuitpython-pirkey_m0-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/es/adafruit-circuitpython-pirkey_m0-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/fil/adafruit-circuitpython-pirkey_m0-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/fr/adafruit-circuitpython-pirkey_m0-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/it_IT/adafruit-circuitpython-pirkey_m0-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/ko/adafruit-circuitpython-pirkey_m0-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/pl/adafruit-circuitpython-pirkey_m0-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/pt_BR/adafruit-circuitpython-pirkey_m0-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/zh_Latn_pinyin/adafruit-circuitpython-pirkey_m0-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -7500,6 +7506,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/ID/adafruit-circuitpython-pirkey_m0-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/de_DE/adafruit-circuitpython-pirkey_m0-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/en_US/adafruit-circuitpython-pirkey_m0-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/en_x_pirate/adafruit-circuitpython-pirkey_m0-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/es/adafruit-circuitpython-pirkey_m0-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/fil/adafruit-circuitpython-pirkey_m0-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/fr/adafruit-circuitpython-pirkey_m0-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/it_IT/adafruit-circuitpython-pirkey_m0-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/ko/adafruit-circuitpython-pirkey_m0-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/pl/adafruit-circuitpython-pirkey_m0-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/pt_BR/adafruit-circuitpython-pirkey_m0-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/zh_Latn_pinyin/adafruit-circuitpython-pirkey_m0-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -7507,48 +7555,6 @@
         "downloads": 0,
         "id": "pyb_nano_v2",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/ID/adafruit-circuitpython-pyb_nano_v2-ID-5.0.0-rc.1.bin"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/de_DE/adafruit-circuitpython-pyb_nano_v2-de_DE-5.0.0-rc.1.bin"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/en_US/adafruit-circuitpython-pyb_nano_v2-en_US-5.0.0-rc.1.bin"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/en_x_pirate/adafruit-circuitpython-pyb_nano_v2-en_x_pirate-5.0.0-rc.1.bin"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/es/adafruit-circuitpython-pyb_nano_v2-es-5.0.0-rc.1.bin"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/fil/adafruit-circuitpython-pyb_nano_v2-fil-5.0.0-rc.1.bin"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/fr/adafruit-circuitpython-pyb_nano_v2-fr-5.0.0-rc.1.bin"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/it_IT/adafruit-circuitpython-pyb_nano_v2-it_IT-5.0.0-rc.1.bin"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/ko/adafruit-circuitpython-pyb_nano_v2-ko-5.0.0-rc.1.bin"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/pl/adafruit-circuitpython-pyb_nano_v2-pl-5.0.0-rc.1.bin"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/pt_BR/adafruit-circuitpython-pyb_nano_v2-pt_BR-5.0.0-rc.1.bin"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/zh_Latn_pinyin/adafruit-circuitpython-pyb_nano_v2-zh_Latn_pinyin-5.0.0-rc.1.bin"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -7590,55 +7596,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/ID/adafruit-circuitpython-pyb_nano_v2-ID-5.1.0-rc.0.bin"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/de_DE/adafruit-circuitpython-pyb_nano_v2-de_DE-5.1.0-rc.0.bin"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/en_US/adafruit-circuitpython-pyb_nano_v2-en_US-5.1.0-rc.0.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/en_x_pirate/adafruit-circuitpython-pyb_nano_v2-en_x_pirate-5.1.0-rc.0.bin"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/es/adafruit-circuitpython-pyb_nano_v2-es-5.1.0-rc.0.bin"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/fil/adafruit-circuitpython-pyb_nano_v2-fil-5.1.0-rc.0.bin"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/fr/adafruit-circuitpython-pyb_nano_v2-fr-5.1.0-rc.0.bin"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/it_IT/adafruit-circuitpython-pyb_nano_v2-it_IT-5.1.0-rc.0.bin"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/ko/adafruit-circuitpython-pyb_nano_v2-ko-5.1.0-rc.0.bin"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/pl/adafruit-circuitpython-pyb_nano_v2-pl-5.1.0-rc.0.bin"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/pt_BR/adafruit-circuitpython-pyb_nano_v2-pt_BR-5.1.0-rc.0.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/zh_Latn_pinyin/adafruit-circuitpython-pyb_nano_v2-zh_Latn_pinyin-5.1.0-rc.0.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 248,
+        "downloads": 0,
         "id": "pybadge",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pybadge/ID/adafruit-circuitpython-pybadge-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pybadge/de_DE/adafruit-circuitpython-pybadge-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pybadge/en_US/adafruit-circuitpython-pybadge-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pybadge/en_x_pirate/adafruit-circuitpython-pybadge-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pybadge/es/adafruit-circuitpython-pybadge-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pybadge/fil/adafruit-circuitpython-pybadge-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pybadge/fr/adafruit-circuitpython-pybadge-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pybadge/it_IT/adafruit-circuitpython-pybadge-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pybadge/ko/adafruit-circuitpython-pybadge-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pybadge/pl/adafruit-circuitpython-pybadge-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pybadge/pt_BR/adafruit-circuitpython-pybadge-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pybadge/zh_Latn_pinyin/adafruit-circuitpython-pybadge-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -7680,55 +7686,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pybadge/ID/adafruit-circuitpython-pybadge-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pybadge/de_DE/adafruit-circuitpython-pybadge-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pybadge/en_US/adafruit-circuitpython-pybadge-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pybadge/en_x_pirate/adafruit-circuitpython-pybadge-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pybadge/es/adafruit-circuitpython-pybadge-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pybadge/fil/adafruit-circuitpython-pybadge-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pybadge/fr/adafruit-circuitpython-pybadge-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pybadge/it_IT/adafruit-circuitpython-pybadge-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pybadge/ko/adafruit-circuitpython-pybadge-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pybadge/pl/adafruit-circuitpython-pybadge-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pybadge/pt_BR/adafruit-circuitpython-pybadge-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pybadge/zh_Latn_pinyin/adafruit-circuitpython-pybadge-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 28,
+        "downloads": 0,
         "id": "pybadge_airlift",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/ID/adafruit-circuitpython-pybadge_airlift-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/de_DE/adafruit-circuitpython-pybadge_airlift-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/en_US/adafruit-circuitpython-pybadge_airlift-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/en_x_pirate/adafruit-circuitpython-pybadge_airlift-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/es/adafruit-circuitpython-pybadge_airlift-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/fil/adafruit-circuitpython-pybadge_airlift-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/fr/adafruit-circuitpython-pybadge_airlift-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/it_IT/adafruit-circuitpython-pybadge_airlift-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/ko/adafruit-circuitpython-pybadge_airlift-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/pl/adafruit-circuitpython-pybadge_airlift-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/pt_BR/adafruit-circuitpython-pybadge_airlift-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/zh_Latn_pinyin/adafruit-circuitpython-pybadge_airlift-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -7770,6 +7776,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/ID/adafruit-circuitpython-pybadge_airlift-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/de_DE/adafruit-circuitpython-pybadge_airlift-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/en_US/adafruit-circuitpython-pybadge_airlift-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/en_x_pirate/adafruit-circuitpython-pybadge_airlift-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/es/adafruit-circuitpython-pybadge_airlift-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/fil/adafruit-circuitpython-pybadge_airlift-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/fr/adafruit-circuitpython-pybadge_airlift-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/it_IT/adafruit-circuitpython-pybadge_airlift-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/ko/adafruit-circuitpython-pybadge_airlift-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/pl/adafruit-circuitpython-pybadge_airlift-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/pt_BR/adafruit-circuitpython-pybadge_airlift-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/zh_Latn_pinyin/adafruit-circuitpython-pybadge_airlift-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -7777,48 +7825,6 @@
         "downloads": 0,
         "id": "pyboard_v11",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/ID/adafruit-circuitpython-pyboard_v11-ID-5.0.0-rc.1.bin"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/de_DE/adafruit-circuitpython-pyboard_v11-de_DE-5.0.0-rc.1.bin"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/en_US/adafruit-circuitpython-pyboard_v11-en_US-5.0.0-rc.1.bin"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/en_x_pirate/adafruit-circuitpython-pyboard_v11-en_x_pirate-5.0.0-rc.1.bin"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/es/adafruit-circuitpython-pyboard_v11-es-5.0.0-rc.1.bin"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/fil/adafruit-circuitpython-pyboard_v11-fil-5.0.0-rc.1.bin"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/fr/adafruit-circuitpython-pyboard_v11-fr-5.0.0-rc.1.bin"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/it_IT/adafruit-circuitpython-pyboard_v11-it_IT-5.0.0-rc.1.bin"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/ko/adafruit-circuitpython-pyboard_v11-ko-5.0.0-rc.1.bin"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/pl/adafruit-circuitpython-pyboard_v11-pl-5.0.0-rc.1.bin"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/pt_BR/adafruit-circuitpython-pyboard_v11-pt_BR-5.0.0-rc.1.bin"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/zh_Latn_pinyin/adafruit-circuitpython-pyboard_v11-zh_Latn_pinyin-5.0.0-rc.1.bin"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -7860,6 +7866,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/ID/adafruit-circuitpython-pyboard_v11-ID-5.1.0-rc.0.bin"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/de_DE/adafruit-circuitpython-pyboard_v11-de_DE-5.1.0-rc.0.bin"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/en_US/adafruit-circuitpython-pyboard_v11-en_US-5.1.0-rc.0.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/en_x_pirate/adafruit-circuitpython-pyboard_v11-en_x_pirate-5.1.0-rc.0.bin"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/es/adafruit-circuitpython-pyboard_v11-es-5.1.0-rc.0.bin"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/fil/adafruit-circuitpython-pyboard_v11-fil-5.1.0-rc.0.bin"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/fr/adafruit-circuitpython-pyboard_v11-fr-5.1.0-rc.0.bin"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/it_IT/adafruit-circuitpython-pyboard_v11-it_IT-5.1.0-rc.0.bin"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/ko/adafruit-circuitpython-pyboard_v11-ko-5.1.0-rc.0.bin"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/pl/adafruit-circuitpython-pyboard_v11-pl-5.1.0-rc.0.bin"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/pt_BR/adafruit-circuitpython-pyboard_v11-pt_BR-5.1.0-rc.0.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/zh_Latn_pinyin/adafruit-circuitpython-pyboard_v11-zh_Latn_pinyin-5.1.0-rc.0.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -7867,48 +7915,6 @@
         "downloads": 0,
         "id": "pycubed",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pycubed/ID/adafruit-circuitpython-pycubed-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pycubed/de_DE/adafruit-circuitpython-pycubed-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pycubed/en_US/adafruit-circuitpython-pycubed-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pycubed/en_x_pirate/adafruit-circuitpython-pycubed-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pycubed/es/adafruit-circuitpython-pycubed-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pycubed/fil/adafruit-circuitpython-pycubed-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pycubed/fr/adafruit-circuitpython-pycubed-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pycubed/it_IT/adafruit-circuitpython-pycubed-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pycubed/ko/adafruit-circuitpython-pycubed-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pycubed/pl/adafruit-circuitpython-pycubed-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pycubed/pt_BR/adafruit-circuitpython-pycubed-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pycubed/zh_Latn_pinyin/adafruit-circuitpython-pycubed-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -7950,55 +7956,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pycubed/ID/adafruit-circuitpython-pycubed-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pycubed/de_DE/adafruit-circuitpython-pycubed-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pycubed/en_US/adafruit-circuitpython-pycubed-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pycubed/en_x_pirate/adafruit-circuitpython-pycubed-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pycubed/es/adafruit-circuitpython-pycubed-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pycubed/fil/adafruit-circuitpython-pycubed-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pycubed/fr/adafruit-circuitpython-pycubed-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pycubed/it_IT/adafruit-circuitpython-pycubed-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pycubed/ko/adafruit-circuitpython-pycubed-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pycubed/pl/adafruit-circuitpython-pycubed-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pycubed/pt_BR/adafruit-circuitpython-pycubed-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pycubed/zh_Latn_pinyin/adafruit-circuitpython-pycubed-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 201,
+        "downloads": 0,
         "id": "pygamer",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pygamer/ID/adafruit-circuitpython-pygamer-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pygamer/de_DE/adafruit-circuitpython-pygamer-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pygamer/en_US/adafruit-circuitpython-pygamer-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pygamer/en_x_pirate/adafruit-circuitpython-pygamer-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pygamer/es/adafruit-circuitpython-pygamer-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pygamer/fil/adafruit-circuitpython-pygamer-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pygamer/fr/adafruit-circuitpython-pygamer-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pygamer/it_IT/adafruit-circuitpython-pygamer-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pygamer/ko/adafruit-circuitpython-pygamer-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pygamer/pl/adafruit-circuitpython-pygamer-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pygamer/pt_BR/adafruit-circuitpython-pygamer-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pygamer/zh_Latn_pinyin/adafruit-circuitpython-pygamer-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -8040,55 +8046,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pygamer/ID/adafruit-circuitpython-pygamer-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pygamer/de_DE/adafruit-circuitpython-pygamer-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pygamer/en_US/adafruit-circuitpython-pygamer-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pygamer/en_x_pirate/adafruit-circuitpython-pygamer-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pygamer/es/adafruit-circuitpython-pygamer-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pygamer/fil/adafruit-circuitpython-pygamer-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pygamer/fr/adafruit-circuitpython-pygamer-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pygamer/it_IT/adafruit-circuitpython-pygamer-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pygamer/ko/adafruit-circuitpython-pygamer-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pygamer/pl/adafruit-circuitpython-pygamer-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pygamer/pt_BR/adafruit-circuitpython-pygamer-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pygamer/zh_Latn_pinyin/adafruit-circuitpython-pygamer-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 31,
+        "downloads": 0,
         "id": "pygamer_advance",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/ID/adafruit-circuitpython-pygamer_advance-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/de_DE/adafruit-circuitpython-pygamer_advance-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/en_US/adafruit-circuitpython-pygamer_advance-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/en_x_pirate/adafruit-circuitpython-pygamer_advance-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/es/adafruit-circuitpython-pygamer_advance-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/fil/adafruit-circuitpython-pygamer_advance-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/fr/adafruit-circuitpython-pygamer_advance-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/it_IT/adafruit-circuitpython-pygamer_advance-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/ko/adafruit-circuitpython-pygamer_advance-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/pl/adafruit-circuitpython-pygamer_advance-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/pt_BR/adafruit-circuitpython-pygamer_advance-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/zh_Latn_pinyin/adafruit-circuitpython-pygamer_advance-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -8130,55 +8136,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/ID/adafruit-circuitpython-pygamer_advance-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/de_DE/adafruit-circuitpython-pygamer_advance-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/en_US/adafruit-circuitpython-pygamer_advance-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/en_x_pirate/adafruit-circuitpython-pygamer_advance-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/es/adafruit-circuitpython-pygamer_advance-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/fil/adafruit-circuitpython-pygamer_advance-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/fr/adafruit-circuitpython-pygamer_advance-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/it_IT/adafruit-circuitpython-pygamer_advance-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/ko/adafruit-circuitpython-pygamer_advance-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/pl/adafruit-circuitpython-pygamer_advance-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/pt_BR/adafruit-circuitpython-pygamer_advance-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/zh_Latn_pinyin/adafruit-circuitpython-pygamer_advance-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 824,
+        "downloads": 0,
         "id": "pyportal",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pyportal/ID/adafruit-circuitpython-pyportal-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pyportal/de_DE/adafruit-circuitpython-pyportal-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pyportal/en_US/adafruit-circuitpython-pyportal-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pyportal/en_x_pirate/adafruit-circuitpython-pyportal-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pyportal/es/adafruit-circuitpython-pyportal-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pyportal/fil/adafruit-circuitpython-pyportal-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pyportal/fr/adafruit-circuitpython-pyportal-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pyportal/it_IT/adafruit-circuitpython-pyportal-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pyportal/ko/adafruit-circuitpython-pyportal-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pyportal/pl/adafruit-circuitpython-pyportal-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pyportal/pt_BR/adafruit-circuitpython-pyportal-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pyportal/zh_Latn_pinyin/adafruit-circuitpython-pyportal-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -8220,6 +8226,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pyportal/ID/adafruit-circuitpython-pyportal-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pyportal/de_DE/adafruit-circuitpython-pyportal-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pyportal/en_US/adafruit-circuitpython-pyportal-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pyportal/en_x_pirate/adafruit-circuitpython-pyportal-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pyportal/es/adafruit-circuitpython-pyportal-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pyportal/fil/adafruit-circuitpython-pyportal-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pyportal/fr/adafruit-circuitpython-pyportal-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pyportal/it_IT/adafruit-circuitpython-pyportal-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pyportal/ko/adafruit-circuitpython-pyportal-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pyportal/pl/adafruit-circuitpython-pyportal-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pyportal/pt_BR/adafruit-circuitpython-pyportal-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pyportal/zh_Latn_pinyin/adafruit-circuitpython-pyportal-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -8227,48 +8275,6 @@
         "downloads": 0,
         "id": "pyportal_pynt",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/ID/adafruit-circuitpython-pyportal_pynt-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/de_DE/adafruit-circuitpython-pyportal_pynt-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/en_US/adafruit-circuitpython-pyportal_pynt-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/en_x_pirate/adafruit-circuitpython-pyportal_pynt-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/es/adafruit-circuitpython-pyportal_pynt-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/fil/adafruit-circuitpython-pyportal_pynt-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/fr/adafruit-circuitpython-pyportal_pynt-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/it_IT/adafruit-circuitpython-pyportal_pynt-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/ko/adafruit-circuitpython-pyportal_pynt-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/pl/adafruit-circuitpython-pyportal_pynt-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/pt_BR/adafruit-circuitpython-pyportal_pynt-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/zh_Latn_pinyin/adafruit-circuitpython-pyportal_pynt-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -8310,6 +8316,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/ID/adafruit-circuitpython-pyportal_pynt-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/de_DE/adafruit-circuitpython-pyportal_pynt-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/en_US/adafruit-circuitpython-pyportal_pynt-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/en_x_pirate/adafruit-circuitpython-pyportal_pynt-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/es/adafruit-circuitpython-pyportal_pynt-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/fil/adafruit-circuitpython-pyportal_pynt-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/fr/adafruit-circuitpython-pyportal_pynt-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/it_IT/adafruit-circuitpython-pyportal_pynt-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/ko/adafruit-circuitpython-pyportal_pynt-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/pl/adafruit-circuitpython-pyportal_pynt-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/pt_BR/adafruit-circuitpython-pyportal_pynt-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/zh_Latn_pinyin/adafruit-circuitpython-pyportal_pynt-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -8317,48 +8365,6 @@
         "downloads": 0,
         "id": "pyportal_titano",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/ID/adafruit-circuitpython-pyportal_titano-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/de_DE/adafruit-circuitpython-pyportal_titano-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/en_US/adafruit-circuitpython-pyportal_titano-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/en_x_pirate/adafruit-circuitpython-pyportal_titano-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/es/adafruit-circuitpython-pyportal_titano-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/fil/adafruit-circuitpython-pyportal_titano-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/fr/adafruit-circuitpython-pyportal_titano-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/it_IT/adafruit-circuitpython-pyportal_titano-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/ko/adafruit-circuitpython-pyportal_titano-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/pl/adafruit-circuitpython-pyportal_titano-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/pt_BR/adafruit-circuitpython-pyportal_titano-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/zh_Latn_pinyin/adafruit-circuitpython-pyportal_titano-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -8400,55 +8406,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/ID/adafruit-circuitpython-pyportal_titano-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/de_DE/adafruit-circuitpython-pyportal_titano-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/en_US/adafruit-circuitpython-pyportal_titano-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/en_x_pirate/adafruit-circuitpython-pyportal_titano-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/es/adafruit-circuitpython-pyportal_titano-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/fil/adafruit-circuitpython-pyportal_titano-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/fr/adafruit-circuitpython-pyportal_titano-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/it_IT/adafruit-circuitpython-pyportal_titano-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/ko/adafruit-circuitpython-pyportal_titano-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/pl/adafruit-circuitpython-pyportal_titano-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/pt_BR/adafruit-circuitpython-pyportal_titano-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/zh_Latn_pinyin/adafruit-circuitpython-pyportal_titano-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 104,
+        "downloads": 0,
         "id": "pyruler",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pyruler/ID/adafruit-circuitpython-pyruler-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pyruler/de_DE/adafruit-circuitpython-pyruler-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pyruler/en_US/adafruit-circuitpython-pyruler-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pyruler/en_x_pirate/adafruit-circuitpython-pyruler-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pyruler/es/adafruit-circuitpython-pyruler-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pyruler/fil/adafruit-circuitpython-pyruler-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pyruler/fr/adafruit-circuitpython-pyruler-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pyruler/it_IT/adafruit-circuitpython-pyruler-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pyruler/ko/adafruit-circuitpython-pyruler-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pyruler/pl/adafruit-circuitpython-pyruler-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pyruler/pt_BR/adafruit-circuitpython-pyruler-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pyruler/zh_Latn_pinyin/adafruit-circuitpython-pyruler-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -8490,6 +8496,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pyruler/ID/adafruit-circuitpython-pyruler-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pyruler/de_DE/adafruit-circuitpython-pyruler-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pyruler/en_US/adafruit-circuitpython-pyruler-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pyruler/en_x_pirate/adafruit-circuitpython-pyruler-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pyruler/es/adafruit-circuitpython-pyruler-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pyruler/fil/adafruit-circuitpython-pyruler-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pyruler/fr/adafruit-circuitpython-pyruler-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pyruler/it_IT/adafruit-circuitpython-pyruler-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pyruler/ko/adafruit-circuitpython-pyruler-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pyruler/pl/adafruit-circuitpython-pyruler-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pyruler/pt_BR/adafruit-circuitpython-pyruler-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pyruler/zh_Latn_pinyin/adafruit-circuitpython-pyruler-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -8497,48 +8545,6 @@
         "downloads": 0,
         "id": "robohatmm1_m4",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/ID/adafruit-circuitpython-robohatmm1_m4-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/de_DE/adafruit-circuitpython-robohatmm1_m4-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/en_US/adafruit-circuitpython-robohatmm1_m4-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/en_x_pirate/adafruit-circuitpython-robohatmm1_m4-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/es/adafruit-circuitpython-robohatmm1_m4-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/fil/adafruit-circuitpython-robohatmm1_m4-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/fr/adafruit-circuitpython-robohatmm1_m4-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/it_IT/adafruit-circuitpython-robohatmm1_m4-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/ko/adafruit-circuitpython-robohatmm1_m4-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/pl/adafruit-circuitpython-robohatmm1_m4-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/pt_BR/adafruit-circuitpython-robohatmm1_m4-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/zh_Latn_pinyin/adafruit-circuitpython-robohatmm1_m4-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -8580,55 +8586,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/ID/adafruit-circuitpython-robohatmm1_m4-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/de_DE/adafruit-circuitpython-robohatmm1_m4-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/en_US/adafruit-circuitpython-robohatmm1_m4-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/en_x_pirate/adafruit-circuitpython-robohatmm1_m4-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/es/adafruit-circuitpython-robohatmm1_m4-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/fil/adafruit-circuitpython-robohatmm1_m4-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/fr/adafruit-circuitpython-robohatmm1_m4-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/it_IT/adafruit-circuitpython-robohatmm1_m4-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/ko/adafruit-circuitpython-robohatmm1_m4-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/pl/adafruit-circuitpython-robohatmm1_m4-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/pt_BR/adafruit-circuitpython-robohatmm1_m4-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/zh_Latn_pinyin/adafruit-circuitpython-robohatmm1_m4-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 39,
+        "downloads": 0,
         "id": "sam32",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/sam32/ID/adafruit-circuitpython-sam32-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/sam32/de_DE/adafruit-circuitpython-sam32-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/sam32/en_US/adafruit-circuitpython-sam32-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/sam32/en_x_pirate/adafruit-circuitpython-sam32-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/sam32/es/adafruit-circuitpython-sam32-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/sam32/fil/adafruit-circuitpython-sam32-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/sam32/fr/adafruit-circuitpython-sam32-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/sam32/it_IT/adafruit-circuitpython-sam32-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/sam32/ko/adafruit-circuitpython-sam32-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/sam32/pl/adafruit-circuitpython-sam32-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/sam32/pt_BR/adafruit-circuitpython-sam32-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/sam32/zh_Latn_pinyin/adafruit-circuitpython-sam32-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -8670,6 +8676,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/sam32/ID/adafruit-circuitpython-sam32-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/sam32/de_DE/adafruit-circuitpython-sam32-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/sam32/en_US/adafruit-circuitpython-sam32-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/sam32/en_x_pirate/adafruit-circuitpython-sam32-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/sam32/es/adafruit-circuitpython-sam32-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/sam32/fil/adafruit-circuitpython-sam32-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/sam32/fr/adafruit-circuitpython-sam32-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/sam32/it_IT/adafruit-circuitpython-sam32-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/sam32/ko/adafruit-circuitpython-sam32-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/sam32/pl/adafruit-circuitpython-sam32-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/sam32/pt_BR/adafruit-circuitpython-sam32-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/sam32/zh_Latn_pinyin/adafruit-circuitpython-sam32-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -8677,48 +8725,6 @@
         "downloads": 0,
         "id": "seeeduino_xiao",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/ID/adafruit-circuitpython-seeeduino_xiao-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/de_DE/adafruit-circuitpython-seeeduino_xiao-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/en_US/adafruit-circuitpython-seeeduino_xiao-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/en_x_pirate/adafruit-circuitpython-seeeduino_xiao-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/es/adafruit-circuitpython-seeeduino_xiao-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/fil/adafruit-circuitpython-seeeduino_xiao-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/fr/adafruit-circuitpython-seeeduino_xiao-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/it_IT/adafruit-circuitpython-seeeduino_xiao-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/ko/adafruit-circuitpython-seeeduino_xiao-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/pl/adafruit-circuitpython-seeeduino_xiao-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/pt_BR/adafruit-circuitpython-seeeduino_xiao-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/zh_Latn_pinyin/adafruit-circuitpython-seeeduino_xiao-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -8760,6 +8766,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/ID/adafruit-circuitpython-seeeduino_xiao-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/de_DE/adafruit-circuitpython-seeeduino_xiao-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/en_US/adafruit-circuitpython-seeeduino_xiao-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/en_x_pirate/adafruit-circuitpython-seeeduino_xiao-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/es/adafruit-circuitpython-seeeduino_xiao-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/fil/adafruit-circuitpython-seeeduino_xiao-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/fr/adafruit-circuitpython-seeeduino_xiao-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/it_IT/adafruit-circuitpython-seeeduino_xiao-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/ko/adafruit-circuitpython-seeeduino_xiao-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/pl/adafruit-circuitpython-seeeduino_xiao-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/pt_BR/adafruit-circuitpython-seeeduino_xiao-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/zh_Latn_pinyin/adafruit-circuitpython-seeeduino_xiao-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -8767,48 +8815,6 @@
         "downloads": 0,
         "id": "serpente",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/serpente/ID/adafruit-circuitpython-serpente-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/serpente/de_DE/adafruit-circuitpython-serpente-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/serpente/en_US/adafruit-circuitpython-serpente-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/serpente/en_x_pirate/adafruit-circuitpython-serpente-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/serpente/es/adafruit-circuitpython-serpente-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/serpente/fil/adafruit-circuitpython-serpente-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/serpente/fr/adafruit-circuitpython-serpente-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/serpente/it_IT/adafruit-circuitpython-serpente-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/serpente/ko/adafruit-circuitpython-serpente-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/serpente/pl/adafruit-circuitpython-serpente-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/serpente/pt_BR/adafruit-circuitpython-serpente-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/serpente/zh_Latn_pinyin/adafruit-circuitpython-serpente-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -8850,6 +8856,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/serpente/ID/adafruit-circuitpython-serpente-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/serpente/de_DE/adafruit-circuitpython-serpente-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/serpente/en_US/adafruit-circuitpython-serpente-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/serpente/en_x_pirate/adafruit-circuitpython-serpente-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/serpente/es/adafruit-circuitpython-serpente-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/serpente/fil/adafruit-circuitpython-serpente-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/serpente/fr/adafruit-circuitpython-serpente-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/serpente/it_IT/adafruit-circuitpython-serpente-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/serpente/ko/adafruit-circuitpython-serpente-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/serpente/pl/adafruit-circuitpython-serpente-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/serpente/pt_BR/adafruit-circuitpython-serpente-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/serpente/zh_Latn_pinyin/adafruit-circuitpython-serpente-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -8857,48 +8905,6 @@
         "downloads": 0,
         "id": "shirtty",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/shirtty/ID/adafruit-circuitpython-shirtty-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/shirtty/de_DE/adafruit-circuitpython-shirtty-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/shirtty/en_US/adafruit-circuitpython-shirtty-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/shirtty/en_x_pirate/adafruit-circuitpython-shirtty-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/shirtty/es/adafruit-circuitpython-shirtty-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/shirtty/fil/adafruit-circuitpython-shirtty-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/shirtty/fr/adafruit-circuitpython-shirtty-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/shirtty/it_IT/adafruit-circuitpython-shirtty-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/shirtty/ko/adafruit-circuitpython-shirtty-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/shirtty/pl/adafruit-circuitpython-shirtty-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/shirtty/pt_BR/adafruit-circuitpython-shirtty-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/shirtty/zh_Latn_pinyin/adafruit-circuitpython-shirtty-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -8940,6 +8946,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/shirtty/ID/adafruit-circuitpython-shirtty-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/shirtty/de_DE/adafruit-circuitpython-shirtty-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/shirtty/en_US/adafruit-circuitpython-shirtty-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/shirtty/en_x_pirate/adafruit-circuitpython-shirtty-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/shirtty/es/adafruit-circuitpython-shirtty-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/shirtty/fil/adafruit-circuitpython-shirtty-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/shirtty/fr/adafruit-circuitpython-shirtty-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/shirtty/it_IT/adafruit-circuitpython-shirtty-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/shirtty/ko/adafruit-circuitpython-shirtty-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/shirtty/pl/adafruit-circuitpython-shirtty-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/shirtty/pt_BR/adafruit-circuitpython-shirtty-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/shirtty/zh_Latn_pinyin/adafruit-circuitpython-shirtty-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -8947,48 +8995,6 @@
         "downloads": 0,
         "id": "snekboard",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/snekboard/ID/adafruit-circuitpython-snekboard-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/snekboard/de_DE/adafruit-circuitpython-snekboard-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/snekboard/en_US/adafruit-circuitpython-snekboard-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/snekboard/en_x_pirate/adafruit-circuitpython-snekboard-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/snekboard/es/adafruit-circuitpython-snekboard-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/snekboard/fil/adafruit-circuitpython-snekboard-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/snekboard/fr/adafruit-circuitpython-snekboard-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/snekboard/it_IT/adafruit-circuitpython-snekboard-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/snekboard/ko/adafruit-circuitpython-snekboard-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/snekboard/pl/adafruit-circuitpython-snekboard-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/snekboard/pt_BR/adafruit-circuitpython-snekboard-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/snekboard/zh_Latn_pinyin/adafruit-circuitpython-snekboard-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -9030,55 +9036,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/snekboard/ID/adafruit-circuitpython-snekboard-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/snekboard/de_DE/adafruit-circuitpython-snekboard-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/snekboard/en_US/adafruit-circuitpython-snekboard-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/snekboard/en_x_pirate/adafruit-circuitpython-snekboard-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/snekboard/es/adafruit-circuitpython-snekboard-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/snekboard/fil/adafruit-circuitpython-snekboard-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/snekboard/fr/adafruit-circuitpython-snekboard-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/snekboard/it_IT/adafruit-circuitpython-snekboard-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/snekboard/ko/adafruit-circuitpython-snekboard-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/snekboard/pl/adafruit-circuitpython-snekboard-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/snekboard/pt_BR/adafruit-circuitpython-snekboard-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/snekboard/zh_Latn_pinyin/adafruit-circuitpython-snekboard-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 31,
+        "downloads": 0,
         "id": "sparkfun_lumidrive",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/ID/adafruit-circuitpython-sparkfun_lumidrive-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/de_DE/adafruit-circuitpython-sparkfun_lumidrive-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/en_US/adafruit-circuitpython-sparkfun_lumidrive-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/en_x_pirate/adafruit-circuitpython-sparkfun_lumidrive-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/es/adafruit-circuitpython-sparkfun_lumidrive-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/fil/adafruit-circuitpython-sparkfun_lumidrive-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/fr/adafruit-circuitpython-sparkfun_lumidrive-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/it_IT/adafruit-circuitpython-sparkfun_lumidrive-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/ko/adafruit-circuitpython-sparkfun_lumidrive-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/pl/adafruit-circuitpython-sparkfun_lumidrive-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/pt_BR/adafruit-circuitpython-sparkfun_lumidrive-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_lumidrive-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -9120,55 +9126,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/ID/adafruit-circuitpython-sparkfun_lumidrive-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/de_DE/adafruit-circuitpython-sparkfun_lumidrive-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/en_US/adafruit-circuitpython-sparkfun_lumidrive-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/en_x_pirate/adafruit-circuitpython-sparkfun_lumidrive-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/es/adafruit-circuitpython-sparkfun_lumidrive-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/fil/adafruit-circuitpython-sparkfun_lumidrive-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/fr/adafruit-circuitpython-sparkfun_lumidrive-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/it_IT/adafruit-circuitpython-sparkfun_lumidrive-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/ko/adafruit-circuitpython-sparkfun_lumidrive-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/pl/adafruit-circuitpython-sparkfun_lumidrive-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/pt_BR/adafruit-circuitpython-sparkfun_lumidrive-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_lumidrive-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 34,
+        "downloads": 0,
         "id": "sparkfun_nrf52840_mini",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/ID/adafruit-circuitpython-sparkfun_nrf52840_mini-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/de_DE/adafruit-circuitpython-sparkfun_nrf52840_mini-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/en_US/adafruit-circuitpython-sparkfun_nrf52840_mini-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/en_x_pirate/adafruit-circuitpython-sparkfun_nrf52840_mini-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/es/adafruit-circuitpython-sparkfun_nrf52840_mini-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/fil/adafruit-circuitpython-sparkfun_nrf52840_mini-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/fr/adafruit-circuitpython-sparkfun_nrf52840_mini-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/it_IT/adafruit-circuitpython-sparkfun_nrf52840_mini-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/ko/adafruit-circuitpython-sparkfun_nrf52840_mini-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/pl/adafruit-circuitpython-sparkfun_nrf52840_mini-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/pt_BR/adafruit-circuitpython-sparkfun_nrf52840_mini-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_nrf52840_mini-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -9210,6 +9216,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/ID/adafruit-circuitpython-sparkfun_nrf52840_mini-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/de_DE/adafruit-circuitpython-sparkfun_nrf52840_mini-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/en_US/adafruit-circuitpython-sparkfun_nrf52840_mini-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/en_x_pirate/adafruit-circuitpython-sparkfun_nrf52840_mini-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/es/adafruit-circuitpython-sparkfun_nrf52840_mini-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/fil/adafruit-circuitpython-sparkfun_nrf52840_mini-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/fr/adafruit-circuitpython-sparkfun_nrf52840_mini-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/it_IT/adafruit-circuitpython-sparkfun_nrf52840_mini-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/ko/adafruit-circuitpython-sparkfun_nrf52840_mini-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/pl/adafruit-circuitpython-sparkfun_nrf52840_mini-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/pt_BR/adafruit-circuitpython-sparkfun_nrf52840_mini-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_nrf52840_mini-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -9217,48 +9265,6 @@
         "downloads": 0,
         "id": "sparkfun_qwiic_micro_no_flash",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/ID/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/de_DE/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/en_US/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/en_x_pirate/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/es/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/fil/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/fr/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/it_IT/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/ko/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/pl/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/pt_BR/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -9300,6 +9306,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/ID/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/de_DE/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/en_US/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/en_x_pirate/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/es/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/fil/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/fr/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/it_IT/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/ko/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/pl/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/pt_BR/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -9307,48 +9355,6 @@
         "downloads": 0,
         "id": "sparkfun_qwiic_micro_with_flash",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/ID/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/de_DE/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/en_US/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/en_x_pirate/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/es/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/fil/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/fr/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/it_IT/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/ko/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/pl/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/pt_BR/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -9390,55 +9396,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/ID/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/de_DE/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/en_US/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/en_x_pirate/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/es/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/fil/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/fr/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/it_IT/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/ko/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/pl/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/pt_BR/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 48,
+        "downloads": 0,
         "id": "sparkfun_redboard_turbo",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/ID/adafruit-circuitpython-sparkfun_redboard_turbo-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/de_DE/adafruit-circuitpython-sparkfun_redboard_turbo-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/en_US/adafruit-circuitpython-sparkfun_redboard_turbo-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/en_x_pirate/adafruit-circuitpython-sparkfun_redboard_turbo-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/es/adafruit-circuitpython-sparkfun_redboard_turbo-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/fil/adafruit-circuitpython-sparkfun_redboard_turbo-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/fr/adafruit-circuitpython-sparkfun_redboard_turbo-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/it_IT/adafruit-circuitpython-sparkfun_redboard_turbo-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/ko/adafruit-circuitpython-sparkfun_redboard_turbo-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/pl/adafruit-circuitpython-sparkfun_redboard_turbo-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/pt_BR/adafruit-circuitpython-sparkfun_redboard_turbo-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_redboard_turbo-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -9480,55 +9486,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/ID/adafruit-circuitpython-sparkfun_redboard_turbo-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/de_DE/adafruit-circuitpython-sparkfun_redboard_turbo-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/en_US/adafruit-circuitpython-sparkfun_redboard_turbo-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/en_x_pirate/adafruit-circuitpython-sparkfun_redboard_turbo-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/es/adafruit-circuitpython-sparkfun_redboard_turbo-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/fil/adafruit-circuitpython-sparkfun_redboard_turbo-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/fr/adafruit-circuitpython-sparkfun_redboard_turbo-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/it_IT/adafruit-circuitpython-sparkfun_redboard_turbo-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/ko/adafruit-circuitpython-sparkfun_redboard_turbo-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/pl/adafruit-circuitpython-sparkfun_redboard_turbo-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/pt_BR/adafruit-circuitpython-sparkfun_redboard_turbo-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_redboard_turbo-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 37,
+        "downloads": 0,
         "id": "sparkfun_samd21_dev",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/ID/adafruit-circuitpython-sparkfun_samd21_dev-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/de_DE/adafruit-circuitpython-sparkfun_samd21_dev-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/en_US/adafruit-circuitpython-sparkfun_samd21_dev-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/en_x_pirate/adafruit-circuitpython-sparkfun_samd21_dev-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/es/adafruit-circuitpython-sparkfun_samd21_dev-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/fil/adafruit-circuitpython-sparkfun_samd21_dev-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/fr/adafruit-circuitpython-sparkfun_samd21_dev-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/it_IT/adafruit-circuitpython-sparkfun_samd21_dev-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/ko/adafruit-circuitpython-sparkfun_samd21_dev-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/pl/adafruit-circuitpython-sparkfun_samd21_dev-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/pt_BR/adafruit-circuitpython-sparkfun_samd21_dev-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_samd21_dev-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -9570,55 +9576,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/ID/adafruit-circuitpython-sparkfun_samd21_dev-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/de_DE/adafruit-circuitpython-sparkfun_samd21_dev-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/en_US/adafruit-circuitpython-sparkfun_samd21_dev-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/en_x_pirate/adafruit-circuitpython-sparkfun_samd21_dev-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/es/adafruit-circuitpython-sparkfun_samd21_dev-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/fil/adafruit-circuitpython-sparkfun_samd21_dev-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/fr/adafruit-circuitpython-sparkfun_samd21_dev-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/it_IT/adafruit-circuitpython-sparkfun_samd21_dev-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/ko/adafruit-circuitpython-sparkfun_samd21_dev-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/pl/adafruit-circuitpython-sparkfun_samd21_dev-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/pt_BR/adafruit-circuitpython-sparkfun_samd21_dev-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_samd21_dev-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 54,
+        "downloads": 0,
         "id": "sparkfun_samd21_mini",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/ID/adafruit-circuitpython-sparkfun_samd21_mini-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/de_DE/adafruit-circuitpython-sparkfun_samd21_mini-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/en_US/adafruit-circuitpython-sparkfun_samd21_mini-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/en_x_pirate/adafruit-circuitpython-sparkfun_samd21_mini-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/es/adafruit-circuitpython-sparkfun_samd21_mini-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/fil/adafruit-circuitpython-sparkfun_samd21_mini-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/fr/adafruit-circuitpython-sparkfun_samd21_mini-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/it_IT/adafruit-circuitpython-sparkfun_samd21_mini-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/ko/adafruit-circuitpython-sparkfun_samd21_mini-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/pl/adafruit-circuitpython-sparkfun_samd21_mini-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/pt_BR/adafruit-circuitpython-sparkfun_samd21_mini-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_samd21_mini-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -9660,6 +9666,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/ID/adafruit-circuitpython-sparkfun_samd21_mini-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/de_DE/adafruit-circuitpython-sparkfun_samd21_mini-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/en_US/adafruit-circuitpython-sparkfun_samd21_mini-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/en_x_pirate/adafruit-circuitpython-sparkfun_samd21_mini-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/es/adafruit-circuitpython-sparkfun_samd21_mini-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/fil/adafruit-circuitpython-sparkfun_samd21_mini-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/fr/adafruit-circuitpython-sparkfun_samd21_mini-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/it_IT/adafruit-circuitpython-sparkfun_samd21_mini-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/ko/adafruit-circuitpython-sparkfun_samd21_mini-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/pl/adafruit-circuitpython-sparkfun_samd21_mini-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/pt_BR/adafruit-circuitpython-sparkfun_samd21_mini-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_samd21_mini-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -9667,48 +9715,6 @@
         "downloads": 0,
         "id": "sparkfun_samd51_thing_plus",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/ID/adafruit-circuitpython-sparkfun_samd51_thing_plus-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/de_DE/adafruit-circuitpython-sparkfun_samd51_thing_plus-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/en_US/adafruit-circuitpython-sparkfun_samd51_thing_plus-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/en_x_pirate/adafruit-circuitpython-sparkfun_samd51_thing_plus-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/es/adafruit-circuitpython-sparkfun_samd51_thing_plus-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/fil/adafruit-circuitpython-sparkfun_samd51_thing_plus-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/fr/adafruit-circuitpython-sparkfun_samd51_thing_plus-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/it_IT/adafruit-circuitpython-sparkfun_samd51_thing_plus-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/ko/adafruit-circuitpython-sparkfun_samd51_thing_plus-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/pl/adafruit-circuitpython-sparkfun_samd51_thing_plus-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/pt_BR/adafruit-circuitpython-sparkfun_samd51_thing_plus-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_samd51_thing_plus-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -9750,6 +9756,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/ID/adafruit-circuitpython-sparkfun_samd51_thing_plus-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/de_DE/adafruit-circuitpython-sparkfun_samd51_thing_plus-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/en_US/adafruit-circuitpython-sparkfun_samd51_thing_plus-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/en_x_pirate/adafruit-circuitpython-sparkfun_samd51_thing_plus-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/es/adafruit-circuitpython-sparkfun_samd51_thing_plus-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/fil/adafruit-circuitpython-sparkfun_samd51_thing_plus-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/fr/adafruit-circuitpython-sparkfun_samd51_thing_plus-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/it_IT/adafruit-circuitpython-sparkfun_samd51_thing_plus-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/ko/adafruit-circuitpython-sparkfun_samd51_thing_plus-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/pl/adafruit-circuitpython-sparkfun_samd51_thing_plus-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/pt_BR/adafruit-circuitpython-sparkfun_samd51_thing_plus-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_samd51_thing_plus-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -9757,48 +9805,6 @@
         "downloads": 0,
         "id": "spresense",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/spresense/ID/adafruit-circuitpython-spresense-ID-5.0.0-rc.1.spk"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/spresense/de_DE/adafruit-circuitpython-spresense-de_DE-5.0.0-rc.1.spk"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/spresense/en_US/adafruit-circuitpython-spresense-en_US-5.0.0-rc.1.spk"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/spresense/en_x_pirate/adafruit-circuitpython-spresense-en_x_pirate-5.0.0-rc.1.spk"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/spresense/es/adafruit-circuitpython-spresense-es-5.0.0-rc.1.spk"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/spresense/fil/adafruit-circuitpython-spresense-fil-5.0.0-rc.1.spk"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/spresense/fr/adafruit-circuitpython-spresense-fr-5.0.0-rc.1.spk"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/spresense/it_IT/adafruit-circuitpython-spresense-it_IT-5.0.0-rc.1.spk"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/spresense/ko/adafruit-circuitpython-spresense-ko-5.0.0-rc.1.spk"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/spresense/pl/adafruit-circuitpython-spresense-pl-5.0.0-rc.1.spk"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/spresense/pt_BR/adafruit-circuitpython-spresense-pt_BR-5.0.0-rc.1.spk"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/spresense/zh_Latn_pinyin/adafruit-circuitpython-spresense-zh_Latn_pinyin-5.0.0-rc.1.spk"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -9840,6 +9846,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/spresense/ID/adafruit-circuitpython-spresense-ID-5.1.0-rc.0.spk"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/spresense/de_DE/adafruit-circuitpython-spresense-de_DE-5.1.0-rc.0.spk"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/spresense/en_US/adafruit-circuitpython-spresense-en_US-5.1.0-rc.0.spk"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/spresense/en_x_pirate/adafruit-circuitpython-spresense-en_x_pirate-5.1.0-rc.0.spk"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/spresense/es/adafruit-circuitpython-spresense-es-5.1.0-rc.0.spk"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/spresense/fil/adafruit-circuitpython-spresense-fil-5.1.0-rc.0.spk"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/spresense/fr/adafruit-circuitpython-spresense-fr-5.1.0-rc.0.spk"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/spresense/it_IT/adafruit-circuitpython-spresense-it_IT-5.1.0-rc.0.spk"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/spresense/ko/adafruit-circuitpython-spresense-ko-5.1.0-rc.0.spk"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/spresense/pl/adafruit-circuitpython-spresense-pl-5.1.0-rc.0.spk"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/spresense/pt_BR/adafruit-circuitpython-spresense-pt_BR-5.1.0-rc.0.spk"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/spresense/zh_Latn_pinyin/adafruit-circuitpython-spresense-zh_Latn_pinyin-5.1.0-rc.0.spk"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -9847,48 +9895,6 @@
         "downloads": 0,
         "id": "stm32f411ce_blackpill",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/ID/adafruit-circuitpython-stm32f411ce_blackpill-ID-5.0.0-rc.1.bin"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/de_DE/adafruit-circuitpython-stm32f411ce_blackpill-de_DE-5.0.0-rc.1.bin"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/en_US/adafruit-circuitpython-stm32f411ce_blackpill-en_US-5.0.0-rc.1.bin"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/en_x_pirate/adafruit-circuitpython-stm32f411ce_blackpill-en_x_pirate-5.0.0-rc.1.bin"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/es/adafruit-circuitpython-stm32f411ce_blackpill-es-5.0.0-rc.1.bin"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/fil/adafruit-circuitpython-stm32f411ce_blackpill-fil-5.0.0-rc.1.bin"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/fr/adafruit-circuitpython-stm32f411ce_blackpill-fr-5.0.0-rc.1.bin"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/it_IT/adafruit-circuitpython-stm32f411ce_blackpill-it_IT-5.0.0-rc.1.bin"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/ko/adafruit-circuitpython-stm32f411ce_blackpill-ko-5.0.0-rc.1.bin"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/pl/adafruit-circuitpython-stm32f411ce_blackpill-pl-5.0.0-rc.1.bin"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/pt_BR/adafruit-circuitpython-stm32f411ce_blackpill-pt_BR-5.0.0-rc.1.bin"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/zh_Latn_pinyin/adafruit-circuitpython-stm32f411ce_blackpill-zh_Latn_pinyin-5.0.0-rc.1.bin"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -9930,6 +9936,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/ID/adafruit-circuitpython-stm32f411ce_blackpill-ID-5.1.0-rc.0.bin"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/de_DE/adafruit-circuitpython-stm32f411ce_blackpill-de_DE-5.1.0-rc.0.bin"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/en_US/adafruit-circuitpython-stm32f411ce_blackpill-en_US-5.1.0-rc.0.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/en_x_pirate/adafruit-circuitpython-stm32f411ce_blackpill-en_x_pirate-5.1.0-rc.0.bin"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/es/adafruit-circuitpython-stm32f411ce_blackpill-es-5.1.0-rc.0.bin"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/fil/adafruit-circuitpython-stm32f411ce_blackpill-fil-5.1.0-rc.0.bin"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/fr/adafruit-circuitpython-stm32f411ce_blackpill-fr-5.1.0-rc.0.bin"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/it_IT/adafruit-circuitpython-stm32f411ce_blackpill-it_IT-5.1.0-rc.0.bin"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/ko/adafruit-circuitpython-stm32f411ce_blackpill-ko-5.1.0-rc.0.bin"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/pl/adafruit-circuitpython-stm32f411ce_blackpill-pl-5.1.0-rc.0.bin"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/pt_BR/adafruit-circuitpython-stm32f411ce_blackpill-pt_BR-5.1.0-rc.0.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/zh_Latn_pinyin/adafruit-circuitpython-stm32f411ce_blackpill-zh_Latn_pinyin-5.1.0-rc.0.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -9937,48 +9985,6 @@
         "downloads": 0,
         "id": "stm32f411ve_discovery",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/ID/adafruit-circuitpython-stm32f411ve_discovery-ID-5.0.0-rc.1.bin"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/de_DE/adafruit-circuitpython-stm32f411ve_discovery-de_DE-5.0.0-rc.1.bin"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/en_US/adafruit-circuitpython-stm32f411ve_discovery-en_US-5.0.0-rc.1.bin"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/en_x_pirate/adafruit-circuitpython-stm32f411ve_discovery-en_x_pirate-5.0.0-rc.1.bin"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/es/adafruit-circuitpython-stm32f411ve_discovery-es-5.0.0-rc.1.bin"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/fil/adafruit-circuitpython-stm32f411ve_discovery-fil-5.0.0-rc.1.bin"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/fr/adafruit-circuitpython-stm32f411ve_discovery-fr-5.0.0-rc.1.bin"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/it_IT/adafruit-circuitpython-stm32f411ve_discovery-it_IT-5.0.0-rc.1.bin"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/ko/adafruit-circuitpython-stm32f411ve_discovery-ko-5.0.0-rc.1.bin"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/pl/adafruit-circuitpython-stm32f411ve_discovery-pl-5.0.0-rc.1.bin"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/pt_BR/adafruit-circuitpython-stm32f411ve_discovery-pt_BR-5.0.0-rc.1.bin"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/zh_Latn_pinyin/adafruit-circuitpython-stm32f411ve_discovery-zh_Latn_pinyin-5.0.0-rc.1.bin"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -10020,6 +10026,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/ID/adafruit-circuitpython-stm32f411ve_discovery-ID-5.1.0-rc.0.bin"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/de_DE/adafruit-circuitpython-stm32f411ve_discovery-de_DE-5.1.0-rc.0.bin"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/en_US/adafruit-circuitpython-stm32f411ve_discovery-en_US-5.1.0-rc.0.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/en_x_pirate/adafruit-circuitpython-stm32f411ve_discovery-en_x_pirate-5.1.0-rc.0.bin"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/es/adafruit-circuitpython-stm32f411ve_discovery-es-5.1.0-rc.0.bin"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/fil/adafruit-circuitpython-stm32f411ve_discovery-fil-5.1.0-rc.0.bin"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/fr/adafruit-circuitpython-stm32f411ve_discovery-fr-5.1.0-rc.0.bin"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/it_IT/adafruit-circuitpython-stm32f411ve_discovery-it_IT-5.1.0-rc.0.bin"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/ko/adafruit-circuitpython-stm32f411ve_discovery-ko-5.1.0-rc.0.bin"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/pl/adafruit-circuitpython-stm32f411ve_discovery-pl-5.1.0-rc.0.bin"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/pt_BR/adafruit-circuitpython-stm32f411ve_discovery-pt_BR-5.1.0-rc.0.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/zh_Latn_pinyin/adafruit-circuitpython-stm32f411ve_discovery-zh_Latn_pinyin-5.1.0-rc.0.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -10027,48 +10075,6 @@
         "downloads": 0,
         "id": "stm32f412zg_discovery",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/ID/adafruit-circuitpython-stm32f412zg_discovery-ID-5.0.0-rc.1.bin"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/de_DE/adafruit-circuitpython-stm32f412zg_discovery-de_DE-5.0.0-rc.1.bin"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/en_US/adafruit-circuitpython-stm32f412zg_discovery-en_US-5.0.0-rc.1.bin"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/en_x_pirate/adafruit-circuitpython-stm32f412zg_discovery-en_x_pirate-5.0.0-rc.1.bin"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/es/adafruit-circuitpython-stm32f412zg_discovery-es-5.0.0-rc.1.bin"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/fil/adafruit-circuitpython-stm32f412zg_discovery-fil-5.0.0-rc.1.bin"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/fr/adafruit-circuitpython-stm32f412zg_discovery-fr-5.0.0-rc.1.bin"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/it_IT/adafruit-circuitpython-stm32f412zg_discovery-it_IT-5.0.0-rc.1.bin"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/ko/adafruit-circuitpython-stm32f412zg_discovery-ko-5.0.0-rc.1.bin"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/pl/adafruit-circuitpython-stm32f412zg_discovery-pl-5.0.0-rc.1.bin"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/pt_BR/adafruit-circuitpython-stm32f412zg_discovery-pt_BR-5.0.0-rc.1.bin"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/zh_Latn_pinyin/adafruit-circuitpython-stm32f412zg_discovery-zh_Latn_pinyin-5.0.0-rc.1.bin"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -10110,6 +10116,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/ID/adafruit-circuitpython-stm32f412zg_discovery-ID-5.1.0-rc.0.bin"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/de_DE/adafruit-circuitpython-stm32f412zg_discovery-de_DE-5.1.0-rc.0.bin"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/en_US/adafruit-circuitpython-stm32f412zg_discovery-en_US-5.1.0-rc.0.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/en_x_pirate/adafruit-circuitpython-stm32f412zg_discovery-en_x_pirate-5.1.0-rc.0.bin"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/es/adafruit-circuitpython-stm32f412zg_discovery-es-5.1.0-rc.0.bin"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/fil/adafruit-circuitpython-stm32f412zg_discovery-fil-5.1.0-rc.0.bin"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/fr/adafruit-circuitpython-stm32f412zg_discovery-fr-5.1.0-rc.0.bin"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/it_IT/adafruit-circuitpython-stm32f412zg_discovery-it_IT-5.1.0-rc.0.bin"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/ko/adafruit-circuitpython-stm32f412zg_discovery-ko-5.1.0-rc.0.bin"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/pl/adafruit-circuitpython-stm32f412zg_discovery-pl-5.1.0-rc.0.bin"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/pt_BR/adafruit-circuitpython-stm32f412zg_discovery-pt_BR-5.1.0-rc.0.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/zh_Latn_pinyin/adafruit-circuitpython-stm32f412zg_discovery-zh_Latn_pinyin-5.1.0-rc.0.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -10117,48 +10165,6 @@
         "downloads": 0,
         "id": "stm32f4_discovery",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/ID/adafruit-circuitpython-stm32f4_discovery-ID-5.0.0-rc.1.bin"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/de_DE/adafruit-circuitpython-stm32f4_discovery-de_DE-5.0.0-rc.1.bin"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/en_US/adafruit-circuitpython-stm32f4_discovery-en_US-5.0.0-rc.1.bin"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/en_x_pirate/adafruit-circuitpython-stm32f4_discovery-en_x_pirate-5.0.0-rc.1.bin"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/es/adafruit-circuitpython-stm32f4_discovery-es-5.0.0-rc.1.bin"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/fil/adafruit-circuitpython-stm32f4_discovery-fil-5.0.0-rc.1.bin"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/fr/adafruit-circuitpython-stm32f4_discovery-fr-5.0.0-rc.1.bin"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/it_IT/adafruit-circuitpython-stm32f4_discovery-it_IT-5.0.0-rc.1.bin"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/ko/adafruit-circuitpython-stm32f4_discovery-ko-5.0.0-rc.1.bin"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/pl/adafruit-circuitpython-stm32f4_discovery-pl-5.0.0-rc.1.bin"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/pt_BR/adafruit-circuitpython-stm32f4_discovery-pt_BR-5.0.0-rc.1.bin"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/zh_Latn_pinyin/adafruit-circuitpython-stm32f4_discovery-zh_Latn_pinyin-5.0.0-rc.1.bin"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -10200,6 +10206,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/ID/adafruit-circuitpython-stm32f4_discovery-ID-5.1.0-rc.0.bin"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/de_DE/adafruit-circuitpython-stm32f4_discovery-de_DE-5.1.0-rc.0.bin"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/en_US/adafruit-circuitpython-stm32f4_discovery-en_US-5.1.0-rc.0.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/en_x_pirate/adafruit-circuitpython-stm32f4_discovery-en_x_pirate-5.1.0-rc.0.bin"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/es/adafruit-circuitpython-stm32f4_discovery-es-5.1.0-rc.0.bin"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/fil/adafruit-circuitpython-stm32f4_discovery-fil-5.1.0-rc.0.bin"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/fr/adafruit-circuitpython-stm32f4_discovery-fr-5.1.0-rc.0.bin"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/it_IT/adafruit-circuitpython-stm32f4_discovery-it_IT-5.1.0-rc.0.bin"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/ko/adafruit-circuitpython-stm32f4_discovery-ko-5.1.0-rc.0.bin"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/pl/adafruit-circuitpython-stm32f4_discovery-pl-5.1.0-rc.0.bin"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/pt_BR/adafruit-circuitpython-stm32f4_discovery-pt_BR-5.1.0-rc.0.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/zh_Latn_pinyin/adafruit-circuitpython-stm32f4_discovery-zh_Latn_pinyin-5.1.0-rc.0.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -10207,48 +10255,6 @@
         "downloads": 0,
         "id": "stringcar_m0_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/ID/adafruit-circuitpython-stringcar_m0_express-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/de_DE/adafruit-circuitpython-stringcar_m0_express-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/en_US/adafruit-circuitpython-stringcar_m0_express-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/en_x_pirate/adafruit-circuitpython-stringcar_m0_express-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/es/adafruit-circuitpython-stringcar_m0_express-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/fil/adafruit-circuitpython-stringcar_m0_express-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/fr/adafruit-circuitpython-stringcar_m0_express-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/it_IT/adafruit-circuitpython-stringcar_m0_express-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/ko/adafruit-circuitpython-stringcar_m0_express-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/pl/adafruit-circuitpython-stringcar_m0_express-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/pt_BR/adafruit-circuitpython-stringcar_m0_express-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/zh_Latn_pinyin/adafruit-circuitpython-stringcar_m0_express-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -10290,6 +10296,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/ID/adafruit-circuitpython-stringcar_m0_express-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/de_DE/adafruit-circuitpython-stringcar_m0_express-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/en_US/adafruit-circuitpython-stringcar_m0_express-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/en_x_pirate/adafruit-circuitpython-stringcar_m0_express-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/es/adafruit-circuitpython-stringcar_m0_express-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/fil/adafruit-circuitpython-stringcar_m0_express-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/fr/adafruit-circuitpython-stringcar_m0_express-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/it_IT/adafruit-circuitpython-stringcar_m0_express-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/ko/adafruit-circuitpython-stringcar_m0_express-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/pl/adafruit-circuitpython-stringcar_m0_express-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/pt_BR/adafruit-circuitpython-stringcar_m0_express-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/zh_Latn_pinyin/adafruit-circuitpython-stringcar_m0_express-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -10297,60 +10345,6 @@
         "downloads": 0,
         "id": "teensy40",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/teensy40/ID/adafruit-circuitpython-teensy40-ID-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/ID/adafruit-circuitpython-teensy40-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/teensy40/de_DE/adafruit-circuitpython-teensy40-de_DE-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/de_DE/adafruit-circuitpython-teensy40-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/teensy40/en_US/adafruit-circuitpython-teensy40-en_US-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/en_US/adafruit-circuitpython-teensy40-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/teensy40/en_x_pirate/adafruit-circuitpython-teensy40-en_x_pirate-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/en_x_pirate/adafruit-circuitpython-teensy40-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/teensy40/es/adafruit-circuitpython-teensy40-es-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/es/adafruit-circuitpython-teensy40-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/teensy40/fil/adafruit-circuitpython-teensy40-fil-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/fil/adafruit-circuitpython-teensy40-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/teensy40/fr/adafruit-circuitpython-teensy40-fr-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/fr/adafruit-circuitpython-teensy40-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/teensy40/it_IT/adafruit-circuitpython-teensy40-it_IT-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/it_IT/adafruit-circuitpython-teensy40-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/teensy40/ko/adafruit-circuitpython-teensy40-ko-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/ko/adafruit-circuitpython-teensy40-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/teensy40/pl/adafruit-circuitpython-teensy40-pl-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/pl/adafruit-circuitpython-teensy40-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/teensy40/pt_BR/adafruit-circuitpython-teensy40-pt_BR-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/pt_BR/adafruit-circuitpython-teensy40-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/teensy40/zh_Latn_pinyin/adafruit-circuitpython-teensy40-zh_Latn_pinyin-5.0.0-rc.1.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/zh_Latn_pinyin/adafruit-circuitpython-teensy40-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -10404,6 +10398,60 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/teensy40/ID/adafruit-circuitpython-teensy40-ID-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/ID/adafruit-circuitpython-teensy40-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/teensy40/de_DE/adafruit-circuitpython-teensy40-de_DE-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/de_DE/adafruit-circuitpython-teensy40-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/teensy40/en_US/adafruit-circuitpython-teensy40-en_US-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/en_US/adafruit-circuitpython-teensy40-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/teensy40/en_x_pirate/adafruit-circuitpython-teensy40-en_x_pirate-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/en_x_pirate/adafruit-circuitpython-teensy40-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/teensy40/es/adafruit-circuitpython-teensy40-es-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/es/adafruit-circuitpython-teensy40-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/teensy40/fil/adafruit-circuitpython-teensy40-fil-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/fil/adafruit-circuitpython-teensy40-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/teensy40/fr/adafruit-circuitpython-teensy40-fr-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/fr/adafruit-circuitpython-teensy40-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/teensy40/it_IT/adafruit-circuitpython-teensy40-it_IT-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/it_IT/adafruit-circuitpython-teensy40-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/teensy40/ko/adafruit-circuitpython-teensy40-ko-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/ko/adafruit-circuitpython-teensy40-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/teensy40/pl/adafruit-circuitpython-teensy40-pl-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/pl/adafruit-circuitpython-teensy40-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/teensy40/pt_BR/adafruit-circuitpython-teensy40-pt_BR-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/pt_BR/adafruit-circuitpython-teensy40-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/teensy40/zh_Latn_pinyin/adafruit-circuitpython-teensy40-zh_Latn_pinyin-5.1.0-rc.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/zh_Latn_pinyin/adafruit-circuitpython-teensy40-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -10411,48 +10459,6 @@
         "downloads": 0,
         "id": "teknikio_bluebird",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/ID/adafruit-circuitpython-teknikio_bluebird-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/de_DE/adafruit-circuitpython-teknikio_bluebird-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/en_US/adafruit-circuitpython-teknikio_bluebird-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/en_x_pirate/adafruit-circuitpython-teknikio_bluebird-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/es/adafruit-circuitpython-teknikio_bluebird-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/fil/adafruit-circuitpython-teknikio_bluebird-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/fr/adafruit-circuitpython-teknikio_bluebird-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/it_IT/adafruit-circuitpython-teknikio_bluebird-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/ko/adafruit-circuitpython-teknikio_bluebird-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/pl/adafruit-circuitpython-teknikio_bluebird-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/pt_BR/adafruit-circuitpython-teknikio_bluebird-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/zh_Latn_pinyin/adafruit-circuitpython-teknikio_bluebird-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -10494,55 +10500,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/ID/adafruit-circuitpython-teknikio_bluebird-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/de_DE/adafruit-circuitpython-teknikio_bluebird-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/en_US/adafruit-circuitpython-teknikio_bluebird-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/en_x_pirate/adafruit-circuitpython-teknikio_bluebird-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/es/adafruit-circuitpython-teknikio_bluebird-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/fil/adafruit-circuitpython-teknikio_bluebird-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/fr/adafruit-circuitpython-teknikio_bluebird-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/it_IT/adafruit-circuitpython-teknikio_bluebird-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/ko/adafruit-circuitpython-teknikio_bluebird-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/pl/adafruit-circuitpython-teknikio_bluebird-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/pt_BR/adafruit-circuitpython-teknikio_bluebird-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/zh_Latn_pinyin/adafruit-circuitpython-teknikio_bluebird-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 271,
+        "downloads": 0,
         "id": "trellis_m4_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/ID/adafruit-circuitpython-trellis_m4_express-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/de_DE/adafruit-circuitpython-trellis_m4_express-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/en_US/adafruit-circuitpython-trellis_m4_express-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/en_x_pirate/adafruit-circuitpython-trellis_m4_express-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/es/adafruit-circuitpython-trellis_m4_express-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/fil/adafruit-circuitpython-trellis_m4_express-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/fr/adafruit-circuitpython-trellis_m4_express-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/it_IT/adafruit-circuitpython-trellis_m4_express-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/ko/adafruit-circuitpython-trellis_m4_express-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/pl/adafruit-circuitpython-trellis_m4_express-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/pt_BR/adafruit-circuitpython-trellis_m4_express-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/zh_Latn_pinyin/adafruit-circuitpython-trellis_m4_express-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -10584,55 +10590,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/ID/adafruit-circuitpython-trellis_m4_express-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/de_DE/adafruit-circuitpython-trellis_m4_express-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/en_US/adafruit-circuitpython-trellis_m4_express-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/en_x_pirate/adafruit-circuitpython-trellis_m4_express-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/es/adafruit-circuitpython-trellis_m4_express-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/fil/adafruit-circuitpython-trellis_m4_express-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/fr/adafruit-circuitpython-trellis_m4_express-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/it_IT/adafruit-circuitpython-trellis_m4_express-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/ko/adafruit-circuitpython-trellis_m4_express-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/pl/adafruit-circuitpython-trellis_m4_express-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/pt_BR/adafruit-circuitpython-trellis_m4_express-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/zh_Latn_pinyin/adafruit-circuitpython-trellis_m4_express-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 1298,
+        "downloads": 0,
         "id": "trinket_m0",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/ID/adafruit-circuitpython-trinket_m0-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/de_DE/adafruit-circuitpython-trinket_m0-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/en_US/adafruit-circuitpython-trinket_m0-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/en_x_pirate/adafruit-circuitpython-trinket_m0-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/es/adafruit-circuitpython-trinket_m0-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/fil/adafruit-circuitpython-trinket_m0-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/fr/adafruit-circuitpython-trinket_m0-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/it_IT/adafruit-circuitpython-trinket_m0-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/ko/adafruit-circuitpython-trinket_m0-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/pl/adafruit-circuitpython-trinket_m0-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/pt_BR/adafruit-circuitpython-trinket_m0-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/zh_Latn_pinyin/adafruit-circuitpython-trinket_m0-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -10674,6 +10680,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0/ID/adafruit-circuitpython-trinket_m0-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0/de_DE/adafruit-circuitpython-trinket_m0-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0/en_US/adafruit-circuitpython-trinket_m0-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0/en_x_pirate/adafruit-circuitpython-trinket_m0-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0/es/adafruit-circuitpython-trinket_m0-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0/fil/adafruit-circuitpython-trinket_m0-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0/fr/adafruit-circuitpython-trinket_m0-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0/it_IT/adafruit-circuitpython-trinket_m0-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0/ko/adafruit-circuitpython-trinket_m0-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0/pl/adafruit-circuitpython-trinket_m0-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0/pt_BR/adafruit-circuitpython-trinket_m0-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0/zh_Latn_pinyin/adafruit-circuitpython-trinket_m0-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -10681,48 +10729,6 @@
         "downloads": 0,
         "id": "trinket_m0_haxpress",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/ID/adafruit-circuitpython-trinket_m0_haxpress-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/de_DE/adafruit-circuitpython-trinket_m0_haxpress-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/en_US/adafruit-circuitpython-trinket_m0_haxpress-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/en_x_pirate/adafruit-circuitpython-trinket_m0_haxpress-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/es/adafruit-circuitpython-trinket_m0_haxpress-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/fil/adafruit-circuitpython-trinket_m0_haxpress-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/fr/adafruit-circuitpython-trinket_m0_haxpress-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/it_IT/adafruit-circuitpython-trinket_m0_haxpress-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/ko/adafruit-circuitpython-trinket_m0_haxpress-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/pl/adafruit-circuitpython-trinket_m0_haxpress-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/pt_BR/adafruit-circuitpython-trinket_m0_haxpress-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/zh_Latn_pinyin/adafruit-circuitpython-trinket_m0_haxpress-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -10764,55 +10770,103 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/ID/adafruit-circuitpython-trinket_m0_haxpress-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/de_DE/adafruit-circuitpython-trinket_m0_haxpress-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/en_US/adafruit-circuitpython-trinket_m0_haxpress-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/en_x_pirate/adafruit-circuitpython-trinket_m0_haxpress-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/es/adafruit-circuitpython-trinket_m0_haxpress-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/fil/adafruit-circuitpython-trinket_m0_haxpress-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/fr/adafruit-circuitpython-trinket_m0_haxpress-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/it_IT/adafruit-circuitpython-trinket_m0_haxpress-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/ko/adafruit-circuitpython-trinket_m0_haxpress-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/pl/adafruit-circuitpython-trinket_m0_haxpress-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/pt_BR/adafruit-circuitpython-trinket_m0_haxpress-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/zh_Latn_pinyin/adafruit-circuitpython-trinket_m0_haxpress-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 24,
-        "id": "uchip",
+        "downloads": 0,
+        "id": "uartlogger2",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/uchip/ID/adafruit-circuitpython-uchip-ID-5.0.0-rc.1.uf2"
+                        "https://downloads.circuitpython.org/bin/uartlogger2/ID/adafruit-circuitpython-uartlogger2-ID-5.1.0-rc.0.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/uchip/de_DE/adafruit-circuitpython-uchip-de_DE-5.0.0-rc.1.uf2"
+                        "https://downloads.circuitpython.org/bin/uartlogger2/de_DE/adafruit-circuitpython-uartlogger2-de_DE-5.1.0-rc.0.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/uchip/en_US/adafruit-circuitpython-uchip-en_US-5.0.0-rc.1.uf2"
+                        "https://downloads.circuitpython.org/bin/uartlogger2/en_US/adafruit-circuitpython-uartlogger2-en_US-5.1.0-rc.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/uchip/en_x_pirate/adafruit-circuitpython-uchip-en_x_pirate-5.0.0-rc.1.uf2"
+                        "https://downloads.circuitpython.org/bin/uartlogger2/en_x_pirate/adafruit-circuitpython-uartlogger2-en_x_pirate-5.1.0-rc.0.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/uchip/es/adafruit-circuitpython-uchip-es-5.0.0-rc.1.uf2"
+                        "https://downloads.circuitpython.org/bin/uartlogger2/es/adafruit-circuitpython-uartlogger2-es-5.1.0-rc.0.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/uchip/fil/adafruit-circuitpython-uchip-fil-5.0.0-rc.1.uf2"
+                        "https://downloads.circuitpython.org/bin/uartlogger2/fil/adafruit-circuitpython-uartlogger2-fil-5.1.0-rc.0.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/uchip/fr/adafruit-circuitpython-uchip-fr-5.0.0-rc.1.uf2"
+                        "https://downloads.circuitpython.org/bin/uartlogger2/fr/adafruit-circuitpython-uartlogger2-fr-5.1.0-rc.0.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/uchip/it_IT/adafruit-circuitpython-uchip-it_IT-5.0.0-rc.1.uf2"
+                        "https://downloads.circuitpython.org/bin/uartlogger2/it_IT/adafruit-circuitpython-uartlogger2-it_IT-5.1.0-rc.0.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/uchip/ko/adafruit-circuitpython-uchip-ko-5.0.0-rc.1.uf2"
+                        "https://downloads.circuitpython.org/bin/uartlogger2/ko/adafruit-circuitpython-uartlogger2-ko-5.1.0-rc.0.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/uchip/pl/adafruit-circuitpython-uchip-pl-5.0.0-rc.1.uf2"
+                        "https://downloads.circuitpython.org/bin/uartlogger2/pl/adafruit-circuitpython-uartlogger2-pl-5.1.0-rc.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/uchip/pt_BR/adafruit-circuitpython-uchip-pt_BR-5.0.0-rc.1.uf2"
+                        "https://downloads.circuitpython.org/bin/uartlogger2/pt_BR/adafruit-circuitpython-uartlogger2-pt_BR-5.1.0-rc.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/uchip/zh_Latn_pinyin/adafruit-circuitpython-uchip-zh_Latn_pinyin-5.0.0-rc.1.uf2"
+                        "https://downloads.circuitpython.org/bin/uartlogger2/zh_Latn_pinyin/adafruit-circuitpython-uartlogger2-zh_Latn_pinyin-5.1.0-rc.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.0.0-rc.1"
-            },
+                "version": "5.1.0-rc.0"
+            }
+        ]
+    },
+    {
+        "downloads": 0,
+        "id": "uchip",
+        "versions": [
             {
                 "files": {
                     "ID": [
@@ -10854,55 +10908,55 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/uchip/ID/adafruit-circuitpython-uchip-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/uchip/de_DE/adafruit-circuitpython-uchip-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/uchip/en_US/adafruit-circuitpython-uchip-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/uchip/en_x_pirate/adafruit-circuitpython-uchip-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/uchip/es/adafruit-circuitpython-uchip-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/uchip/fil/adafruit-circuitpython-uchip-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/uchip/fr/adafruit-circuitpython-uchip-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/uchip/it_IT/adafruit-circuitpython-uchip-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/uchip/ko/adafruit-circuitpython-uchip-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/uchip/pl/adafruit-circuitpython-uchip-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/uchip/pt_BR/adafruit-circuitpython-uchip-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/uchip/zh_Latn_pinyin/adafruit-circuitpython-uchip-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
     {
-        "downloads": 32,
+        "downloads": 0,
         "id": "ugame10",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/ugame10/ID/adafruit-circuitpython-ugame10-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/ugame10/de_DE/adafruit-circuitpython-ugame10-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/ugame10/en_US/adafruit-circuitpython-ugame10-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/ugame10/en_x_pirate/adafruit-circuitpython-ugame10-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/ugame10/es/adafruit-circuitpython-ugame10-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/ugame10/fil/adafruit-circuitpython-ugame10-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/ugame10/fr/adafruit-circuitpython-ugame10-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/ugame10/it_IT/adafruit-circuitpython-ugame10-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/ugame10/ko/adafruit-circuitpython-ugame10-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/ugame10/pl/adafruit-circuitpython-ugame10-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/ugame10/pt_BR/adafruit-circuitpython-ugame10-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/ugame10/zh_Latn_pinyin/adafruit-circuitpython-ugame10-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -10944,6 +10998,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/ugame10/ID/adafruit-circuitpython-ugame10-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/ugame10/de_DE/adafruit-circuitpython-ugame10-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/ugame10/en_US/adafruit-circuitpython-ugame10-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/ugame10/en_x_pirate/adafruit-circuitpython-ugame10-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/ugame10/es/adafruit-circuitpython-ugame10-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/ugame10/fil/adafruit-circuitpython-ugame10-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/ugame10/fr/adafruit-circuitpython-ugame10-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/ugame10/it_IT/adafruit-circuitpython-ugame10-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/ugame10/ko/adafruit-circuitpython-ugame10-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/ugame10/pl/adafruit-circuitpython-ugame10-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/ugame10/pt_BR/adafruit-circuitpython-ugame10-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/ugame10/zh_Latn_pinyin/adafruit-circuitpython-ugame10-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -10951,48 +11047,6 @@
         "downloads": 0,
         "id": "winterbloom_sol",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/ID/adafruit-circuitpython-winterbloom_sol-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/de_DE/adafruit-circuitpython-winterbloom_sol-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/en_US/adafruit-circuitpython-winterbloom_sol-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/en_x_pirate/adafruit-circuitpython-winterbloom_sol-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/es/adafruit-circuitpython-winterbloom_sol-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/fil/adafruit-circuitpython-winterbloom_sol-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/fr/adafruit-circuitpython-winterbloom_sol-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/it_IT/adafruit-circuitpython-winterbloom_sol-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/ko/adafruit-circuitpython-winterbloom_sol-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/pl/adafruit-circuitpython-winterbloom_sol-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/pt_BR/adafruit-circuitpython-winterbloom_sol-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/zh_Latn_pinyin/adafruit-circuitpython-winterbloom_sol-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -11034,6 +11088,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/ID/adafruit-circuitpython-winterbloom_sol-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/de_DE/adafruit-circuitpython-winterbloom_sol-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/en_US/adafruit-circuitpython-winterbloom_sol-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/en_x_pirate/adafruit-circuitpython-winterbloom_sol-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/es/adafruit-circuitpython-winterbloom_sol-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/fil/adafruit-circuitpython-winterbloom_sol-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/fr/adafruit-circuitpython-winterbloom_sol-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/it_IT/adafruit-circuitpython-winterbloom_sol-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/ko/adafruit-circuitpython-winterbloom_sol-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/pl/adafruit-circuitpython-winterbloom_sol-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/pt_BR/adafruit-circuitpython-winterbloom_sol-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/zh_Latn_pinyin/adafruit-circuitpython-winterbloom_sol-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -11041,48 +11137,6 @@
         "downloads": 0,
         "id": "xinabox_cc03",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/ID/adafruit-circuitpython-xinabox_cc03-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/de_DE/adafruit-circuitpython-xinabox_cc03-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/en_US/adafruit-circuitpython-xinabox_cc03-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/en_x_pirate/adafruit-circuitpython-xinabox_cc03-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/es/adafruit-circuitpython-xinabox_cc03-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/fil/adafruit-circuitpython-xinabox_cc03-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/fr/adafruit-circuitpython-xinabox_cc03-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/it_IT/adafruit-circuitpython-xinabox_cc03-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/ko/adafruit-circuitpython-xinabox_cc03-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/pl/adafruit-circuitpython-xinabox_cc03-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/pt_BR/adafruit-circuitpython-xinabox_cc03-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/zh_Latn_pinyin/adafruit-circuitpython-xinabox_cc03-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -11124,6 +11178,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/ID/adafruit-circuitpython-xinabox_cc03-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/de_DE/adafruit-circuitpython-xinabox_cc03-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/en_US/adafruit-circuitpython-xinabox_cc03-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/en_x_pirate/adafruit-circuitpython-xinabox_cc03-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/es/adafruit-circuitpython-xinabox_cc03-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/fil/adafruit-circuitpython-xinabox_cc03-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/fr/adafruit-circuitpython-xinabox_cc03-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/it_IT/adafruit-circuitpython-xinabox_cc03-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/ko/adafruit-circuitpython-xinabox_cc03-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/pl/adafruit-circuitpython-xinabox_cc03-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/pt_BR/adafruit-circuitpython-xinabox_cc03-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/zh_Latn_pinyin/adafruit-circuitpython-xinabox_cc03-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     },
@@ -11131,48 +11227,6 @@
         "downloads": 0,
         "id": "xinabox_cs11",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/ID/adafruit-circuitpython-xinabox_cs11-ID-5.0.0-rc.1.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/de_DE/adafruit-circuitpython-xinabox_cs11-de_DE-5.0.0-rc.1.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/en_US/adafruit-circuitpython-xinabox_cs11-en_US-5.0.0-rc.1.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/en_x_pirate/adafruit-circuitpython-xinabox_cs11-en_x_pirate-5.0.0-rc.1.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/es/adafruit-circuitpython-xinabox_cs11-es-5.0.0-rc.1.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/fil/adafruit-circuitpython-xinabox_cs11-fil-5.0.0-rc.1.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/fr/adafruit-circuitpython-xinabox_cs11-fr-5.0.0-rc.1.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/it_IT/adafruit-circuitpython-xinabox_cs11-it_IT-5.0.0-rc.1.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/ko/adafruit-circuitpython-xinabox_cs11-ko-5.0.0-rc.1.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/pl/adafruit-circuitpython-xinabox_cs11-pl-5.0.0-rc.1.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/pt_BR/adafruit-circuitpython-xinabox_cs11-pt_BR-5.0.0-rc.1.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/zh_Latn_pinyin/adafruit-circuitpython-xinabox_cs11-zh_Latn_pinyin-5.0.0-rc.1.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.0.0-rc.1"
-            },
             {
                 "files": {
                     "ID": [
@@ -11214,6 +11268,48 @@
                 },
                 "stable": true,
                 "version": "5.0.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/ID/adafruit-circuitpython-xinabox_cs11-ID-5.1.0-rc.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/de_DE/adafruit-circuitpython-xinabox_cs11-de_DE-5.1.0-rc.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/en_US/adafruit-circuitpython-xinabox_cs11-en_US-5.1.0-rc.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/en_x_pirate/adafruit-circuitpython-xinabox_cs11-en_x_pirate-5.1.0-rc.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/es/adafruit-circuitpython-xinabox_cs11-es-5.1.0-rc.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/fil/adafruit-circuitpython-xinabox_cs11-fil-5.1.0-rc.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/fr/adafruit-circuitpython-xinabox_cs11-fr-5.1.0-rc.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/it_IT/adafruit-circuitpython-xinabox_cs11-it_IT-5.1.0-rc.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/ko/adafruit-circuitpython-xinabox_cs11-ko-5.1.0-rc.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/pl/adafruit-circuitpython-xinabox_cs11-pl-5.1.0-rc.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/pt_BR/adafruit-circuitpython-xinabox_cs11-pt_BR-5.1.0-rc.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/zh_Latn_pinyin/adafruit-circuitpython-xinabox_cs11-zh_Latn_pinyin-5.1.0-rc.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.1.0-rc.0"
             }
         ]
     }


### PR DESCRIPTION
Automated website update for release 5.1.0-rc.0 by Blinka.

New boards:
* TG-Watch02A
* uartlogger2


