### PR TITLE
Added Date Sorting for Blinka boards

### DIFF
--- a/_blinka/beaglebone_black.md
+++ b/_blinka/beaglebone_black.md
@@ -8,6 +8,7 @@ board_url: "https://beagleboard.org/black"
 board_image: "beaglebone_black.jpg"
 downloads_display: true
 blinka: true
+date_added: 2019-12-3
 features:
   - Ethernet
   - HDMI

--- a/_blinka/beaglebone_black_industrial.md
+++ b/_blinka/beaglebone_black_industrial.md
@@ -8,6 +8,7 @@ board_url: "https://beagleboard.org/e14-bbbi"
 board_image: "beaglebone_black_industrial.jpg"
 downloads_display: true
 blinka: true
+date_added: 2019-12-3
 features:
   - Ethernet
   - HDMI

--- a/_blinka/beaglebone_black_wireless.md
+++ b/_blinka/beaglebone_black_wireless.md
@@ -8,6 +8,7 @@ board_url: "https://beagleboard.org/black-wireless"
 board_image: "beaglebone_black_wireless.jpg"
 downloads_display: true
 blinka: true
+date_added: 2020-3-25
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/beaglebone_green_wireless.md
+++ b/_blinka/beaglebone_green_wireless.md
@@ -8,6 +8,7 @@ board_url: "https://beagleboard.org/green-wireless"
 board_image: "beaglebone_green_wireless.jpg"
 downloads_display: true
 blinka: true
+date_added: 2019-12-3
 features:
   - Wi-Fi
 ---

--- a/_blinka/binho_nova.md
+++ b/_blinka/binho_nova.md
@@ -8,6 +8,7 @@ board_url: "https://binho.io/"
 board_image: "binho_nova.jpg"
 downloads_display: true
 blinka: true
+date_added: 2019-12-3
 features:
 ---
 

--- a/_blinka/dragonboard_410c.md
+++ b/_blinka/dragonboard_410c.md
@@ -9,6 +9,7 @@ board_image: "dragonboard_410c.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-libraries-on-linux-and-the-96boards-dragonboard-410c"
 downloads_display: true
 blinka: true
+date_added: 2019-6-29
 features:
   - Wi-Fi
   - HDMI

--- a/_blinka/ft232h.md
+++ b/_blinka/ft232h.md
@@ -8,6 +8,7 @@ board_url: "https://www.adafruit.com/product/2264"
 board_image: "ft232h.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-any-computer-with-ft232h"
 downloads_display: true
+date_added: 2019-9-30
 blinka: true
 features:
 ---

--- a/_blinka/giant_board.md
+++ b/_blinka/giant_board.md
@@ -8,6 +8,7 @@ board_url: "https://www.crowdsupply.com/groboards/giant-board"
 board_image: "giant_board.jpg"
 downloads_display: true
 blinka: true
+date_added: 2019-12-3
 features:
   - Feather-Compatible
 ---

--- a/_blinka/google_coral.md
+++ b/_blinka/google_coral.md
@@ -9,6 +9,7 @@ board_image: "google_coral.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-google-coral-linux-blinka"
 downloads_display: true
 blinka: true
+date_added: 2019-5-13
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/hifive_unleashed.md
+++ b/_blinka/hifive_unleashed.md
@@ -8,6 +8,7 @@ board_url: "https://www.crowdsupply.com/sifive/hifive-unleashed"
 board_image: "hifive_unleashed.jpg"
 downloads_display: true
 blinka: true
+date_added: 2020-3-25
 features:
   - Ethernet
 ---

--- a/_blinka/jetson_nano.md
+++ b/_blinka/jetson_nano.md
@@ -9,6 +9,7 @@ board_image: "jetson_nano.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-libraries-on-linux-and-the-nvidia-jetson-nano"
 downloads_display: true
 blinka: true
+date_added: 2019-9-10
 features:
   - Ethernet
   - HDMI

--- a/_blinka/jetson_tx1.md
+++ b/_blinka/jetson_tx1.md
@@ -8,6 +8,7 @@ board_url: "https://developer.nvidia.com/embedded/jetson-tx1"
 board_image: "jetson_tx1.jpg"
 downloads_display: true
 blinka: true
+date_added: 2019-12-3
 features:
   - Ethernet
   - HDMI

