### PR TITLE
revert uf2 bootloader to 3.7.0 while testing

### DIFF
--- a/_data/bootloaders.json
+++ b/_data/bootloaders.json
@@ -4,7 +4,7 @@
             "version": "0.3.2",
         },
         "atmel-samd": {
-            "version": "v3.8.0",
+            "version": "v3.7.0",
         },
         "stm": {
         },


### PR DESCRIPTION
@makermelissa please approve this right now while I investigate a bootloader bug report which could be a big issue