### PR TITLE
Update atmel-samd bootloader to v3.9.0; add new bootloader boards

### DIFF
--- a/_data/bootloaders.json
+++ b/_data/bootloaders.json
@@ -4,7 +4,7 @@
             "version": "0.3.2",
         },
         "atmel-samd": {
-            "version": "v3.7.0",
+            "version": "v3.9.0",
         },
         "stm": {
         },
@@ -16,6 +16,7 @@
     "boards": {
         "8086_commander": {
             "family": "atmel-samd",
+            "bootloader_id": "8086_commander",
         },
         "aramcon_badge_2019": {
             "family": "nrf52840",
@@ -440,7 +441,7 @@
         },
         "uartlogger2": {
             "family": "atmel-samd",
-            "bootloader_id": "trinket_m0",
+            "bootloader_id": "uartlogger2",
         },
         "uchip": {
             "family": "atmel-samd",

--- a/_data/bootloaders.json
+++ b/_data/bootloaders.json
@@ -177,7 +177,7 @@
         },
         "feather_radiofruit_zigbee": {
             "family": "atmel-samd",
-            "bootloader_id": "feather_m0",
+            "bootloader_id": "radiofruit_m0",
         },
         "feather_stm32f405_express": {
             "family": "atmel-samd",


### PR DESCRIPTION
- Update `atmel-samd` latest bootloader to v3.9.0. Bootloader updaters have been tested on Metro M0, Metro M4, and CPX.
- Add bootloader info for new boards `8086_commander` and `uartlogger2`.