--- a/_blinka/jetson_tx2.md
+++ b/_blinka/jetson_tx2.md
@@ -8,6 +8,7 @@ board_url: "https://developer.nvidia.com/embedded/jetson-tx2-developer-kit"
 board_image: "jetson_tx2.jpg"
 downloads_display: true
 blinka: true
+date_added: 2019-12-3
 features:
   - Ethernet
   - HDMI

--- a/_blinka/jetson_xavier.md
+++ b/_blinka/jetson_xavier.md
@@ -8,6 +8,7 @@ board_url: "https://developer.nvidia.com/embedded/jetson-agx-xavier-developer-ki
 board_image: "jetson_xavier.jpg"
 downloads_display: true
 blinka: true
+date_added: 2019-12-3
 features:
   - Ethernet
   - HDMI

--- a/_blinka/jetson_xavier_nx.md
+++ b/_blinka/jetson_xavier_nx.md
@@ -8,6 +8,7 @@ board_url: "https://developer.nvidia.com/embedded/jetson-xavier-nx"
 board_image: "jetson_xavier_nx.jpg"
 downloads_display: true
 blinka: true
+date_added: 2020-3-25
 features:
 
 ---

--- a/_blinka/mcp2221.md
+++ b/_blinka/mcp2221.md
@@ -9,6 +9,7 @@ board_image: "mcp2221.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-libraries-on-any-computer-with-mcp2221"
 downloads_display: true
 blinka: true
+date_added: 2020-3-25
 features:
 ---
 

--- a/_blinka/odroid_c2.md
+++ b/_blinka/odroid_c2.md
@@ -9,6 +9,7 @@ board_image: "odroid_c2.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-libaries-linux-odroid-c2"
 downloads_display: true
 blinka: true
+date_added: 2019-6-17
 features:
   - Ethernet
   - HDMI

--- a/_blinka/odroid_n2.md
+++ b/_blinka/odroid_n2.md
@@ -8,6 +8,7 @@ board_url: "https://www.hardkernel.com/shop/odroid-n2-with-2gbyte-ram/"
 board_image: "odroid_n2.jpg"
 downloads_display: true
 blinka: true
+date_added: 2019-12-3
 features:
   - Ethernet
   - USB 3.0

--- a/_blinka/orange_pi_lite.md
+++ b/_blinka/orange_pi_lite.md
@@ -9,6 +9,7 @@ board_image: "orange_pi_lite.png"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-orangepi-linux/circuitpython-orangepi"
 downloads_display: true
 blinka: true
+date_added: 2020-1-18
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/orange_pi_one.md
+++ b/_blinka/orange_pi_one.md
@@ -9,6 +9,7 @@ board_image: "orange_pi_one.png"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-orangepi-linux/circuitpython-orangepi"
 downloads_display: true
 blinka: true
+date_added: 2020-1-18
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/orange_pi_pc.md
+++ b/_blinka/orange_pi_pc.md
@@ -9,6 +9,7 @@ board_image: "orange_pi_pc.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-orangepi-linux/circuitpython-orangepi"
 downloads_display: true
 blinka: true
+date_added: 2019-6-4
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/orange_pi_pc_plus.md
+++ b/_blinka/orange_pi_pc_plus.md
@@ -9,6 +9,7 @@ board_image: "orange_pi_pc_plus.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-orangepi-linux/circuitpython-orangepi"
 downloads_display: true
 blinka: true
+date_added: 2020-3-25
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/orange_pi_plus_2e.md
+++ b/_blinka/orange_pi_plus_2e.md
@@ -9,6 +9,7 @@ board_image: "orange_pi_plus_2e.png"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-orangepi-linux/circuitpython-orangepi"
 downloads_display: true
 blinka: true
+date_added: 2020-1-18
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/orange_pi_r1.md
+++ b/_blinka/orange_pi_r1.md
@@ -9,6 +9,7 @@ board_image: "orange_pi_r1.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-orangepi-linux/circuitpython-orangepi"
 downloads_display: true
 blinka: true
+date_added: 2019-6-4
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/orange_pi_zero.md
+++ b/_blinka/orange_pi_zero.md
@@ -9,6 +9,7 @@ board_image: "orange_pi_zero.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-orangepi-linux/circuitpython-orangepi"
 downloads_display: true
 blinka: true
