### PR TITLE
Don't show instructions if blank

### DIFF
--- a/_includes/download/blinka.html
+++ b/_includes/download/blinka.html
@@ -11,7 +11,7 @@
     For SPI we'll use the spidev python library, etc. These details don't matter
     so much because they all happen underneath the adafruit_blinka layer.
   </p>
-  {% if page.download_instructions != nil %}
+  {% if page.download_instructions != nil and page.download_instructions != "" %}
   <div>
       <a class="download-button" href="{{ page.download_instructions }}">INSTALLATION INSTRUCTIONS<i class="fas fa-arrow-circle-right" aria-hidden="true"></i></a>
     <div class="clear"></div>


### PR DESCRIPTION
Fixes #468. Download instructions weren't showing if non-existent, but still showed if empty. This fixes that.