+date_added: 2019-12-3
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/pine64.md
+++ b/_blinka/pine64.md
@@ -9,6 +9,7 @@ board_image: "pine64.png"
 download_instructions: ""
 downloads_display: false
 blinka: true
+date_added: 2020-1-9
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/pocketbeagle.md
+++ b/_blinka/pocketbeagle.md
@@ -2,12 +2,13 @@
 layout: download
 board_id: "pocketbeagle"
 title: "PocketBeagle"
-name: "BeagleBone Black"
+name: "PocketBeagle"
 manufacturer: "BeagleBoard"
 board_url: "https://beagleboard.org/pocket"
 board_image: "pocketbeagle.jpg"
 downloads_display: true
 blinka: true
+date_added: 2019-12-3
 features:
   - Ethernet
   - HDMI

--- a/_blinka/raspberry_pi_1a.md
+++ b/_blinka/raspberry_pi_1a.md
@@ -9,6 +9,7 @@ board_image: "raspberry_pi_1a.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
+date_added: 2019-6-17
 features:
 - HDMI
 ---

--- a/_blinka/raspberry_pi_1aplus.md
+++ b/_blinka/raspberry_pi_1aplus.md
@@ -9,6 +9,7 @@ board_image: "raspberry_pi_1aplus.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
+date_added: 2019-6-17
 features:
   - HDMI
   - 40-pin GPIO

--- a/_blinka/raspberry_pi_1b.md
+++ b/_blinka/raspberry_pi_1b.md
@@ -9,6 +9,7 @@ board_image: "raspberry_pi_1b.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
+date_added: 2019-6-17
 features:
 - Ethernet
 - HDMI

--- a/_blinka/raspberry_pi_1bplus.md
+++ b/_blinka/raspberry_pi_1bplus.md
@@ -9,6 +9,7 @@ board_image: "raspberry_pi_1bplus.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
+date_added: 2019-6-17
 features:
   - Ethernet
   - HDMI

--- a/_blinka/raspberry_pi_2b.md
+++ b/_blinka/raspberry_pi_2b.md
@@ -9,6 +9,7 @@ board_image: "raspberry_pi_2b.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
+date_added: 2019-6-17
 features:
   - Ethernet
   - HDMI

--- a/_blinka/raspberry_pi_3aplus.md
+++ b/_blinka/raspberry_pi_3aplus.md
@@ -9,6 +9,7 @@ board_image: "raspberry_pi_3aplus.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
+date_added: 2019-6-17
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/raspberry_pi_3b.md
+++ b/_blinka/raspberry_pi_3b.md
@@ -9,6 +9,7 @@ board_image: "raspberry_pi_3b.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
+date_added: 2019-6-17
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/raspberry_pi_3bplus.md
+++ b/_blinka/raspberry_pi_3bplus.md
@@ -9,6 +9,7 @@ board_image: "raspberry_pi_3bplus.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
+date_added: 2019-6-17
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/raspberry_pi_4b.md
+++ b/_blinka/raspberry_pi_4b.md
@@ -9,6 +9,7 @@ board_image: "raspberry_pi_4b.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
+date_added: 2019-6-24
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/raspberry_pi_cm1.md
+++ b/_blinka/raspberry_pi_cm1.md
@@ -9,6 +9,7 @@ board_image: "raspberry_pi_cm1.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
+date_added: 2019-6-24
 features:
   - HDMI
 ---

--- a/_blinka/raspberry_pi_cm3.md
+++ b/_blinka/raspberry_pi_cm3.md
@@ -9,6 +9,7 @@ board_image: "raspberry_pi_cm3.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
+date_added: 2019-6-24
 features:
   - HDMI
 ---

--- a/_blinka/raspberry_pi_cm3lite.md
+++ b/_blinka/raspberry_pi_cm3lite.md
@@ -9,6 +9,7 @@ board_image: "raspberry_pi_cm3lite.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
+date_added: 2019-6-24
 features:
   - HDMI
 ---

--- a/_blinka/raspberry_pi_cm3plus.md
+++ b/_blinka/raspberry_pi_cm3plus.md
@@ -9,6 +9,7 @@ board_image: "raspberry_pi_cm3plus.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
+date_added: 2019-6-24
 features:
   - HDMI
 ---

--- a/_blinka/raspberry_pi_cm3pluslite.md
+++ b/_blinka/raspberry_pi_cm3pluslite.md
@@ -9,6 +9,7 @@ board_image: "raspberry_pi_cm3pluslite.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
+date_added: 2019-6-24
 features:
   - HDMI
 ---

--- a/_blinka/raspberry_pi_zero.md
+++ b/_blinka/raspberry_pi_zero.md
@@ -9,6 +9,7 @@ board_image: "raspberry_pi_zero.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
+date_added: 2019-6-17
 features:
 - HDMI
 - 40-pin GPIO

--- a/_blinka/raspberry_pi_zerow.md
+++ b/_blinka/raspberry_pi_zerow.md
@@ -9,6 +9,7 @@ board_image: "raspberry_pi_zerow.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
+date_added: 2019-6-17
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/assets/javascript/downloads.js
+++ b/assets/javascript/downloads.js
@@ -73,7 +73,7 @@ function handlePageLoad() {
     });
   }
 
-  if (sort_by.length) {
+  if (sort_by != null && sort_by.length) {
     document.querySelector("input[name='sort-by'][value='" + sort_by + "']").click();
   }
 }
@@ -276,15 +276,13 @@ function handleSortResults(event) {
     .sort(function (a, b) {
       switch(sortType) {
         case 'alpha-asc':
-          console.log(a.dataset.name.localeCompare(b.dataset.name));
           return a.dataset.name.localeCompare(b.dataset.name);
         case 'alpha-desc':
           return b.dataset.name.localeCompare(a.dataset.name);
         case 'date-asc':
-          return a.dataset.date < b.dataset.date ? 1 : -1;
-        case 'date-desc':
-          //console.log(a.dataset.date + " is greater than " + b.dataset.date + " = " + (a.dataset.date > b.dataset.date));
           return a.dataset.date > b.dataset.date ? 1 : -1;
+        case 'date-desc':
+          return a.dataset.date < b.dataset.date ? 1 : -1;
         default:
           // sort by download count is the default
           return parseInt(a.dataset.downloads, 10) < parseInt(b.dataset.downloads, 10) ? 1 : -1;

--- a/blinka.html
+++ b/blinka.html
@@ -42,6 +42,8 @@ permalink: /blinka
             <li><input type="radio" name="sort-by" value="downloads" aria-label="Downloads" checked> Downloads</li>
             <li><input type="radio" name="sort-by" value="alpha-asc" aria-label="Board Name (A to Z)"> Board Name (A to Z)</li>
             <li><input type="radio" name="sort-by" value="alpha-desc" aria-label="Board Name (Z to A)"> Board Name (Z to A)</li>
+            <li><input type="radio" name="sort-by" value="date-desc" aria-label="Date Added (Newest First)"> Date Added (Newest First)</li>
+            <li><input type="radio" name="sort-by" value="date-asc" aria-label="Date Added (Oldest First)"> Date Added (Oldest First)</li>
           </ul>
         </fieldset>
       </div>
@@ -59,7 +61,8 @@ permalink: /blinka
                               data-name="{{ board.name }}"
                               data-downloads="0"
                               data-manufacturer="{{ board.manufacturer }}"
-                              data-features="{{ board.features | join: ','}}">
+                              data-features="{{ board.features | join: ','}}"
+                              data-date="{{ board.date_added }}">
           <a href="{{ board.url | relative_url }}">
             <div>
               <div class="img-responsive-4by3">

--- a/template.md
+++ b/template.md
@@ -6,6 +6,7 @@ name: "<board name>"
 manufacturer: "<board manufacturer>"
 board_url: ""
 board_image: "unknown.jpg"
+date_added: 2020-3-31
 downloads_display: true
 blinka: false
 download_instructions: "BLINKA ONLY - url"


### PR DESCRIPTION
Added date Sorting for Blinka boards. Fixes #299. Went through and added "data_added" using initial GitHub PR dates. Cleaned up some console.log statements. This also fixes the PocketBeagle Name. Also fixes a Javascript error I found when loading Blinka page on live site:
```
Uncaught TypeError: Cannot read property 'length' of null
    at handlePageLoad (downloads.js:76)
    at HTMLDocument.<anonymous> (downloads.js:26)
```
I tested this locally and it seems to work very well.