### PR TITLE
Automated website update for release 5.4.0-beta.0

### DIFF
--- a/_board/nucleo_f746zg.md
+++ b/_board/nucleo_f746zg.md
@@ -1,0 +1,20 @@
+---
+layout: download
+board_id: "nucleo_f746zg"
+title: "STM32F746 Nucleo Download"
+name: "STM32F746 Nucleo"
+manufacturer: "ST"
+board_url: "https://www.st.com/content/st_com/en/products/evaluation-tools/product-evaluation-tools/mcu-mpu-eval-tools/stm32-mcu-mpu-eval-tools/stm32-nucleo-boards/nucleo-f746zg.html"
+board_image: "unknown.jpg"
+date_added: 2020-04-23
+features:
+---
+
+The STM32F746 Nucleo dev board from ST.
+
+## Purchase
+* [ST](https://www.st.com/content/st_com/en/products/evaluation-tools/product-evaluation-tools/mcu-mpu-eval-tools/stm32-mcu-mpu-eval-tools/stm32-nucleo-boards/nucleo-f746zg.html)
+
+## Contribute
+
+Have some info to add for this board? Edit the source for this page [here](https://github.com/adafruit/circuitpython-org/edit/master/_board/{{ page.board_id }}.md).

--- a/_board/nucleo_f767zi.md
+++ b/_board/nucleo_f767zi.md
@@ -1,0 +1,20 @@
+---
+layout: download
+board_id: "nucleo_f767zi"
+title: "STM32F767 Nucleo Download"
+name: "STM32F767 Nucleo"
+manufacturer: "ST"
+board_url: "https://www.st.com/content/st_com/en/products/evaluation-tools/product-evaluation-tools/mcu-mpu-eval-tools/stm32-mcu-mpu-eval-tools/stm32-nucleo-boards/nucleo-f767zi.html"
+board_image: "unknown.jpg"
+date_added: 2020-04-06
+features:
+---
+
+The STM32F767 Nucleo dev board from ST.
+
+## Purchase
+* [ST](https://www.st.com/content/st_com/en/products/evaluation-tools/product-evaluation-tools/mcu-mpu-eval-tools/stm32-mcu-mpu-eval-tools/stm32-nucleo-boards/nucleo-f767zi.html)
+
+## Contribute
+
+Have some info to add for this board? Edit the source for this page [here](https://github.com/adafruit/circuitpython-org/edit/master/_board/{{ page.board_id }}.md).

--- a/_board/nucleo_h743zi_2.md
+++ b/_board/nucleo_h743zi_2.md
@@ -1,0 +1,20 @@
+---
+layout: download
+board_id: "nucleo_h743zi_2"
+title: "STM32H743 Nucleo Download"
+name: "STM32H743 Nucleo"
+manufacturer: "ST"
+board_url: "https://www.st.com/content/st_com/en/products/evaluation-tools/product-evaluation-tools/mcu-mpu-eval-tools/stm32-mcu-mpu-eval-tools/stm32-nucleo-boards/nucleo-h743zi.html"
+board_image: "unknown.jpg"
+date_added: 2020-04-01
+features:
+---
+
+The STM32H743 Nucleo dev board from ST.
+
+## Purchase
+* [ST](https://www.st.com/content/st_com/en/products/evaluation-tools/product-evaluation-tools/mcu-mpu-eval-tools/stm32-mcu-mpu-eval-tools/stm32-nucleo-boards/nucleo-h743zi.html)
+
+## Contribute
+
+Have some info to add for this board? Edit the source for this page [here](https://github.com/adafruit/circuitpython-org/edit/master/_board/{{ page.board_id }}.md).

--- a/_board/openmv_h7.md
+++ b/_board/openmv_h7.md
@@ -1,0 +1,21 @@
+---
+layout: download
+board_id: "openmv_h7"
+title: "OpenMV H7 Download"
+name: "OpenMV H7"
+manufacturer: "OpenMV"
+board_url: "https://openmv.io/collections/products/products/openmv-cam-h7"
+board_image: "unknown.jpg"
+date_added: 2020-04-30
+features:
+---
+
+STM32H7 powered OpenMV camera board.
+
+## Purchase
+
+[OpenMV](https://openmv.io/collections/products/products/openmv-cam-h7)
+
+## Contribute
+
+Have some info to add for this board? Edit the source for this page [here](https://github.com/adafruit/circuitpython-org/edit/master/_board/{{ page.board_id }}.md).

--- a/_board/pca10100.md
+++ b/_board/pca10100.md
@@ -1,0 +1,21 @@
+---
+layout: download
+board_id: "pca10100"
+title: "nRF52833 DK (PCA10100) Download"
+name: "nRF52833 DK (PCA10100)"
+manufacturer: "Nordic"
+board_url: "https://www.nordicsemi.com/Software-and-tools/Development-Kits/nRF52833-DK"
+board_image: "unknown.jpg"
+date_added: 2019-05-04
+features:
+  - Bluetooth/BTLE
+---
+
+The nRF52833 development kit from Nordic.
+
+## Purchase
+* [Price Comparison](https://www.nordicsemi.com/About-us/BuyOnline?search_token=nRF52833-DK&series_token=nRF52833)
+
+## Contribute
+
+Have some info to add for this board? Edit the source for this page [here](https://github.com/adafruit/circuitpython-org/edit/master/_board/{{ page.board_id }}.md).

--- a/_board/pitaya_go.md
+++ b/_board/pitaya_go.md
@@ -1,0 +1,21 @@
+---
+layout: download
+board_id: "pitaya_go"
+title: "Pitaya Go Download"
+name: "Pitaya Go"
+manufacturer: "MakerDiary"
+board_url: ""
+board_image: "unknown.jpg"
+date_added: 2019-05-11
+features:
+  - Bluetooth/BTLE
+---
+
+BLE and Wifi board in a small for factor.
+
+## Purchase
+* [MakerDiary](https://store.makerdiary.com/products/pitaya-go)
+
+## Contribute
+
+Have some info to add for this board? Edit the source for this page [here](https://github.com/adafruit/circuitpython-org/edit/master/_board/{{ page.board_id }}.md).

--- a/_board/simmel.md
+++ b/_board/simmel.md
@@ -1,0 +1,19 @@
+---
+layout: download
+board_id: "simmel"
+title: "Simmel Download"
+name: "Simmel Board"
+manufacturer: "Simmel Project"
+board_url: "https://github.com/simmel-project/frontpage"
+board_image: "unknown.jpg"
+date_added: 2019-04-29
+---
+
+Simmel is a platform that enables COVID-19 contact tracing while preserving user privacy. It is a wearable hardware beacon and scanner which can broadcast and record randomized user IDs. Contacts are stored within the wearable device, so you retain full control of your trace history until you choose to share it.
+
+## Learn More
+* [Github](https://github.com/simmel-project/frontpage)
+
+## Contribute
+
+Have some info to add for this board? Edit the source for this page [here](https://github.com/adafruit/circuitpython-org/edit/master/_board/{{ page.board_id }}.md).

--- a/_board/stm32f746g_discovery.md
+++ b/_board/stm32f746g_discovery.md
@@ -1,0 +1,21 @@
+---
+layout: download
+board_id: "stm32f746g_discovery"
+title: "STM32F746 Discovery kit Download"
+name: "STM32F746 Discovery kit"
+manufacturer: "ST"
+board_url: "https://www.st.com/content/st_com/en/products/evaluation-tools/product-evaluation-tools/mcu-mpu-eval-tools/stm32-mcu-mpu-eval-tools/stm32-discovery-kits/32f746gdiscovery.html"
+board_image: "unknown.jpg"
+date_added: 2020-04-27
+features:
+  - Display
+---
+
+The STM32F746 Discovery kit from ST.
+
+## Purchase
+* [ST](https://www.st.com/content/st_com/en/products/evaluation-tools/product-evaluation-tools/mcu-mpu-eval-tools/stm32-mcu-mpu-eval-tools/stm32-discovery-kits/32f746gdiscovery.html)
+
+## Contribute
+
+Have some info to add for this board? Edit the source for this page [here](https://github.com/adafruit/circuitpython-org/edit/master/_board/{{ page.board_id }}.md).

--- a/_board/teensy41.md
+++ b/_board/teensy41.md
@@ -1,0 +1,21 @@
+---
+layout: download
+board_id: "teensy41"
+title: "Teensy 4.1 Download"
+name: "Teensy 4.1"
+manufacturer: "PJRC"
+board_url: "https://www.pjrc.com/store/teensy41.html"
+board_image: "unknown.jpg"
+date_added: 2020-05-11
+features:
+
+---
+
+Teensy with iMX RT 1062 and more pins broken out than the Teensy 4.0.
+
+## Purchase
+* [PJRC](https://www.pjrc.com/store/teensy41.html)
+
+## Contribute
+
+Have some info to add for this board? Edit the source for this page [here](https://github.com/adafruit/circuitpython-org/edit/master/_board/{{ page.board_id }}.md).

--- a/_data/files.json
+++ b/_data/files.json
@@ -1,50 +1,8 @@
 [
     {
-        "downloads": 42,
+        "downloads": 0,
         "id": "8086_commander",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/8086_commander/ID/adafruit-circuitpython-8086_commander-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/8086_commander/de_DE/adafruit-circuitpython-8086_commander-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/8086_commander/en_US/adafruit-circuitpython-8086_commander-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/8086_commander/en_x_pirate/adafruit-circuitpython-8086_commander-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/8086_commander/es/adafruit-circuitpython-8086_commander-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/8086_commander/fil/adafruit-circuitpython-8086_commander-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/8086_commander/fr/adafruit-circuitpython-8086_commander-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/8086_commander/it_IT/adafruit-circuitpython-8086_commander-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/8086_commander/ko/adafruit-circuitpython-8086_commander-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/8086_commander/pl/adafruit-circuitpython-8086_commander-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/8086_commander/pt_BR/adafruit-circuitpython-8086_commander-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/8086_commander/zh_Latn_pinyin/adafruit-circuitpython-8086_commander-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -86,55 +44,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/8086_commander/ID/adafruit-circuitpython-8086_commander-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/8086_commander/de_DE/adafruit-circuitpython-8086_commander-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/8086_commander/en_US/adafruit-circuitpython-8086_commander-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/8086_commander/en_x_pirate/adafruit-circuitpython-8086_commander-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/8086_commander/es/adafruit-circuitpython-8086_commander-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/8086_commander/fil/adafruit-circuitpython-8086_commander-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/8086_commander/fr/adafruit-circuitpython-8086_commander-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/8086_commander/it_IT/adafruit-circuitpython-8086_commander-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/8086_commander/ko/adafruit-circuitpython-8086_commander-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/8086_commander/pl/adafruit-circuitpython-8086_commander-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/8086_commander/pt_BR/adafruit-circuitpython-8086_commander-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/8086_commander/sv/adafruit-circuitpython-8086_commander-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/8086_commander/zh_Latn_pinyin/adafruit-circuitpython-8086_commander-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 15,
+        "downloads": 0,
         "id": "TG-Watch02A",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/TG-Watch02A/ID/adafruit-circuitpython-TG-Watch02A-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/TG-Watch02A/de_DE/adafruit-circuitpython-TG-Watch02A-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/TG-Watch02A/en_US/adafruit-circuitpython-TG-Watch02A-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/TG-Watch02A/en_x_pirate/adafruit-circuitpython-TG-Watch02A-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/TG-Watch02A/es/adafruit-circuitpython-TG-Watch02A-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/TG-Watch02A/fil/adafruit-circuitpython-TG-Watch02A-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/TG-Watch02A/fr/adafruit-circuitpython-TG-Watch02A-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/TG-Watch02A/it_IT/adafruit-circuitpython-TG-Watch02A-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/TG-Watch02A/ko/adafruit-circuitpython-TG-Watch02A-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/TG-Watch02A/pl/adafruit-circuitpython-TG-Watch02A-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/TG-Watch02A/pt_BR/adafruit-circuitpython-TG-Watch02A-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/TG-Watch02A/zh_Latn_pinyin/adafruit-circuitpython-TG-Watch02A-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -176,55 +137,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/ID/adafruit-circuitpython-TG-Watch02A-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/de_DE/adafruit-circuitpython-TG-Watch02A-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/en_US/adafruit-circuitpython-TG-Watch02A-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/en_x_pirate/adafruit-circuitpython-TG-Watch02A-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/es/adafruit-circuitpython-TG-Watch02A-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/fil/adafruit-circuitpython-TG-Watch02A-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/fr/adafruit-circuitpython-TG-Watch02A-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/it_IT/adafruit-circuitpython-TG-Watch02A-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/ko/adafruit-circuitpython-TG-Watch02A-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/pl/adafruit-circuitpython-TG-Watch02A-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/pt_BR/adafruit-circuitpython-TG-Watch02A-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/sv/adafruit-circuitpython-TG-Watch02A-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/zh_Latn_pinyin/adafruit-circuitpython-TG-Watch02A-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 27,
+        "downloads": 0,
         "id": "aramcon_badge_2019",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/ID/adafruit-circuitpython-aramcon_badge_2019-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/de_DE/adafruit-circuitpython-aramcon_badge_2019-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/en_US/adafruit-circuitpython-aramcon_badge_2019-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/en_x_pirate/adafruit-circuitpython-aramcon_badge_2019-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/es/adafruit-circuitpython-aramcon_badge_2019-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/fil/adafruit-circuitpython-aramcon_badge_2019-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/fr/adafruit-circuitpython-aramcon_badge_2019-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/it_IT/adafruit-circuitpython-aramcon_badge_2019-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/ko/adafruit-circuitpython-aramcon_badge_2019-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/pl/adafruit-circuitpython-aramcon_badge_2019-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/pt_BR/adafruit-circuitpython-aramcon_badge_2019-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/zh_Latn_pinyin/adafruit-circuitpython-aramcon_badge_2019-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -266,67 +230,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/ID/adafruit-circuitpython-aramcon_badge_2019-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/de_DE/adafruit-circuitpython-aramcon_badge_2019-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/en_US/adafruit-circuitpython-aramcon_badge_2019-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/en_x_pirate/adafruit-circuitpython-aramcon_badge_2019-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/es/adafruit-circuitpython-aramcon_badge_2019-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/fil/adafruit-circuitpython-aramcon_badge_2019-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/fr/adafruit-circuitpython-aramcon_badge_2019-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/it_IT/adafruit-circuitpython-aramcon_badge_2019-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/ko/adafruit-circuitpython-aramcon_badge_2019-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/pl/adafruit-circuitpython-aramcon_badge_2019-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/pt_BR/adafruit-circuitpython-aramcon_badge_2019-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/sv/adafruit-circuitpython-aramcon_badge_2019-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/zh_Latn_pinyin/adafruit-circuitpython-aramcon_badge_2019-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 18,
+        "downloads": 0,
         "id": "arduino_mkr1300",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/ID/adafruit-circuitpython-arduino_mkr1300-ID-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/ID/adafruit-circuitpython-arduino_mkr1300-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/de_DE/adafruit-circuitpython-arduino_mkr1300-de_DE-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/de_DE/adafruit-circuitpython-arduino_mkr1300-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/en_US/adafruit-circuitpython-arduino_mkr1300-en_US-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/en_US/adafruit-circuitpython-arduino_mkr1300-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/en_x_pirate/adafruit-circuitpython-arduino_mkr1300-en_x_pirate-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/en_x_pirate/adafruit-circuitpython-arduino_mkr1300-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/es/adafruit-circuitpython-arduino_mkr1300-es-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/es/adafruit-circuitpython-arduino_mkr1300-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/fil/adafruit-circuitpython-arduino_mkr1300-fil-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/fil/adafruit-circuitpython-arduino_mkr1300-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/fr/adafruit-circuitpython-arduino_mkr1300-fr-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/fr/adafruit-circuitpython-arduino_mkr1300-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/it_IT/adafruit-circuitpython-arduino_mkr1300-it_IT-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/it_IT/adafruit-circuitpython-arduino_mkr1300-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/ko/adafruit-circuitpython-arduino_mkr1300-ko-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/ko/adafruit-circuitpython-arduino_mkr1300-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/pl/adafruit-circuitpython-arduino_mkr1300-pl-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/pl/adafruit-circuitpython-arduino_mkr1300-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/pt_BR/adafruit-circuitpython-arduino_mkr1300-pt_BR-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/pt_BR/adafruit-circuitpython-arduino_mkr1300-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/zh_Latn_pinyin/adafruit-circuitpython-arduino_mkr1300-zh_Latn_pinyin-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/zh_Latn_pinyin/adafruit-circuitpython-arduino_mkr1300-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -380,67 +335,71 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/ID/adafruit-circuitpython-arduino_mkr1300-ID-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/ID/adafruit-circuitpython-arduino_mkr1300-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/de_DE/adafruit-circuitpython-arduino_mkr1300-de_DE-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/de_DE/adafruit-circuitpython-arduino_mkr1300-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/en_US/adafruit-circuitpython-arduino_mkr1300-en_US-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/en_US/adafruit-circuitpython-arduino_mkr1300-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/en_x_pirate/adafruit-circuitpython-arduino_mkr1300-en_x_pirate-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/en_x_pirate/adafruit-circuitpython-arduino_mkr1300-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/es/adafruit-circuitpython-arduino_mkr1300-es-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/es/adafruit-circuitpython-arduino_mkr1300-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/fil/adafruit-circuitpython-arduino_mkr1300-fil-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/fil/adafruit-circuitpython-arduino_mkr1300-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/fr/adafruit-circuitpython-arduino_mkr1300-fr-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/fr/adafruit-circuitpython-arduino_mkr1300-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/it_IT/adafruit-circuitpython-arduino_mkr1300-it_IT-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/it_IT/adafruit-circuitpython-arduino_mkr1300-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/ko/adafruit-circuitpython-arduino_mkr1300-ko-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/ko/adafruit-circuitpython-arduino_mkr1300-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/pl/adafruit-circuitpython-arduino_mkr1300-pl-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/pl/adafruit-circuitpython-arduino_mkr1300-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/pt_BR/adafruit-circuitpython-arduino_mkr1300-pt_BR-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/pt_BR/adafruit-circuitpython-arduino_mkr1300-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/sv/adafruit-circuitpython-arduino_mkr1300-sv-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/sv/adafruit-circuitpython-arduino_mkr1300-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/zh_Latn_pinyin/adafruit-circuitpython-arduino_mkr1300-zh_Latn_pinyin-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/zh_Latn_pinyin/adafruit-circuitpython-arduino_mkr1300-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 25,
+        "downloads": 0,
         "id": "arduino_mkrzero",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/ID/adafruit-circuitpython-arduino_mkrzero-ID-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/ID/adafruit-circuitpython-arduino_mkrzero-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/de_DE/adafruit-circuitpython-arduino_mkrzero-de_DE-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/de_DE/adafruit-circuitpython-arduino_mkrzero-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/en_US/adafruit-circuitpython-arduino_mkrzero-en_US-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/en_US/adafruit-circuitpython-arduino_mkrzero-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/en_x_pirate/adafruit-circuitpython-arduino_mkrzero-en_x_pirate-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/en_x_pirate/adafruit-circuitpython-arduino_mkrzero-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/es/adafruit-circuitpython-arduino_mkrzero-es-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/es/adafruit-circuitpython-arduino_mkrzero-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/fil/adafruit-circuitpython-arduino_mkrzero-fil-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/fil/adafruit-circuitpython-arduino_mkrzero-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/fr/adafruit-circuitpython-arduino_mkrzero-fr-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/fr/adafruit-circuitpython-arduino_mkrzero-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/it_IT/adafruit-circuitpython-arduino_mkrzero-it_IT-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/it_IT/adafruit-circuitpython-arduino_mkrzero-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/ko/adafruit-circuitpython-arduino_mkrzero-ko-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/ko/adafruit-circuitpython-arduino_mkrzero-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/pl/adafruit-circuitpython-arduino_mkrzero-pl-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/pl/adafruit-circuitpython-arduino_mkrzero-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/pt_BR/adafruit-circuitpython-arduino_mkrzero-pt_BR-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/pt_BR/adafruit-circuitpython-arduino_mkrzero-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/zh_Latn_pinyin/adafruit-circuitpython-arduino_mkrzero-zh_Latn_pinyin-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/zh_Latn_pinyin/adafruit-circuitpython-arduino_mkrzero-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -494,55 +453,71 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/ID/adafruit-circuitpython-arduino_mkrzero-ID-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/ID/adafruit-circuitpython-arduino_mkrzero-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/de_DE/adafruit-circuitpython-arduino_mkrzero-de_DE-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/de_DE/adafruit-circuitpython-arduino_mkrzero-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/en_US/adafruit-circuitpython-arduino_mkrzero-en_US-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/en_US/adafruit-circuitpython-arduino_mkrzero-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/en_x_pirate/adafruit-circuitpython-arduino_mkrzero-en_x_pirate-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/en_x_pirate/adafruit-circuitpython-arduino_mkrzero-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/es/adafruit-circuitpython-arduino_mkrzero-es-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/es/adafruit-circuitpython-arduino_mkrzero-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/fil/adafruit-circuitpython-arduino_mkrzero-fil-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/fil/adafruit-circuitpython-arduino_mkrzero-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/fr/adafruit-circuitpython-arduino_mkrzero-fr-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/fr/adafruit-circuitpython-arduino_mkrzero-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/it_IT/adafruit-circuitpython-arduino_mkrzero-it_IT-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/it_IT/adafruit-circuitpython-arduino_mkrzero-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/ko/adafruit-circuitpython-arduino_mkrzero-ko-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/ko/adafruit-circuitpython-arduino_mkrzero-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/pl/adafruit-circuitpython-arduino_mkrzero-pl-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/pl/adafruit-circuitpython-arduino_mkrzero-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/pt_BR/adafruit-circuitpython-arduino_mkrzero-pt_BR-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/pt_BR/adafruit-circuitpython-arduino_mkrzero-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/sv/adafruit-circuitpython-arduino_mkrzero-sv-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/sv/adafruit-circuitpython-arduino_mkrzero-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/zh_Latn_pinyin/adafruit-circuitpython-arduino_mkrzero-zh_Latn_pinyin-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/zh_Latn_pinyin/adafruit-circuitpython-arduino_mkrzero-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 53,
+        "downloads": 0,
         "id": "arduino_nano_33_ble",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/ID/adafruit-circuitpython-arduino_nano_33_ble-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/de_DE/adafruit-circuitpython-arduino_nano_33_ble-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/en_US/adafruit-circuitpython-arduino_nano_33_ble-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/en_x_pirate/adafruit-circuitpython-arduino_nano_33_ble-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/es/adafruit-circuitpython-arduino_nano_33_ble-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/fil/adafruit-circuitpython-arduino_nano_33_ble-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/fr/adafruit-circuitpython-arduino_nano_33_ble-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/it_IT/adafruit-circuitpython-arduino_nano_33_ble-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/ko/adafruit-circuitpython-arduino_nano_33_ble-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/pl/adafruit-circuitpython-arduino_nano_33_ble-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/pt_BR/adafruit-circuitpython-arduino_nano_33_ble-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/zh_Latn_pinyin/adafruit-circuitpython-arduino_nano_33_ble-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -584,67 +559,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/ID/adafruit-circuitpython-arduino_nano_33_ble-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/de_DE/adafruit-circuitpython-arduino_nano_33_ble-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/en_US/adafruit-circuitpython-arduino_nano_33_ble-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/en_x_pirate/adafruit-circuitpython-arduino_nano_33_ble-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/es/adafruit-circuitpython-arduino_nano_33_ble-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/fil/adafruit-circuitpython-arduino_nano_33_ble-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/fr/adafruit-circuitpython-arduino_nano_33_ble-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/it_IT/adafruit-circuitpython-arduino_nano_33_ble-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/ko/adafruit-circuitpython-arduino_nano_33_ble-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/pl/adafruit-circuitpython-arduino_nano_33_ble-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/pt_BR/adafruit-circuitpython-arduino_nano_33_ble-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/sv/adafruit-circuitpython-arduino_nano_33_ble-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/zh_Latn_pinyin/adafruit-circuitpython-arduino_nano_33_ble-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 24,
+        "downloads": 0,
         "id": "arduino_nano_33_iot",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/ID/adafruit-circuitpython-arduino_nano_33_iot-ID-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/ID/adafruit-circuitpython-arduino_nano_33_iot-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/de_DE/adafruit-circuitpython-arduino_nano_33_iot-de_DE-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/de_DE/adafruit-circuitpython-arduino_nano_33_iot-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/en_US/adafruit-circuitpython-arduino_nano_33_iot-en_US-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/en_US/adafruit-circuitpython-arduino_nano_33_iot-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/en_x_pirate/adafruit-circuitpython-arduino_nano_33_iot-en_x_pirate-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/en_x_pirate/adafruit-circuitpython-arduino_nano_33_iot-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/es/adafruit-circuitpython-arduino_nano_33_iot-es-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/es/adafruit-circuitpython-arduino_nano_33_iot-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/fil/adafruit-circuitpython-arduino_nano_33_iot-fil-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/fil/adafruit-circuitpython-arduino_nano_33_iot-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/fr/adafruit-circuitpython-arduino_nano_33_iot-fr-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/fr/adafruit-circuitpython-arduino_nano_33_iot-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/it_IT/adafruit-circuitpython-arduino_nano_33_iot-it_IT-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/it_IT/adafruit-circuitpython-arduino_nano_33_iot-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/ko/adafruit-circuitpython-arduino_nano_33_iot-ko-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/ko/adafruit-circuitpython-arduino_nano_33_iot-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/pl/adafruit-circuitpython-arduino_nano_33_iot-pl-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/pl/adafruit-circuitpython-arduino_nano_33_iot-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/pt_BR/adafruit-circuitpython-arduino_nano_33_iot-pt_BR-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/pt_BR/adafruit-circuitpython-arduino_nano_33_iot-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/zh_Latn_pinyin/adafruit-circuitpython-arduino_nano_33_iot-zh_Latn_pinyin-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/zh_Latn_pinyin/adafruit-circuitpython-arduino_nano_33_iot-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -698,67 +664,71 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/ID/adafruit-circuitpython-arduino_nano_33_iot-ID-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/ID/adafruit-circuitpython-arduino_nano_33_iot-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/de_DE/adafruit-circuitpython-arduino_nano_33_iot-de_DE-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/de_DE/adafruit-circuitpython-arduino_nano_33_iot-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/en_US/adafruit-circuitpython-arduino_nano_33_iot-en_US-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/en_US/adafruit-circuitpython-arduino_nano_33_iot-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/en_x_pirate/adafruit-circuitpython-arduino_nano_33_iot-en_x_pirate-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/en_x_pirate/adafruit-circuitpython-arduino_nano_33_iot-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/es/adafruit-circuitpython-arduino_nano_33_iot-es-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/es/adafruit-circuitpython-arduino_nano_33_iot-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/fil/adafruit-circuitpython-arduino_nano_33_iot-fil-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/fil/adafruit-circuitpython-arduino_nano_33_iot-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/fr/adafruit-circuitpython-arduino_nano_33_iot-fr-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/fr/adafruit-circuitpython-arduino_nano_33_iot-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/it_IT/adafruit-circuitpython-arduino_nano_33_iot-it_IT-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/it_IT/adafruit-circuitpython-arduino_nano_33_iot-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/ko/adafruit-circuitpython-arduino_nano_33_iot-ko-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/ko/adafruit-circuitpython-arduino_nano_33_iot-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/pl/adafruit-circuitpython-arduino_nano_33_iot-pl-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/pl/adafruit-circuitpython-arduino_nano_33_iot-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/pt_BR/adafruit-circuitpython-arduino_nano_33_iot-pt_BR-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/pt_BR/adafruit-circuitpython-arduino_nano_33_iot-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/sv/adafruit-circuitpython-arduino_nano_33_iot-sv-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/sv/adafruit-circuitpython-arduino_nano_33_iot-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/zh_Latn_pinyin/adafruit-circuitpython-arduino_nano_33_iot-zh_Latn_pinyin-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/zh_Latn_pinyin/adafruit-circuitpython-arduino_nano_33_iot-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 38,
+        "downloads": 0,
         "id": "arduino_zero",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/ID/adafruit-circuitpython-arduino_zero-ID-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/ID/adafruit-circuitpython-arduino_zero-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/de_DE/adafruit-circuitpython-arduino_zero-de_DE-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/de_DE/adafruit-circuitpython-arduino_zero-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/en_US/adafruit-circuitpython-arduino_zero-en_US-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/en_US/adafruit-circuitpython-arduino_zero-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/en_x_pirate/adafruit-circuitpython-arduino_zero-en_x_pirate-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/en_x_pirate/adafruit-circuitpython-arduino_zero-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/es/adafruit-circuitpython-arduino_zero-es-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/es/adafruit-circuitpython-arduino_zero-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/fil/adafruit-circuitpython-arduino_zero-fil-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/fil/adafruit-circuitpython-arduino_zero-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/fr/adafruit-circuitpython-arduino_zero-fr-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/fr/adafruit-circuitpython-arduino_zero-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/it_IT/adafruit-circuitpython-arduino_zero-it_IT-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/it_IT/adafruit-circuitpython-arduino_zero-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/ko/adafruit-circuitpython-arduino_zero-ko-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/ko/adafruit-circuitpython-arduino_zero-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/pl/adafruit-circuitpython-arduino_zero-pl-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/pl/adafruit-circuitpython-arduino_zero-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/pt_BR/adafruit-circuitpython-arduino_zero-pt_BR-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/pt_BR/adafruit-circuitpython-arduino_zero-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/zh_Latn_pinyin/adafruit-circuitpython-arduino_zero-zh_Latn_pinyin-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/zh_Latn_pinyin/adafruit-circuitpython-arduino_zero-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -812,55 +782,71 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/arduino_zero/ID/adafruit-circuitpython-arduino_zero-ID-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/ID/adafruit-circuitpython-arduino_zero-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/arduino_zero/de_DE/adafruit-circuitpython-arduino_zero-de_DE-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/de_DE/adafruit-circuitpython-arduino_zero-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/arduino_zero/en_US/adafruit-circuitpython-arduino_zero-en_US-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/en_US/adafruit-circuitpython-arduino_zero-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/arduino_zero/en_x_pirate/adafruit-circuitpython-arduino_zero-en_x_pirate-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/en_x_pirate/adafruit-circuitpython-arduino_zero-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/arduino_zero/es/adafruit-circuitpython-arduino_zero-es-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/es/adafruit-circuitpython-arduino_zero-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/arduino_zero/fil/adafruit-circuitpython-arduino_zero-fil-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/fil/adafruit-circuitpython-arduino_zero-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/arduino_zero/fr/adafruit-circuitpython-arduino_zero-fr-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/fr/adafruit-circuitpython-arduino_zero-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/arduino_zero/it_IT/adafruit-circuitpython-arduino_zero-it_IT-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/it_IT/adafruit-circuitpython-arduino_zero-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/arduino_zero/ko/adafruit-circuitpython-arduino_zero-ko-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/ko/adafruit-circuitpython-arduino_zero-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/arduino_zero/pl/adafruit-circuitpython-arduino_zero-pl-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/pl/adafruit-circuitpython-arduino_zero-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/arduino_zero/pt_BR/adafruit-circuitpython-arduino_zero-pt_BR-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/pt_BR/adafruit-circuitpython-arduino_zero-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/arduino_zero/sv/adafruit-circuitpython-arduino_zero-sv-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/sv/adafruit-circuitpython-arduino_zero-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/arduino_zero/zh_Latn_pinyin/adafruit-circuitpython-arduino_zero-zh_Latn_pinyin-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/zh_Latn_pinyin/adafruit-circuitpython-arduino_zero-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 25,
+        "downloads": 0,
         "id": "bast_pro_mini_m0",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/ID/adafruit-circuitpython-bast_pro_mini_m0-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/de_DE/adafruit-circuitpython-bast_pro_mini_m0-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/en_US/adafruit-circuitpython-bast_pro_mini_m0-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/en_x_pirate/adafruit-circuitpython-bast_pro_mini_m0-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/es/adafruit-circuitpython-bast_pro_mini_m0-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/fil/adafruit-circuitpython-bast_pro_mini_m0-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/fr/adafruit-circuitpython-bast_pro_mini_m0-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/it_IT/adafruit-circuitpython-bast_pro_mini_m0-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/ko/adafruit-circuitpython-bast_pro_mini_m0-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/pl/adafruit-circuitpython-bast_pro_mini_m0-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/pt_BR/adafruit-circuitpython-bast_pro_mini_m0-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/zh_Latn_pinyin/adafruit-circuitpython-bast_pro_mini_m0-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -902,55 +888,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/ID/adafruit-circuitpython-bast_pro_mini_m0-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/de_DE/adafruit-circuitpython-bast_pro_mini_m0-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/en_US/adafruit-circuitpython-bast_pro_mini_m0-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/en_x_pirate/adafruit-circuitpython-bast_pro_mini_m0-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/es/adafruit-circuitpython-bast_pro_mini_m0-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/fil/adafruit-circuitpython-bast_pro_mini_m0-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/fr/adafruit-circuitpython-bast_pro_mini_m0-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/it_IT/adafruit-circuitpython-bast_pro_mini_m0-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/ko/adafruit-circuitpython-bast_pro_mini_m0-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/pl/adafruit-circuitpython-bast_pro_mini_m0-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/pt_BR/adafruit-circuitpython-bast_pro_mini_m0-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/sv/adafruit-circuitpython-bast_pro_mini_m0-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/zh_Latn_pinyin/adafruit-circuitpython-bast_pro_mini_m0-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 28,
+        "downloads": 0,
         "id": "bdmicro_vina_m0",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/ID/adafruit-circuitpython-bdmicro_vina_m0-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/de_DE/adafruit-circuitpython-bdmicro_vina_m0-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/en_US/adafruit-circuitpython-bdmicro_vina_m0-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/en_x_pirate/adafruit-circuitpython-bdmicro_vina_m0-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/es/adafruit-circuitpython-bdmicro_vina_m0-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/fil/adafruit-circuitpython-bdmicro_vina_m0-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/fr/adafruit-circuitpython-bdmicro_vina_m0-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/it_IT/adafruit-circuitpython-bdmicro_vina_m0-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/ko/adafruit-circuitpython-bdmicro_vina_m0-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/pl/adafruit-circuitpython-bdmicro_vina_m0-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/pt_BR/adafruit-circuitpython-bdmicro_vina_m0-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/zh_Latn_pinyin/adafruit-circuitpython-bdmicro_vina_m0-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -992,55 +981,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/ID/adafruit-circuitpython-bdmicro_vina_m0-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/de_DE/adafruit-circuitpython-bdmicro_vina_m0-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/en_US/adafruit-circuitpython-bdmicro_vina_m0-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/en_x_pirate/adafruit-circuitpython-bdmicro_vina_m0-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/es/adafruit-circuitpython-bdmicro_vina_m0-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/fil/adafruit-circuitpython-bdmicro_vina_m0-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/fr/adafruit-circuitpython-bdmicro_vina_m0-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/it_IT/adafruit-circuitpython-bdmicro_vina_m0-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/ko/adafruit-circuitpython-bdmicro_vina_m0-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/pl/adafruit-circuitpython-bdmicro_vina_m0-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/pt_BR/adafruit-circuitpython-bdmicro_vina_m0-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/sv/adafruit-circuitpython-bdmicro_vina_m0-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/zh_Latn_pinyin/adafruit-circuitpython-bdmicro_vina_m0-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 9,
+        "downloads": 0,
         "id": "capablerobot_usbhub",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/ID/adafruit-circuitpython-capablerobot_usbhub-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/de_DE/adafruit-circuitpython-capablerobot_usbhub-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/en_US/adafruit-circuitpython-capablerobot_usbhub-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/en_x_pirate/adafruit-circuitpython-capablerobot_usbhub-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/es/adafruit-circuitpython-capablerobot_usbhub-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/fil/adafruit-circuitpython-capablerobot_usbhub-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/fr/adafruit-circuitpython-capablerobot_usbhub-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/it_IT/adafruit-circuitpython-capablerobot_usbhub-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/ko/adafruit-circuitpython-capablerobot_usbhub-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/pl/adafruit-circuitpython-capablerobot_usbhub-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/pt_BR/adafruit-circuitpython-capablerobot_usbhub-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/zh_Latn_pinyin/adafruit-circuitpython-capablerobot_usbhub-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -1082,55 +1074,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/ID/adafruit-circuitpython-capablerobot_usbhub-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/de_DE/adafruit-circuitpython-capablerobot_usbhub-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/en_US/adafruit-circuitpython-capablerobot_usbhub-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/en_x_pirate/adafruit-circuitpython-capablerobot_usbhub-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/es/adafruit-circuitpython-capablerobot_usbhub-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/fil/adafruit-circuitpython-capablerobot_usbhub-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/fr/adafruit-circuitpython-capablerobot_usbhub-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/it_IT/adafruit-circuitpython-capablerobot_usbhub-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/ko/adafruit-circuitpython-capablerobot_usbhub-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/pl/adafruit-circuitpython-capablerobot_usbhub-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/pt_BR/adafruit-circuitpython-capablerobot_usbhub-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/sv/adafruit-circuitpython-capablerobot_usbhub-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/zh_Latn_pinyin/adafruit-circuitpython-capablerobot_usbhub-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 29,
+        "downloads": 0,
         "id": "catwan_usbstick",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/ID/adafruit-circuitpython-catwan_usbstick-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/de_DE/adafruit-circuitpython-catwan_usbstick-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/en_US/adafruit-circuitpython-catwan_usbstick-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/en_x_pirate/adafruit-circuitpython-catwan_usbstick-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/es/adafruit-circuitpython-catwan_usbstick-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/fil/adafruit-circuitpython-catwan_usbstick-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/fr/adafruit-circuitpython-catwan_usbstick-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/it_IT/adafruit-circuitpython-catwan_usbstick-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/ko/adafruit-circuitpython-catwan_usbstick-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/pl/adafruit-circuitpython-catwan_usbstick-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/pt_BR/adafruit-circuitpython-catwan_usbstick-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/zh_Latn_pinyin/adafruit-circuitpython-catwan_usbstick-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -1172,55 +1167,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/ID/adafruit-circuitpython-catwan_usbstick-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/de_DE/adafruit-circuitpython-catwan_usbstick-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/en_US/adafruit-circuitpython-catwan_usbstick-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/en_x_pirate/adafruit-circuitpython-catwan_usbstick-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/es/adafruit-circuitpython-catwan_usbstick-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/fil/adafruit-circuitpython-catwan_usbstick-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/fr/adafruit-circuitpython-catwan_usbstick-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/it_IT/adafruit-circuitpython-catwan_usbstick-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/ko/adafruit-circuitpython-catwan_usbstick-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/pl/adafruit-circuitpython-catwan_usbstick-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/pt_BR/adafruit-circuitpython-catwan_usbstick-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/sv/adafruit-circuitpython-catwan_usbstick-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/zh_Latn_pinyin/adafruit-circuitpython-catwan_usbstick-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 15,
+        "downloads": 0,
         "id": "circuitbrains_basic_m0",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/ID/adafruit-circuitpython-circuitbrains_basic_m0-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/de_DE/adafruit-circuitpython-circuitbrains_basic_m0-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/en_US/adafruit-circuitpython-circuitbrains_basic_m0-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/en_x_pirate/adafruit-circuitpython-circuitbrains_basic_m0-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/es/adafruit-circuitpython-circuitbrains_basic_m0-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/fil/adafruit-circuitpython-circuitbrains_basic_m0-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/fr/adafruit-circuitpython-circuitbrains_basic_m0-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/it_IT/adafruit-circuitpython-circuitbrains_basic_m0-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/ko/adafruit-circuitpython-circuitbrains_basic_m0-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/pl/adafruit-circuitpython-circuitbrains_basic_m0-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/pt_BR/adafruit-circuitpython-circuitbrains_basic_m0-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/zh_Latn_pinyin/adafruit-circuitpython-circuitbrains_basic_m0-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -1262,55 +1260,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/ID/adafruit-circuitpython-circuitbrains_basic_m0-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/de_DE/adafruit-circuitpython-circuitbrains_basic_m0-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/en_US/adafruit-circuitpython-circuitbrains_basic_m0-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/en_x_pirate/adafruit-circuitpython-circuitbrains_basic_m0-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/es/adafruit-circuitpython-circuitbrains_basic_m0-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/fil/adafruit-circuitpython-circuitbrains_basic_m0-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/fr/adafruit-circuitpython-circuitbrains_basic_m0-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/it_IT/adafruit-circuitpython-circuitbrains_basic_m0-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/ko/adafruit-circuitpython-circuitbrains_basic_m0-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/pl/adafruit-circuitpython-circuitbrains_basic_m0-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/pt_BR/adafruit-circuitpython-circuitbrains_basic_m0-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/sv/adafruit-circuitpython-circuitbrains_basic_m0-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/zh_Latn_pinyin/adafruit-circuitpython-circuitbrains_basic_m0-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 31,
+        "downloads": 0,
         "id": "circuitbrains_deluxe_m4",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/ID/adafruit-circuitpython-circuitbrains_deluxe_m4-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/de_DE/adafruit-circuitpython-circuitbrains_deluxe_m4-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/en_US/adafruit-circuitpython-circuitbrains_deluxe_m4-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/en_x_pirate/adafruit-circuitpython-circuitbrains_deluxe_m4-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/es/adafruit-circuitpython-circuitbrains_deluxe_m4-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/fil/adafruit-circuitpython-circuitbrains_deluxe_m4-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/fr/adafruit-circuitpython-circuitbrains_deluxe_m4-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/it_IT/adafruit-circuitpython-circuitbrains_deluxe_m4-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/ko/adafruit-circuitpython-circuitbrains_deluxe_m4-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/pl/adafruit-circuitpython-circuitbrains_deluxe_m4-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/pt_BR/adafruit-circuitpython-circuitbrains_deluxe_m4-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/zh_Latn_pinyin/adafruit-circuitpython-circuitbrains_deluxe_m4-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -1352,55 +1353,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/ID/adafruit-circuitpython-circuitbrains_deluxe_m4-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/de_DE/adafruit-circuitpython-circuitbrains_deluxe_m4-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/en_US/adafruit-circuitpython-circuitbrains_deluxe_m4-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/en_x_pirate/adafruit-circuitpython-circuitbrains_deluxe_m4-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/es/adafruit-circuitpython-circuitbrains_deluxe_m4-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/fil/adafruit-circuitpython-circuitbrains_deluxe_m4-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/fr/adafruit-circuitpython-circuitbrains_deluxe_m4-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/it_IT/adafruit-circuitpython-circuitbrains_deluxe_m4-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/ko/adafruit-circuitpython-circuitbrains_deluxe_m4-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/pl/adafruit-circuitpython-circuitbrains_deluxe_m4-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/pt_BR/adafruit-circuitpython-circuitbrains_deluxe_m4-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/sv/adafruit-circuitpython-circuitbrains_deluxe_m4-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/zh_Latn_pinyin/adafruit-circuitpython-circuitbrains_deluxe_m4-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 214,
+        "downloads": 0,
         "id": "circuitplayground_bluefruit",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/ID/adafruit-circuitpython-circuitplayground_bluefruit-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/de_DE/adafruit-circuitpython-circuitplayground_bluefruit-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/en_US/adafruit-circuitpython-circuitplayground_bluefruit-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/en_x_pirate/adafruit-circuitpython-circuitplayground_bluefruit-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/es/adafruit-circuitpython-circuitplayground_bluefruit-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/fil/adafruit-circuitpython-circuitplayground_bluefruit-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/fr/adafruit-circuitpython-circuitplayground_bluefruit-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/it_IT/adafruit-circuitpython-circuitplayground_bluefruit-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/ko/adafruit-circuitpython-circuitplayground_bluefruit-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/pl/adafruit-circuitpython-circuitplayground_bluefruit-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/pt_BR/adafruit-circuitpython-circuitplayground_bluefruit-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_bluefruit-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -1442,55 +1446,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/ID/adafruit-circuitpython-circuitplayground_bluefruit-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/de_DE/adafruit-circuitpython-circuitplayground_bluefruit-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/en_US/adafruit-circuitpython-circuitplayground_bluefruit-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/en_x_pirate/adafruit-circuitpython-circuitplayground_bluefruit-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/es/adafruit-circuitpython-circuitplayground_bluefruit-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/fil/adafruit-circuitpython-circuitplayground_bluefruit-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/fr/adafruit-circuitpython-circuitplayground_bluefruit-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/it_IT/adafruit-circuitpython-circuitplayground_bluefruit-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/ko/adafruit-circuitpython-circuitplayground_bluefruit-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/pl/adafruit-circuitpython-circuitplayground_bluefruit-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/pt_BR/adafruit-circuitpython-circuitplayground_bluefruit-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/sv/adafruit-circuitpython-circuitplayground_bluefruit-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_bluefruit-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 556,
+        "downloads": 0,
         "id": "circuitplayground_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/ID/adafruit-circuitpython-circuitplayground_express-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/de_DE/adafruit-circuitpython-circuitplayground_express-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/en_US/adafruit-circuitpython-circuitplayground_express-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/en_x_pirate/adafruit-circuitpython-circuitplayground_express-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/es/adafruit-circuitpython-circuitplayground_express-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/fil/adafruit-circuitpython-circuitplayground_express-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/fr/adafruit-circuitpython-circuitplayground_express-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/it_IT/adafruit-circuitpython-circuitplayground_express-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/ko/adafruit-circuitpython-circuitplayground_express-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/pl/adafruit-circuitpython-circuitplayground_express-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/pt_BR/adafruit-circuitpython-circuitplayground_express-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_express-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -1532,55 +1539,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/ID/adafruit-circuitpython-circuitplayground_express-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/de_DE/adafruit-circuitpython-circuitplayground_express-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/en_US/adafruit-circuitpython-circuitplayground_express-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/en_x_pirate/adafruit-circuitpython-circuitplayground_express-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/es/adafruit-circuitpython-circuitplayground_express-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/fil/adafruit-circuitpython-circuitplayground_express-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/fr/adafruit-circuitpython-circuitplayground_express-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/it_IT/adafruit-circuitpython-circuitplayground_express-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/ko/adafruit-circuitpython-circuitplayground_express-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/pl/adafruit-circuitpython-circuitplayground_express-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/pt_BR/adafruit-circuitpython-circuitplayground_express-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/sv/adafruit-circuitpython-circuitplayground_express-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 5,
+        "downloads": 0,
         "id": "circuitplayground_express_4h",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/ID/adafruit-circuitpython-circuitplayground_express_4h-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/de_DE/adafruit-circuitpython-circuitplayground_express_4h-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/en_US/adafruit-circuitpython-circuitplayground_express_4h-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/en_x_pirate/adafruit-circuitpython-circuitplayground_express_4h-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/es/adafruit-circuitpython-circuitplayground_express_4h-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/fil/adafruit-circuitpython-circuitplayground_express_4h-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/fr/adafruit-circuitpython-circuitplayground_express_4h-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/it_IT/adafruit-circuitpython-circuitplayground_express_4h-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/ko/adafruit-circuitpython-circuitplayground_express_4h-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/pl/adafruit-circuitpython-circuitplayground_express_4h-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/pt_BR/adafruit-circuitpython-circuitplayground_express_4h-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_express_4h-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -1622,55 +1632,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/ID/adafruit-circuitpython-circuitplayground_express_4h-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/de_DE/adafruit-circuitpython-circuitplayground_express_4h-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/en_US/adafruit-circuitpython-circuitplayground_express_4h-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/en_x_pirate/adafruit-circuitpython-circuitplayground_express_4h-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/es/adafruit-circuitpython-circuitplayground_express_4h-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/fil/adafruit-circuitpython-circuitplayground_express_4h-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/fr/adafruit-circuitpython-circuitplayground_express_4h-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/it_IT/adafruit-circuitpython-circuitplayground_express_4h-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/ko/adafruit-circuitpython-circuitplayground_express_4h-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/pl/adafruit-circuitpython-circuitplayground_express_4h-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/pt_BR/adafruit-circuitpython-circuitplayground_express_4h-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/sv/adafruit-circuitpython-circuitplayground_express_4h-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_express_4h-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 54,
+        "downloads": 0,
         "id": "circuitplayground_express_crickit",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/ID/adafruit-circuitpython-circuitplayground_express_crickit-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/de_DE/adafruit-circuitpython-circuitplayground_express_crickit-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/en_US/adafruit-circuitpython-circuitplayground_express_crickit-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/en_x_pirate/adafruit-circuitpython-circuitplayground_express_crickit-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/es/adafruit-circuitpython-circuitplayground_express_crickit-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/fil/adafruit-circuitpython-circuitplayground_express_crickit-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/fr/adafruit-circuitpython-circuitplayground_express_crickit-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/it_IT/adafruit-circuitpython-circuitplayground_express_crickit-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/ko/adafruit-circuitpython-circuitplayground_express_crickit-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/pl/adafruit-circuitpython-circuitplayground_express_crickit-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/pt_BR/adafruit-circuitpython-circuitplayground_express_crickit-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_express_crickit-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -1712,55 +1725,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/ID/adafruit-circuitpython-circuitplayground_express_crickit-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/de_DE/adafruit-circuitpython-circuitplayground_express_crickit-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/en_US/adafruit-circuitpython-circuitplayground_express_crickit-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/en_x_pirate/adafruit-circuitpython-circuitplayground_express_crickit-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/es/adafruit-circuitpython-circuitplayground_express_crickit-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/fil/adafruit-circuitpython-circuitplayground_express_crickit-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/fr/adafruit-circuitpython-circuitplayground_express_crickit-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/it_IT/adafruit-circuitpython-circuitplayground_express_crickit-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/ko/adafruit-circuitpython-circuitplayground_express_crickit-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/pl/adafruit-circuitpython-circuitplayground_express_crickit-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/pt_BR/adafruit-circuitpython-circuitplayground_express_crickit-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/sv/adafruit-circuitpython-circuitplayground_express_crickit-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_express_crickit-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 31,
+        "downloads": 0,
         "id": "circuitplayground_express_digikey_pycon2019",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/ID/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/de_DE/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/en_US/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/en_x_pirate/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/es/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/fil/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/fr/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/it_IT/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/ko/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/pl/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/pt_BR/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -1802,55 +1818,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/ID/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/de_DE/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/en_US/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/en_x_pirate/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/es/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/fil/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/fr/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/it_IT/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/ko/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/pl/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/pt_BR/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/sv/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 42,
+        "downloads": 0,
         "id": "circuitplayground_express_displayio",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/ID/adafruit-circuitpython-circuitplayground_express_displayio-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/de_DE/adafruit-circuitpython-circuitplayground_express_displayio-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/en_US/adafruit-circuitpython-circuitplayground_express_displayio-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/en_x_pirate/adafruit-circuitpython-circuitplayground_express_displayio-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/es/adafruit-circuitpython-circuitplayground_express_displayio-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/fil/adafruit-circuitpython-circuitplayground_express_displayio-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/fr/adafruit-circuitpython-circuitplayground_express_displayio-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/it_IT/adafruit-circuitpython-circuitplayground_express_displayio-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/ko/adafruit-circuitpython-circuitplayground_express_displayio-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/pl/adafruit-circuitpython-circuitplayground_express_displayio-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/pt_BR/adafruit-circuitpython-circuitplayground_express_displayio-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_express_displayio-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -1892,55 +1911,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/ID/adafruit-circuitpython-circuitplayground_express_displayio-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/de_DE/adafruit-circuitpython-circuitplayground_express_displayio-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/en_US/adafruit-circuitpython-circuitplayground_express_displayio-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/en_x_pirate/adafruit-circuitpython-circuitplayground_express_displayio-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/es/adafruit-circuitpython-circuitplayground_express_displayio-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/fil/adafruit-circuitpython-circuitplayground_express_displayio-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/fr/adafruit-circuitpython-circuitplayground_express_displayio-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/it_IT/adafruit-circuitpython-circuitplayground_express_displayio-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/ko/adafruit-circuitpython-circuitplayground_express_displayio-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/pl/adafruit-circuitpython-circuitplayground_express_displayio-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/pt_BR/adafruit-circuitpython-circuitplayground_express_displayio-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/sv/adafruit-circuitpython-circuitplayground_express_displayio-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_express_displayio-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 119,
+        "downloads": 0,
         "id": "clue_nrf52840_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/ID/adafruit-circuitpython-clue_nrf52840_express-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/de_DE/adafruit-circuitpython-clue_nrf52840_express-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/en_US/adafruit-circuitpython-clue_nrf52840_express-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/en_x_pirate/adafruit-circuitpython-clue_nrf52840_express-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/es/adafruit-circuitpython-clue_nrf52840_express-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/fil/adafruit-circuitpython-clue_nrf52840_express-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/fr/adafruit-circuitpython-clue_nrf52840_express-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/it_IT/adafruit-circuitpython-clue_nrf52840_express-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/ko/adafruit-circuitpython-clue_nrf52840_express-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/pl/adafruit-circuitpython-clue_nrf52840_express-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/pt_BR/adafruit-circuitpython-clue_nrf52840_express-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/zh_Latn_pinyin/adafruit-circuitpython-clue_nrf52840_express-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -1982,55 +2004,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/ID/adafruit-circuitpython-clue_nrf52840_express-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/de_DE/adafruit-circuitpython-clue_nrf52840_express-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/en_US/adafruit-circuitpython-clue_nrf52840_express-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/en_x_pirate/adafruit-circuitpython-clue_nrf52840_express-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/es/adafruit-circuitpython-clue_nrf52840_express-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/fil/adafruit-circuitpython-clue_nrf52840_express-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/fr/adafruit-circuitpython-clue_nrf52840_express-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/it_IT/adafruit-circuitpython-clue_nrf52840_express-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/ko/adafruit-circuitpython-clue_nrf52840_express-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/pl/adafruit-circuitpython-clue_nrf52840_express-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/pt_BR/adafruit-circuitpython-clue_nrf52840_express-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/sv/adafruit-circuitpython-clue_nrf52840_express-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/zh_Latn_pinyin/adafruit-circuitpython-clue_nrf52840_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 25,
+        "downloads": 0,
         "id": "cp32-m4",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/ID/adafruit-circuitpython-cp32-m4-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/de_DE/adafruit-circuitpython-cp32-m4-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/en_US/adafruit-circuitpython-cp32-m4-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/en_x_pirate/adafruit-circuitpython-cp32-m4-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/es/adafruit-circuitpython-cp32-m4-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/fil/adafruit-circuitpython-cp32-m4-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/fr/adafruit-circuitpython-cp32-m4-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/it_IT/adafruit-circuitpython-cp32-m4-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/ko/adafruit-circuitpython-cp32-m4-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/pl/adafruit-circuitpython-cp32-m4-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/pt_BR/adafruit-circuitpython-cp32-m4-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/zh_Latn_pinyin/adafruit-circuitpython-cp32-m4-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -2072,6 +2097,51 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/cp32-m4/ID/adafruit-circuitpython-cp32-m4-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/cp32-m4/de_DE/adafruit-circuitpython-cp32-m4-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/cp32-m4/en_US/adafruit-circuitpython-cp32-m4-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/cp32-m4/en_x_pirate/adafruit-circuitpython-cp32-m4-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/cp32-m4/es/adafruit-circuitpython-cp32-m4-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/cp32-m4/fil/adafruit-circuitpython-cp32-m4-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/cp32-m4/fr/adafruit-circuitpython-cp32-m4-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/cp32-m4/it_IT/adafruit-circuitpython-cp32-m4-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/cp32-m4/ko/adafruit-circuitpython-cp32-m4-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/cp32-m4/pl/adafruit-circuitpython-cp32-m4-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/cp32-m4/pt_BR/adafruit-circuitpython-cp32-m4-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/cp32-m4/sv/adafruit-circuitpython-cp32-m4-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/cp32-m4/zh_Latn_pinyin/adafruit-circuitpython-cp32-m4-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
@@ -2079,48 +2149,6 @@
         "downloads": 0,
         "id": "datalore_ip_m4",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/ID/adafruit-circuitpython-datalore_ip_m4-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/de_DE/adafruit-circuitpython-datalore_ip_m4-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/en_US/adafruit-circuitpython-datalore_ip_m4-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/en_x_pirate/adafruit-circuitpython-datalore_ip_m4-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/es/adafruit-circuitpython-datalore_ip_m4-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/fil/adafruit-circuitpython-datalore_ip_m4-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/fr/adafruit-circuitpython-datalore_ip_m4-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/it_IT/adafruit-circuitpython-datalore_ip_m4-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/ko/adafruit-circuitpython-datalore_ip_m4-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/pl/adafruit-circuitpython-datalore_ip_m4-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/pt_BR/adafruit-circuitpython-datalore_ip_m4-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/zh_Latn_pinyin/adafruit-circuitpython-datalore_ip_m4-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -2162,55 +2190,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/ID/adafruit-circuitpython-datalore_ip_m4-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/de_DE/adafruit-circuitpython-datalore_ip_m4-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/en_US/adafruit-circuitpython-datalore_ip_m4-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/en_x_pirate/adafruit-circuitpython-datalore_ip_m4-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/es/adafruit-circuitpython-datalore_ip_m4-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/fil/adafruit-circuitpython-datalore_ip_m4-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/fr/adafruit-circuitpython-datalore_ip_m4-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/it_IT/adafruit-circuitpython-datalore_ip_m4-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/ko/adafruit-circuitpython-datalore_ip_m4-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/pl/adafruit-circuitpython-datalore_ip_m4-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/pt_BR/adafruit-circuitpython-datalore_ip_m4-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/sv/adafruit-circuitpython-datalore_ip_m4-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/zh_Latn_pinyin/adafruit-circuitpython-datalore_ip_m4-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 15,
+        "downloads": 0,
         "id": "datum_distance",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/ID/adafruit-circuitpython-datum_distance-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/de_DE/adafruit-circuitpython-datum_distance-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/en_US/adafruit-circuitpython-datum_distance-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/en_x_pirate/adafruit-circuitpython-datum_distance-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/es/adafruit-circuitpython-datum_distance-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/fil/adafruit-circuitpython-datum_distance-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/fr/adafruit-circuitpython-datum_distance-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/it_IT/adafruit-circuitpython-datum_distance-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/ko/adafruit-circuitpython-datum_distance-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/pl/adafruit-circuitpython-datum_distance-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/pt_BR/adafruit-circuitpython-datum_distance-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/zh_Latn_pinyin/adafruit-circuitpython-datum_distance-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -2252,55 +2283,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/datum_distance/ID/adafruit-circuitpython-datum_distance-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/datum_distance/de_DE/adafruit-circuitpython-datum_distance-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/datum_distance/en_US/adafruit-circuitpython-datum_distance-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/datum_distance/en_x_pirate/adafruit-circuitpython-datum_distance-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/datum_distance/es/adafruit-circuitpython-datum_distance-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/datum_distance/fil/adafruit-circuitpython-datum_distance-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/datum_distance/fr/adafruit-circuitpython-datum_distance-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/datum_distance/it_IT/adafruit-circuitpython-datum_distance-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/datum_distance/ko/adafruit-circuitpython-datum_distance-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/datum_distance/pl/adafruit-circuitpython-datum_distance-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/datum_distance/pt_BR/adafruit-circuitpython-datum_distance-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/datum_distance/sv/adafruit-circuitpython-datum_distance-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/datum_distance/zh_Latn_pinyin/adafruit-circuitpython-datum_distance-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 16,
+        "downloads": 0,
         "id": "datum_imu",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/ID/adafruit-circuitpython-datum_imu-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/de_DE/adafruit-circuitpython-datum_imu-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/en_US/adafruit-circuitpython-datum_imu-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/en_x_pirate/adafruit-circuitpython-datum_imu-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/es/adafruit-circuitpython-datum_imu-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/fil/adafruit-circuitpython-datum_imu-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/fr/adafruit-circuitpython-datum_imu-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/it_IT/adafruit-circuitpython-datum_imu-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/ko/adafruit-circuitpython-datum_imu-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/pl/adafruit-circuitpython-datum_imu-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/pt_BR/adafruit-circuitpython-datum_imu-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/zh_Latn_pinyin/adafruit-circuitpython-datum_imu-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -2342,55 +2376,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/datum_imu/ID/adafruit-circuitpython-datum_imu-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/datum_imu/de_DE/adafruit-circuitpython-datum_imu-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/datum_imu/en_US/adafruit-circuitpython-datum_imu-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/datum_imu/en_x_pirate/adafruit-circuitpython-datum_imu-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/datum_imu/es/adafruit-circuitpython-datum_imu-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/datum_imu/fil/adafruit-circuitpython-datum_imu-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/datum_imu/fr/adafruit-circuitpython-datum_imu-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/datum_imu/it_IT/adafruit-circuitpython-datum_imu-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/datum_imu/ko/adafruit-circuitpython-datum_imu-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/datum_imu/pl/adafruit-circuitpython-datum_imu-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/datum_imu/pt_BR/adafruit-circuitpython-datum_imu-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/datum_imu/sv/adafruit-circuitpython-datum_imu-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/datum_imu/zh_Latn_pinyin/adafruit-circuitpython-datum_imu-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 6,
+        "downloads": 0,
         "id": "datum_light",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/datum_light/ID/adafruit-circuitpython-datum_light-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/datum_light/de_DE/adafruit-circuitpython-datum_light-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/datum_light/en_US/adafruit-circuitpython-datum_light-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/datum_light/en_x_pirate/adafruit-circuitpython-datum_light-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/datum_light/es/adafruit-circuitpython-datum_light-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/datum_light/fil/adafruit-circuitpython-datum_light-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/datum_light/fr/adafruit-circuitpython-datum_light-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/datum_light/it_IT/adafruit-circuitpython-datum_light-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/datum_light/ko/adafruit-circuitpython-datum_light-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/datum_light/pl/adafruit-circuitpython-datum_light-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/datum_light/pt_BR/adafruit-circuitpython-datum_light-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/datum_light/zh_Latn_pinyin/adafruit-circuitpython-datum_light-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -2432,55 +2469,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/datum_light/ID/adafruit-circuitpython-datum_light-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/datum_light/de_DE/adafruit-circuitpython-datum_light-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/datum_light/en_US/adafruit-circuitpython-datum_light-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/datum_light/en_x_pirate/adafruit-circuitpython-datum_light-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/datum_light/es/adafruit-circuitpython-datum_light-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/datum_light/fil/adafruit-circuitpython-datum_light-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/datum_light/fr/adafruit-circuitpython-datum_light-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/datum_light/it_IT/adafruit-circuitpython-datum_light-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/datum_light/ko/adafruit-circuitpython-datum_light-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/datum_light/pl/adafruit-circuitpython-datum_light-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/datum_light/pt_BR/adafruit-circuitpython-datum_light-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/datum_light/sv/adafruit-circuitpython-datum_light-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/datum_light/zh_Latn_pinyin/adafruit-circuitpython-datum_light-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 31,
+        "downloads": 0,
         "id": "datum_weather",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/ID/adafruit-circuitpython-datum_weather-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/de_DE/adafruit-circuitpython-datum_weather-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/en_US/adafruit-circuitpython-datum_weather-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/en_x_pirate/adafruit-circuitpython-datum_weather-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/es/adafruit-circuitpython-datum_weather-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/fil/adafruit-circuitpython-datum_weather-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/fr/adafruit-circuitpython-datum_weather-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/it_IT/adafruit-circuitpython-datum_weather-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/ko/adafruit-circuitpython-datum_weather-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/pl/adafruit-circuitpython-datum_weather-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/pt_BR/adafruit-circuitpython-datum_weather-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/zh_Latn_pinyin/adafruit-circuitpython-datum_weather-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -2522,55 +2562,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/datum_weather/ID/adafruit-circuitpython-datum_weather-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/datum_weather/de_DE/adafruit-circuitpython-datum_weather-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/datum_weather/en_US/adafruit-circuitpython-datum_weather-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/datum_weather/en_x_pirate/adafruit-circuitpython-datum_weather-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/datum_weather/es/adafruit-circuitpython-datum_weather-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/datum_weather/fil/adafruit-circuitpython-datum_weather-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/datum_weather/fr/adafruit-circuitpython-datum_weather-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/datum_weather/it_IT/adafruit-circuitpython-datum_weather-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/datum_weather/ko/adafruit-circuitpython-datum_weather-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/datum_weather/pl/adafruit-circuitpython-datum_weather-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/datum_weather/pt_BR/adafruit-circuitpython-datum_weather-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/datum_weather/sv/adafruit-circuitpython-datum_weather-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/datum_weather/zh_Latn_pinyin/adafruit-circuitpython-datum_weather-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 60,
+        "downloads": 0,
         "id": "edgebadge",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/ID/adafruit-circuitpython-edgebadge-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/de_DE/adafruit-circuitpython-edgebadge-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/en_US/adafruit-circuitpython-edgebadge-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/en_x_pirate/adafruit-circuitpython-edgebadge-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/es/adafruit-circuitpython-edgebadge-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/fil/adafruit-circuitpython-edgebadge-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/fr/adafruit-circuitpython-edgebadge-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/it_IT/adafruit-circuitpython-edgebadge-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/ko/adafruit-circuitpython-edgebadge-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/pl/adafruit-circuitpython-edgebadge-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/pt_BR/adafruit-circuitpython-edgebadge-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/zh_Latn_pinyin/adafruit-circuitpython-edgebadge-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -2612,55 +2655,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/edgebadge/ID/adafruit-circuitpython-edgebadge-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/edgebadge/de_DE/adafruit-circuitpython-edgebadge-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/edgebadge/en_US/adafruit-circuitpython-edgebadge-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/edgebadge/en_x_pirate/adafruit-circuitpython-edgebadge-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/edgebadge/es/adafruit-circuitpython-edgebadge-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/edgebadge/fil/adafruit-circuitpython-edgebadge-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/edgebadge/fr/adafruit-circuitpython-edgebadge-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/edgebadge/it_IT/adafruit-circuitpython-edgebadge-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/edgebadge/ko/adafruit-circuitpython-edgebadge-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/edgebadge/pl/adafruit-circuitpython-edgebadge-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/edgebadge/pt_BR/adafruit-circuitpython-edgebadge-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/edgebadge/sv/adafruit-circuitpython-edgebadge-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/edgebadge/zh_Latn_pinyin/adafruit-circuitpython-edgebadge-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 29,
+        "downloads": 0,
         "id": "electronut_labs_blip",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/ID/adafruit-circuitpython-electronut_labs_blip-ID-5.3.0-rc.0.hex"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/de_DE/adafruit-circuitpython-electronut_labs_blip-de_DE-5.3.0-rc.0.hex"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/en_US/adafruit-circuitpython-electronut_labs_blip-en_US-5.3.0-rc.0.hex"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/en_x_pirate/adafruit-circuitpython-electronut_labs_blip-en_x_pirate-5.3.0-rc.0.hex"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/es/adafruit-circuitpython-electronut_labs_blip-es-5.3.0-rc.0.hex"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/fil/adafruit-circuitpython-electronut_labs_blip-fil-5.3.0-rc.0.hex"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/fr/adafruit-circuitpython-electronut_labs_blip-fr-5.3.0-rc.0.hex"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/it_IT/adafruit-circuitpython-electronut_labs_blip-it_IT-5.3.0-rc.0.hex"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/ko/adafruit-circuitpython-electronut_labs_blip-ko-5.3.0-rc.0.hex"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/pl/adafruit-circuitpython-electronut_labs_blip-pl-5.3.0-rc.0.hex"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/pt_BR/adafruit-circuitpython-electronut_labs_blip-pt_BR-5.3.0-rc.0.hex"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/zh_Latn_pinyin/adafruit-circuitpython-electronut_labs_blip-zh_Latn_pinyin-5.3.0-rc.0.hex"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -2702,55 +2748,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/ID/adafruit-circuitpython-electronut_labs_blip-ID-5.4.0-beta.0.hex"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/de_DE/adafruit-circuitpython-electronut_labs_blip-de_DE-5.4.0-beta.0.hex"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/en_US/adafruit-circuitpython-electronut_labs_blip-en_US-5.4.0-beta.0.hex"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/en_x_pirate/adafruit-circuitpython-electronut_labs_blip-en_x_pirate-5.4.0-beta.0.hex"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/es/adafruit-circuitpython-electronut_labs_blip-es-5.4.0-beta.0.hex"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/fil/adafruit-circuitpython-electronut_labs_blip-fil-5.4.0-beta.0.hex"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/fr/adafruit-circuitpython-electronut_labs_blip-fr-5.4.0-beta.0.hex"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/it_IT/adafruit-circuitpython-electronut_labs_blip-it_IT-5.4.0-beta.0.hex"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/ko/adafruit-circuitpython-electronut_labs_blip-ko-5.4.0-beta.0.hex"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/pl/adafruit-circuitpython-electronut_labs_blip-pl-5.4.0-beta.0.hex"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/pt_BR/adafruit-circuitpython-electronut_labs_blip-pt_BR-5.4.0-beta.0.hex"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/sv/adafruit-circuitpython-electronut_labs_blip-sv-5.4.0-beta.0.hex"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/zh_Latn_pinyin/adafruit-circuitpython-electronut_labs_blip-zh_Latn_pinyin-5.4.0-beta.0.hex"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 29,
+        "downloads": 0,
         "id": "electronut_labs_papyr",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/ID/adafruit-circuitpython-electronut_labs_papyr-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/de_DE/adafruit-circuitpython-electronut_labs_papyr-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/en_US/adafruit-circuitpython-electronut_labs_papyr-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/en_x_pirate/adafruit-circuitpython-electronut_labs_papyr-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/es/adafruit-circuitpython-electronut_labs_papyr-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/fil/adafruit-circuitpython-electronut_labs_papyr-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/fr/adafruit-circuitpython-electronut_labs_papyr-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/it_IT/adafruit-circuitpython-electronut_labs_papyr-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/ko/adafruit-circuitpython-electronut_labs_papyr-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/pl/adafruit-circuitpython-electronut_labs_papyr-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/pt_BR/adafruit-circuitpython-electronut_labs_papyr-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/zh_Latn_pinyin/adafruit-circuitpython-electronut_labs_papyr-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -2792,55 +2841,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/ID/adafruit-circuitpython-electronut_labs_papyr-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/de_DE/adafruit-circuitpython-electronut_labs_papyr-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/en_US/adafruit-circuitpython-electronut_labs_papyr-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/en_x_pirate/adafruit-circuitpython-electronut_labs_papyr-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/es/adafruit-circuitpython-electronut_labs_papyr-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/fil/adafruit-circuitpython-electronut_labs_papyr-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/fr/adafruit-circuitpython-electronut_labs_papyr-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/it_IT/adafruit-circuitpython-electronut_labs_papyr-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/ko/adafruit-circuitpython-electronut_labs_papyr-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/pl/adafruit-circuitpython-electronut_labs_papyr-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/pt_BR/adafruit-circuitpython-electronut_labs_papyr-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/sv/adafruit-circuitpython-electronut_labs_papyr-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/zh_Latn_pinyin/adafruit-circuitpython-electronut_labs_papyr-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 27,
+        "downloads": 0,
         "id": "escornabot_makech",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/ID/adafruit-circuitpython-escornabot_makech-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/de_DE/adafruit-circuitpython-escornabot_makech-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/en_US/adafruit-circuitpython-escornabot_makech-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/en_x_pirate/adafruit-circuitpython-escornabot_makech-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/es/adafruit-circuitpython-escornabot_makech-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/fil/adafruit-circuitpython-escornabot_makech-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/fr/adafruit-circuitpython-escornabot_makech-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/it_IT/adafruit-circuitpython-escornabot_makech-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/ko/adafruit-circuitpython-escornabot_makech-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/pl/adafruit-circuitpython-escornabot_makech-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/pt_BR/adafruit-circuitpython-escornabot_makech-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/zh_Latn_pinyin/adafruit-circuitpython-escornabot_makech-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -2882,55 +2934,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/ID/adafruit-circuitpython-escornabot_makech-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/de_DE/adafruit-circuitpython-escornabot_makech-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/en_US/adafruit-circuitpython-escornabot_makech-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/en_x_pirate/adafruit-circuitpython-escornabot_makech-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/es/adafruit-circuitpython-escornabot_makech-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/fil/adafruit-circuitpython-escornabot_makech-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/fr/adafruit-circuitpython-escornabot_makech-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/it_IT/adafruit-circuitpython-escornabot_makech-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/ko/adafruit-circuitpython-escornabot_makech-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/pl/adafruit-circuitpython-escornabot_makech-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/pt_BR/adafruit-circuitpython-escornabot_makech-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/sv/adafruit-circuitpython-escornabot_makech-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/zh_Latn_pinyin/adafruit-circuitpython-escornabot_makech-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 7,
+        "downloads": 0,
         "id": "espruino_pico",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/ID/adafruit-circuitpython-espruino_pico-ID-5.3.0-rc.0.bin"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/de_DE/adafruit-circuitpython-espruino_pico-de_DE-5.3.0-rc.0.bin"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/en_US/adafruit-circuitpython-espruino_pico-en_US-5.3.0-rc.0.bin"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/en_x_pirate/adafruit-circuitpython-espruino_pico-en_x_pirate-5.3.0-rc.0.bin"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/es/adafruit-circuitpython-espruino_pico-es-5.3.0-rc.0.bin"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/fil/adafruit-circuitpython-espruino_pico-fil-5.3.0-rc.0.bin"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/fr/adafruit-circuitpython-espruino_pico-fr-5.3.0-rc.0.bin"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/it_IT/adafruit-circuitpython-espruino_pico-it_IT-5.3.0-rc.0.bin"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/ko/adafruit-circuitpython-espruino_pico-ko-5.3.0-rc.0.bin"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/pl/adafruit-circuitpython-espruino_pico-pl-5.3.0-rc.0.bin"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/pt_BR/adafruit-circuitpython-espruino_pico-pt_BR-5.3.0-rc.0.bin"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/zh_Latn_pinyin/adafruit-circuitpython-espruino_pico-zh_Latn_pinyin-5.3.0-rc.0.bin"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -2972,55 +3027,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/espruino_pico/ID/adafruit-circuitpython-espruino_pico-ID-5.4.0-beta.0.bin"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/espruino_pico/de_DE/adafruit-circuitpython-espruino_pico-de_DE-5.4.0-beta.0.bin"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/espruino_pico/en_US/adafruit-circuitpython-espruino_pico-en_US-5.4.0-beta.0.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/espruino_pico/en_x_pirate/adafruit-circuitpython-espruino_pico-en_x_pirate-5.4.0-beta.0.bin"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/espruino_pico/es/adafruit-circuitpython-espruino_pico-es-5.4.0-beta.0.bin"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/espruino_pico/fil/adafruit-circuitpython-espruino_pico-fil-5.4.0-beta.0.bin"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/espruino_pico/fr/adafruit-circuitpython-espruino_pico-fr-5.4.0-beta.0.bin"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/espruino_pico/it_IT/adafruit-circuitpython-espruino_pico-it_IT-5.4.0-beta.0.bin"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/espruino_pico/ko/adafruit-circuitpython-espruino_pico-ko-5.4.0-beta.0.bin"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/espruino_pico/pl/adafruit-circuitpython-espruino_pico-pl-5.4.0-beta.0.bin"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/espruino_pico/pt_BR/adafruit-circuitpython-espruino_pico-pt_BR-5.4.0-beta.0.bin"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/espruino_pico/sv/adafruit-circuitpython-espruino_pico-sv-5.4.0-beta.0.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/espruino_pico/zh_Latn_pinyin/adafruit-circuitpython-espruino_pico-zh_Latn_pinyin-5.4.0-beta.0.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 7,
+        "downloads": 0,
         "id": "espruino_wifi",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/ID/adafruit-circuitpython-espruino_wifi-ID-5.3.0-rc.0.bin"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/de_DE/adafruit-circuitpython-espruino_wifi-de_DE-5.3.0-rc.0.bin"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/en_US/adafruit-circuitpython-espruino_wifi-en_US-5.3.0-rc.0.bin"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/en_x_pirate/adafruit-circuitpython-espruino_wifi-en_x_pirate-5.3.0-rc.0.bin"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/es/adafruit-circuitpython-espruino_wifi-es-5.3.0-rc.0.bin"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/fil/adafruit-circuitpython-espruino_wifi-fil-5.3.0-rc.0.bin"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/fr/adafruit-circuitpython-espruino_wifi-fr-5.3.0-rc.0.bin"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/it_IT/adafruit-circuitpython-espruino_wifi-it_IT-5.3.0-rc.0.bin"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/ko/adafruit-circuitpython-espruino_wifi-ko-5.3.0-rc.0.bin"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/pl/adafruit-circuitpython-espruino_wifi-pl-5.3.0-rc.0.bin"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/pt_BR/adafruit-circuitpython-espruino_wifi-pt_BR-5.3.0-rc.0.bin"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/zh_Latn_pinyin/adafruit-circuitpython-espruino_wifi-zh_Latn_pinyin-5.3.0-rc.0.bin"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -3062,55 +3120,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/ID/adafruit-circuitpython-espruino_wifi-ID-5.4.0-beta.0.bin"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/de_DE/adafruit-circuitpython-espruino_wifi-de_DE-5.4.0-beta.0.bin"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/en_US/adafruit-circuitpython-espruino_wifi-en_US-5.4.0-beta.0.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/en_x_pirate/adafruit-circuitpython-espruino_wifi-en_x_pirate-5.4.0-beta.0.bin"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/es/adafruit-circuitpython-espruino_wifi-es-5.4.0-beta.0.bin"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/fil/adafruit-circuitpython-espruino_wifi-fil-5.4.0-beta.0.bin"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/fr/adafruit-circuitpython-espruino_wifi-fr-5.4.0-beta.0.bin"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/it_IT/adafruit-circuitpython-espruino_wifi-it_IT-5.4.0-beta.0.bin"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/ko/adafruit-circuitpython-espruino_wifi-ko-5.4.0-beta.0.bin"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/pl/adafruit-circuitpython-espruino_wifi-pl-5.4.0-beta.0.bin"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/pt_BR/adafruit-circuitpython-espruino_wifi-pt_BR-5.4.0-beta.0.bin"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/sv/adafruit-circuitpython-espruino_wifi-sv-5.4.0-beta.0.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/zh_Latn_pinyin/adafruit-circuitpython-espruino_wifi-zh_Latn_pinyin-5.4.0-beta.0.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 44,
+        "downloads": 0,
         "id": "feather_bluefruit_sense",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/ID/adafruit-circuitpython-feather_bluefruit_sense-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/de_DE/adafruit-circuitpython-feather_bluefruit_sense-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/en_US/adafruit-circuitpython-feather_bluefruit_sense-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/en_x_pirate/adafruit-circuitpython-feather_bluefruit_sense-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/es/adafruit-circuitpython-feather_bluefruit_sense-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/fil/adafruit-circuitpython-feather_bluefruit_sense-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/fr/adafruit-circuitpython-feather_bluefruit_sense-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/it_IT/adafruit-circuitpython-feather_bluefruit_sense-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/ko/adafruit-circuitpython-feather_bluefruit_sense-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/pl/adafruit-circuitpython-feather_bluefruit_sense-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/pt_BR/adafruit-circuitpython-feather_bluefruit_sense-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/zh_Latn_pinyin/adafruit-circuitpython-feather_bluefruit_sense-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -3152,67 +3213,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/ID/adafruit-circuitpython-feather_bluefruit_sense-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/de_DE/adafruit-circuitpython-feather_bluefruit_sense-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/en_US/adafruit-circuitpython-feather_bluefruit_sense-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/en_x_pirate/adafruit-circuitpython-feather_bluefruit_sense-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/es/adafruit-circuitpython-feather_bluefruit_sense-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/fil/adafruit-circuitpython-feather_bluefruit_sense-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/fr/adafruit-circuitpython-feather_bluefruit_sense-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/it_IT/adafruit-circuitpython-feather_bluefruit_sense-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/ko/adafruit-circuitpython-feather_bluefruit_sense-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/pl/adafruit-circuitpython-feather_bluefruit_sense-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/pt_BR/adafruit-circuitpython-feather_bluefruit_sense-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/sv/adafruit-circuitpython-feather_bluefruit_sense-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/zh_Latn_pinyin/adafruit-circuitpython-feather_bluefruit_sense-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 32,
+        "downloads": 0,
         "id": "feather_m0_adalogger",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/ID/adafruit-circuitpython-feather_m0_adalogger-ID-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/ID/adafruit-circuitpython-feather_m0_adalogger-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/de_DE/adafruit-circuitpython-feather_m0_adalogger-de_DE-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/de_DE/adafruit-circuitpython-feather_m0_adalogger-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/en_US/adafruit-circuitpython-feather_m0_adalogger-en_US-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/en_US/adafruit-circuitpython-feather_m0_adalogger-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/en_x_pirate/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/en_x_pirate/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/es/adafruit-circuitpython-feather_m0_adalogger-es-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/es/adafruit-circuitpython-feather_m0_adalogger-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/fil/adafruit-circuitpython-feather_m0_adalogger-fil-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/fil/adafruit-circuitpython-feather_m0_adalogger-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/fr/adafruit-circuitpython-feather_m0_adalogger-fr-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/fr/adafruit-circuitpython-feather_m0_adalogger-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/it_IT/adafruit-circuitpython-feather_m0_adalogger-it_IT-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/it_IT/adafruit-circuitpython-feather_m0_adalogger-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/ko/adafruit-circuitpython-feather_m0_adalogger-ko-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/ko/adafruit-circuitpython-feather_m0_adalogger-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/pl/adafruit-circuitpython-feather_m0_adalogger-pl-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/pl/adafruit-circuitpython-feather_m0_adalogger-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/pt_BR/adafruit-circuitpython-feather_m0_adalogger-pt_BR-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/pt_BR/adafruit-circuitpython-feather_m0_adalogger-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_adalogger-zh_Latn_pinyin-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_adalogger-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -3266,67 +3318,71 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/ID/adafruit-circuitpython-feather_m0_adalogger-ID-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/ID/adafruit-circuitpython-feather_m0_adalogger-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/de_DE/adafruit-circuitpython-feather_m0_adalogger-de_DE-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/de_DE/adafruit-circuitpython-feather_m0_adalogger-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/en_US/adafruit-circuitpython-feather_m0_adalogger-en_US-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/en_US/adafruit-circuitpython-feather_m0_adalogger-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/en_x_pirate/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/en_x_pirate/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/es/adafruit-circuitpython-feather_m0_adalogger-es-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/es/adafruit-circuitpython-feather_m0_adalogger-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/fil/adafruit-circuitpython-feather_m0_adalogger-fil-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/fil/adafruit-circuitpython-feather_m0_adalogger-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/fr/adafruit-circuitpython-feather_m0_adalogger-fr-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/fr/adafruit-circuitpython-feather_m0_adalogger-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/it_IT/adafruit-circuitpython-feather_m0_adalogger-it_IT-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/it_IT/adafruit-circuitpython-feather_m0_adalogger-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/ko/adafruit-circuitpython-feather_m0_adalogger-ko-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/ko/adafruit-circuitpython-feather_m0_adalogger-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/pl/adafruit-circuitpython-feather_m0_adalogger-pl-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/pl/adafruit-circuitpython-feather_m0_adalogger-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/pt_BR/adafruit-circuitpython-feather_m0_adalogger-pt_BR-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/pt_BR/adafruit-circuitpython-feather_m0_adalogger-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/sv/adafruit-circuitpython-feather_m0_adalogger-sv-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/sv/adafruit-circuitpython-feather_m0_adalogger-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_adalogger-zh_Latn_pinyin-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_adalogger-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 56,
+        "downloads": 0,
         "id": "feather_m0_basic",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/ID/adafruit-circuitpython-feather_m0_basic-ID-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/ID/adafruit-circuitpython-feather_m0_basic-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/de_DE/adafruit-circuitpython-feather_m0_basic-de_DE-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/de_DE/adafruit-circuitpython-feather_m0_basic-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/en_US/adafruit-circuitpython-feather_m0_basic-en_US-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/en_US/adafruit-circuitpython-feather_m0_basic-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/en_x_pirate/adafruit-circuitpython-feather_m0_basic-en_x_pirate-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/en_x_pirate/adafruit-circuitpython-feather_m0_basic-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/es/adafruit-circuitpython-feather_m0_basic-es-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/es/adafruit-circuitpython-feather_m0_basic-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/fil/adafruit-circuitpython-feather_m0_basic-fil-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/fil/adafruit-circuitpython-feather_m0_basic-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/fr/adafruit-circuitpython-feather_m0_basic-fr-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/fr/adafruit-circuitpython-feather_m0_basic-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/it_IT/adafruit-circuitpython-feather_m0_basic-it_IT-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/it_IT/adafruit-circuitpython-feather_m0_basic-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/ko/adafruit-circuitpython-feather_m0_basic-ko-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/ko/adafruit-circuitpython-feather_m0_basic-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/pl/adafruit-circuitpython-feather_m0_basic-pl-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/pl/adafruit-circuitpython-feather_m0_basic-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/pt_BR/adafruit-circuitpython-feather_m0_basic-pt_BR-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/pt_BR/adafruit-circuitpython-feather_m0_basic-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_basic-zh_Latn_pinyin-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_basic-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -3380,55 +3436,71 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/ID/adafruit-circuitpython-feather_m0_basic-ID-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/ID/adafruit-circuitpython-feather_m0_basic-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/de_DE/adafruit-circuitpython-feather_m0_basic-de_DE-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/de_DE/adafruit-circuitpython-feather_m0_basic-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/en_US/adafruit-circuitpython-feather_m0_basic-en_US-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/en_US/adafruit-circuitpython-feather_m0_basic-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/en_x_pirate/adafruit-circuitpython-feather_m0_basic-en_x_pirate-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/en_x_pirate/adafruit-circuitpython-feather_m0_basic-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/es/adafruit-circuitpython-feather_m0_basic-es-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/es/adafruit-circuitpython-feather_m0_basic-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/fil/adafruit-circuitpython-feather_m0_basic-fil-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/fil/adafruit-circuitpython-feather_m0_basic-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/fr/adafruit-circuitpython-feather_m0_basic-fr-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/fr/adafruit-circuitpython-feather_m0_basic-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/it_IT/adafruit-circuitpython-feather_m0_basic-it_IT-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/it_IT/adafruit-circuitpython-feather_m0_basic-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/ko/adafruit-circuitpython-feather_m0_basic-ko-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/ko/adafruit-circuitpython-feather_m0_basic-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/pl/adafruit-circuitpython-feather_m0_basic-pl-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/pl/adafruit-circuitpython-feather_m0_basic-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/pt_BR/adafruit-circuitpython-feather_m0_basic-pt_BR-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/pt_BR/adafruit-circuitpython-feather_m0_basic-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/sv/adafruit-circuitpython-feather_m0_basic-sv-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/sv/adafruit-circuitpython-feather_m0_basic-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_basic-zh_Latn_pinyin-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_basic-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 185,
+        "downloads": 0,
         "id": "feather_m0_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/ID/adafruit-circuitpython-feather_m0_express-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/de_DE/adafruit-circuitpython-feather_m0_express-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/en_US/adafruit-circuitpython-feather_m0_express-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/en_x_pirate/adafruit-circuitpython-feather_m0_express-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/es/adafruit-circuitpython-feather_m0_express-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/fil/adafruit-circuitpython-feather_m0_express-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/fr/adafruit-circuitpython-feather_m0_express-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/it_IT/adafruit-circuitpython-feather_m0_express-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/ko/adafruit-circuitpython-feather_m0_express-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/pl/adafruit-circuitpython-feather_m0_express-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/pt_BR/adafruit-circuitpython-feather_m0_express-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_express-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -3470,55 +3542,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/ID/adafruit-circuitpython-feather_m0_express-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/de_DE/adafruit-circuitpython-feather_m0_express-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/en_US/adafruit-circuitpython-feather_m0_express-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/en_x_pirate/adafruit-circuitpython-feather_m0_express-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/es/adafruit-circuitpython-feather_m0_express-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/fil/adafruit-circuitpython-feather_m0_express-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/fr/adafruit-circuitpython-feather_m0_express-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/it_IT/adafruit-circuitpython-feather_m0_express-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/ko/adafruit-circuitpython-feather_m0_express-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/pl/adafruit-circuitpython-feather_m0_express-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/pt_BR/adafruit-circuitpython-feather_m0_express-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/sv/adafruit-circuitpython-feather_m0_express-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 27,
+        "downloads": 0,
         "id": "feather_m0_express_crickit",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/ID/adafruit-circuitpython-feather_m0_express_crickit-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/de_DE/adafruit-circuitpython-feather_m0_express_crickit-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/en_US/adafruit-circuitpython-feather_m0_express_crickit-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/en_x_pirate/adafruit-circuitpython-feather_m0_express_crickit-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/es/adafruit-circuitpython-feather_m0_express_crickit-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/fil/adafruit-circuitpython-feather_m0_express_crickit-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/fr/adafruit-circuitpython-feather_m0_express_crickit-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/it_IT/adafruit-circuitpython-feather_m0_express_crickit-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/ko/adafruit-circuitpython-feather_m0_express_crickit-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/pl/adafruit-circuitpython-feather_m0_express_crickit-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/pt_BR/adafruit-circuitpython-feather_m0_express_crickit-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_express_crickit-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -3560,67 +3635,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/ID/adafruit-circuitpython-feather_m0_express_crickit-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/de_DE/adafruit-circuitpython-feather_m0_express_crickit-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/en_US/adafruit-circuitpython-feather_m0_express_crickit-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/en_x_pirate/adafruit-circuitpython-feather_m0_express_crickit-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/es/adafruit-circuitpython-feather_m0_express_crickit-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/fil/adafruit-circuitpython-feather_m0_express_crickit-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/fr/adafruit-circuitpython-feather_m0_express_crickit-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/it_IT/adafruit-circuitpython-feather_m0_express_crickit-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/ko/adafruit-circuitpython-feather_m0_express_crickit-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/pl/adafruit-circuitpython-feather_m0_express_crickit-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/pt_BR/adafruit-circuitpython-feather_m0_express_crickit-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/sv/adafruit-circuitpython-feather_m0_express_crickit-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_express_crickit-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 19,
+        "downloads": 0,
         "id": "feather_m0_rfm69",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/ID/adafruit-circuitpython-feather_m0_rfm69-ID-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/ID/adafruit-circuitpython-feather_m0_rfm69-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/de_DE/adafruit-circuitpython-feather_m0_rfm69-de_DE-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/de_DE/adafruit-circuitpython-feather_m0_rfm69-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/en_US/adafruit-circuitpython-feather_m0_rfm69-en_US-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/en_US/adafruit-circuitpython-feather_m0_rfm69-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/en_x_pirate/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/en_x_pirate/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/es/adafruit-circuitpython-feather_m0_rfm69-es-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/es/adafruit-circuitpython-feather_m0_rfm69-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/fil/adafruit-circuitpython-feather_m0_rfm69-fil-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/fil/adafruit-circuitpython-feather_m0_rfm69-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/fr/adafruit-circuitpython-feather_m0_rfm69-fr-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/fr/adafruit-circuitpython-feather_m0_rfm69-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/it_IT/adafruit-circuitpython-feather_m0_rfm69-it_IT-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/it_IT/adafruit-circuitpython-feather_m0_rfm69-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/ko/adafruit-circuitpython-feather_m0_rfm69-ko-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/ko/adafruit-circuitpython-feather_m0_rfm69-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/pl/adafruit-circuitpython-feather_m0_rfm69-pl-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/pl/adafruit-circuitpython-feather_m0_rfm69-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/pt_BR/adafruit-circuitpython-feather_m0_rfm69-pt_BR-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/pt_BR/adafruit-circuitpython-feather_m0_rfm69-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_rfm69-zh_Latn_pinyin-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_rfm69-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -3674,67 +3740,71 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/ID/adafruit-circuitpython-feather_m0_rfm69-ID-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/ID/adafruit-circuitpython-feather_m0_rfm69-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/de_DE/adafruit-circuitpython-feather_m0_rfm69-de_DE-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/de_DE/adafruit-circuitpython-feather_m0_rfm69-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/en_US/adafruit-circuitpython-feather_m0_rfm69-en_US-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/en_US/adafruit-circuitpython-feather_m0_rfm69-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/en_x_pirate/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/en_x_pirate/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/es/adafruit-circuitpython-feather_m0_rfm69-es-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/es/adafruit-circuitpython-feather_m0_rfm69-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/fil/adafruit-circuitpython-feather_m0_rfm69-fil-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/fil/adafruit-circuitpython-feather_m0_rfm69-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/fr/adafruit-circuitpython-feather_m0_rfm69-fr-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/fr/adafruit-circuitpython-feather_m0_rfm69-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/it_IT/adafruit-circuitpython-feather_m0_rfm69-it_IT-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/it_IT/adafruit-circuitpython-feather_m0_rfm69-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/ko/adafruit-circuitpython-feather_m0_rfm69-ko-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/ko/adafruit-circuitpython-feather_m0_rfm69-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/pl/adafruit-circuitpython-feather_m0_rfm69-pl-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/pl/adafruit-circuitpython-feather_m0_rfm69-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/pt_BR/adafruit-circuitpython-feather_m0_rfm69-pt_BR-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/pt_BR/adafruit-circuitpython-feather_m0_rfm69-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/sv/adafruit-circuitpython-feather_m0_rfm69-sv-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/sv/adafruit-circuitpython-feather_m0_rfm69-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_rfm69-zh_Latn_pinyin-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_rfm69-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 56,
+        "downloads": 0,
         "id": "feather_m0_rfm9x",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/ID/adafruit-circuitpython-feather_m0_rfm9x-ID-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/ID/adafruit-circuitpython-feather_m0_rfm9x-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/de_DE/adafruit-circuitpython-feather_m0_rfm9x-de_DE-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/de_DE/adafruit-circuitpython-feather_m0_rfm9x-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/en_US/adafruit-circuitpython-feather_m0_rfm9x-en_US-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/en_US/adafruit-circuitpython-feather_m0_rfm9x-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/en_x_pirate/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/en_x_pirate/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/es/adafruit-circuitpython-feather_m0_rfm9x-es-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/es/adafruit-circuitpython-feather_m0_rfm9x-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/fil/adafruit-circuitpython-feather_m0_rfm9x-fil-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/fil/adafruit-circuitpython-feather_m0_rfm9x-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/fr/adafruit-circuitpython-feather_m0_rfm9x-fr-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/fr/adafruit-circuitpython-feather_m0_rfm9x-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/it_IT/adafruit-circuitpython-feather_m0_rfm9x-it_IT-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/it_IT/adafruit-circuitpython-feather_m0_rfm9x-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/ko/adafruit-circuitpython-feather_m0_rfm9x-ko-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/ko/adafruit-circuitpython-feather_m0_rfm9x-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/pl/adafruit-circuitpython-feather_m0_rfm9x-pl-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/pl/adafruit-circuitpython-feather_m0_rfm9x-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/pt_BR/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/pt_BR/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_rfm9x-zh_Latn_pinyin-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_rfm9x-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -3788,55 +3858,71 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/ID/adafruit-circuitpython-feather_m0_rfm9x-ID-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/ID/adafruit-circuitpython-feather_m0_rfm9x-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/de_DE/adafruit-circuitpython-feather_m0_rfm9x-de_DE-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/de_DE/adafruit-circuitpython-feather_m0_rfm9x-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/en_US/adafruit-circuitpython-feather_m0_rfm9x-en_US-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/en_US/adafruit-circuitpython-feather_m0_rfm9x-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/en_x_pirate/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/en_x_pirate/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/es/adafruit-circuitpython-feather_m0_rfm9x-es-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/es/adafruit-circuitpython-feather_m0_rfm9x-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/fil/adafruit-circuitpython-feather_m0_rfm9x-fil-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/fil/adafruit-circuitpython-feather_m0_rfm9x-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/fr/adafruit-circuitpython-feather_m0_rfm9x-fr-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/fr/adafruit-circuitpython-feather_m0_rfm9x-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/it_IT/adafruit-circuitpython-feather_m0_rfm9x-it_IT-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/it_IT/adafruit-circuitpython-feather_m0_rfm9x-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/ko/adafruit-circuitpython-feather_m0_rfm9x-ko-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/ko/adafruit-circuitpython-feather_m0_rfm9x-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/pl/adafruit-circuitpython-feather_m0_rfm9x-pl-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/pl/adafruit-circuitpython-feather_m0_rfm9x-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/pt_BR/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/pt_BR/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/sv/adafruit-circuitpython-feather_m0_rfm9x-sv-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/sv/adafruit-circuitpython-feather_m0_rfm9x-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_rfm9x-zh_Latn_pinyin-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_rfm9x-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 27,
+        "downloads": 0,
         "id": "feather_m0_supersized",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/ID/adafruit-circuitpython-feather_m0_supersized-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/de_DE/adafruit-circuitpython-feather_m0_supersized-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/en_US/adafruit-circuitpython-feather_m0_supersized-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/en_x_pirate/adafruit-circuitpython-feather_m0_supersized-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/es/adafruit-circuitpython-feather_m0_supersized-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/fil/adafruit-circuitpython-feather_m0_supersized-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/fr/adafruit-circuitpython-feather_m0_supersized-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/it_IT/adafruit-circuitpython-feather_m0_supersized-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/ko/adafruit-circuitpython-feather_m0_supersized-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/pl/adafruit-circuitpython-feather_m0_supersized-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/pt_BR/adafruit-circuitpython-feather_m0_supersized-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_supersized-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -3878,55 +3964,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/ID/adafruit-circuitpython-feather_m0_supersized-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/de_DE/adafruit-circuitpython-feather_m0_supersized-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/en_US/adafruit-circuitpython-feather_m0_supersized-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/en_x_pirate/adafruit-circuitpython-feather_m0_supersized-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/es/adafruit-circuitpython-feather_m0_supersized-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/fil/adafruit-circuitpython-feather_m0_supersized-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/fr/adafruit-circuitpython-feather_m0_supersized-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/it_IT/adafruit-circuitpython-feather_m0_supersized-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/ko/adafruit-circuitpython-feather_m0_supersized-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/pl/adafruit-circuitpython-feather_m0_supersized-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/pt_BR/adafruit-circuitpython-feather_m0_supersized-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/sv/adafruit-circuitpython-feather_m0_supersized-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_supersized-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 310,
+        "downloads": 0,
         "id": "feather_m4_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/ID/adafruit-circuitpython-feather_m4_express-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/de_DE/adafruit-circuitpython-feather_m4_express-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/en_US/adafruit-circuitpython-feather_m4_express-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/en_x_pirate/adafruit-circuitpython-feather_m4_express-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/es/adafruit-circuitpython-feather_m4_express-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/fil/adafruit-circuitpython-feather_m4_express-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/fr/adafruit-circuitpython-feather_m4_express-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/it_IT/adafruit-circuitpython-feather_m4_express-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/ko/adafruit-circuitpython-feather_m4_express-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/pl/adafruit-circuitpython-feather_m4_express-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/pt_BR/adafruit-circuitpython-feather_m4_express-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/zh_Latn_pinyin/adafruit-circuitpython-feather_m4_express-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -3968,67 +4057,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/ID/adafruit-circuitpython-feather_m4_express-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/de_DE/adafruit-circuitpython-feather_m4_express-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/en_US/adafruit-circuitpython-feather_m4_express-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/en_x_pirate/adafruit-circuitpython-feather_m4_express-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/es/adafruit-circuitpython-feather_m4_express-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/fil/adafruit-circuitpython-feather_m4_express-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/fr/adafruit-circuitpython-feather_m4_express-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/it_IT/adafruit-circuitpython-feather_m4_express-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/ko/adafruit-circuitpython-feather_m4_express-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/pl/adafruit-circuitpython-feather_m4_express-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/pt_BR/adafruit-circuitpython-feather_m4_express-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/sv/adafruit-circuitpython-feather_m4_express-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/zh_Latn_pinyin/adafruit-circuitpython-feather_m4_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 12,
+        "downloads": 0,
         "id": "feather_m7_1011",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/ID/adafruit-circuitpython-feather_m7_1011-ID-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/ID/adafruit-circuitpython-feather_m7_1011-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/de_DE/adafruit-circuitpython-feather_m7_1011-de_DE-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/de_DE/adafruit-circuitpython-feather_m7_1011-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/en_US/adafruit-circuitpython-feather_m7_1011-en_US-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/en_US/adafruit-circuitpython-feather_m7_1011-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/en_x_pirate/adafruit-circuitpython-feather_m7_1011-en_x_pirate-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/en_x_pirate/adafruit-circuitpython-feather_m7_1011-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/es/adafruit-circuitpython-feather_m7_1011-es-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/es/adafruit-circuitpython-feather_m7_1011-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/fil/adafruit-circuitpython-feather_m7_1011-fil-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/fil/adafruit-circuitpython-feather_m7_1011-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/fr/adafruit-circuitpython-feather_m7_1011-fr-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/fr/adafruit-circuitpython-feather_m7_1011-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/it_IT/adafruit-circuitpython-feather_m7_1011-it_IT-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/it_IT/adafruit-circuitpython-feather_m7_1011-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/ko/adafruit-circuitpython-feather_m7_1011-ko-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/ko/adafruit-circuitpython-feather_m7_1011-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/pl/adafruit-circuitpython-feather_m7_1011-pl-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/pl/adafruit-circuitpython-feather_m7_1011-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/pt_BR/adafruit-circuitpython-feather_m7_1011-pt_BR-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/pt_BR/adafruit-circuitpython-feather_m7_1011-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/zh_Latn_pinyin/adafruit-circuitpython-feather_m7_1011-zh_Latn_pinyin-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/zh_Latn_pinyin/adafruit-circuitpython-feather_m7_1011-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -4082,67 +4162,71 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/ID/adafruit-circuitpython-feather_m7_1011-ID-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/ID/adafruit-circuitpython-feather_m7_1011-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/de_DE/adafruit-circuitpython-feather_m7_1011-de_DE-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/de_DE/adafruit-circuitpython-feather_m7_1011-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/en_US/adafruit-circuitpython-feather_m7_1011-en_US-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/en_US/adafruit-circuitpython-feather_m7_1011-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/en_x_pirate/adafruit-circuitpython-feather_m7_1011-en_x_pirate-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/en_x_pirate/adafruit-circuitpython-feather_m7_1011-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/es/adafruit-circuitpython-feather_m7_1011-es-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/es/adafruit-circuitpython-feather_m7_1011-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/fil/adafruit-circuitpython-feather_m7_1011-fil-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/fil/adafruit-circuitpython-feather_m7_1011-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/fr/adafruit-circuitpython-feather_m7_1011-fr-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/fr/adafruit-circuitpython-feather_m7_1011-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/it_IT/adafruit-circuitpython-feather_m7_1011-it_IT-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/it_IT/adafruit-circuitpython-feather_m7_1011-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/ko/adafruit-circuitpython-feather_m7_1011-ko-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/ko/adafruit-circuitpython-feather_m7_1011-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/pl/adafruit-circuitpython-feather_m7_1011-pl-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/pl/adafruit-circuitpython-feather_m7_1011-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/pt_BR/adafruit-circuitpython-feather_m7_1011-pt_BR-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/pt_BR/adafruit-circuitpython-feather_m7_1011-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/sv/adafruit-circuitpython-feather_m7_1011-sv-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/sv/adafruit-circuitpython-feather_m7_1011-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/zh_Latn_pinyin/adafruit-circuitpython-feather_m7_1011-zh_Latn_pinyin-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/zh_Latn_pinyin/adafruit-circuitpython-feather_m7_1011-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 13,
+        "downloads": 0,
         "id": "feather_mimxrt1011",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/ID/adafruit-circuitpython-feather_mimxrt1011-ID-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/ID/adafruit-circuitpython-feather_mimxrt1011-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/de_DE/adafruit-circuitpython-feather_mimxrt1011-de_DE-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/de_DE/adafruit-circuitpython-feather_mimxrt1011-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/en_US/adafruit-circuitpython-feather_mimxrt1011-en_US-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/en_US/adafruit-circuitpython-feather_mimxrt1011-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/en_x_pirate/adafruit-circuitpython-feather_mimxrt1011-en_x_pirate-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/en_x_pirate/adafruit-circuitpython-feather_mimxrt1011-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/es/adafruit-circuitpython-feather_mimxrt1011-es-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/es/adafruit-circuitpython-feather_mimxrt1011-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/fil/adafruit-circuitpython-feather_mimxrt1011-fil-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/fil/adafruit-circuitpython-feather_mimxrt1011-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/fr/adafruit-circuitpython-feather_mimxrt1011-fr-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/fr/adafruit-circuitpython-feather_mimxrt1011-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/it_IT/adafruit-circuitpython-feather_mimxrt1011-it_IT-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/it_IT/adafruit-circuitpython-feather_mimxrt1011-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/ko/adafruit-circuitpython-feather_mimxrt1011-ko-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/ko/adafruit-circuitpython-feather_mimxrt1011-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/pl/adafruit-circuitpython-feather_mimxrt1011-pl-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/pl/adafruit-circuitpython-feather_mimxrt1011-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/pt_BR/adafruit-circuitpython-feather_mimxrt1011-pt_BR-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/pt_BR/adafruit-circuitpython-feather_mimxrt1011-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/zh_Latn_pinyin/adafruit-circuitpython-feather_mimxrt1011-zh_Latn_pinyin-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/zh_Latn_pinyin/adafruit-circuitpython-feather_mimxrt1011-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -4196,67 +4280,71 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/ID/adafruit-circuitpython-feather_mimxrt1011-ID-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/ID/adafruit-circuitpython-feather_mimxrt1011-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/de_DE/adafruit-circuitpython-feather_mimxrt1011-de_DE-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/de_DE/adafruit-circuitpython-feather_mimxrt1011-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/en_US/adafruit-circuitpython-feather_mimxrt1011-en_US-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/en_US/adafruit-circuitpython-feather_mimxrt1011-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/en_x_pirate/adafruit-circuitpython-feather_mimxrt1011-en_x_pirate-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/en_x_pirate/adafruit-circuitpython-feather_mimxrt1011-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/es/adafruit-circuitpython-feather_mimxrt1011-es-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/es/adafruit-circuitpython-feather_mimxrt1011-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/fil/adafruit-circuitpython-feather_mimxrt1011-fil-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/fil/adafruit-circuitpython-feather_mimxrt1011-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/fr/adafruit-circuitpython-feather_mimxrt1011-fr-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/fr/adafruit-circuitpython-feather_mimxrt1011-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/it_IT/adafruit-circuitpython-feather_mimxrt1011-it_IT-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/it_IT/adafruit-circuitpython-feather_mimxrt1011-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/ko/adafruit-circuitpython-feather_mimxrt1011-ko-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/ko/adafruit-circuitpython-feather_mimxrt1011-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/pl/adafruit-circuitpython-feather_mimxrt1011-pl-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/pl/adafruit-circuitpython-feather_mimxrt1011-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/pt_BR/adafruit-circuitpython-feather_mimxrt1011-pt_BR-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/pt_BR/adafruit-circuitpython-feather_mimxrt1011-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/sv/adafruit-circuitpython-feather_mimxrt1011-sv-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/sv/adafruit-circuitpython-feather_mimxrt1011-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/zh_Latn_pinyin/adafruit-circuitpython-feather_mimxrt1011-zh_Latn_pinyin-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/zh_Latn_pinyin/adafruit-circuitpython-feather_mimxrt1011-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 16,
+        "downloads": 0,
         "id": "feather_mimxrt1062",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/ID/adafruit-circuitpython-feather_mimxrt1062-ID-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/ID/adafruit-circuitpython-feather_mimxrt1062-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/de_DE/adafruit-circuitpython-feather_mimxrt1062-de_DE-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/de_DE/adafruit-circuitpython-feather_mimxrt1062-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/en_US/adafruit-circuitpython-feather_mimxrt1062-en_US-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/en_US/adafruit-circuitpython-feather_mimxrt1062-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/en_x_pirate/adafruit-circuitpython-feather_mimxrt1062-en_x_pirate-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/en_x_pirate/adafruit-circuitpython-feather_mimxrt1062-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/es/adafruit-circuitpython-feather_mimxrt1062-es-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/es/adafruit-circuitpython-feather_mimxrt1062-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/fil/adafruit-circuitpython-feather_mimxrt1062-fil-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/fil/adafruit-circuitpython-feather_mimxrt1062-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/fr/adafruit-circuitpython-feather_mimxrt1062-fr-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/fr/adafruit-circuitpython-feather_mimxrt1062-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/it_IT/adafruit-circuitpython-feather_mimxrt1062-it_IT-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/it_IT/adafruit-circuitpython-feather_mimxrt1062-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/ko/adafruit-circuitpython-feather_mimxrt1062-ko-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/ko/adafruit-circuitpython-feather_mimxrt1062-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/pl/adafruit-circuitpython-feather_mimxrt1062-pl-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/pl/adafruit-circuitpython-feather_mimxrt1062-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/pt_BR/adafruit-circuitpython-feather_mimxrt1062-pt_BR-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/pt_BR/adafruit-circuitpython-feather_mimxrt1062-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/zh_Latn_pinyin/adafruit-circuitpython-feather_mimxrt1062-zh_Latn_pinyin-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/zh_Latn_pinyin/adafruit-circuitpython-feather_mimxrt1062-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -4310,55 +4398,71 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/ID/adafruit-circuitpython-feather_mimxrt1062-ID-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/ID/adafruit-circuitpython-feather_mimxrt1062-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/de_DE/adafruit-circuitpython-feather_mimxrt1062-de_DE-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/de_DE/adafruit-circuitpython-feather_mimxrt1062-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/en_US/adafruit-circuitpython-feather_mimxrt1062-en_US-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/en_US/adafruit-circuitpython-feather_mimxrt1062-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/en_x_pirate/adafruit-circuitpython-feather_mimxrt1062-en_x_pirate-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/en_x_pirate/adafruit-circuitpython-feather_mimxrt1062-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/es/adafruit-circuitpython-feather_mimxrt1062-es-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/es/adafruit-circuitpython-feather_mimxrt1062-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/fil/adafruit-circuitpython-feather_mimxrt1062-fil-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/fil/adafruit-circuitpython-feather_mimxrt1062-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/fr/adafruit-circuitpython-feather_mimxrt1062-fr-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/fr/adafruit-circuitpython-feather_mimxrt1062-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/it_IT/adafruit-circuitpython-feather_mimxrt1062-it_IT-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/it_IT/adafruit-circuitpython-feather_mimxrt1062-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/ko/adafruit-circuitpython-feather_mimxrt1062-ko-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/ko/adafruit-circuitpython-feather_mimxrt1062-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/pl/adafruit-circuitpython-feather_mimxrt1062-pl-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/pl/adafruit-circuitpython-feather_mimxrt1062-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/pt_BR/adafruit-circuitpython-feather_mimxrt1062-pt_BR-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/pt_BR/adafruit-circuitpython-feather_mimxrt1062-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/sv/adafruit-circuitpython-feather_mimxrt1062-sv-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/sv/adafruit-circuitpython-feather_mimxrt1062-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/zh_Latn_pinyin/adafruit-circuitpython-feather_mimxrt1062-zh_Latn_pinyin-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/zh_Latn_pinyin/adafruit-circuitpython-feather_mimxrt1062-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 124,
+        "downloads": 0,
         "id": "feather_nrf52840_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/ID/adafruit-circuitpython-feather_nrf52840_express-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/de_DE/adafruit-circuitpython-feather_nrf52840_express-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/en_US/adafruit-circuitpython-feather_nrf52840_express-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/en_x_pirate/adafruit-circuitpython-feather_nrf52840_express-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/es/adafruit-circuitpython-feather_nrf52840_express-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/fil/adafruit-circuitpython-feather_nrf52840_express-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/fr/adafruit-circuitpython-feather_nrf52840_express-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/it_IT/adafruit-circuitpython-feather_nrf52840_express-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/ko/adafruit-circuitpython-feather_nrf52840_express-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/pl/adafruit-circuitpython-feather_nrf52840_express-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/pt_BR/adafruit-circuitpython-feather_nrf52840_express-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/zh_Latn_pinyin/adafruit-circuitpython-feather_nrf52840_express-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -4400,55 +4504,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/ID/adafruit-circuitpython-feather_nrf52840_express-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/de_DE/adafruit-circuitpython-feather_nrf52840_express-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/en_US/adafruit-circuitpython-feather_nrf52840_express-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/en_x_pirate/adafruit-circuitpython-feather_nrf52840_express-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/es/adafruit-circuitpython-feather_nrf52840_express-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/fil/adafruit-circuitpython-feather_nrf52840_express-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/fr/adafruit-circuitpython-feather_nrf52840_express-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/it_IT/adafruit-circuitpython-feather_nrf52840_express-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/ko/adafruit-circuitpython-feather_nrf52840_express-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/pl/adafruit-circuitpython-feather_nrf52840_express-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/pt_BR/adafruit-circuitpython-feather_nrf52840_express-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/sv/adafruit-circuitpython-feather_nrf52840_express-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/zh_Latn_pinyin/adafruit-circuitpython-feather_nrf52840_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 1,
+        "downloads": 0,
         "id": "feather_radiofruit_zigbee",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/ID/adafruit-circuitpython-feather_radiofruit_zigbee-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/de_DE/adafruit-circuitpython-feather_radiofruit_zigbee-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/en_US/adafruit-circuitpython-feather_radiofruit_zigbee-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/en_x_pirate/adafruit-circuitpython-feather_radiofruit_zigbee-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/es/adafruit-circuitpython-feather_radiofruit_zigbee-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/fil/adafruit-circuitpython-feather_radiofruit_zigbee-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/fr/adafruit-circuitpython-feather_radiofruit_zigbee-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/it_IT/adafruit-circuitpython-feather_radiofruit_zigbee-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/ko/adafruit-circuitpython-feather_radiofruit_zigbee-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/pl/adafruit-circuitpython-feather_radiofruit_zigbee-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/pt_BR/adafruit-circuitpython-feather_radiofruit_zigbee-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/zh_Latn_pinyin/adafruit-circuitpython-feather_radiofruit_zigbee-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -4490,55 +4597,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/ID/adafruit-circuitpython-feather_radiofruit_zigbee-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/de_DE/adafruit-circuitpython-feather_radiofruit_zigbee-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/en_US/adafruit-circuitpython-feather_radiofruit_zigbee-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/en_x_pirate/adafruit-circuitpython-feather_radiofruit_zigbee-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/es/adafruit-circuitpython-feather_radiofruit_zigbee-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/fil/adafruit-circuitpython-feather_radiofruit_zigbee-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/fr/adafruit-circuitpython-feather_radiofruit_zigbee-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/it_IT/adafruit-circuitpython-feather_radiofruit_zigbee-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/ko/adafruit-circuitpython-feather_radiofruit_zigbee-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/pl/adafruit-circuitpython-feather_radiofruit_zigbee-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/pt_BR/adafruit-circuitpython-feather_radiofruit_zigbee-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/sv/adafruit-circuitpython-feather_radiofruit_zigbee-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/zh_Latn_pinyin/adafruit-circuitpython-feather_radiofruit_zigbee-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 60,
+        "downloads": 0,
         "id": "feather_stm32f405_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/ID/adafruit-circuitpython-feather_stm32f405_express-ID-5.3.0-rc.0.bin"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/de_DE/adafruit-circuitpython-feather_stm32f405_express-de_DE-5.3.0-rc.0.bin"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/en_US/adafruit-circuitpython-feather_stm32f405_express-en_US-5.3.0-rc.0.bin"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/en_x_pirate/adafruit-circuitpython-feather_stm32f405_express-en_x_pirate-5.3.0-rc.0.bin"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/es/adafruit-circuitpython-feather_stm32f405_express-es-5.3.0-rc.0.bin"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/fil/adafruit-circuitpython-feather_stm32f405_express-fil-5.3.0-rc.0.bin"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/fr/adafruit-circuitpython-feather_stm32f405_express-fr-5.3.0-rc.0.bin"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/it_IT/adafruit-circuitpython-feather_stm32f405_express-it_IT-5.3.0-rc.0.bin"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/ko/adafruit-circuitpython-feather_stm32f405_express-ko-5.3.0-rc.0.bin"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/pl/adafruit-circuitpython-feather_stm32f405_express-pl-5.3.0-rc.0.bin"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/pt_BR/adafruit-circuitpython-feather_stm32f405_express-pt_BR-5.3.0-rc.0.bin"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/zh_Latn_pinyin/adafruit-circuitpython-feather_stm32f405_express-zh_Latn_pinyin-5.3.0-rc.0.bin"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -4580,55 +4690,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/ID/adafruit-circuitpython-feather_stm32f405_express-ID-5.4.0-beta.0.bin"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/de_DE/adafruit-circuitpython-feather_stm32f405_express-de_DE-5.4.0-beta.0.bin"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/en_US/adafruit-circuitpython-feather_stm32f405_express-en_US-5.4.0-beta.0.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/en_x_pirate/adafruit-circuitpython-feather_stm32f405_express-en_x_pirate-5.4.0-beta.0.bin"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/es/adafruit-circuitpython-feather_stm32f405_express-es-5.4.0-beta.0.bin"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/fil/adafruit-circuitpython-feather_stm32f405_express-fil-5.4.0-beta.0.bin"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/fr/adafruit-circuitpython-feather_stm32f405_express-fr-5.4.0-beta.0.bin"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/it_IT/adafruit-circuitpython-feather_stm32f405_express-it_IT-5.4.0-beta.0.bin"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/ko/adafruit-circuitpython-feather_stm32f405_express-ko-5.4.0-beta.0.bin"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/pl/adafruit-circuitpython-feather_stm32f405_express-pl-5.4.0-beta.0.bin"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/pt_BR/adafruit-circuitpython-feather_stm32f405_express-pt_BR-5.4.0-beta.0.bin"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/sv/adafruit-circuitpython-feather_stm32f405_express-sv-5.4.0-beta.0.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/zh_Latn_pinyin/adafruit-circuitpython-feather_stm32f405_express-zh_Latn_pinyin-5.4.0-beta.0.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 42,
+        "downloads": 0,
         "id": "fomu",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/fomu/ID/adafruit-circuitpython-fomu-ID-5.3.0-rc.0.dfu"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/fomu/de_DE/adafruit-circuitpython-fomu-de_DE-5.3.0-rc.0.dfu"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/fomu/en_US/adafruit-circuitpython-fomu-en_US-5.3.0-rc.0.dfu"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/fomu/en_x_pirate/adafruit-circuitpython-fomu-en_x_pirate-5.3.0-rc.0.dfu"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/fomu/es/adafruit-circuitpython-fomu-es-5.3.0-rc.0.dfu"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/fomu/fil/adafruit-circuitpython-fomu-fil-5.3.0-rc.0.dfu"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/fomu/fr/adafruit-circuitpython-fomu-fr-5.3.0-rc.0.dfu"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/fomu/it_IT/adafruit-circuitpython-fomu-it_IT-5.3.0-rc.0.dfu"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/fomu/ko/adafruit-circuitpython-fomu-ko-5.3.0-rc.0.dfu"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/fomu/pl/adafruit-circuitpython-fomu-pl-5.3.0-rc.0.dfu"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/fomu/pt_BR/adafruit-circuitpython-fomu-pt_BR-5.3.0-rc.0.dfu"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/fomu/zh_Latn_pinyin/adafruit-circuitpython-fomu-zh_Latn_pinyin-5.3.0-rc.0.dfu"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -4670,6 +4783,51 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/fomu/ID/adafruit-circuitpython-fomu-ID-5.4.0-beta.0.dfu"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/fomu/de_DE/adafruit-circuitpython-fomu-de_DE-5.4.0-beta.0.dfu"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/fomu/en_US/adafruit-circuitpython-fomu-en_US-5.4.0-beta.0.dfu"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/fomu/en_x_pirate/adafruit-circuitpython-fomu-en_x_pirate-5.4.0-beta.0.dfu"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/fomu/es/adafruit-circuitpython-fomu-es-5.4.0-beta.0.dfu"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/fomu/fil/adafruit-circuitpython-fomu-fil-5.4.0-beta.0.dfu"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/fomu/fr/adafruit-circuitpython-fomu-fr-5.4.0-beta.0.dfu"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/fomu/it_IT/adafruit-circuitpython-fomu-it_IT-5.4.0-beta.0.dfu"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/fomu/ko/adafruit-circuitpython-fomu-ko-5.4.0-beta.0.dfu"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/fomu/pl/adafruit-circuitpython-fomu-pl-5.4.0-beta.0.dfu"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/fomu/pt_BR/adafruit-circuitpython-fomu-pt_BR-5.4.0-beta.0.dfu"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/fomu/sv/adafruit-circuitpython-fomu-sv-5.4.0-beta.0.dfu"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/fomu/zh_Latn_pinyin/adafruit-circuitpython-fomu-zh_Latn_pinyin-5.4.0-beta.0.dfu"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
@@ -4679,51 +4837,9 @@
         "versions": []
     },
     {
-        "downloads": 101,
+        "downloads": 0,
         "id": "gemma_m0",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/ID/adafruit-circuitpython-gemma_m0-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/de_DE/adafruit-circuitpython-gemma_m0-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/en_US/adafruit-circuitpython-gemma_m0-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/en_x_pirate/adafruit-circuitpython-gemma_m0-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/es/adafruit-circuitpython-gemma_m0-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/fil/adafruit-circuitpython-gemma_m0-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/fr/adafruit-circuitpython-gemma_m0-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/it_IT/adafruit-circuitpython-gemma_m0-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/ko/adafruit-circuitpython-gemma_m0-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/pl/adafruit-circuitpython-gemma_m0-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/pt_BR/adafruit-circuitpython-gemma_m0-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/zh_Latn_pinyin/adafruit-circuitpython-gemma_m0-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -4765,55 +4881,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0/ID/adafruit-circuitpython-gemma_m0-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0/de_DE/adafruit-circuitpython-gemma_m0-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0/en_US/adafruit-circuitpython-gemma_m0-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0/en_x_pirate/adafruit-circuitpython-gemma_m0-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0/es/adafruit-circuitpython-gemma_m0-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0/fil/adafruit-circuitpython-gemma_m0-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0/fr/adafruit-circuitpython-gemma_m0-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0/it_IT/adafruit-circuitpython-gemma_m0-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0/ko/adafruit-circuitpython-gemma_m0-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0/pl/adafruit-circuitpython-gemma_m0-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0/pt_BR/adafruit-circuitpython-gemma_m0-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0/sv/adafruit-circuitpython-gemma_m0-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0/zh_Latn_pinyin/adafruit-circuitpython-gemma_m0-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 18,
+        "downloads": 0,
         "id": "gemma_m0_pycon2018",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/ID/adafruit-circuitpython-gemma_m0_pycon2018-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/de_DE/adafruit-circuitpython-gemma_m0_pycon2018-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/en_US/adafruit-circuitpython-gemma_m0_pycon2018-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/en_x_pirate/adafruit-circuitpython-gemma_m0_pycon2018-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/es/adafruit-circuitpython-gemma_m0_pycon2018-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/fil/adafruit-circuitpython-gemma_m0_pycon2018-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/fr/adafruit-circuitpython-gemma_m0_pycon2018-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/it_IT/adafruit-circuitpython-gemma_m0_pycon2018-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/ko/adafruit-circuitpython-gemma_m0_pycon2018-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/pl/adafruit-circuitpython-gemma_m0_pycon2018-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/pt_BR/adafruit-circuitpython-gemma_m0_pycon2018-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/zh_Latn_pinyin/adafruit-circuitpython-gemma_m0_pycon2018-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -4855,55 +4974,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/ID/adafruit-circuitpython-gemma_m0_pycon2018-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/de_DE/adafruit-circuitpython-gemma_m0_pycon2018-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/en_US/adafruit-circuitpython-gemma_m0_pycon2018-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/en_x_pirate/adafruit-circuitpython-gemma_m0_pycon2018-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/es/adafruit-circuitpython-gemma_m0_pycon2018-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/fil/adafruit-circuitpython-gemma_m0_pycon2018-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/fr/adafruit-circuitpython-gemma_m0_pycon2018-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/it_IT/adafruit-circuitpython-gemma_m0_pycon2018-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/ko/adafruit-circuitpython-gemma_m0_pycon2018-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/pl/adafruit-circuitpython-gemma_m0_pycon2018-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/pt_BR/adafruit-circuitpython-gemma_m0_pycon2018-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/sv/adafruit-circuitpython-gemma_m0_pycon2018-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/zh_Latn_pinyin/adafruit-circuitpython-gemma_m0_pycon2018-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 84,
+        "downloads": 0,
         "id": "grandcentral_m4_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/ID/adafruit-circuitpython-grandcentral_m4_express-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/de_DE/adafruit-circuitpython-grandcentral_m4_express-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/en_US/adafruit-circuitpython-grandcentral_m4_express-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/en_x_pirate/adafruit-circuitpython-grandcentral_m4_express-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/es/adafruit-circuitpython-grandcentral_m4_express-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/fil/adafruit-circuitpython-grandcentral_m4_express-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/fr/adafruit-circuitpython-grandcentral_m4_express-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/it_IT/adafruit-circuitpython-grandcentral_m4_express-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/ko/adafruit-circuitpython-grandcentral_m4_express-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/pl/adafruit-circuitpython-grandcentral_m4_express-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/pt_BR/adafruit-circuitpython-grandcentral_m4_express-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/zh_Latn_pinyin/adafruit-circuitpython-grandcentral_m4_express-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -4945,55 +5067,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/ID/adafruit-circuitpython-grandcentral_m4_express-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/de_DE/adafruit-circuitpython-grandcentral_m4_express-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/en_US/adafruit-circuitpython-grandcentral_m4_express-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/en_x_pirate/adafruit-circuitpython-grandcentral_m4_express-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/es/adafruit-circuitpython-grandcentral_m4_express-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/fil/adafruit-circuitpython-grandcentral_m4_express-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/fr/adafruit-circuitpython-grandcentral_m4_express-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/it_IT/adafruit-circuitpython-grandcentral_m4_express-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/ko/adafruit-circuitpython-grandcentral_m4_express-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/pl/adafruit-circuitpython-grandcentral_m4_express-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/pt_BR/adafruit-circuitpython-grandcentral_m4_express-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/sv/adafruit-circuitpython-grandcentral_m4_express-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/zh_Latn_pinyin/adafruit-circuitpython-grandcentral_m4_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 47,
+        "downloads": 0,
         "id": "hallowing_m0_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/ID/adafruit-circuitpython-hallowing_m0_express-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/de_DE/adafruit-circuitpython-hallowing_m0_express-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/en_US/adafruit-circuitpython-hallowing_m0_express-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/en_x_pirate/adafruit-circuitpython-hallowing_m0_express-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/es/adafruit-circuitpython-hallowing_m0_express-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/fil/adafruit-circuitpython-hallowing_m0_express-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/fr/adafruit-circuitpython-hallowing_m0_express-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/it_IT/adafruit-circuitpython-hallowing_m0_express-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/ko/adafruit-circuitpython-hallowing_m0_express-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/pl/adafruit-circuitpython-hallowing_m0_express-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/pt_BR/adafruit-circuitpython-hallowing_m0_express-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/zh_Latn_pinyin/adafruit-circuitpython-hallowing_m0_express-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -5035,55 +5160,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/ID/adafruit-circuitpython-hallowing_m0_express-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/de_DE/adafruit-circuitpython-hallowing_m0_express-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/en_US/adafruit-circuitpython-hallowing_m0_express-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/en_x_pirate/adafruit-circuitpython-hallowing_m0_express-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/es/adafruit-circuitpython-hallowing_m0_express-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/fil/adafruit-circuitpython-hallowing_m0_express-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/fr/adafruit-circuitpython-hallowing_m0_express-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/it_IT/adafruit-circuitpython-hallowing_m0_express-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/ko/adafruit-circuitpython-hallowing_m0_express-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/pl/adafruit-circuitpython-hallowing_m0_express-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/pt_BR/adafruit-circuitpython-hallowing_m0_express-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/sv/adafruit-circuitpython-hallowing_m0_express-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/zh_Latn_pinyin/adafruit-circuitpython-hallowing_m0_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 42,
+        "downloads": 0,
         "id": "hallowing_m4_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/ID/adafruit-circuitpython-hallowing_m4_express-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/de_DE/adafruit-circuitpython-hallowing_m4_express-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/en_US/adafruit-circuitpython-hallowing_m4_express-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/en_x_pirate/adafruit-circuitpython-hallowing_m4_express-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/es/adafruit-circuitpython-hallowing_m4_express-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/fil/adafruit-circuitpython-hallowing_m4_express-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/fr/adafruit-circuitpython-hallowing_m4_express-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/it_IT/adafruit-circuitpython-hallowing_m4_express-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/ko/adafruit-circuitpython-hallowing_m4_express-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/pl/adafruit-circuitpython-hallowing_m4_express-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/pt_BR/adafruit-circuitpython-hallowing_m4_express-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/zh_Latn_pinyin/adafruit-circuitpython-hallowing_m4_express-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -5125,67 +5253,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/ID/adafruit-circuitpython-hallowing_m4_express-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/de_DE/adafruit-circuitpython-hallowing_m4_express-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/en_US/adafruit-circuitpython-hallowing_m4_express-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/en_x_pirate/adafruit-circuitpython-hallowing_m4_express-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/es/adafruit-circuitpython-hallowing_m4_express-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/fil/adafruit-circuitpython-hallowing_m4_express-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/fr/adafruit-circuitpython-hallowing_m4_express-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/it_IT/adafruit-circuitpython-hallowing_m4_express-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/ko/adafruit-circuitpython-hallowing_m4_express-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/pl/adafruit-circuitpython-hallowing_m4_express-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/pt_BR/adafruit-circuitpython-hallowing_m4_express-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/sv/adafruit-circuitpython-hallowing_m4_express-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/zh_Latn_pinyin/adafruit-circuitpython-hallowing_m4_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 17,
+        "downloads": 0,
         "id": "imxrt1010_evk",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/ID/adafruit-circuitpython-imxrt1010_evk-ID-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/ID/adafruit-circuitpython-imxrt1010_evk-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/de_DE/adafruit-circuitpython-imxrt1010_evk-de_DE-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/de_DE/adafruit-circuitpython-imxrt1010_evk-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/en_US/adafruit-circuitpython-imxrt1010_evk-en_US-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/en_US/adafruit-circuitpython-imxrt1010_evk-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/en_x_pirate/adafruit-circuitpython-imxrt1010_evk-en_x_pirate-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/en_x_pirate/adafruit-circuitpython-imxrt1010_evk-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/es/adafruit-circuitpython-imxrt1010_evk-es-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/es/adafruit-circuitpython-imxrt1010_evk-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/fil/adafruit-circuitpython-imxrt1010_evk-fil-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/fil/adafruit-circuitpython-imxrt1010_evk-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/fr/adafruit-circuitpython-imxrt1010_evk-fr-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/fr/adafruit-circuitpython-imxrt1010_evk-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/it_IT/adafruit-circuitpython-imxrt1010_evk-it_IT-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/it_IT/adafruit-circuitpython-imxrt1010_evk-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/ko/adafruit-circuitpython-imxrt1010_evk-ko-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/ko/adafruit-circuitpython-imxrt1010_evk-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/pl/adafruit-circuitpython-imxrt1010_evk-pl-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/pl/adafruit-circuitpython-imxrt1010_evk-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/pt_BR/adafruit-circuitpython-imxrt1010_evk-pt_BR-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/pt_BR/adafruit-circuitpython-imxrt1010_evk-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1010_evk-zh_Latn_pinyin-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1010_evk-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -5239,67 +5358,71 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/ID/adafruit-circuitpython-imxrt1010_evk-ID-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/ID/adafruit-circuitpython-imxrt1010_evk-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/de_DE/adafruit-circuitpython-imxrt1010_evk-de_DE-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/de_DE/adafruit-circuitpython-imxrt1010_evk-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/en_US/adafruit-circuitpython-imxrt1010_evk-en_US-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/en_US/adafruit-circuitpython-imxrt1010_evk-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/en_x_pirate/adafruit-circuitpython-imxrt1010_evk-en_x_pirate-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/en_x_pirate/adafruit-circuitpython-imxrt1010_evk-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/es/adafruit-circuitpython-imxrt1010_evk-es-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/es/adafruit-circuitpython-imxrt1010_evk-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/fil/adafruit-circuitpython-imxrt1010_evk-fil-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/fil/adafruit-circuitpython-imxrt1010_evk-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/fr/adafruit-circuitpython-imxrt1010_evk-fr-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/fr/adafruit-circuitpython-imxrt1010_evk-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/it_IT/adafruit-circuitpython-imxrt1010_evk-it_IT-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/it_IT/adafruit-circuitpython-imxrt1010_evk-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/ko/adafruit-circuitpython-imxrt1010_evk-ko-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/ko/adafruit-circuitpython-imxrt1010_evk-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/pl/adafruit-circuitpython-imxrt1010_evk-pl-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/pl/adafruit-circuitpython-imxrt1010_evk-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/pt_BR/adafruit-circuitpython-imxrt1010_evk-pt_BR-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/pt_BR/adafruit-circuitpython-imxrt1010_evk-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/sv/adafruit-circuitpython-imxrt1010_evk-sv-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/sv/adafruit-circuitpython-imxrt1010_evk-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1010_evk-zh_Latn_pinyin-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1010_evk-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 6,
+        "downloads": 0,
         "id": "imxrt1020_evk",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/ID/adafruit-circuitpython-imxrt1020_evk-ID-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/ID/adafruit-circuitpython-imxrt1020_evk-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/de_DE/adafruit-circuitpython-imxrt1020_evk-de_DE-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/de_DE/adafruit-circuitpython-imxrt1020_evk-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/en_US/adafruit-circuitpython-imxrt1020_evk-en_US-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/en_US/adafruit-circuitpython-imxrt1020_evk-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/en_x_pirate/adafruit-circuitpython-imxrt1020_evk-en_x_pirate-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/en_x_pirate/adafruit-circuitpython-imxrt1020_evk-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/es/adafruit-circuitpython-imxrt1020_evk-es-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/es/adafruit-circuitpython-imxrt1020_evk-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/fil/adafruit-circuitpython-imxrt1020_evk-fil-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/fil/adafruit-circuitpython-imxrt1020_evk-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/fr/adafruit-circuitpython-imxrt1020_evk-fr-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/fr/adafruit-circuitpython-imxrt1020_evk-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/it_IT/adafruit-circuitpython-imxrt1020_evk-it_IT-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/it_IT/adafruit-circuitpython-imxrt1020_evk-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/ko/adafruit-circuitpython-imxrt1020_evk-ko-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/ko/adafruit-circuitpython-imxrt1020_evk-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/pl/adafruit-circuitpython-imxrt1020_evk-pl-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/pl/adafruit-circuitpython-imxrt1020_evk-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/pt_BR/adafruit-circuitpython-imxrt1020_evk-pt_BR-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/pt_BR/adafruit-circuitpython-imxrt1020_evk-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1020_evk-zh_Latn_pinyin-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1020_evk-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -5353,67 +5476,71 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/ID/adafruit-circuitpython-imxrt1020_evk-ID-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/ID/adafruit-circuitpython-imxrt1020_evk-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/de_DE/adafruit-circuitpython-imxrt1020_evk-de_DE-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/de_DE/adafruit-circuitpython-imxrt1020_evk-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/en_US/adafruit-circuitpython-imxrt1020_evk-en_US-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/en_US/adafruit-circuitpython-imxrt1020_evk-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/en_x_pirate/adafruit-circuitpython-imxrt1020_evk-en_x_pirate-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/en_x_pirate/adafruit-circuitpython-imxrt1020_evk-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/es/adafruit-circuitpython-imxrt1020_evk-es-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/es/adafruit-circuitpython-imxrt1020_evk-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/fil/adafruit-circuitpython-imxrt1020_evk-fil-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/fil/adafruit-circuitpython-imxrt1020_evk-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/fr/adafruit-circuitpython-imxrt1020_evk-fr-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/fr/adafruit-circuitpython-imxrt1020_evk-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/it_IT/adafruit-circuitpython-imxrt1020_evk-it_IT-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/it_IT/adafruit-circuitpython-imxrt1020_evk-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/ko/adafruit-circuitpython-imxrt1020_evk-ko-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/ko/adafruit-circuitpython-imxrt1020_evk-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/pl/adafruit-circuitpython-imxrt1020_evk-pl-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/pl/adafruit-circuitpython-imxrt1020_evk-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/pt_BR/adafruit-circuitpython-imxrt1020_evk-pt_BR-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/pt_BR/adafruit-circuitpython-imxrt1020_evk-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/sv/adafruit-circuitpython-imxrt1020_evk-sv-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/sv/adafruit-circuitpython-imxrt1020_evk-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1020_evk-zh_Latn_pinyin-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1020_evk-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 5,
+        "downloads": 0,
         "id": "imxrt1060_evk",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/ID/adafruit-circuitpython-imxrt1060_evk-ID-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/ID/adafruit-circuitpython-imxrt1060_evk-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/de_DE/adafruit-circuitpython-imxrt1060_evk-de_DE-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/de_DE/adafruit-circuitpython-imxrt1060_evk-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/en_US/adafruit-circuitpython-imxrt1060_evk-en_US-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/en_US/adafruit-circuitpython-imxrt1060_evk-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/en_x_pirate/adafruit-circuitpython-imxrt1060_evk-en_x_pirate-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/en_x_pirate/adafruit-circuitpython-imxrt1060_evk-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/es/adafruit-circuitpython-imxrt1060_evk-es-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/es/adafruit-circuitpython-imxrt1060_evk-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/fil/adafruit-circuitpython-imxrt1060_evk-fil-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/fil/adafruit-circuitpython-imxrt1060_evk-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/fr/adafruit-circuitpython-imxrt1060_evk-fr-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/fr/adafruit-circuitpython-imxrt1060_evk-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/it_IT/adafruit-circuitpython-imxrt1060_evk-it_IT-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/it_IT/adafruit-circuitpython-imxrt1060_evk-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/ko/adafruit-circuitpython-imxrt1060_evk-ko-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/ko/adafruit-circuitpython-imxrt1060_evk-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/pl/adafruit-circuitpython-imxrt1060_evk-pl-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/pl/adafruit-circuitpython-imxrt1060_evk-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/pt_BR/adafruit-circuitpython-imxrt1060_evk-pt_BR-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/pt_BR/adafruit-circuitpython-imxrt1060_evk-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1060_evk-zh_Latn_pinyin-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1060_evk-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -5467,55 +5594,71 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/ID/adafruit-circuitpython-imxrt1060_evk-ID-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/ID/adafruit-circuitpython-imxrt1060_evk-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/de_DE/adafruit-circuitpython-imxrt1060_evk-de_DE-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/de_DE/adafruit-circuitpython-imxrt1060_evk-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/en_US/adafruit-circuitpython-imxrt1060_evk-en_US-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/en_US/adafruit-circuitpython-imxrt1060_evk-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/en_x_pirate/adafruit-circuitpython-imxrt1060_evk-en_x_pirate-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/en_x_pirate/adafruit-circuitpython-imxrt1060_evk-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/es/adafruit-circuitpython-imxrt1060_evk-es-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/es/adafruit-circuitpython-imxrt1060_evk-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/fil/adafruit-circuitpython-imxrt1060_evk-fil-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/fil/adafruit-circuitpython-imxrt1060_evk-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/fr/adafruit-circuitpython-imxrt1060_evk-fr-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/fr/adafruit-circuitpython-imxrt1060_evk-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/it_IT/adafruit-circuitpython-imxrt1060_evk-it_IT-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/it_IT/adafruit-circuitpython-imxrt1060_evk-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/ko/adafruit-circuitpython-imxrt1060_evk-ko-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/ko/adafruit-circuitpython-imxrt1060_evk-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/pl/adafruit-circuitpython-imxrt1060_evk-pl-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/pl/adafruit-circuitpython-imxrt1060_evk-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/pt_BR/adafruit-circuitpython-imxrt1060_evk-pt_BR-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/pt_BR/adafruit-circuitpython-imxrt1060_evk-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/sv/adafruit-circuitpython-imxrt1060_evk-sv-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/sv/adafruit-circuitpython-imxrt1060_evk-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1060_evk-zh_Latn_pinyin-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1060_evk-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 83,
+        "downloads": 0,
         "id": "itsybitsy_m0_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/ID/adafruit-circuitpython-itsybitsy_m0_express-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/de_DE/adafruit-circuitpython-itsybitsy_m0_express-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/en_US/adafruit-circuitpython-itsybitsy_m0_express-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/en_x_pirate/adafruit-circuitpython-itsybitsy_m0_express-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/es/adafruit-circuitpython-itsybitsy_m0_express-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/fil/adafruit-circuitpython-itsybitsy_m0_express-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/fr/adafruit-circuitpython-itsybitsy_m0_express-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/it_IT/adafruit-circuitpython-itsybitsy_m0_express-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/ko/adafruit-circuitpython-itsybitsy_m0_express-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/pl/adafruit-circuitpython-itsybitsy_m0_express-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/pt_BR/adafruit-circuitpython-itsybitsy_m0_express-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/zh_Latn_pinyin/adafruit-circuitpython-itsybitsy_m0_express-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -5557,55 +5700,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/ID/adafruit-circuitpython-itsybitsy_m0_express-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/de_DE/adafruit-circuitpython-itsybitsy_m0_express-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/en_US/adafruit-circuitpython-itsybitsy_m0_express-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/en_x_pirate/adafruit-circuitpython-itsybitsy_m0_express-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/es/adafruit-circuitpython-itsybitsy_m0_express-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/fil/adafruit-circuitpython-itsybitsy_m0_express-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/fr/adafruit-circuitpython-itsybitsy_m0_express-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/it_IT/adafruit-circuitpython-itsybitsy_m0_express-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/ko/adafruit-circuitpython-itsybitsy_m0_express-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/pl/adafruit-circuitpython-itsybitsy_m0_express-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/pt_BR/adafruit-circuitpython-itsybitsy_m0_express-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/sv/adafruit-circuitpython-itsybitsy_m0_express-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/zh_Latn_pinyin/adafruit-circuitpython-itsybitsy_m0_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 167,
+        "downloads": 0,
         "id": "itsybitsy_m4_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/ID/adafruit-circuitpython-itsybitsy_m4_express-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/de_DE/adafruit-circuitpython-itsybitsy_m4_express-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/en_US/adafruit-circuitpython-itsybitsy_m4_express-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/en_x_pirate/adafruit-circuitpython-itsybitsy_m4_express-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/es/adafruit-circuitpython-itsybitsy_m4_express-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/fil/adafruit-circuitpython-itsybitsy_m4_express-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/fr/adafruit-circuitpython-itsybitsy_m4_express-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/it_IT/adafruit-circuitpython-itsybitsy_m4_express-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/ko/adafruit-circuitpython-itsybitsy_m4_express-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/pl/adafruit-circuitpython-itsybitsy_m4_express-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/pt_BR/adafruit-circuitpython-itsybitsy_m4_express-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/zh_Latn_pinyin/adafruit-circuitpython-itsybitsy_m4_express-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -5647,55 +5793,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/ID/adafruit-circuitpython-itsybitsy_m4_express-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/de_DE/adafruit-circuitpython-itsybitsy_m4_express-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/en_US/adafruit-circuitpython-itsybitsy_m4_express-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/en_x_pirate/adafruit-circuitpython-itsybitsy_m4_express-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/es/adafruit-circuitpython-itsybitsy_m4_express-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/fil/adafruit-circuitpython-itsybitsy_m4_express-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/fr/adafruit-circuitpython-itsybitsy_m4_express-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/it_IT/adafruit-circuitpython-itsybitsy_m4_express-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/ko/adafruit-circuitpython-itsybitsy_m4_express-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/pl/adafruit-circuitpython-itsybitsy_m4_express-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/pt_BR/adafruit-circuitpython-itsybitsy_m4_express-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/sv/adafruit-circuitpython-itsybitsy_m4_express-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/zh_Latn_pinyin/adafruit-circuitpython-itsybitsy_m4_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 69,
+        "downloads": 0,
         "id": "itsybitsy_nrf52840_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/ID/adafruit-circuitpython-itsybitsy_nrf52840_express-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/de_DE/adafruit-circuitpython-itsybitsy_nrf52840_express-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/en_US/adafruit-circuitpython-itsybitsy_nrf52840_express-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/en_x_pirate/adafruit-circuitpython-itsybitsy_nrf52840_express-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/es/adafruit-circuitpython-itsybitsy_nrf52840_express-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/fil/adafruit-circuitpython-itsybitsy_nrf52840_express-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/fr/adafruit-circuitpython-itsybitsy_nrf52840_express-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/it_IT/adafruit-circuitpython-itsybitsy_nrf52840_express-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/ko/adafruit-circuitpython-itsybitsy_nrf52840_express-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/pl/adafruit-circuitpython-itsybitsy_nrf52840_express-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/pt_BR/adafruit-circuitpython-itsybitsy_nrf52840_express-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/zh_Latn_pinyin/adafruit-circuitpython-itsybitsy_nrf52840_express-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -5737,55 +5886,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/ID/adafruit-circuitpython-itsybitsy_nrf52840_express-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/de_DE/adafruit-circuitpython-itsybitsy_nrf52840_express-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/en_US/adafruit-circuitpython-itsybitsy_nrf52840_express-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/en_x_pirate/adafruit-circuitpython-itsybitsy_nrf52840_express-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/es/adafruit-circuitpython-itsybitsy_nrf52840_express-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/fil/adafruit-circuitpython-itsybitsy_nrf52840_express-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/fr/adafruit-circuitpython-itsybitsy_nrf52840_express-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/it_IT/adafruit-circuitpython-itsybitsy_nrf52840_express-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/ko/adafruit-circuitpython-itsybitsy_nrf52840_express-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/pl/adafruit-circuitpython-itsybitsy_nrf52840_express-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/pt_BR/adafruit-circuitpython-itsybitsy_nrf52840_express-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/sv/adafruit-circuitpython-itsybitsy_nrf52840_express-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/zh_Latn_pinyin/adafruit-circuitpython-itsybitsy_nrf52840_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 31,
+        "downloads": 0,
         "id": "kicksat-sprite",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/ID/adafruit-circuitpython-kicksat-sprite-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/de_DE/adafruit-circuitpython-kicksat-sprite-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/en_US/adafruit-circuitpython-kicksat-sprite-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/en_x_pirate/adafruit-circuitpython-kicksat-sprite-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/es/adafruit-circuitpython-kicksat-sprite-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/fil/adafruit-circuitpython-kicksat-sprite-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/fr/adafruit-circuitpython-kicksat-sprite-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/it_IT/adafruit-circuitpython-kicksat-sprite-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/ko/adafruit-circuitpython-kicksat-sprite-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/pl/adafruit-circuitpython-kicksat-sprite-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/pt_BR/adafruit-circuitpython-kicksat-sprite-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/zh_Latn_pinyin/adafruit-circuitpython-kicksat-sprite-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -5827,55 +5979,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/ID/adafruit-circuitpython-kicksat-sprite-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/de_DE/adafruit-circuitpython-kicksat-sprite-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/en_US/adafruit-circuitpython-kicksat-sprite-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/en_x_pirate/adafruit-circuitpython-kicksat-sprite-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/es/adafruit-circuitpython-kicksat-sprite-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/fil/adafruit-circuitpython-kicksat-sprite-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/fr/adafruit-circuitpython-kicksat-sprite-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/it_IT/adafruit-circuitpython-kicksat-sprite-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/ko/adafruit-circuitpython-kicksat-sprite-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/pl/adafruit-circuitpython-kicksat-sprite-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/pt_BR/adafruit-circuitpython-kicksat-sprite-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/sv/adafruit-circuitpython-kicksat-sprite-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/zh_Latn_pinyin/adafruit-circuitpython-kicksat-sprite-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 35,
+        "downloads": 0,
         "id": "makerdiary_nrf52840_mdk",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/ID/adafruit-circuitpython-makerdiary_nrf52840_mdk-ID-5.3.0-rc.0.hex"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/de_DE/adafruit-circuitpython-makerdiary_nrf52840_mdk-de_DE-5.3.0-rc.0.hex"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/en_US/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_US-5.3.0-rc.0.hex"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/en_x_pirate/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_x_pirate-5.3.0-rc.0.hex"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/es/adafruit-circuitpython-makerdiary_nrf52840_mdk-es-5.3.0-rc.0.hex"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/fil/adafruit-circuitpython-makerdiary_nrf52840_mdk-fil-5.3.0-rc.0.hex"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/fr/adafruit-circuitpython-makerdiary_nrf52840_mdk-fr-5.3.0-rc.0.hex"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/it_IT/adafruit-circuitpython-makerdiary_nrf52840_mdk-it_IT-5.3.0-rc.0.hex"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/ko/adafruit-circuitpython-makerdiary_nrf52840_mdk-ko-5.3.0-rc.0.hex"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/pl/adafruit-circuitpython-makerdiary_nrf52840_mdk-pl-5.3.0-rc.0.hex"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/pt_BR/adafruit-circuitpython-makerdiary_nrf52840_mdk-pt_BR-5.3.0-rc.0.hex"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/zh_Latn_pinyin/adafruit-circuitpython-makerdiary_nrf52840_mdk-zh_Latn_pinyin-5.3.0-rc.0.hex"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -5917,55 +6072,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/ID/adafruit-circuitpython-makerdiary_nrf52840_mdk-ID-5.4.0-beta.0.hex"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/de_DE/adafruit-circuitpython-makerdiary_nrf52840_mdk-de_DE-5.4.0-beta.0.hex"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/en_US/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_US-5.4.0-beta.0.hex"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/en_x_pirate/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_x_pirate-5.4.0-beta.0.hex"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/es/adafruit-circuitpython-makerdiary_nrf52840_mdk-es-5.4.0-beta.0.hex"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/fil/adafruit-circuitpython-makerdiary_nrf52840_mdk-fil-5.4.0-beta.0.hex"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/fr/adafruit-circuitpython-makerdiary_nrf52840_mdk-fr-5.4.0-beta.0.hex"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/it_IT/adafruit-circuitpython-makerdiary_nrf52840_mdk-it_IT-5.4.0-beta.0.hex"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/ko/adafruit-circuitpython-makerdiary_nrf52840_mdk-ko-5.4.0-beta.0.hex"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/pl/adafruit-circuitpython-makerdiary_nrf52840_mdk-pl-5.4.0-beta.0.hex"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/pt_BR/adafruit-circuitpython-makerdiary_nrf52840_mdk-pt_BR-5.4.0-beta.0.hex"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/sv/adafruit-circuitpython-makerdiary_nrf52840_mdk-sv-5.4.0-beta.0.hex"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/zh_Latn_pinyin/adafruit-circuitpython-makerdiary_nrf52840_mdk-zh_Latn_pinyin-5.4.0-beta.0.hex"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 48,
+        "downloads": 0,
         "id": "makerdiary_nrf52840_mdk_usb_dongle",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/ID/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-ID-5.3.0-rc.0.hex"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/de_DE/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-de_DE-5.3.0-rc.0.hex"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/en_US/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_US-5.3.0-rc.0.hex"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/en_x_pirate/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_x_pirate-5.3.0-rc.0.hex"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/es/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-es-5.3.0-rc.0.hex"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/fil/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fil-5.3.0-rc.0.hex"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/fr/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fr-5.3.0-rc.0.hex"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/it_IT/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-it_IT-5.3.0-rc.0.hex"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/ko/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-ko-5.3.0-rc.0.hex"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/pl/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pl-5.3.0-rc.0.hex"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/pt_BR/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pt_BR-5.3.0-rc.0.hex"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/zh_Latn_pinyin/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-zh_Latn_pinyin-5.3.0-rc.0.hex"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -6007,55 +6165,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/ID/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-ID-5.4.0-beta.0.hex"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/de_DE/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-de_DE-5.4.0-beta.0.hex"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/en_US/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_US-5.4.0-beta.0.hex"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/en_x_pirate/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_x_pirate-5.4.0-beta.0.hex"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/es/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-es-5.4.0-beta.0.hex"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/fil/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fil-5.4.0-beta.0.hex"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/fr/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fr-5.4.0-beta.0.hex"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/it_IT/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-it_IT-5.4.0-beta.0.hex"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/ko/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-ko-5.4.0-beta.0.hex"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/pl/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pl-5.4.0-beta.0.hex"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/pt_BR/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pt_BR-5.4.0-beta.0.hex"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/sv/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-sv-5.4.0-beta.0.hex"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/zh_Latn_pinyin/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-zh_Latn_pinyin-5.4.0-beta.0.hex"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 11,
+        "downloads": 0,
         "id": "meowbit_v121",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/ID/adafruit-circuitpython-meowbit_v121-ID-5.3.0-rc.0.bin"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/de_DE/adafruit-circuitpython-meowbit_v121-de_DE-5.3.0-rc.0.bin"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/en_US/adafruit-circuitpython-meowbit_v121-en_US-5.3.0-rc.0.bin"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/en_x_pirate/adafruit-circuitpython-meowbit_v121-en_x_pirate-5.3.0-rc.0.bin"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/es/adafruit-circuitpython-meowbit_v121-es-5.3.0-rc.0.bin"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/fil/adafruit-circuitpython-meowbit_v121-fil-5.3.0-rc.0.bin"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/fr/adafruit-circuitpython-meowbit_v121-fr-5.3.0-rc.0.bin"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/it_IT/adafruit-circuitpython-meowbit_v121-it_IT-5.3.0-rc.0.bin"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/ko/adafruit-circuitpython-meowbit_v121-ko-5.3.0-rc.0.bin"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/pl/adafruit-circuitpython-meowbit_v121-pl-5.3.0-rc.0.bin"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/pt_BR/adafruit-circuitpython-meowbit_v121-pt_BR-5.3.0-rc.0.bin"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/zh_Latn_pinyin/adafruit-circuitpython-meowbit_v121-zh_Latn_pinyin-5.3.0-rc.0.bin"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -6097,55 +6258,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/ID/adafruit-circuitpython-meowbit_v121-ID-5.4.0-beta.0.bin"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/de_DE/adafruit-circuitpython-meowbit_v121-de_DE-5.4.0-beta.0.bin"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/en_US/adafruit-circuitpython-meowbit_v121-en_US-5.4.0-beta.0.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/en_x_pirate/adafruit-circuitpython-meowbit_v121-en_x_pirate-5.4.0-beta.0.bin"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/es/adafruit-circuitpython-meowbit_v121-es-5.4.0-beta.0.bin"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/fil/adafruit-circuitpython-meowbit_v121-fil-5.4.0-beta.0.bin"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/fr/adafruit-circuitpython-meowbit_v121-fr-5.4.0-beta.0.bin"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/it_IT/adafruit-circuitpython-meowbit_v121-it_IT-5.4.0-beta.0.bin"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/ko/adafruit-circuitpython-meowbit_v121-ko-5.4.0-beta.0.bin"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/pl/adafruit-circuitpython-meowbit_v121-pl-5.4.0-beta.0.bin"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/pt_BR/adafruit-circuitpython-meowbit_v121-pt_BR-5.4.0-beta.0.bin"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/sv/adafruit-circuitpython-meowbit_v121-sv-5.4.0-beta.0.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/zh_Latn_pinyin/adafruit-circuitpython-meowbit_v121-zh_Latn_pinyin-5.4.0-beta.0.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 27,
+        "downloads": 0,
         "id": "meowmeow",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/ID/adafruit-circuitpython-meowmeow-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/de_DE/adafruit-circuitpython-meowmeow-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/en_US/adafruit-circuitpython-meowmeow-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/en_x_pirate/adafruit-circuitpython-meowmeow-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/es/adafruit-circuitpython-meowmeow-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/fil/adafruit-circuitpython-meowmeow-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/fr/adafruit-circuitpython-meowmeow-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/it_IT/adafruit-circuitpython-meowmeow-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/ko/adafruit-circuitpython-meowmeow-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/pl/adafruit-circuitpython-meowmeow-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/pt_BR/adafruit-circuitpython-meowmeow-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/zh_Latn_pinyin/adafruit-circuitpython-meowmeow-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -6187,55 +6351,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/meowmeow/ID/adafruit-circuitpython-meowmeow-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/meowmeow/de_DE/adafruit-circuitpython-meowmeow-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/meowmeow/en_US/adafruit-circuitpython-meowmeow-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/meowmeow/en_x_pirate/adafruit-circuitpython-meowmeow-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/meowmeow/es/adafruit-circuitpython-meowmeow-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/meowmeow/fil/adafruit-circuitpython-meowmeow-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/meowmeow/fr/adafruit-circuitpython-meowmeow-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/meowmeow/it_IT/adafruit-circuitpython-meowmeow-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/meowmeow/ko/adafruit-circuitpython-meowmeow-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/meowmeow/pl/adafruit-circuitpython-meowmeow-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/meowmeow/pt_BR/adafruit-circuitpython-meowmeow-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/meowmeow/sv/adafruit-circuitpython-meowmeow-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/meowmeow/zh_Latn_pinyin/adafruit-circuitpython-meowmeow-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 140,
+        "downloads": 0,
         "id": "metro_m0_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/ID/adafruit-circuitpython-metro_m0_express-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/de_DE/adafruit-circuitpython-metro_m0_express-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/en_US/adafruit-circuitpython-metro_m0_express-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/en_x_pirate/adafruit-circuitpython-metro_m0_express-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/es/adafruit-circuitpython-metro_m0_express-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/fil/adafruit-circuitpython-metro_m0_express-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/fr/adafruit-circuitpython-metro_m0_express-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/it_IT/adafruit-circuitpython-metro_m0_express-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/ko/adafruit-circuitpython-metro_m0_express-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/pl/adafruit-circuitpython-metro_m0_express-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/pt_BR/adafruit-circuitpython-metro_m0_express-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/zh_Latn_pinyin/adafruit-circuitpython-metro_m0_express-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -6277,55 +6444,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/ID/adafruit-circuitpython-metro_m0_express-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/de_DE/adafruit-circuitpython-metro_m0_express-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/en_US/adafruit-circuitpython-metro_m0_express-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/en_x_pirate/adafruit-circuitpython-metro_m0_express-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/es/adafruit-circuitpython-metro_m0_express-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/fil/adafruit-circuitpython-metro_m0_express-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/fr/adafruit-circuitpython-metro_m0_express-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/it_IT/adafruit-circuitpython-metro_m0_express-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/ko/adafruit-circuitpython-metro_m0_express-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/pl/adafruit-circuitpython-metro_m0_express-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/pt_BR/adafruit-circuitpython-metro_m0_express-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/sv/adafruit-circuitpython-metro_m0_express-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/zh_Latn_pinyin/adafruit-circuitpython-metro_m0_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 70,
+        "downloads": 0,
         "id": "metro_m4_airlift_lite",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/ID/adafruit-circuitpython-metro_m4_airlift_lite-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/de_DE/adafruit-circuitpython-metro_m4_airlift_lite-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/en_US/adafruit-circuitpython-metro_m4_airlift_lite-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/en_x_pirate/adafruit-circuitpython-metro_m4_airlift_lite-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/es/adafruit-circuitpython-metro_m4_airlift_lite-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/fil/adafruit-circuitpython-metro_m4_airlift_lite-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/fr/adafruit-circuitpython-metro_m4_airlift_lite-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/it_IT/adafruit-circuitpython-metro_m4_airlift_lite-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/ko/adafruit-circuitpython-metro_m4_airlift_lite-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/pl/adafruit-circuitpython-metro_m4_airlift_lite-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/pt_BR/adafruit-circuitpython-metro_m4_airlift_lite-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/zh_Latn_pinyin/adafruit-circuitpython-metro_m4_airlift_lite-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -6367,55 +6537,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/ID/adafruit-circuitpython-metro_m4_airlift_lite-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/de_DE/adafruit-circuitpython-metro_m4_airlift_lite-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/en_US/adafruit-circuitpython-metro_m4_airlift_lite-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/en_x_pirate/adafruit-circuitpython-metro_m4_airlift_lite-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/es/adafruit-circuitpython-metro_m4_airlift_lite-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/fil/adafruit-circuitpython-metro_m4_airlift_lite-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/fr/adafruit-circuitpython-metro_m4_airlift_lite-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/it_IT/adafruit-circuitpython-metro_m4_airlift_lite-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/ko/adafruit-circuitpython-metro_m4_airlift_lite-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/pl/adafruit-circuitpython-metro_m4_airlift_lite-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/pt_BR/adafruit-circuitpython-metro_m4_airlift_lite-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/sv/adafruit-circuitpython-metro_m4_airlift_lite-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/zh_Latn_pinyin/adafruit-circuitpython-metro_m4_airlift_lite-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 96,
+        "downloads": 0,
         "id": "metro_m4_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/ID/adafruit-circuitpython-metro_m4_express-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/de_DE/adafruit-circuitpython-metro_m4_express-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/en_US/adafruit-circuitpython-metro_m4_express-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/en_x_pirate/adafruit-circuitpython-metro_m4_express-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/es/adafruit-circuitpython-metro_m4_express-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/fil/adafruit-circuitpython-metro_m4_express-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/fr/adafruit-circuitpython-metro_m4_express-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/it_IT/adafruit-circuitpython-metro_m4_express-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/ko/adafruit-circuitpython-metro_m4_express-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/pl/adafruit-circuitpython-metro_m4_express-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/pt_BR/adafruit-circuitpython-metro_m4_express-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/zh_Latn_pinyin/adafruit-circuitpython-metro_m4_express-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -6457,55 +6630,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/ID/adafruit-circuitpython-metro_m4_express-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/de_DE/adafruit-circuitpython-metro_m4_express-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/en_US/adafruit-circuitpython-metro_m4_express-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/en_x_pirate/adafruit-circuitpython-metro_m4_express-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/es/adafruit-circuitpython-metro_m4_express-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/fil/adafruit-circuitpython-metro_m4_express-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/fr/adafruit-circuitpython-metro_m4_express-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/it_IT/adafruit-circuitpython-metro_m4_express-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/ko/adafruit-circuitpython-metro_m4_express-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/pl/adafruit-circuitpython-metro_m4_express-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/pt_BR/adafruit-circuitpython-metro_m4_express-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/sv/adafruit-circuitpython-metro_m4_express-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/zh_Latn_pinyin/adafruit-circuitpython-metro_m4_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 28,
+        "downloads": 0,
         "id": "metro_nrf52840_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/ID/adafruit-circuitpython-metro_nrf52840_express-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/de_DE/adafruit-circuitpython-metro_nrf52840_express-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/en_US/adafruit-circuitpython-metro_nrf52840_express-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/en_x_pirate/adafruit-circuitpython-metro_nrf52840_express-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/es/adafruit-circuitpython-metro_nrf52840_express-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/fil/adafruit-circuitpython-metro_nrf52840_express-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/fr/adafruit-circuitpython-metro_nrf52840_express-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/it_IT/adafruit-circuitpython-metro_nrf52840_express-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/ko/adafruit-circuitpython-metro_nrf52840_express-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/pl/adafruit-circuitpython-metro_nrf52840_express-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/pt_BR/adafruit-circuitpython-metro_nrf52840_express-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/zh_Latn_pinyin/adafruit-circuitpython-metro_nrf52840_express-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -6547,55 +6723,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/ID/adafruit-circuitpython-metro_nrf52840_express-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/de_DE/adafruit-circuitpython-metro_nrf52840_express-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/en_US/adafruit-circuitpython-metro_nrf52840_express-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/en_x_pirate/adafruit-circuitpython-metro_nrf52840_express-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/es/adafruit-circuitpython-metro_nrf52840_express-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/fil/adafruit-circuitpython-metro_nrf52840_express-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/fr/adafruit-circuitpython-metro_nrf52840_express-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/it_IT/adafruit-circuitpython-metro_nrf52840_express-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/ko/adafruit-circuitpython-metro_nrf52840_express-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/pl/adafruit-circuitpython-metro_nrf52840_express-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/pt_BR/adafruit-circuitpython-metro_nrf52840_express-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/sv/adafruit-circuitpython-metro_nrf52840_express-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/zh_Latn_pinyin/adafruit-circuitpython-metro_nrf52840_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 21,
+        "downloads": 0,
         "id": "mini_sam_m4",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/ID/adafruit-circuitpython-mini_sam_m4-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/de_DE/adafruit-circuitpython-mini_sam_m4-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/en_US/adafruit-circuitpython-mini_sam_m4-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/en_x_pirate/adafruit-circuitpython-mini_sam_m4-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/es/adafruit-circuitpython-mini_sam_m4-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/fil/adafruit-circuitpython-mini_sam_m4-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/fr/adafruit-circuitpython-mini_sam_m4-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/it_IT/adafruit-circuitpython-mini_sam_m4-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/ko/adafruit-circuitpython-mini_sam_m4-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/pl/adafruit-circuitpython-mini_sam_m4-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/pt_BR/adafruit-circuitpython-mini_sam_m4-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/zh_Latn_pinyin/adafruit-circuitpython-mini_sam_m4-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -6637,55 +6816,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/ID/adafruit-circuitpython-mini_sam_m4-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/de_DE/adafruit-circuitpython-mini_sam_m4-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/en_US/adafruit-circuitpython-mini_sam_m4-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/en_x_pirate/adafruit-circuitpython-mini_sam_m4-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/es/adafruit-circuitpython-mini_sam_m4-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/fil/adafruit-circuitpython-mini_sam_m4-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/fr/adafruit-circuitpython-mini_sam_m4-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/it_IT/adafruit-circuitpython-mini_sam_m4-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/ko/adafruit-circuitpython-mini_sam_m4-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/pl/adafruit-circuitpython-mini_sam_m4-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/pt_BR/adafruit-circuitpython-mini_sam_m4-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/sv/adafruit-circuitpython-mini_sam_m4-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/zh_Latn_pinyin/adafruit-circuitpython-mini_sam_m4-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 56,
+        "downloads": 0,
         "id": "monster_m4sk",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/ID/adafruit-circuitpython-monster_m4sk-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/de_DE/adafruit-circuitpython-monster_m4sk-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/en_US/adafruit-circuitpython-monster_m4sk-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/en_x_pirate/adafruit-circuitpython-monster_m4sk-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/es/adafruit-circuitpython-monster_m4sk-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/fil/adafruit-circuitpython-monster_m4sk-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/fr/adafruit-circuitpython-monster_m4sk-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/it_IT/adafruit-circuitpython-monster_m4sk-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/ko/adafruit-circuitpython-monster_m4sk-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/pl/adafruit-circuitpython-monster_m4sk-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/pt_BR/adafruit-circuitpython-monster_m4sk-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/zh_Latn_pinyin/adafruit-circuitpython-monster_m4sk-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -6727,55 +6909,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/ID/adafruit-circuitpython-monster_m4sk-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/de_DE/adafruit-circuitpython-monster_m4sk-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/en_US/adafruit-circuitpython-monster_m4sk-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/en_x_pirate/adafruit-circuitpython-monster_m4sk-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/es/adafruit-circuitpython-monster_m4sk-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/fil/adafruit-circuitpython-monster_m4sk-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/fr/adafruit-circuitpython-monster_m4sk-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/it_IT/adafruit-circuitpython-monster_m4sk-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/ko/adafruit-circuitpython-monster_m4sk-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/pl/adafruit-circuitpython-monster_m4sk-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/pt_BR/adafruit-circuitpython-monster_m4sk-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/sv/adafruit-circuitpython-monster_m4sk-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/zh_Latn_pinyin/adafruit-circuitpython-monster_m4sk-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 13,
+        "downloads": 0,
         "id": "ndgarage_ndbit6",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/ID/adafruit-circuitpython-ndgarage_ndbit6-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/de_DE/adafruit-circuitpython-ndgarage_ndbit6-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/en_US/adafruit-circuitpython-ndgarage_ndbit6-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/en_x_pirate/adafruit-circuitpython-ndgarage_ndbit6-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/es/adafruit-circuitpython-ndgarage_ndbit6-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/fil/adafruit-circuitpython-ndgarage_ndbit6-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/fr/adafruit-circuitpython-ndgarage_ndbit6-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/it_IT/adafruit-circuitpython-ndgarage_ndbit6-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/ko/adafruit-circuitpython-ndgarage_ndbit6-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/pl/adafruit-circuitpython-ndgarage_ndbit6-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/pt_BR/adafruit-circuitpython-ndgarage_ndbit6-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/zh_Latn_pinyin/adafruit-circuitpython-ndgarage_ndbit6-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -6817,55 +7002,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/ID/adafruit-circuitpython-ndgarage_ndbit6-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/de_DE/adafruit-circuitpython-ndgarage_ndbit6-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/en_US/adafruit-circuitpython-ndgarage_ndbit6-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/en_x_pirate/adafruit-circuitpython-ndgarage_ndbit6-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/es/adafruit-circuitpython-ndgarage_ndbit6-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/fil/adafruit-circuitpython-ndgarage_ndbit6-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/fr/adafruit-circuitpython-ndgarage_ndbit6-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/it_IT/adafruit-circuitpython-ndgarage_ndbit6-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/ko/adafruit-circuitpython-ndgarage_ndbit6-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/pl/adafruit-circuitpython-ndgarage_ndbit6-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/pt_BR/adafruit-circuitpython-ndgarage_ndbit6-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/sv/adafruit-circuitpython-ndgarage_ndbit6-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/zh_Latn_pinyin/adafruit-circuitpython-ndgarage_ndbit6-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 16,
+        "downloads": 0,
         "id": "nfc_copy_cat",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/ID/adafruit-circuitpython-nfc_copy_cat-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/de_DE/adafruit-circuitpython-nfc_copy_cat-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/en_US/adafruit-circuitpython-nfc_copy_cat-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/en_x_pirate/adafruit-circuitpython-nfc_copy_cat-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/es/adafruit-circuitpython-nfc_copy_cat-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/fil/adafruit-circuitpython-nfc_copy_cat-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/fr/adafruit-circuitpython-nfc_copy_cat-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/it_IT/adafruit-circuitpython-nfc_copy_cat-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/ko/adafruit-circuitpython-nfc_copy_cat-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/pl/adafruit-circuitpython-nfc_copy_cat-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/pt_BR/adafruit-circuitpython-nfc_copy_cat-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/zh_Latn_pinyin/adafruit-circuitpython-nfc_copy_cat-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -6907,6 +7095,102 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/ID/adafruit-circuitpython-nfc_copy_cat-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/de_DE/adafruit-circuitpython-nfc_copy_cat-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/en_US/adafruit-circuitpython-nfc_copy_cat-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/en_x_pirate/adafruit-circuitpython-nfc_copy_cat-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/es/adafruit-circuitpython-nfc_copy_cat-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/fil/adafruit-circuitpython-nfc_copy_cat-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/fr/adafruit-circuitpython-nfc_copy_cat-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/it_IT/adafruit-circuitpython-nfc_copy_cat-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/ko/adafruit-circuitpython-nfc_copy_cat-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/pl/adafruit-circuitpython-nfc_copy_cat-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/pt_BR/adafruit-circuitpython-nfc_copy_cat-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/sv/adafruit-circuitpython-nfc_copy_cat-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/zh_Latn_pinyin/adafruit-circuitpython-nfc_copy_cat-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
+            }
+        ]
+    },
+    {
+        "downloads": 0,
+        "id": "nucleo_f746zg",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/ID/adafruit-circuitpython-nucleo_f746zg-ID-5.4.0-beta.0.bin"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/de_DE/adafruit-circuitpython-nucleo_f746zg-de_DE-5.4.0-beta.0.bin"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/en_US/adafruit-circuitpython-nucleo_f746zg-en_US-5.4.0-beta.0.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/en_x_pirate/adafruit-circuitpython-nucleo_f746zg-en_x_pirate-5.4.0-beta.0.bin"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/es/adafruit-circuitpython-nucleo_f746zg-es-5.4.0-beta.0.bin"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/fil/adafruit-circuitpython-nucleo_f746zg-fil-5.4.0-beta.0.bin"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/fr/adafruit-circuitpython-nucleo_f746zg-fr-5.4.0-beta.0.bin"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/it_IT/adafruit-circuitpython-nucleo_f746zg-it_IT-5.4.0-beta.0.bin"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/ko/adafruit-circuitpython-nucleo_f746zg-ko-5.4.0-beta.0.bin"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/pl/adafruit-circuitpython-nucleo_f746zg-pl-5.4.0-beta.0.bin"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/pt_BR/adafruit-circuitpython-nucleo_f746zg-pt_BR-5.4.0-beta.0.bin"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/sv/adafruit-circuitpython-nucleo_f746zg-sv-5.4.0-beta.0.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/zh_Latn_pinyin/adafruit-circuitpython-nucleo_f746zg-zh_Latn_pinyin-5.4.0-beta.0.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
@@ -6914,48 +7198,6 @@
         "downloads": 0,
         "id": "nucleo_f767zi",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/ID/adafruit-circuitpython-nucleo_f767zi-ID-5.3.0-rc.0.bin"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/de_DE/adafruit-circuitpython-nucleo_f767zi-de_DE-5.3.0-rc.0.bin"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/en_US/adafruit-circuitpython-nucleo_f767zi-en_US-5.3.0-rc.0.bin"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/en_x_pirate/adafruit-circuitpython-nucleo_f767zi-en_x_pirate-5.3.0-rc.0.bin"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/es/adafruit-circuitpython-nucleo_f767zi-es-5.3.0-rc.0.bin"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/fil/adafruit-circuitpython-nucleo_f767zi-fil-5.3.0-rc.0.bin"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/fr/adafruit-circuitpython-nucleo_f767zi-fr-5.3.0-rc.0.bin"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/it_IT/adafruit-circuitpython-nucleo_f767zi-it_IT-5.3.0-rc.0.bin"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/ko/adafruit-circuitpython-nucleo_f767zi-ko-5.3.0-rc.0.bin"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/pl/adafruit-circuitpython-nucleo_f767zi-pl-5.3.0-rc.0.bin"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/pt_BR/adafruit-circuitpython-nucleo_f767zi-pt_BR-5.3.0-rc.0.bin"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/zh_Latn_pinyin/adafruit-circuitpython-nucleo_f767zi-zh_Latn_pinyin-5.3.0-rc.0.bin"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -6997,6 +7239,51 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/ID/adafruit-circuitpython-nucleo_f767zi-ID-5.4.0-beta.0.bin"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/de_DE/adafruit-circuitpython-nucleo_f767zi-de_DE-5.4.0-beta.0.bin"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/en_US/adafruit-circuitpython-nucleo_f767zi-en_US-5.4.0-beta.0.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/en_x_pirate/adafruit-circuitpython-nucleo_f767zi-en_x_pirate-5.4.0-beta.0.bin"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/es/adafruit-circuitpython-nucleo_f767zi-es-5.4.0-beta.0.bin"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/fil/adafruit-circuitpython-nucleo_f767zi-fil-5.4.0-beta.0.bin"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/fr/adafruit-circuitpython-nucleo_f767zi-fr-5.4.0-beta.0.bin"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/it_IT/adafruit-circuitpython-nucleo_f767zi-it_IT-5.4.0-beta.0.bin"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/ko/adafruit-circuitpython-nucleo_f767zi-ko-5.4.0-beta.0.bin"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/pl/adafruit-circuitpython-nucleo_f767zi-pl-5.4.0-beta.0.bin"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/pt_BR/adafruit-circuitpython-nucleo_f767zi-pt_BR-5.4.0-beta.0.bin"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/sv/adafruit-circuitpython-nucleo_f767zi-sv-5.4.0-beta.0.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/zh_Latn_pinyin/adafruit-circuitpython-nucleo_f767zi-zh_Latn_pinyin-5.4.0-beta.0.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
@@ -7004,48 +7291,6 @@
         "downloads": 0,
         "id": "nucleo_h743zi_2",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/ID/adafruit-circuitpython-nucleo_h743zi_2-ID-5.3.0-rc.0.bin"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/de_DE/adafruit-circuitpython-nucleo_h743zi_2-de_DE-5.3.0-rc.0.bin"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/en_US/adafruit-circuitpython-nucleo_h743zi_2-en_US-5.3.0-rc.0.bin"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/en_x_pirate/adafruit-circuitpython-nucleo_h743zi_2-en_x_pirate-5.3.0-rc.0.bin"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/es/adafruit-circuitpython-nucleo_h743zi_2-es-5.3.0-rc.0.bin"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/fil/adafruit-circuitpython-nucleo_h743zi_2-fil-5.3.0-rc.0.bin"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/fr/adafruit-circuitpython-nucleo_h743zi_2-fr-5.3.0-rc.0.bin"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/it_IT/adafruit-circuitpython-nucleo_h743zi_2-it_IT-5.3.0-rc.0.bin"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/ko/adafruit-circuitpython-nucleo_h743zi_2-ko-5.3.0-rc.0.bin"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/pl/adafruit-circuitpython-nucleo_h743zi_2-pl-5.3.0-rc.0.bin"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/pt_BR/adafruit-circuitpython-nucleo_h743zi_2-pt_BR-5.3.0-rc.0.bin"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/zh_Latn_pinyin/adafruit-circuitpython-nucleo_h743zi_2-zh_Latn_pinyin-5.3.0-rc.0.bin"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -7087,55 +7332,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/ID/adafruit-circuitpython-nucleo_h743zi_2-ID-5.4.0-beta.0.bin"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/de_DE/adafruit-circuitpython-nucleo_h743zi_2-de_DE-5.4.0-beta.0.bin"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/en_US/adafruit-circuitpython-nucleo_h743zi_2-en_US-5.4.0-beta.0.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/en_x_pirate/adafruit-circuitpython-nucleo_h743zi_2-en_x_pirate-5.4.0-beta.0.bin"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/es/adafruit-circuitpython-nucleo_h743zi_2-es-5.4.0-beta.0.bin"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/fil/adafruit-circuitpython-nucleo_h743zi_2-fil-5.4.0-beta.0.bin"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/fr/adafruit-circuitpython-nucleo_h743zi_2-fr-5.4.0-beta.0.bin"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/it_IT/adafruit-circuitpython-nucleo_h743zi_2-it_IT-5.4.0-beta.0.bin"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/ko/adafruit-circuitpython-nucleo_h743zi_2-ko-5.4.0-beta.0.bin"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/pl/adafruit-circuitpython-nucleo_h743zi_2-pl-5.4.0-beta.0.bin"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/pt_BR/adafruit-circuitpython-nucleo_h743zi_2-pt_BR-5.4.0-beta.0.bin"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/sv/adafruit-circuitpython-nucleo_h743zi_2-sv-5.4.0-beta.0.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/zh_Latn_pinyin/adafruit-circuitpython-nucleo_h743zi_2-zh_Latn_pinyin-5.4.0-beta.0.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 51,
+        "downloads": 0,
         "id": "ohs2020_badge",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/ID/adafruit-circuitpython-ohs2020_badge-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/de_DE/adafruit-circuitpython-ohs2020_badge-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/en_US/adafruit-circuitpython-ohs2020_badge-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/en_x_pirate/adafruit-circuitpython-ohs2020_badge-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/es/adafruit-circuitpython-ohs2020_badge-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/fil/adafruit-circuitpython-ohs2020_badge-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/fr/adafruit-circuitpython-ohs2020_badge-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/it_IT/adafruit-circuitpython-ohs2020_badge-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/ko/adafruit-circuitpython-ohs2020_badge-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/pl/adafruit-circuitpython-ohs2020_badge-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/pt_BR/adafruit-circuitpython-ohs2020_badge-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/zh_Latn_pinyin/adafruit-circuitpython-ohs2020_badge-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -7177,55 +7425,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/ID/adafruit-circuitpython-ohs2020_badge-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/de_DE/adafruit-circuitpython-ohs2020_badge-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/en_US/adafruit-circuitpython-ohs2020_badge-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/en_x_pirate/adafruit-circuitpython-ohs2020_badge-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/es/adafruit-circuitpython-ohs2020_badge-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/fil/adafruit-circuitpython-ohs2020_badge-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/fr/adafruit-circuitpython-ohs2020_badge-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/it_IT/adafruit-circuitpython-ohs2020_badge-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/ko/adafruit-circuitpython-ohs2020_badge-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/pl/adafruit-circuitpython-ohs2020_badge-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/pt_BR/adafruit-circuitpython-ohs2020_badge-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/sv/adafruit-circuitpython-ohs2020_badge-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/zh_Latn_pinyin/adafruit-circuitpython-ohs2020_badge-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 26,
+        "downloads": 0,
         "id": "openbook_m4",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/ID/adafruit-circuitpython-openbook_m4-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/de_DE/adafruit-circuitpython-openbook_m4-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/en_US/adafruit-circuitpython-openbook_m4-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/en_x_pirate/adafruit-circuitpython-openbook_m4-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/es/adafruit-circuitpython-openbook_m4-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/fil/adafruit-circuitpython-openbook_m4-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/fr/adafruit-circuitpython-openbook_m4-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/it_IT/adafruit-circuitpython-openbook_m4-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/ko/adafruit-circuitpython-openbook_m4-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/pl/adafruit-circuitpython-openbook_m4-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/pt_BR/adafruit-circuitpython-openbook_m4-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/zh_Latn_pinyin/adafruit-circuitpython-openbook_m4-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -7267,55 +7518,109 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/openbook_m4/ID/adafruit-circuitpython-openbook_m4-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/openbook_m4/de_DE/adafruit-circuitpython-openbook_m4-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/openbook_m4/en_US/adafruit-circuitpython-openbook_m4-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/openbook_m4/en_x_pirate/adafruit-circuitpython-openbook_m4-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/openbook_m4/es/adafruit-circuitpython-openbook_m4-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/openbook_m4/fil/adafruit-circuitpython-openbook_m4-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/openbook_m4/fr/adafruit-circuitpython-openbook_m4-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/openbook_m4/it_IT/adafruit-circuitpython-openbook_m4-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/openbook_m4/ko/adafruit-circuitpython-openbook_m4-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/openbook_m4/pl/adafruit-circuitpython-openbook_m4-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/openbook_m4/pt_BR/adafruit-circuitpython-openbook_m4-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/openbook_m4/sv/adafruit-circuitpython-openbook_m4-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/openbook_m4/zh_Latn_pinyin/adafruit-circuitpython-openbook_m4-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 33,
-        "id": "particle_argon",
+        "downloads": 0,
+        "id": "openmv_h7",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/ID/adafruit-circuitpython-particle_argon-ID-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/openmv_h7/ID/adafruit-circuitpython-openmv_h7-ID-5.4.0-beta.0.bin"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/de_DE/adafruit-circuitpython-particle_argon-de_DE-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/openmv_h7/de_DE/adafruit-circuitpython-openmv_h7-de_DE-5.4.0-beta.0.bin"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/en_US/adafruit-circuitpython-particle_argon-en_US-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/openmv_h7/en_US/adafruit-circuitpython-openmv_h7-en_US-5.4.0-beta.0.bin"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/en_x_pirate/adafruit-circuitpython-particle_argon-en_x_pirate-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/openmv_h7/en_x_pirate/adafruit-circuitpython-openmv_h7-en_x_pirate-5.4.0-beta.0.bin"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/es/adafruit-circuitpython-particle_argon-es-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/openmv_h7/es/adafruit-circuitpython-openmv_h7-es-5.4.0-beta.0.bin"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/fil/adafruit-circuitpython-particle_argon-fil-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/openmv_h7/fil/adafruit-circuitpython-openmv_h7-fil-5.4.0-beta.0.bin"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/fr/adafruit-circuitpython-particle_argon-fr-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/openmv_h7/fr/adafruit-circuitpython-openmv_h7-fr-5.4.0-beta.0.bin"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/it_IT/adafruit-circuitpython-particle_argon-it_IT-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/openmv_h7/it_IT/adafruit-circuitpython-openmv_h7-it_IT-5.4.0-beta.0.bin"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/ko/adafruit-circuitpython-particle_argon-ko-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/openmv_h7/ko/adafruit-circuitpython-openmv_h7-ko-5.4.0-beta.0.bin"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/pl/adafruit-circuitpython-particle_argon-pl-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/openmv_h7/pl/adafruit-circuitpython-openmv_h7-pl-5.4.0-beta.0.bin"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/pt_BR/adafruit-circuitpython-particle_argon-pt_BR-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/openmv_h7/pt_BR/adafruit-circuitpython-openmv_h7-pt_BR-5.4.0-beta.0.bin"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/openmv_h7/sv/adafruit-circuitpython-openmv_h7-sv-5.4.0-beta.0.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/zh_Latn_pinyin/adafruit-circuitpython-particle_argon-zh_Latn_pinyin-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/openmv_h7/zh_Latn_pinyin/adafruit-circuitpython-openmv_h7-zh_Latn_pinyin-5.4.0-beta.0.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.3.0-rc.0"
-            },
+                "version": "5.4.0-beta.0"
+            }
+        ]
+    },
+    {
+        "downloads": 0,
+        "id": "particle_argon",
+        "versions": [
             {
                 "files": {
                     "ID": [
@@ -7357,55 +7662,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/particle_argon/ID/adafruit-circuitpython-particle_argon-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/particle_argon/de_DE/adafruit-circuitpython-particle_argon-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/particle_argon/en_US/adafruit-circuitpython-particle_argon-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/particle_argon/en_x_pirate/adafruit-circuitpython-particle_argon-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/particle_argon/es/adafruit-circuitpython-particle_argon-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/particle_argon/fil/adafruit-circuitpython-particle_argon-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/particle_argon/fr/adafruit-circuitpython-particle_argon-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/particle_argon/it_IT/adafruit-circuitpython-particle_argon-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/particle_argon/ko/adafruit-circuitpython-particle_argon-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/particle_argon/pl/adafruit-circuitpython-particle_argon-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/particle_argon/pt_BR/adafruit-circuitpython-particle_argon-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/particle_argon/sv/adafruit-circuitpython-particle_argon-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/particle_argon/zh_Latn_pinyin/adafruit-circuitpython-particle_argon-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 15,
+        "downloads": 0,
         "id": "particle_boron",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/ID/adafruit-circuitpython-particle_boron-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/de_DE/adafruit-circuitpython-particle_boron-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/en_US/adafruit-circuitpython-particle_boron-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/en_x_pirate/adafruit-circuitpython-particle_boron-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/es/adafruit-circuitpython-particle_boron-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/fil/adafruit-circuitpython-particle_boron-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/fr/adafruit-circuitpython-particle_boron-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/it_IT/adafruit-circuitpython-particle_boron-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/ko/adafruit-circuitpython-particle_boron-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/pl/adafruit-circuitpython-particle_boron-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/pt_BR/adafruit-circuitpython-particle_boron-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/zh_Latn_pinyin/adafruit-circuitpython-particle_boron-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -7447,55 +7755,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/particle_boron/ID/adafruit-circuitpython-particle_boron-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/particle_boron/de_DE/adafruit-circuitpython-particle_boron-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/particle_boron/en_US/adafruit-circuitpython-particle_boron-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/particle_boron/en_x_pirate/adafruit-circuitpython-particle_boron-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/particle_boron/es/adafruit-circuitpython-particle_boron-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/particle_boron/fil/adafruit-circuitpython-particle_boron-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/particle_boron/fr/adafruit-circuitpython-particle_boron-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/particle_boron/it_IT/adafruit-circuitpython-particle_boron-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/particle_boron/ko/adafruit-circuitpython-particle_boron-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/particle_boron/pl/adafruit-circuitpython-particle_boron-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/particle_boron/pt_BR/adafruit-circuitpython-particle_boron-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/particle_boron/sv/adafruit-circuitpython-particle_boron-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/particle_boron/zh_Latn_pinyin/adafruit-circuitpython-particle_boron-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 63,
+        "downloads": 0,
         "id": "particle_xenon",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/ID/adafruit-circuitpython-particle_xenon-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/de_DE/adafruit-circuitpython-particle_xenon-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/en_US/adafruit-circuitpython-particle_xenon-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/en_x_pirate/adafruit-circuitpython-particle_xenon-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/es/adafruit-circuitpython-particle_xenon-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/fil/adafruit-circuitpython-particle_xenon-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/fr/adafruit-circuitpython-particle_xenon-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/it_IT/adafruit-circuitpython-particle_xenon-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/ko/adafruit-circuitpython-particle_xenon-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/pl/adafruit-circuitpython-particle_xenon-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/pt_BR/adafruit-circuitpython-particle_xenon-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/zh_Latn_pinyin/adafruit-circuitpython-particle_xenon-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -7537,6 +7848,51 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/particle_xenon/ID/adafruit-circuitpython-particle_xenon-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/particle_xenon/de_DE/adafruit-circuitpython-particle_xenon-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/particle_xenon/en_US/adafruit-circuitpython-particle_xenon-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/particle_xenon/en_x_pirate/adafruit-circuitpython-particle_xenon-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/particle_xenon/es/adafruit-circuitpython-particle_xenon-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/particle_xenon/fil/adafruit-circuitpython-particle_xenon-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/particle_xenon/fr/adafruit-circuitpython-particle_xenon-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/particle_xenon/it_IT/adafruit-circuitpython-particle_xenon-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/particle_xenon/ko/adafruit-circuitpython-particle_xenon-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/particle_xenon/pl/adafruit-circuitpython-particle_xenon-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/particle_xenon/pt_BR/adafruit-circuitpython-particle_xenon-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/particle_xenon/sv/adafruit-circuitpython-particle_xenon-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/particle_xenon/zh_Latn_pinyin/adafruit-circuitpython-particle_xenon-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
@@ -7546,63 +7902,9 @@
         "versions": []
     },
     {
-        "downloads": 22,
+        "downloads": 0,
         "id": "pca10056",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pca10056/ID/adafruit-circuitpython-pca10056-ID-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/ID/adafruit-circuitpython-pca10056-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pca10056/de_DE/adafruit-circuitpython-pca10056-de_DE-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/de_DE/adafruit-circuitpython-pca10056-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pca10056/en_US/adafruit-circuitpython-pca10056-en_US-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/en_US/adafruit-circuitpython-pca10056-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pca10056/en_x_pirate/adafruit-circuitpython-pca10056-en_x_pirate-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/en_x_pirate/adafruit-circuitpython-pca10056-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pca10056/es/adafruit-circuitpython-pca10056-es-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/es/adafruit-circuitpython-pca10056-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pca10056/fil/adafruit-circuitpython-pca10056-fil-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/fil/adafruit-circuitpython-pca10056-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pca10056/fr/adafruit-circuitpython-pca10056-fr-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/fr/adafruit-circuitpython-pca10056-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pca10056/it_IT/adafruit-circuitpython-pca10056-it_IT-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/it_IT/adafruit-circuitpython-pca10056-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pca10056/ko/adafruit-circuitpython-pca10056-ko-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/ko/adafruit-circuitpython-pca10056-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pca10056/pl/adafruit-circuitpython-pca10056-pl-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/pl/adafruit-circuitpython-pca10056-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pca10056/pt_BR/adafruit-circuitpython-pca10056-pt_BR-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/pt_BR/adafruit-circuitpython-pca10056-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pca10056/zh_Latn_pinyin/adafruit-circuitpython-pca10056-zh_Latn_pinyin-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/zh_Latn_pinyin/adafruit-circuitpython-pca10056-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -7656,67 +7958,71 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pca10056/ID/adafruit-circuitpython-pca10056-ID-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/ID/adafruit-circuitpython-pca10056-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pca10056/de_DE/adafruit-circuitpython-pca10056-de_DE-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/de_DE/adafruit-circuitpython-pca10056-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pca10056/en_US/adafruit-circuitpython-pca10056-en_US-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/en_US/adafruit-circuitpython-pca10056-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pca10056/en_x_pirate/adafruit-circuitpython-pca10056-en_x_pirate-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/en_x_pirate/adafruit-circuitpython-pca10056-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pca10056/es/adafruit-circuitpython-pca10056-es-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/es/adafruit-circuitpython-pca10056-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pca10056/fil/adafruit-circuitpython-pca10056-fil-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/fil/adafruit-circuitpython-pca10056-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pca10056/fr/adafruit-circuitpython-pca10056-fr-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/fr/adafruit-circuitpython-pca10056-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pca10056/it_IT/adafruit-circuitpython-pca10056-it_IT-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/it_IT/adafruit-circuitpython-pca10056-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pca10056/ko/adafruit-circuitpython-pca10056-ko-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/ko/adafruit-circuitpython-pca10056-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pca10056/pl/adafruit-circuitpython-pca10056-pl-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/pl/adafruit-circuitpython-pca10056-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pca10056/pt_BR/adafruit-circuitpython-pca10056-pt_BR-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/pt_BR/adafruit-circuitpython-pca10056-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/pca10056/sv/adafruit-circuitpython-pca10056-sv-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/sv/adafruit-circuitpython-pca10056-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pca10056/zh_Latn_pinyin/adafruit-circuitpython-pca10056-zh_Latn_pinyin-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/zh_Latn_pinyin/adafruit-circuitpython-pca10056-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 45,
+        "downloads": 0,
         "id": "pca10059",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pca10059/ID/adafruit-circuitpython-pca10059-ID-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/ID/adafruit-circuitpython-pca10059-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pca10059/de_DE/adafruit-circuitpython-pca10059-de_DE-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/de_DE/adafruit-circuitpython-pca10059-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pca10059/en_US/adafruit-circuitpython-pca10059-en_US-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/en_US/adafruit-circuitpython-pca10059-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pca10059/en_x_pirate/adafruit-circuitpython-pca10059-en_x_pirate-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/en_x_pirate/adafruit-circuitpython-pca10059-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pca10059/es/adafruit-circuitpython-pca10059-es-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/es/adafruit-circuitpython-pca10059-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pca10059/fil/adafruit-circuitpython-pca10059-fil-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/fil/adafruit-circuitpython-pca10059-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pca10059/fr/adafruit-circuitpython-pca10059-fr-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/fr/adafruit-circuitpython-pca10059-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pca10059/it_IT/adafruit-circuitpython-pca10059-it_IT-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/it_IT/adafruit-circuitpython-pca10059-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pca10059/ko/adafruit-circuitpython-pca10059-ko-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/ko/adafruit-circuitpython-pca10059-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pca10059/pl/adafruit-circuitpython-pca10059-pl-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/pl/adafruit-circuitpython-pca10059-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pca10059/pt_BR/adafruit-circuitpython-pca10059-pt_BR-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/pt_BR/adafruit-circuitpython-pca10059-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pca10059/zh_Latn_pinyin/adafruit-circuitpython-pca10059-zh_Latn_pinyin-5.3.0-rc.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/zh_Latn_pinyin/adafruit-circuitpython-pca10059-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -7770,55 +8076,122 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pca10059/ID/adafruit-circuitpython-pca10059-ID-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/ID/adafruit-circuitpython-pca10059-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pca10059/de_DE/adafruit-circuitpython-pca10059-de_DE-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/de_DE/adafruit-circuitpython-pca10059-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pca10059/en_US/adafruit-circuitpython-pca10059-en_US-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/en_US/adafruit-circuitpython-pca10059-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pca10059/en_x_pirate/adafruit-circuitpython-pca10059-en_x_pirate-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/en_x_pirate/adafruit-circuitpython-pca10059-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pca10059/es/adafruit-circuitpython-pca10059-es-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/es/adafruit-circuitpython-pca10059-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pca10059/fil/adafruit-circuitpython-pca10059-fil-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/fil/adafruit-circuitpython-pca10059-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pca10059/fr/adafruit-circuitpython-pca10059-fr-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/fr/adafruit-circuitpython-pca10059-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pca10059/it_IT/adafruit-circuitpython-pca10059-it_IT-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/it_IT/adafruit-circuitpython-pca10059-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pca10059/ko/adafruit-circuitpython-pca10059-ko-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/ko/adafruit-circuitpython-pca10059-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pca10059/pl/adafruit-circuitpython-pca10059-pl-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/pl/adafruit-circuitpython-pca10059-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pca10059/pt_BR/adafruit-circuitpython-pca10059-pt_BR-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/pt_BR/adafruit-circuitpython-pca10059-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/pca10059/sv/adafruit-circuitpython-pca10059-sv-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/sv/adafruit-circuitpython-pca10059-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pca10059/zh_Latn_pinyin/adafruit-circuitpython-pca10059-zh_Latn_pinyin-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/zh_Latn_pinyin/adafruit-circuitpython-pca10059-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 44,
-        "id": "pewpew10",
+        "downloads": 0,
+        "id": "pca10100",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/ID/adafruit-circuitpython-pewpew10-ID-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10100/ID/adafruit-circuitpython-pca10100-ID-5.4.0-beta.0.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/de_DE/adafruit-circuitpython-pewpew10-de_DE-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10100/de_DE/adafruit-circuitpython-pca10100-de_DE-5.4.0-beta.0.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/en_US/adafruit-circuitpython-pewpew10-en_US-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10100/en_US/adafruit-circuitpython-pca10100-en_US-5.4.0-beta.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/en_x_pirate/adafruit-circuitpython-pewpew10-en_x_pirate-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10100/en_x_pirate/adafruit-circuitpython-pca10100-en_x_pirate-5.4.0-beta.0.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/es/adafruit-circuitpython-pewpew10-es-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10100/es/adafruit-circuitpython-pca10100-es-5.4.0-beta.0.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/fil/adafruit-circuitpython-pewpew10-fil-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10100/fil/adafruit-circuitpython-pca10100-fil-5.4.0-beta.0.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/fr/adafruit-circuitpython-pewpew10-fr-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10100/fr/adafruit-circuitpython-pca10100-fr-5.4.0-beta.0.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/it_IT/adafruit-circuitpython-pewpew10-it_IT-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10100/it_IT/adafruit-circuitpython-pca10100-it_IT-5.4.0-beta.0.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/ko/adafruit-circuitpython-pewpew10-ko-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10100/ko/adafruit-circuitpython-pca10100-ko-5.4.0-beta.0.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/pl/adafruit-circuitpython-pewpew10-pl-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10100/pl/adafruit-circuitpython-pca10100-pl-5.4.0-beta.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/pt_BR/adafruit-circuitpython-pewpew10-pt_BR-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10100/pt_BR/adafruit-circuitpython-pca10100-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/pca10100/sv/adafruit-circuitpython-pca10100-sv-5.4.0-beta.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/zh_Latn_pinyin/adafruit-circuitpython-pewpew10-zh_Latn_pinyin-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10100/zh_Latn_pinyin/adafruit-circuitpython-pca10100-zh_Latn_pinyin-5.4.0-beta.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.3.0-rc.0"
-            },
+                "version": "5.4.0-beta.0"
+            }
+        ]
+    },
+    {
+        "downloads": 0,
+        "id": "pewpew10",
+        "versions": [
             {
                 "files": {
                     "ID": [
@@ -7860,55 +8233,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pewpew10/ID/adafruit-circuitpython-pewpew10-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pewpew10/de_DE/adafruit-circuitpython-pewpew10-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pewpew10/en_US/adafruit-circuitpython-pewpew10-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pewpew10/en_x_pirate/adafruit-circuitpython-pewpew10-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pewpew10/es/adafruit-circuitpython-pewpew10-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pewpew10/fil/adafruit-circuitpython-pewpew10-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pewpew10/fr/adafruit-circuitpython-pewpew10-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pewpew10/it_IT/adafruit-circuitpython-pewpew10-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pewpew10/ko/adafruit-circuitpython-pewpew10-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pewpew10/pl/adafruit-circuitpython-pewpew10-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pewpew10/pt_BR/adafruit-circuitpython-pewpew10-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/pewpew10/sv/adafruit-circuitpython-pewpew10-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pewpew10/zh_Latn_pinyin/adafruit-circuitpython-pewpew10-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 27,
+        "downloads": 0,
         "id": "pewpew13",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/ID/adafruit-circuitpython-pewpew13-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/de_DE/adafruit-circuitpython-pewpew13-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/en_US/adafruit-circuitpython-pewpew13-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/en_x_pirate/adafruit-circuitpython-pewpew13-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/es/adafruit-circuitpython-pewpew13-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/fil/adafruit-circuitpython-pewpew13-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/fr/adafruit-circuitpython-pewpew13-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/it_IT/adafruit-circuitpython-pewpew13-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/ko/adafruit-circuitpython-pewpew13-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/pl/adafruit-circuitpython-pewpew13-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/pt_BR/adafruit-circuitpython-pewpew13-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/zh_Latn_pinyin/adafruit-circuitpython-pewpew13-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -7950,55 +8326,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pewpew13/ID/adafruit-circuitpython-pewpew13-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pewpew13/de_DE/adafruit-circuitpython-pewpew13-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pewpew13/en_US/adafruit-circuitpython-pewpew13-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pewpew13/en_x_pirate/adafruit-circuitpython-pewpew13-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pewpew13/es/adafruit-circuitpython-pewpew13-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pewpew13/fil/adafruit-circuitpython-pewpew13-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pewpew13/fr/adafruit-circuitpython-pewpew13-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pewpew13/it_IT/adafruit-circuitpython-pewpew13-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pewpew13/ko/adafruit-circuitpython-pewpew13-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pewpew13/pl/adafruit-circuitpython-pewpew13-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pewpew13/pt_BR/adafruit-circuitpython-pewpew13-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/pewpew13/sv/adafruit-circuitpython-pewpew13-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pewpew13/zh_Latn_pinyin/adafruit-circuitpython-pewpew13-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 24,
+        "downloads": 0,
         "id": "pewpew_m4",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/ID/adafruit-circuitpython-pewpew_m4-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/de_DE/adafruit-circuitpython-pewpew_m4-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/en_US/adafruit-circuitpython-pewpew_m4-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/en_x_pirate/adafruit-circuitpython-pewpew_m4-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/es/adafruit-circuitpython-pewpew_m4-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/fil/adafruit-circuitpython-pewpew_m4-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/fr/adafruit-circuitpython-pewpew_m4-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/it_IT/adafruit-circuitpython-pewpew_m4-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/ko/adafruit-circuitpython-pewpew_m4-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/pl/adafruit-circuitpython-pewpew_m4-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/pt_BR/adafruit-circuitpython-pewpew_m4-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/zh_Latn_pinyin/adafruit-circuitpython-pewpew_m4-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -8040,55 +8419,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/ID/adafruit-circuitpython-pewpew_m4-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/de_DE/adafruit-circuitpython-pewpew_m4-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/en_US/adafruit-circuitpython-pewpew_m4-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/en_x_pirate/adafruit-circuitpython-pewpew_m4-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/es/adafruit-circuitpython-pewpew_m4-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/fil/adafruit-circuitpython-pewpew_m4-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/fr/adafruit-circuitpython-pewpew_m4-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/it_IT/adafruit-circuitpython-pewpew_m4-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/ko/adafruit-circuitpython-pewpew_m4-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/pl/adafruit-circuitpython-pewpew_m4-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/pt_BR/adafruit-circuitpython-pewpew_m4-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/sv/adafruit-circuitpython-pewpew_m4-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/zh_Latn_pinyin/adafruit-circuitpython-pewpew_m4-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 28,
+        "downloads": 0,
         "id": "pirkey_m0",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/ID/adafruit-circuitpython-pirkey_m0-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/de_DE/adafruit-circuitpython-pirkey_m0-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/en_US/adafruit-circuitpython-pirkey_m0-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/en_x_pirate/adafruit-circuitpython-pirkey_m0-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/es/adafruit-circuitpython-pirkey_m0-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/fil/adafruit-circuitpython-pirkey_m0-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/fr/adafruit-circuitpython-pirkey_m0-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/it_IT/adafruit-circuitpython-pirkey_m0-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/ko/adafruit-circuitpython-pirkey_m0-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/pl/adafruit-circuitpython-pirkey_m0-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/pt_BR/adafruit-circuitpython-pirkey_m0-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/zh_Latn_pinyin/adafruit-circuitpython-pirkey_m0-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -8130,55 +8512,109 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/ID/adafruit-circuitpython-pirkey_m0-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/de_DE/adafruit-circuitpython-pirkey_m0-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/en_US/adafruit-circuitpython-pirkey_m0-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/en_x_pirate/adafruit-circuitpython-pirkey_m0-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/es/adafruit-circuitpython-pirkey_m0-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/fil/adafruit-circuitpython-pirkey_m0-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/fr/adafruit-circuitpython-pirkey_m0-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/it_IT/adafruit-circuitpython-pirkey_m0-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/ko/adafruit-circuitpython-pirkey_m0-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/pl/adafruit-circuitpython-pirkey_m0-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/pt_BR/adafruit-circuitpython-pirkey_m0-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/sv/adafruit-circuitpython-pirkey_m0-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/zh_Latn_pinyin/adafruit-circuitpython-pirkey_m0-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 6,
-        "id": "pyb_nano_v2",
+        "downloads": 0,
+        "id": "pitaya_go",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/ID/adafruit-circuitpython-pyb_nano_v2-ID-5.3.0-rc.0.bin"
+                        "https://downloads.circuitpython.org/bin/pitaya_go/ID/adafruit-circuitpython-pitaya_go-ID-5.4.0-beta.0.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/de_DE/adafruit-circuitpython-pyb_nano_v2-de_DE-5.3.0-rc.0.bin"
+                        "https://downloads.circuitpython.org/bin/pitaya_go/de_DE/adafruit-circuitpython-pitaya_go-de_DE-5.4.0-beta.0.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/en_US/adafruit-circuitpython-pyb_nano_v2-en_US-5.3.0-rc.0.bin"
+                        "https://downloads.circuitpython.org/bin/pitaya_go/en_US/adafruit-circuitpython-pitaya_go-en_US-5.4.0-beta.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/en_x_pirate/adafruit-circuitpython-pyb_nano_v2-en_x_pirate-5.3.0-rc.0.bin"
+                        "https://downloads.circuitpython.org/bin/pitaya_go/en_x_pirate/adafruit-circuitpython-pitaya_go-en_x_pirate-5.4.0-beta.0.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/es/adafruit-circuitpython-pyb_nano_v2-es-5.3.0-rc.0.bin"
+                        "https://downloads.circuitpython.org/bin/pitaya_go/es/adafruit-circuitpython-pitaya_go-es-5.4.0-beta.0.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/fil/adafruit-circuitpython-pyb_nano_v2-fil-5.3.0-rc.0.bin"
+                        "https://downloads.circuitpython.org/bin/pitaya_go/fil/adafruit-circuitpython-pitaya_go-fil-5.4.0-beta.0.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/fr/adafruit-circuitpython-pyb_nano_v2-fr-5.3.0-rc.0.bin"
+                        "https://downloads.circuitpython.org/bin/pitaya_go/fr/adafruit-circuitpython-pitaya_go-fr-5.4.0-beta.0.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/it_IT/adafruit-circuitpython-pyb_nano_v2-it_IT-5.3.0-rc.0.bin"
+                        "https://downloads.circuitpython.org/bin/pitaya_go/it_IT/adafruit-circuitpython-pitaya_go-it_IT-5.4.0-beta.0.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/ko/adafruit-circuitpython-pyb_nano_v2-ko-5.3.0-rc.0.bin"
+                        "https://downloads.circuitpython.org/bin/pitaya_go/ko/adafruit-circuitpython-pitaya_go-ko-5.4.0-beta.0.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/pl/adafruit-circuitpython-pyb_nano_v2-pl-5.3.0-rc.0.bin"
+                        "https://downloads.circuitpython.org/bin/pitaya_go/pl/adafruit-circuitpython-pitaya_go-pl-5.4.0-beta.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/pt_BR/adafruit-circuitpython-pyb_nano_v2-pt_BR-5.3.0-rc.0.bin"
+                        "https://downloads.circuitpython.org/bin/pitaya_go/pt_BR/adafruit-circuitpython-pitaya_go-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/pitaya_go/sv/adafruit-circuitpython-pitaya_go-sv-5.4.0-beta.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/zh_Latn_pinyin/adafruit-circuitpython-pyb_nano_v2-zh_Latn_pinyin-5.3.0-rc.0.bin"
+                        "https://downloads.circuitpython.org/bin/pitaya_go/zh_Latn_pinyin/adafruit-circuitpython-pitaya_go-zh_Latn_pinyin-5.4.0-beta.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.3.0-rc.0"
-            },
+                "version": "5.4.0-beta.0"
+            }
+        ]
+    },
+    {
+        "downloads": 0,
+        "id": "pyb_nano_v2",
+        "versions": [
             {
                 "files": {
                     "ID": [
@@ -8220,55 +8656,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/ID/adafruit-circuitpython-pyb_nano_v2-ID-5.4.0-beta.0.bin"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/de_DE/adafruit-circuitpython-pyb_nano_v2-de_DE-5.4.0-beta.0.bin"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/en_US/adafruit-circuitpython-pyb_nano_v2-en_US-5.4.0-beta.0.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/en_x_pirate/adafruit-circuitpython-pyb_nano_v2-en_x_pirate-5.4.0-beta.0.bin"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/es/adafruit-circuitpython-pyb_nano_v2-es-5.4.0-beta.0.bin"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/fil/adafruit-circuitpython-pyb_nano_v2-fil-5.4.0-beta.0.bin"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/fr/adafruit-circuitpython-pyb_nano_v2-fr-5.4.0-beta.0.bin"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/it_IT/adafruit-circuitpython-pyb_nano_v2-it_IT-5.4.0-beta.0.bin"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/ko/adafruit-circuitpython-pyb_nano_v2-ko-5.4.0-beta.0.bin"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/pl/adafruit-circuitpython-pyb_nano_v2-pl-5.4.0-beta.0.bin"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/pt_BR/adafruit-circuitpython-pyb_nano_v2-pt_BR-5.4.0-beta.0.bin"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/sv/adafruit-circuitpython-pyb_nano_v2-sv-5.4.0-beta.0.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/zh_Latn_pinyin/adafruit-circuitpython-pyb_nano_v2-zh_Latn_pinyin-5.4.0-beta.0.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 97,
+        "downloads": 0,
         "id": "pybadge",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pybadge/ID/adafruit-circuitpython-pybadge-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pybadge/de_DE/adafruit-circuitpython-pybadge-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pybadge/en_US/adafruit-circuitpython-pybadge-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pybadge/en_x_pirate/adafruit-circuitpython-pybadge-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pybadge/es/adafruit-circuitpython-pybadge-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pybadge/fil/adafruit-circuitpython-pybadge-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pybadge/fr/adafruit-circuitpython-pybadge-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pybadge/it_IT/adafruit-circuitpython-pybadge-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pybadge/ko/adafruit-circuitpython-pybadge-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pybadge/pl/adafruit-circuitpython-pybadge-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pybadge/pt_BR/adafruit-circuitpython-pybadge-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pybadge/zh_Latn_pinyin/adafruit-circuitpython-pybadge-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -8310,55 +8749,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pybadge/ID/adafruit-circuitpython-pybadge-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pybadge/de_DE/adafruit-circuitpython-pybadge-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pybadge/en_US/adafruit-circuitpython-pybadge-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pybadge/en_x_pirate/adafruit-circuitpython-pybadge-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pybadge/es/adafruit-circuitpython-pybadge-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pybadge/fil/adafruit-circuitpython-pybadge-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pybadge/fr/adafruit-circuitpython-pybadge-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pybadge/it_IT/adafruit-circuitpython-pybadge-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pybadge/ko/adafruit-circuitpython-pybadge-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pybadge/pl/adafruit-circuitpython-pybadge-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pybadge/pt_BR/adafruit-circuitpython-pybadge-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/pybadge/sv/adafruit-circuitpython-pybadge-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pybadge/zh_Latn_pinyin/adafruit-circuitpython-pybadge-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 6,
+        "downloads": 0,
         "id": "pybadge_airlift",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/ID/adafruit-circuitpython-pybadge_airlift-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/de_DE/adafruit-circuitpython-pybadge_airlift-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/en_US/adafruit-circuitpython-pybadge_airlift-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/en_x_pirate/adafruit-circuitpython-pybadge_airlift-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/es/adafruit-circuitpython-pybadge_airlift-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/fil/adafruit-circuitpython-pybadge_airlift-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/fr/adafruit-circuitpython-pybadge_airlift-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/it_IT/adafruit-circuitpython-pybadge_airlift-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/ko/adafruit-circuitpython-pybadge_airlift-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/pl/adafruit-circuitpython-pybadge_airlift-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/pt_BR/adafruit-circuitpython-pybadge_airlift-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/zh_Latn_pinyin/adafruit-circuitpython-pybadge_airlift-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -8400,55 +8842,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/ID/adafruit-circuitpython-pybadge_airlift-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/de_DE/adafruit-circuitpython-pybadge_airlift-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/en_US/adafruit-circuitpython-pybadge_airlift-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/en_x_pirate/adafruit-circuitpython-pybadge_airlift-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/es/adafruit-circuitpython-pybadge_airlift-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/fil/adafruit-circuitpython-pybadge_airlift-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/fr/adafruit-circuitpython-pybadge_airlift-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/it_IT/adafruit-circuitpython-pybadge_airlift-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/ko/adafruit-circuitpython-pybadge_airlift-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/pl/adafruit-circuitpython-pybadge_airlift-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/pt_BR/adafruit-circuitpython-pybadge_airlift-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/sv/adafruit-circuitpython-pybadge_airlift-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/zh_Latn_pinyin/adafruit-circuitpython-pybadge_airlift-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 47,
+        "downloads": 0,
         "id": "pyboard_v11",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/ID/adafruit-circuitpython-pyboard_v11-ID-5.3.0-rc.0.bin"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/de_DE/adafruit-circuitpython-pyboard_v11-de_DE-5.3.0-rc.0.bin"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/en_US/adafruit-circuitpython-pyboard_v11-en_US-5.3.0-rc.0.bin"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/en_x_pirate/adafruit-circuitpython-pyboard_v11-en_x_pirate-5.3.0-rc.0.bin"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/es/adafruit-circuitpython-pyboard_v11-es-5.3.0-rc.0.bin"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/fil/adafruit-circuitpython-pyboard_v11-fil-5.3.0-rc.0.bin"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/fr/adafruit-circuitpython-pyboard_v11-fr-5.3.0-rc.0.bin"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/it_IT/adafruit-circuitpython-pyboard_v11-it_IT-5.3.0-rc.0.bin"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/ko/adafruit-circuitpython-pyboard_v11-ko-5.3.0-rc.0.bin"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/pl/adafruit-circuitpython-pyboard_v11-pl-5.3.0-rc.0.bin"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/pt_BR/adafruit-circuitpython-pyboard_v11-pt_BR-5.3.0-rc.0.bin"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/zh_Latn_pinyin/adafruit-circuitpython-pyboard_v11-zh_Latn_pinyin-5.3.0-rc.0.bin"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -8490,55 +8935,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/ID/adafruit-circuitpython-pyboard_v11-ID-5.4.0-beta.0.bin"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/de_DE/adafruit-circuitpython-pyboard_v11-de_DE-5.4.0-beta.0.bin"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/en_US/adafruit-circuitpython-pyboard_v11-en_US-5.4.0-beta.0.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/en_x_pirate/adafruit-circuitpython-pyboard_v11-en_x_pirate-5.4.0-beta.0.bin"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/es/adafruit-circuitpython-pyboard_v11-es-5.4.0-beta.0.bin"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/fil/adafruit-circuitpython-pyboard_v11-fil-5.4.0-beta.0.bin"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/fr/adafruit-circuitpython-pyboard_v11-fr-5.4.0-beta.0.bin"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/it_IT/adafruit-circuitpython-pyboard_v11-it_IT-5.4.0-beta.0.bin"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/ko/adafruit-circuitpython-pyboard_v11-ko-5.4.0-beta.0.bin"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/pl/adafruit-circuitpython-pyboard_v11-pl-5.4.0-beta.0.bin"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/pt_BR/adafruit-circuitpython-pyboard_v11-pt_BR-5.4.0-beta.0.bin"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/sv/adafruit-circuitpython-pyboard_v11-sv-5.4.0-beta.0.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/zh_Latn_pinyin/adafruit-circuitpython-pyboard_v11-zh_Latn_pinyin-5.4.0-beta.0.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 44,
+        "downloads": 0,
         "id": "pycubed",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pycubed/ID/adafruit-circuitpython-pycubed-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pycubed/de_DE/adafruit-circuitpython-pycubed-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pycubed/en_US/adafruit-circuitpython-pycubed-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pycubed/en_x_pirate/adafruit-circuitpython-pycubed-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pycubed/es/adafruit-circuitpython-pycubed-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pycubed/fil/adafruit-circuitpython-pycubed-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pycubed/fr/adafruit-circuitpython-pycubed-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pycubed/it_IT/adafruit-circuitpython-pycubed-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pycubed/ko/adafruit-circuitpython-pycubed-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pycubed/pl/adafruit-circuitpython-pycubed-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pycubed/pt_BR/adafruit-circuitpython-pycubed-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pycubed/zh_Latn_pinyin/adafruit-circuitpython-pycubed-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -8580,55 +9028,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pycubed/ID/adafruit-circuitpython-pycubed-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pycubed/de_DE/adafruit-circuitpython-pycubed-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pycubed/en_US/adafruit-circuitpython-pycubed-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pycubed/en_x_pirate/adafruit-circuitpython-pycubed-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pycubed/es/adafruit-circuitpython-pycubed-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pycubed/fil/adafruit-circuitpython-pycubed-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pycubed/fr/adafruit-circuitpython-pycubed-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pycubed/it_IT/adafruit-circuitpython-pycubed-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pycubed/ko/adafruit-circuitpython-pycubed-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pycubed/pl/adafruit-circuitpython-pycubed-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pycubed/pt_BR/adafruit-circuitpython-pycubed-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/pycubed/sv/adafruit-circuitpython-pycubed-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pycubed/zh_Latn_pinyin/adafruit-circuitpython-pycubed-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 111,
+        "downloads": 0,
         "id": "pygamer",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pygamer/ID/adafruit-circuitpython-pygamer-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pygamer/de_DE/adafruit-circuitpython-pygamer-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pygamer/en_US/adafruit-circuitpython-pygamer-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pygamer/en_x_pirate/adafruit-circuitpython-pygamer-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pygamer/es/adafruit-circuitpython-pygamer-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pygamer/fil/adafruit-circuitpython-pygamer-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pygamer/fr/adafruit-circuitpython-pygamer-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pygamer/it_IT/adafruit-circuitpython-pygamer-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pygamer/ko/adafruit-circuitpython-pygamer-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pygamer/pl/adafruit-circuitpython-pygamer-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pygamer/pt_BR/adafruit-circuitpython-pygamer-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pygamer/zh_Latn_pinyin/adafruit-circuitpython-pygamer-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -8670,55 +9121,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pygamer/ID/adafruit-circuitpython-pygamer-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pygamer/de_DE/adafruit-circuitpython-pygamer-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pygamer/en_US/adafruit-circuitpython-pygamer-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pygamer/en_x_pirate/adafruit-circuitpython-pygamer-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pygamer/es/adafruit-circuitpython-pygamer-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pygamer/fil/adafruit-circuitpython-pygamer-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pygamer/fr/adafruit-circuitpython-pygamer-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pygamer/it_IT/adafruit-circuitpython-pygamer-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pygamer/ko/adafruit-circuitpython-pygamer-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pygamer/pl/adafruit-circuitpython-pygamer-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pygamer/pt_BR/adafruit-circuitpython-pygamer-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/pygamer/sv/adafruit-circuitpython-pygamer-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pygamer/zh_Latn_pinyin/adafruit-circuitpython-pygamer-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 20,
+        "downloads": 0,
         "id": "pygamer_advance",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/ID/adafruit-circuitpython-pygamer_advance-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/de_DE/adafruit-circuitpython-pygamer_advance-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/en_US/adafruit-circuitpython-pygamer_advance-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/en_x_pirate/adafruit-circuitpython-pygamer_advance-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/es/adafruit-circuitpython-pygamer_advance-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/fil/adafruit-circuitpython-pygamer_advance-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/fr/adafruit-circuitpython-pygamer_advance-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/it_IT/adafruit-circuitpython-pygamer_advance-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/ko/adafruit-circuitpython-pygamer_advance-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/pl/adafruit-circuitpython-pygamer_advance-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/pt_BR/adafruit-circuitpython-pygamer_advance-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/zh_Latn_pinyin/adafruit-circuitpython-pygamer_advance-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -8760,55 +9214,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/ID/adafruit-circuitpython-pygamer_advance-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/de_DE/adafruit-circuitpython-pygamer_advance-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/en_US/adafruit-circuitpython-pygamer_advance-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/en_x_pirate/adafruit-circuitpython-pygamer_advance-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/es/adafruit-circuitpython-pygamer_advance-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/fil/adafruit-circuitpython-pygamer_advance-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/fr/adafruit-circuitpython-pygamer_advance-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/it_IT/adafruit-circuitpython-pygamer_advance-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/ko/adafruit-circuitpython-pygamer_advance-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/pl/adafruit-circuitpython-pygamer_advance-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/pt_BR/adafruit-circuitpython-pygamer_advance-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/sv/adafruit-circuitpython-pygamer_advance-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/zh_Latn_pinyin/adafruit-circuitpython-pygamer_advance-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 275,
+        "downloads": 0,
         "id": "pyportal",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pyportal/ID/adafruit-circuitpython-pyportal-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pyportal/de_DE/adafruit-circuitpython-pyportal-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pyportal/en_US/adafruit-circuitpython-pyportal-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pyportal/en_x_pirate/adafruit-circuitpython-pyportal-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pyportal/es/adafruit-circuitpython-pyportal-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pyportal/fil/adafruit-circuitpython-pyportal-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pyportal/fr/adafruit-circuitpython-pyportal-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pyportal/it_IT/adafruit-circuitpython-pyportal-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pyportal/ko/adafruit-circuitpython-pyportal-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pyportal/pl/adafruit-circuitpython-pyportal-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pyportal/pt_BR/adafruit-circuitpython-pyportal-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pyportal/zh_Latn_pinyin/adafruit-circuitpython-pyportal-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -8850,55 +9307,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pyportal/ID/adafruit-circuitpython-pyportal-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pyportal/de_DE/adafruit-circuitpython-pyportal-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pyportal/en_US/adafruit-circuitpython-pyportal-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pyportal/en_x_pirate/adafruit-circuitpython-pyportal-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pyportal/es/adafruit-circuitpython-pyportal-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pyportal/fil/adafruit-circuitpython-pyportal-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pyportal/fr/adafruit-circuitpython-pyportal-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pyportal/it_IT/adafruit-circuitpython-pyportal-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pyportal/ko/adafruit-circuitpython-pyportal-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pyportal/pl/adafruit-circuitpython-pyportal-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pyportal/pt_BR/adafruit-circuitpython-pyportal-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/pyportal/sv/adafruit-circuitpython-pyportal-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pyportal/zh_Latn_pinyin/adafruit-circuitpython-pyportal-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 37,
+        "downloads": 0,
         "id": "pyportal_pynt",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/ID/adafruit-circuitpython-pyportal_pynt-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/de_DE/adafruit-circuitpython-pyportal_pynt-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/en_US/adafruit-circuitpython-pyportal_pynt-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/en_x_pirate/adafruit-circuitpython-pyportal_pynt-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/es/adafruit-circuitpython-pyportal_pynt-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/fil/adafruit-circuitpython-pyportal_pynt-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/fr/adafruit-circuitpython-pyportal_pynt-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/it_IT/adafruit-circuitpython-pyportal_pynt-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/ko/adafruit-circuitpython-pyportal_pynt-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/pl/adafruit-circuitpython-pyportal_pynt-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/pt_BR/adafruit-circuitpython-pyportal_pynt-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/zh_Latn_pinyin/adafruit-circuitpython-pyportal_pynt-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -8940,55 +9400,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/ID/adafruit-circuitpython-pyportal_pynt-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/de_DE/adafruit-circuitpython-pyportal_pynt-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/en_US/adafruit-circuitpython-pyportal_pynt-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/en_x_pirate/adafruit-circuitpython-pyportal_pynt-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/es/adafruit-circuitpython-pyportal_pynt-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/fil/adafruit-circuitpython-pyportal_pynt-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/fr/adafruit-circuitpython-pyportal_pynt-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/it_IT/adafruit-circuitpython-pyportal_pynt-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/ko/adafruit-circuitpython-pyportal_pynt-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/pl/adafruit-circuitpython-pyportal_pynt-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/pt_BR/adafruit-circuitpython-pyportal_pynt-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/sv/adafruit-circuitpython-pyportal_pynt-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/zh_Latn_pinyin/adafruit-circuitpython-pyportal_pynt-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 26,
+        "downloads": 0,
         "id": "pyportal_titano",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/ID/adafruit-circuitpython-pyportal_titano-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/de_DE/adafruit-circuitpython-pyportal_titano-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/en_US/adafruit-circuitpython-pyportal_titano-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/en_x_pirate/adafruit-circuitpython-pyportal_titano-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/es/adafruit-circuitpython-pyportal_titano-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/fil/adafruit-circuitpython-pyportal_titano-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/fr/adafruit-circuitpython-pyportal_titano-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/it_IT/adafruit-circuitpython-pyportal_titano-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/ko/adafruit-circuitpython-pyportal_titano-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/pl/adafruit-circuitpython-pyportal_titano-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/pt_BR/adafruit-circuitpython-pyportal_titano-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/zh_Latn_pinyin/adafruit-circuitpython-pyportal_titano-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -9030,55 +9493,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/ID/adafruit-circuitpython-pyportal_titano-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/de_DE/adafruit-circuitpython-pyportal_titano-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/en_US/adafruit-circuitpython-pyportal_titano-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/en_x_pirate/adafruit-circuitpython-pyportal_titano-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/es/adafruit-circuitpython-pyportal_titano-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/fil/adafruit-circuitpython-pyportal_titano-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/fr/adafruit-circuitpython-pyportal_titano-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/it_IT/adafruit-circuitpython-pyportal_titano-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/ko/adafruit-circuitpython-pyportal_titano-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/pl/adafruit-circuitpython-pyportal_titano-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/pt_BR/adafruit-circuitpython-pyportal_titano-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/sv/adafruit-circuitpython-pyportal_titano-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/zh_Latn_pinyin/adafruit-circuitpython-pyportal_titano-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 52,
+        "downloads": 0,
         "id": "pyruler",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/pyruler/ID/adafruit-circuitpython-pyruler-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pyruler/de_DE/adafruit-circuitpython-pyruler-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/pyruler/en_US/adafruit-circuitpython-pyruler-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pyruler/en_x_pirate/adafruit-circuitpython-pyruler-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/pyruler/es/adafruit-circuitpython-pyruler-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/pyruler/fil/adafruit-circuitpython-pyruler-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/pyruler/fr/adafruit-circuitpython-pyruler-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pyruler/it_IT/adafruit-circuitpython-pyruler-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/pyruler/ko/adafruit-circuitpython-pyruler-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/pyruler/pl/adafruit-circuitpython-pyruler-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pyruler/pt_BR/adafruit-circuitpython-pyruler-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pyruler/zh_Latn_pinyin/adafruit-circuitpython-pyruler-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -9120,55 +9586,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pyruler/ID/adafruit-circuitpython-pyruler-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pyruler/de_DE/adafruit-circuitpython-pyruler-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pyruler/en_US/adafruit-circuitpython-pyruler-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pyruler/en_x_pirate/adafruit-circuitpython-pyruler-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pyruler/es/adafruit-circuitpython-pyruler-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pyruler/fil/adafruit-circuitpython-pyruler-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pyruler/fr/adafruit-circuitpython-pyruler-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pyruler/it_IT/adafruit-circuitpython-pyruler-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pyruler/ko/adafruit-circuitpython-pyruler-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pyruler/pl/adafruit-circuitpython-pyruler-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pyruler/pt_BR/adafruit-circuitpython-pyruler-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/pyruler/sv/adafruit-circuitpython-pyruler-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pyruler/zh_Latn_pinyin/adafruit-circuitpython-pyruler-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 33,
+        "downloads": 0,
         "id": "robohatmm1_m4",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/ID/adafruit-circuitpython-robohatmm1_m4-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/de_DE/adafruit-circuitpython-robohatmm1_m4-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/en_US/adafruit-circuitpython-robohatmm1_m4-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/en_x_pirate/adafruit-circuitpython-robohatmm1_m4-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/es/adafruit-circuitpython-robohatmm1_m4-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/fil/adafruit-circuitpython-robohatmm1_m4-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/fr/adafruit-circuitpython-robohatmm1_m4-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/it_IT/adafruit-circuitpython-robohatmm1_m4-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/ko/adafruit-circuitpython-robohatmm1_m4-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/pl/adafruit-circuitpython-robohatmm1_m4-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/pt_BR/adafruit-circuitpython-robohatmm1_m4-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/zh_Latn_pinyin/adafruit-circuitpython-robohatmm1_m4-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -9210,55 +9679,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/ID/adafruit-circuitpython-robohatmm1_m4-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/de_DE/adafruit-circuitpython-robohatmm1_m4-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/en_US/adafruit-circuitpython-robohatmm1_m4-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/en_x_pirate/adafruit-circuitpython-robohatmm1_m4-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/es/adafruit-circuitpython-robohatmm1_m4-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/fil/adafruit-circuitpython-robohatmm1_m4-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/fr/adafruit-circuitpython-robohatmm1_m4-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/it_IT/adafruit-circuitpython-robohatmm1_m4-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/ko/adafruit-circuitpython-robohatmm1_m4-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/pl/adafruit-circuitpython-robohatmm1_m4-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/pt_BR/adafruit-circuitpython-robohatmm1_m4-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/sv/adafruit-circuitpython-robohatmm1_m4-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/zh_Latn_pinyin/adafruit-circuitpython-robohatmm1_m4-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 41,
+        "downloads": 0,
         "id": "sam32",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/sam32/ID/adafruit-circuitpython-sam32-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/sam32/de_DE/adafruit-circuitpython-sam32-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/sam32/en_US/adafruit-circuitpython-sam32-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/sam32/en_x_pirate/adafruit-circuitpython-sam32-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/sam32/es/adafruit-circuitpython-sam32-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/sam32/fil/adafruit-circuitpython-sam32-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/sam32/fr/adafruit-circuitpython-sam32-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/sam32/it_IT/adafruit-circuitpython-sam32-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/sam32/ko/adafruit-circuitpython-sam32-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/sam32/pl/adafruit-circuitpython-sam32-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/sam32/pt_BR/adafruit-circuitpython-sam32-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/sam32/zh_Latn_pinyin/adafruit-circuitpython-sam32-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -9300,55 +9772,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/sam32/ID/adafruit-circuitpython-sam32-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/sam32/de_DE/adafruit-circuitpython-sam32-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/sam32/en_US/adafruit-circuitpython-sam32-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/sam32/en_x_pirate/adafruit-circuitpython-sam32-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/sam32/es/adafruit-circuitpython-sam32-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/sam32/fil/adafruit-circuitpython-sam32-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/sam32/fr/adafruit-circuitpython-sam32-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/sam32/it_IT/adafruit-circuitpython-sam32-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/sam32/ko/adafruit-circuitpython-sam32-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/sam32/pl/adafruit-circuitpython-sam32-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/sam32/pt_BR/adafruit-circuitpython-sam32-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/sam32/sv/adafruit-circuitpython-sam32-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/sam32/zh_Latn_pinyin/adafruit-circuitpython-sam32-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 66,
+        "downloads": 0,
         "id": "seeeduino_xiao",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/ID/adafruit-circuitpython-seeeduino_xiao-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/de_DE/adafruit-circuitpython-seeeduino_xiao-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/en_US/adafruit-circuitpython-seeeduino_xiao-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/en_x_pirate/adafruit-circuitpython-seeeduino_xiao-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/es/adafruit-circuitpython-seeeduino_xiao-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/fil/adafruit-circuitpython-seeeduino_xiao-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/fr/adafruit-circuitpython-seeeduino_xiao-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/it_IT/adafruit-circuitpython-seeeduino_xiao-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/ko/adafruit-circuitpython-seeeduino_xiao-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/pl/adafruit-circuitpython-seeeduino_xiao-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/pt_BR/adafruit-circuitpython-seeeduino_xiao-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/zh_Latn_pinyin/adafruit-circuitpython-seeeduino_xiao-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -9390,55 +9865,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/ID/adafruit-circuitpython-seeeduino_xiao-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/de_DE/adafruit-circuitpython-seeeduino_xiao-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/en_US/adafruit-circuitpython-seeeduino_xiao-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/en_x_pirate/adafruit-circuitpython-seeeduino_xiao-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/es/adafruit-circuitpython-seeeduino_xiao-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/fil/adafruit-circuitpython-seeeduino_xiao-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/fr/adafruit-circuitpython-seeeduino_xiao-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/it_IT/adafruit-circuitpython-seeeduino_xiao-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/ko/adafruit-circuitpython-seeeduino_xiao-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/pl/adafruit-circuitpython-seeeduino_xiao-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/pt_BR/adafruit-circuitpython-seeeduino_xiao-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/sv/adafruit-circuitpython-seeeduino_xiao-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/zh_Latn_pinyin/adafruit-circuitpython-seeeduino_xiao-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 64,
+        "downloads": 0,
         "id": "serpente",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/serpente/ID/adafruit-circuitpython-serpente-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/serpente/de_DE/adafruit-circuitpython-serpente-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/serpente/en_US/adafruit-circuitpython-serpente-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/serpente/en_x_pirate/adafruit-circuitpython-serpente-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/serpente/es/adafruit-circuitpython-serpente-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/serpente/fil/adafruit-circuitpython-serpente-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/serpente/fr/adafruit-circuitpython-serpente-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/serpente/it_IT/adafruit-circuitpython-serpente-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/serpente/ko/adafruit-circuitpython-serpente-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/serpente/pl/adafruit-circuitpython-serpente-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/serpente/pt_BR/adafruit-circuitpython-serpente-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/serpente/zh_Latn_pinyin/adafruit-circuitpython-serpente-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -9480,55 +9958,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/serpente/ID/adafruit-circuitpython-serpente-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/serpente/de_DE/adafruit-circuitpython-serpente-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/serpente/en_US/adafruit-circuitpython-serpente-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/serpente/en_x_pirate/adafruit-circuitpython-serpente-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/serpente/es/adafruit-circuitpython-serpente-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/serpente/fil/adafruit-circuitpython-serpente-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/serpente/fr/adafruit-circuitpython-serpente-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/serpente/it_IT/adafruit-circuitpython-serpente-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/serpente/ko/adafruit-circuitpython-serpente-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/serpente/pl/adafruit-circuitpython-serpente-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/serpente/pt_BR/adafruit-circuitpython-serpente-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/serpente/sv/adafruit-circuitpython-serpente-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/serpente/zh_Latn_pinyin/adafruit-circuitpython-serpente-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 25,
+        "downloads": 0,
         "id": "shirtty",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/shirtty/ID/adafruit-circuitpython-shirtty-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/shirtty/de_DE/adafruit-circuitpython-shirtty-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/shirtty/en_US/adafruit-circuitpython-shirtty-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/shirtty/en_x_pirate/adafruit-circuitpython-shirtty-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/shirtty/es/adafruit-circuitpython-shirtty-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/shirtty/fil/adafruit-circuitpython-shirtty-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/shirtty/fr/adafruit-circuitpython-shirtty-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/shirtty/it_IT/adafruit-circuitpython-shirtty-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/shirtty/ko/adafruit-circuitpython-shirtty-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/shirtty/pl/adafruit-circuitpython-shirtty-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/shirtty/pt_BR/adafruit-circuitpython-shirtty-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/shirtty/zh_Latn_pinyin/adafruit-circuitpython-shirtty-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -9570,55 +10051,109 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/shirtty/ID/adafruit-circuitpython-shirtty-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/shirtty/de_DE/adafruit-circuitpython-shirtty-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/shirtty/en_US/adafruit-circuitpython-shirtty-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/shirtty/en_x_pirate/adafruit-circuitpython-shirtty-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/shirtty/es/adafruit-circuitpython-shirtty-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/shirtty/fil/adafruit-circuitpython-shirtty-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/shirtty/fr/adafruit-circuitpython-shirtty-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/shirtty/it_IT/adafruit-circuitpython-shirtty-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/shirtty/ko/adafruit-circuitpython-shirtty-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/shirtty/pl/adafruit-circuitpython-shirtty-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/shirtty/pt_BR/adafruit-circuitpython-shirtty-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/shirtty/sv/adafruit-circuitpython-shirtty-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/shirtty/zh_Latn_pinyin/adafruit-circuitpython-shirtty-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 26,
-        "id": "snekboard",
+        "downloads": 0,
+        "id": "simmel",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/snekboard/ID/adafruit-circuitpython-snekboard-ID-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/simmel/ID/adafruit-circuitpython-simmel-ID-5.4.0-beta.0.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/snekboard/de_DE/adafruit-circuitpython-snekboard-de_DE-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/simmel/de_DE/adafruit-circuitpython-simmel-de_DE-5.4.0-beta.0.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/snekboard/en_US/adafruit-circuitpython-snekboard-en_US-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/simmel/en_US/adafruit-circuitpython-simmel-en_US-5.4.0-beta.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/snekboard/en_x_pirate/adafruit-circuitpython-snekboard-en_x_pirate-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/simmel/en_x_pirate/adafruit-circuitpython-simmel-en_x_pirate-5.4.0-beta.0.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/snekboard/es/adafruit-circuitpython-snekboard-es-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/simmel/es/adafruit-circuitpython-simmel-es-5.4.0-beta.0.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/snekboard/fil/adafruit-circuitpython-snekboard-fil-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/simmel/fil/adafruit-circuitpython-simmel-fil-5.4.0-beta.0.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/snekboard/fr/adafruit-circuitpython-snekboard-fr-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/simmel/fr/adafruit-circuitpython-simmel-fr-5.4.0-beta.0.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/snekboard/it_IT/adafruit-circuitpython-snekboard-it_IT-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/simmel/it_IT/adafruit-circuitpython-simmel-it_IT-5.4.0-beta.0.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/snekboard/ko/adafruit-circuitpython-snekboard-ko-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/simmel/ko/adafruit-circuitpython-simmel-ko-5.4.0-beta.0.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/snekboard/pl/adafruit-circuitpython-snekboard-pl-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/simmel/pl/adafruit-circuitpython-simmel-pl-5.4.0-beta.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/snekboard/pt_BR/adafruit-circuitpython-snekboard-pt_BR-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/simmel/pt_BR/adafruit-circuitpython-simmel-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/simmel/sv/adafruit-circuitpython-simmel-sv-5.4.0-beta.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/snekboard/zh_Latn_pinyin/adafruit-circuitpython-snekboard-zh_Latn_pinyin-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/simmel/zh_Latn_pinyin/adafruit-circuitpython-simmel-zh_Latn_pinyin-5.4.0-beta.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.3.0-rc.0"
-            },
+                "version": "5.4.0-beta.0"
+            }
+        ]
+    },
+    {
+        "downloads": 0,
+        "id": "snekboard",
+        "versions": [
             {
                 "files": {
                     "ID": [
@@ -9660,55 +10195,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/snekboard/ID/adafruit-circuitpython-snekboard-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/snekboard/de_DE/adafruit-circuitpython-snekboard-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/snekboard/en_US/adafruit-circuitpython-snekboard-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/snekboard/en_x_pirate/adafruit-circuitpython-snekboard-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/snekboard/es/adafruit-circuitpython-snekboard-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/snekboard/fil/adafruit-circuitpython-snekboard-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/snekboard/fr/adafruit-circuitpython-snekboard-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/snekboard/it_IT/adafruit-circuitpython-snekboard-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/snekboard/ko/adafruit-circuitpython-snekboard-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/snekboard/pl/adafruit-circuitpython-snekboard-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/snekboard/pt_BR/adafruit-circuitpython-snekboard-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/snekboard/sv/adafruit-circuitpython-snekboard-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/snekboard/zh_Latn_pinyin/adafruit-circuitpython-snekboard-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 32,
+        "downloads": 0,
         "id": "sparkfun_lumidrive",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/ID/adafruit-circuitpython-sparkfun_lumidrive-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/de_DE/adafruit-circuitpython-sparkfun_lumidrive-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/en_US/adafruit-circuitpython-sparkfun_lumidrive-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/en_x_pirate/adafruit-circuitpython-sparkfun_lumidrive-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/es/adafruit-circuitpython-sparkfun_lumidrive-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/fil/adafruit-circuitpython-sparkfun_lumidrive-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/fr/adafruit-circuitpython-sparkfun_lumidrive-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/it_IT/adafruit-circuitpython-sparkfun_lumidrive-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/ko/adafruit-circuitpython-sparkfun_lumidrive-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/pl/adafruit-circuitpython-sparkfun_lumidrive-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/pt_BR/adafruit-circuitpython-sparkfun_lumidrive-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_lumidrive-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -9750,55 +10288,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/ID/adafruit-circuitpython-sparkfun_lumidrive-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/de_DE/adafruit-circuitpython-sparkfun_lumidrive-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/en_US/adafruit-circuitpython-sparkfun_lumidrive-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/en_x_pirate/adafruit-circuitpython-sparkfun_lumidrive-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/es/adafruit-circuitpython-sparkfun_lumidrive-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/fil/adafruit-circuitpython-sparkfun_lumidrive-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/fr/adafruit-circuitpython-sparkfun_lumidrive-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/it_IT/adafruit-circuitpython-sparkfun_lumidrive-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/ko/adafruit-circuitpython-sparkfun_lumidrive-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/pl/adafruit-circuitpython-sparkfun_lumidrive-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/pt_BR/adafruit-circuitpython-sparkfun_lumidrive-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/sv/adafruit-circuitpython-sparkfun_lumidrive-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_lumidrive-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 25,
+        "downloads": 0,
         "id": "sparkfun_nrf52840_mini",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/ID/adafruit-circuitpython-sparkfun_nrf52840_mini-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/de_DE/adafruit-circuitpython-sparkfun_nrf52840_mini-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/en_US/adafruit-circuitpython-sparkfun_nrf52840_mini-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/en_x_pirate/adafruit-circuitpython-sparkfun_nrf52840_mini-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/es/adafruit-circuitpython-sparkfun_nrf52840_mini-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/fil/adafruit-circuitpython-sparkfun_nrf52840_mini-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/fr/adafruit-circuitpython-sparkfun_nrf52840_mini-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/it_IT/adafruit-circuitpython-sparkfun_nrf52840_mini-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/ko/adafruit-circuitpython-sparkfun_nrf52840_mini-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/pl/adafruit-circuitpython-sparkfun_nrf52840_mini-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/pt_BR/adafruit-circuitpython-sparkfun_nrf52840_mini-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_nrf52840_mini-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -9840,55 +10381,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/ID/adafruit-circuitpython-sparkfun_nrf52840_mini-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/de_DE/adafruit-circuitpython-sparkfun_nrf52840_mini-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/en_US/adafruit-circuitpython-sparkfun_nrf52840_mini-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/en_x_pirate/adafruit-circuitpython-sparkfun_nrf52840_mini-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/es/adafruit-circuitpython-sparkfun_nrf52840_mini-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/fil/adafruit-circuitpython-sparkfun_nrf52840_mini-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/fr/adafruit-circuitpython-sparkfun_nrf52840_mini-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/it_IT/adafruit-circuitpython-sparkfun_nrf52840_mini-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/ko/adafruit-circuitpython-sparkfun_nrf52840_mini-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/pl/adafruit-circuitpython-sparkfun_nrf52840_mini-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/pt_BR/adafruit-circuitpython-sparkfun_nrf52840_mini-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/sv/adafruit-circuitpython-sparkfun_nrf52840_mini-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_nrf52840_mini-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 17,
+        "downloads": 0,
         "id": "sparkfun_qwiic_micro_no_flash",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/ID/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/de_DE/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/en_US/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/en_x_pirate/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/es/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/fil/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/fr/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/it_IT/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/ko/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/pl/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/pt_BR/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -9930,55 +10474,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/ID/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/de_DE/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/en_US/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/en_x_pirate/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/es/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/fil/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/fr/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/it_IT/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/ko/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/pl/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/pt_BR/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/sv/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 16,
+        "downloads": 0,
         "id": "sparkfun_qwiic_micro_with_flash",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/ID/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/de_DE/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/en_US/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/en_x_pirate/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/es/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/fil/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/fr/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/it_IT/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/ko/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/pl/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/pt_BR/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -10020,55 +10567,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/ID/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/de_DE/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/en_US/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/en_x_pirate/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/es/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/fil/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/fr/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/it_IT/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/ko/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/pl/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/pt_BR/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/sv/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 30,
+        "downloads": 0,
         "id": "sparkfun_redboard_turbo",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/ID/adafruit-circuitpython-sparkfun_redboard_turbo-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/de_DE/adafruit-circuitpython-sparkfun_redboard_turbo-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/en_US/adafruit-circuitpython-sparkfun_redboard_turbo-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/en_x_pirate/adafruit-circuitpython-sparkfun_redboard_turbo-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/es/adafruit-circuitpython-sparkfun_redboard_turbo-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/fil/adafruit-circuitpython-sparkfun_redboard_turbo-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/fr/adafruit-circuitpython-sparkfun_redboard_turbo-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/it_IT/adafruit-circuitpython-sparkfun_redboard_turbo-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/ko/adafruit-circuitpython-sparkfun_redboard_turbo-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/pl/adafruit-circuitpython-sparkfun_redboard_turbo-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/pt_BR/adafruit-circuitpython-sparkfun_redboard_turbo-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_redboard_turbo-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -10110,55 +10660,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/ID/adafruit-circuitpython-sparkfun_redboard_turbo-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/de_DE/adafruit-circuitpython-sparkfun_redboard_turbo-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/en_US/adafruit-circuitpython-sparkfun_redboard_turbo-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/en_x_pirate/adafruit-circuitpython-sparkfun_redboard_turbo-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/es/adafruit-circuitpython-sparkfun_redboard_turbo-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/fil/adafruit-circuitpython-sparkfun_redboard_turbo-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/fr/adafruit-circuitpython-sparkfun_redboard_turbo-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/it_IT/adafruit-circuitpython-sparkfun_redboard_turbo-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/ko/adafruit-circuitpython-sparkfun_redboard_turbo-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/pl/adafruit-circuitpython-sparkfun_redboard_turbo-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/pt_BR/adafruit-circuitpython-sparkfun_redboard_turbo-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/sv/adafruit-circuitpython-sparkfun_redboard_turbo-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_redboard_turbo-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 24,
+        "downloads": 0,
         "id": "sparkfun_samd21_dev",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/ID/adafruit-circuitpython-sparkfun_samd21_dev-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/de_DE/adafruit-circuitpython-sparkfun_samd21_dev-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/en_US/adafruit-circuitpython-sparkfun_samd21_dev-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/en_x_pirate/adafruit-circuitpython-sparkfun_samd21_dev-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/es/adafruit-circuitpython-sparkfun_samd21_dev-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/fil/adafruit-circuitpython-sparkfun_samd21_dev-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/fr/adafruit-circuitpython-sparkfun_samd21_dev-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/it_IT/adafruit-circuitpython-sparkfun_samd21_dev-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/ko/adafruit-circuitpython-sparkfun_samd21_dev-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/pl/adafruit-circuitpython-sparkfun_samd21_dev-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/pt_BR/adafruit-circuitpython-sparkfun_samd21_dev-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_samd21_dev-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -10200,55 +10753,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/ID/adafruit-circuitpython-sparkfun_samd21_dev-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/de_DE/adafruit-circuitpython-sparkfun_samd21_dev-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/en_US/adafruit-circuitpython-sparkfun_samd21_dev-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/en_x_pirate/adafruit-circuitpython-sparkfun_samd21_dev-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/es/adafruit-circuitpython-sparkfun_samd21_dev-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/fil/adafruit-circuitpython-sparkfun_samd21_dev-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/fr/adafruit-circuitpython-sparkfun_samd21_dev-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/it_IT/adafruit-circuitpython-sparkfun_samd21_dev-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/ko/adafruit-circuitpython-sparkfun_samd21_dev-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/pl/adafruit-circuitpython-sparkfun_samd21_dev-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/pt_BR/adafruit-circuitpython-sparkfun_samd21_dev-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/sv/adafruit-circuitpython-sparkfun_samd21_dev-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_samd21_dev-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 25,
+        "downloads": 0,
         "id": "sparkfun_samd21_mini",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/ID/adafruit-circuitpython-sparkfun_samd21_mini-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/de_DE/adafruit-circuitpython-sparkfun_samd21_mini-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/en_US/adafruit-circuitpython-sparkfun_samd21_mini-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/en_x_pirate/adafruit-circuitpython-sparkfun_samd21_mini-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/es/adafruit-circuitpython-sparkfun_samd21_mini-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/fil/adafruit-circuitpython-sparkfun_samd21_mini-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/fr/adafruit-circuitpython-sparkfun_samd21_mini-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/it_IT/adafruit-circuitpython-sparkfun_samd21_mini-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/ko/adafruit-circuitpython-sparkfun_samd21_mini-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/pl/adafruit-circuitpython-sparkfun_samd21_mini-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/pt_BR/adafruit-circuitpython-sparkfun_samd21_mini-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_samd21_mini-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -10290,55 +10846,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/ID/adafruit-circuitpython-sparkfun_samd21_mini-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/de_DE/adafruit-circuitpython-sparkfun_samd21_mini-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/en_US/adafruit-circuitpython-sparkfun_samd21_mini-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/en_x_pirate/adafruit-circuitpython-sparkfun_samd21_mini-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/es/adafruit-circuitpython-sparkfun_samd21_mini-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/fil/adafruit-circuitpython-sparkfun_samd21_mini-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/fr/adafruit-circuitpython-sparkfun_samd21_mini-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/it_IT/adafruit-circuitpython-sparkfun_samd21_mini-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/ko/adafruit-circuitpython-sparkfun_samd21_mini-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/pl/adafruit-circuitpython-sparkfun_samd21_mini-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/pt_BR/adafruit-circuitpython-sparkfun_samd21_mini-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/sv/adafruit-circuitpython-sparkfun_samd21_mini-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_samd21_mini-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 21,
+        "downloads": 0,
         "id": "sparkfun_samd51_thing_plus",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/ID/adafruit-circuitpython-sparkfun_samd51_thing_plus-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/de_DE/adafruit-circuitpython-sparkfun_samd51_thing_plus-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/en_US/adafruit-circuitpython-sparkfun_samd51_thing_plus-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/en_x_pirate/adafruit-circuitpython-sparkfun_samd51_thing_plus-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/es/adafruit-circuitpython-sparkfun_samd51_thing_plus-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/fil/adafruit-circuitpython-sparkfun_samd51_thing_plus-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/fr/adafruit-circuitpython-sparkfun_samd51_thing_plus-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/it_IT/adafruit-circuitpython-sparkfun_samd51_thing_plus-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/ko/adafruit-circuitpython-sparkfun_samd51_thing_plus-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/pl/adafruit-circuitpython-sparkfun_samd51_thing_plus-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/pt_BR/adafruit-circuitpython-sparkfun_samd51_thing_plus-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_samd51_thing_plus-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -10380,55 +10939,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/ID/adafruit-circuitpython-sparkfun_samd51_thing_plus-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/de_DE/adafruit-circuitpython-sparkfun_samd51_thing_plus-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/en_US/adafruit-circuitpython-sparkfun_samd51_thing_plus-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/en_x_pirate/adafruit-circuitpython-sparkfun_samd51_thing_plus-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/es/adafruit-circuitpython-sparkfun_samd51_thing_plus-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/fil/adafruit-circuitpython-sparkfun_samd51_thing_plus-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/fr/adafruit-circuitpython-sparkfun_samd51_thing_plus-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/it_IT/adafruit-circuitpython-sparkfun_samd51_thing_plus-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/ko/adafruit-circuitpython-sparkfun_samd51_thing_plus-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/pl/adafruit-circuitpython-sparkfun_samd51_thing_plus-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/pt_BR/adafruit-circuitpython-sparkfun_samd51_thing_plus-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/sv/adafruit-circuitpython-sparkfun_samd51_thing_plus-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_samd51_thing_plus-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 49,
+        "downloads": 0,
         "id": "spresense",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/spresense/ID/adafruit-circuitpython-spresense-ID-5.3.0-rc.0.spk"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/spresense/de_DE/adafruit-circuitpython-spresense-de_DE-5.3.0-rc.0.spk"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/spresense/en_US/adafruit-circuitpython-spresense-en_US-5.3.0-rc.0.spk"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/spresense/en_x_pirate/adafruit-circuitpython-spresense-en_x_pirate-5.3.0-rc.0.spk"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/spresense/es/adafruit-circuitpython-spresense-es-5.3.0-rc.0.spk"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/spresense/fil/adafruit-circuitpython-spresense-fil-5.3.0-rc.0.spk"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/spresense/fr/adafruit-circuitpython-spresense-fr-5.3.0-rc.0.spk"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/spresense/it_IT/adafruit-circuitpython-spresense-it_IT-5.3.0-rc.0.spk"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/spresense/ko/adafruit-circuitpython-spresense-ko-5.3.0-rc.0.spk"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/spresense/pl/adafruit-circuitpython-spresense-pl-5.3.0-rc.0.spk"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/spresense/pt_BR/adafruit-circuitpython-spresense-pt_BR-5.3.0-rc.0.spk"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/spresense/zh_Latn_pinyin/adafruit-circuitpython-spresense-zh_Latn_pinyin-5.3.0-rc.0.spk"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -10470,55 +11032,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/spresense/ID/adafruit-circuitpython-spresense-ID-5.4.0-beta.0.spk"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/spresense/de_DE/adafruit-circuitpython-spresense-de_DE-5.4.0-beta.0.spk"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/spresense/en_US/adafruit-circuitpython-spresense-en_US-5.4.0-beta.0.spk"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/spresense/en_x_pirate/adafruit-circuitpython-spresense-en_x_pirate-5.4.0-beta.0.spk"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/spresense/es/adafruit-circuitpython-spresense-es-5.4.0-beta.0.spk"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/spresense/fil/adafruit-circuitpython-spresense-fil-5.4.0-beta.0.spk"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/spresense/fr/adafruit-circuitpython-spresense-fr-5.4.0-beta.0.spk"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/spresense/it_IT/adafruit-circuitpython-spresense-it_IT-5.4.0-beta.0.spk"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/spresense/ko/adafruit-circuitpython-spresense-ko-5.4.0-beta.0.spk"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/spresense/pl/adafruit-circuitpython-spresense-pl-5.4.0-beta.0.spk"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/spresense/pt_BR/adafruit-circuitpython-spresense-pt_BR-5.4.0-beta.0.spk"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/spresense/sv/adafruit-circuitpython-spresense-sv-5.4.0-beta.0.spk"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/spresense/zh_Latn_pinyin/adafruit-circuitpython-spresense-zh_Latn_pinyin-5.4.0-beta.0.spk"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 29,
+        "downloads": 0,
         "id": "stm32f411ce_blackpill",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/ID/adafruit-circuitpython-stm32f411ce_blackpill-ID-5.3.0-rc.0.bin"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/de_DE/adafruit-circuitpython-stm32f411ce_blackpill-de_DE-5.3.0-rc.0.bin"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/en_US/adafruit-circuitpython-stm32f411ce_blackpill-en_US-5.3.0-rc.0.bin"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/en_x_pirate/adafruit-circuitpython-stm32f411ce_blackpill-en_x_pirate-5.3.0-rc.0.bin"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/es/adafruit-circuitpython-stm32f411ce_blackpill-es-5.3.0-rc.0.bin"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/fil/adafruit-circuitpython-stm32f411ce_blackpill-fil-5.3.0-rc.0.bin"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/fr/adafruit-circuitpython-stm32f411ce_blackpill-fr-5.3.0-rc.0.bin"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/it_IT/adafruit-circuitpython-stm32f411ce_blackpill-it_IT-5.3.0-rc.0.bin"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/ko/adafruit-circuitpython-stm32f411ce_blackpill-ko-5.3.0-rc.0.bin"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/pl/adafruit-circuitpython-stm32f411ce_blackpill-pl-5.3.0-rc.0.bin"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/pt_BR/adafruit-circuitpython-stm32f411ce_blackpill-pt_BR-5.3.0-rc.0.bin"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/zh_Latn_pinyin/adafruit-circuitpython-stm32f411ce_blackpill-zh_Latn_pinyin-5.3.0-rc.0.bin"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -10560,55 +11125,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/ID/adafruit-circuitpython-stm32f411ce_blackpill-ID-5.4.0-beta.0.bin"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/de_DE/adafruit-circuitpython-stm32f411ce_blackpill-de_DE-5.4.0-beta.0.bin"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/en_US/adafruit-circuitpython-stm32f411ce_blackpill-en_US-5.4.0-beta.0.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/en_x_pirate/adafruit-circuitpython-stm32f411ce_blackpill-en_x_pirate-5.4.0-beta.0.bin"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/es/adafruit-circuitpython-stm32f411ce_blackpill-es-5.4.0-beta.0.bin"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/fil/adafruit-circuitpython-stm32f411ce_blackpill-fil-5.4.0-beta.0.bin"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/fr/adafruit-circuitpython-stm32f411ce_blackpill-fr-5.4.0-beta.0.bin"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/it_IT/adafruit-circuitpython-stm32f411ce_blackpill-it_IT-5.4.0-beta.0.bin"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/ko/adafruit-circuitpython-stm32f411ce_blackpill-ko-5.4.0-beta.0.bin"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/pl/adafruit-circuitpython-stm32f411ce_blackpill-pl-5.4.0-beta.0.bin"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/pt_BR/adafruit-circuitpython-stm32f411ce_blackpill-pt_BR-5.4.0-beta.0.bin"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/sv/adafruit-circuitpython-stm32f411ce_blackpill-sv-5.4.0-beta.0.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/zh_Latn_pinyin/adafruit-circuitpython-stm32f411ce_blackpill-zh_Latn_pinyin-5.4.0-beta.0.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 8,
+        "downloads": 0,
         "id": "stm32f411ve_discovery",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/ID/adafruit-circuitpython-stm32f411ve_discovery-ID-5.3.0-rc.0.bin"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/de_DE/adafruit-circuitpython-stm32f411ve_discovery-de_DE-5.3.0-rc.0.bin"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/en_US/adafruit-circuitpython-stm32f411ve_discovery-en_US-5.3.0-rc.0.bin"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/en_x_pirate/adafruit-circuitpython-stm32f411ve_discovery-en_x_pirate-5.3.0-rc.0.bin"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/es/adafruit-circuitpython-stm32f411ve_discovery-es-5.3.0-rc.0.bin"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/fil/adafruit-circuitpython-stm32f411ve_discovery-fil-5.3.0-rc.0.bin"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/fr/adafruit-circuitpython-stm32f411ve_discovery-fr-5.3.0-rc.0.bin"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/it_IT/adafruit-circuitpython-stm32f411ve_discovery-it_IT-5.3.0-rc.0.bin"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/ko/adafruit-circuitpython-stm32f411ve_discovery-ko-5.3.0-rc.0.bin"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/pl/adafruit-circuitpython-stm32f411ve_discovery-pl-5.3.0-rc.0.bin"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/pt_BR/adafruit-circuitpython-stm32f411ve_discovery-pt_BR-5.3.0-rc.0.bin"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/zh_Latn_pinyin/adafruit-circuitpython-stm32f411ve_discovery-zh_Latn_pinyin-5.3.0-rc.0.bin"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -10650,55 +11218,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/ID/adafruit-circuitpython-stm32f411ve_discovery-ID-5.4.0-beta.0.bin"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/de_DE/adafruit-circuitpython-stm32f411ve_discovery-de_DE-5.4.0-beta.0.bin"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/en_US/adafruit-circuitpython-stm32f411ve_discovery-en_US-5.4.0-beta.0.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/en_x_pirate/adafruit-circuitpython-stm32f411ve_discovery-en_x_pirate-5.4.0-beta.0.bin"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/es/adafruit-circuitpython-stm32f411ve_discovery-es-5.4.0-beta.0.bin"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/fil/adafruit-circuitpython-stm32f411ve_discovery-fil-5.4.0-beta.0.bin"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/fr/adafruit-circuitpython-stm32f411ve_discovery-fr-5.4.0-beta.0.bin"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/it_IT/adafruit-circuitpython-stm32f411ve_discovery-it_IT-5.4.0-beta.0.bin"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/ko/adafruit-circuitpython-stm32f411ve_discovery-ko-5.4.0-beta.0.bin"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/pl/adafruit-circuitpython-stm32f411ve_discovery-pl-5.4.0-beta.0.bin"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/pt_BR/adafruit-circuitpython-stm32f411ve_discovery-pt_BR-5.4.0-beta.0.bin"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/sv/adafruit-circuitpython-stm32f411ve_discovery-sv-5.4.0-beta.0.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/zh_Latn_pinyin/adafruit-circuitpython-stm32f411ve_discovery-zh_Latn_pinyin-5.4.0-beta.0.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 9,
+        "downloads": 0,
         "id": "stm32f412zg_discovery",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/ID/adafruit-circuitpython-stm32f412zg_discovery-ID-5.3.0-rc.0.bin"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/de_DE/adafruit-circuitpython-stm32f412zg_discovery-de_DE-5.3.0-rc.0.bin"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/en_US/adafruit-circuitpython-stm32f412zg_discovery-en_US-5.3.0-rc.0.bin"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/en_x_pirate/adafruit-circuitpython-stm32f412zg_discovery-en_x_pirate-5.3.0-rc.0.bin"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/es/adafruit-circuitpython-stm32f412zg_discovery-es-5.3.0-rc.0.bin"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/fil/adafruit-circuitpython-stm32f412zg_discovery-fil-5.3.0-rc.0.bin"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/fr/adafruit-circuitpython-stm32f412zg_discovery-fr-5.3.0-rc.0.bin"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/it_IT/adafruit-circuitpython-stm32f412zg_discovery-it_IT-5.3.0-rc.0.bin"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/ko/adafruit-circuitpython-stm32f412zg_discovery-ko-5.3.0-rc.0.bin"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/pl/adafruit-circuitpython-stm32f412zg_discovery-pl-5.3.0-rc.0.bin"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/pt_BR/adafruit-circuitpython-stm32f412zg_discovery-pt_BR-5.3.0-rc.0.bin"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/zh_Latn_pinyin/adafruit-circuitpython-stm32f412zg_discovery-zh_Latn_pinyin-5.3.0-rc.0.bin"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -10740,55 +11311,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/ID/adafruit-circuitpython-stm32f412zg_discovery-ID-5.4.0-beta.0.bin"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/de_DE/adafruit-circuitpython-stm32f412zg_discovery-de_DE-5.4.0-beta.0.bin"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/en_US/adafruit-circuitpython-stm32f412zg_discovery-en_US-5.4.0-beta.0.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/en_x_pirate/adafruit-circuitpython-stm32f412zg_discovery-en_x_pirate-5.4.0-beta.0.bin"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/es/adafruit-circuitpython-stm32f412zg_discovery-es-5.4.0-beta.0.bin"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/fil/adafruit-circuitpython-stm32f412zg_discovery-fil-5.4.0-beta.0.bin"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/fr/adafruit-circuitpython-stm32f412zg_discovery-fr-5.4.0-beta.0.bin"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/it_IT/adafruit-circuitpython-stm32f412zg_discovery-it_IT-5.4.0-beta.0.bin"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/ko/adafruit-circuitpython-stm32f412zg_discovery-ko-5.4.0-beta.0.bin"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/pl/adafruit-circuitpython-stm32f412zg_discovery-pl-5.4.0-beta.0.bin"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/pt_BR/adafruit-circuitpython-stm32f412zg_discovery-pt_BR-5.4.0-beta.0.bin"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/sv/adafruit-circuitpython-stm32f412zg_discovery-sv-5.4.0-beta.0.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/zh_Latn_pinyin/adafruit-circuitpython-stm32f412zg_discovery-zh_Latn_pinyin-5.4.0-beta.0.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 45,
+        "downloads": 0,
         "id": "stm32f4_discovery",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/ID/adafruit-circuitpython-stm32f4_discovery-ID-5.3.0-rc.0.bin"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/de_DE/adafruit-circuitpython-stm32f4_discovery-de_DE-5.3.0-rc.0.bin"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/en_US/adafruit-circuitpython-stm32f4_discovery-en_US-5.3.0-rc.0.bin"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/en_x_pirate/adafruit-circuitpython-stm32f4_discovery-en_x_pirate-5.3.0-rc.0.bin"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/es/adafruit-circuitpython-stm32f4_discovery-es-5.3.0-rc.0.bin"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/fil/adafruit-circuitpython-stm32f4_discovery-fil-5.3.0-rc.0.bin"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/fr/adafruit-circuitpython-stm32f4_discovery-fr-5.3.0-rc.0.bin"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/it_IT/adafruit-circuitpython-stm32f4_discovery-it_IT-5.3.0-rc.0.bin"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/ko/adafruit-circuitpython-stm32f4_discovery-ko-5.3.0-rc.0.bin"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/pl/adafruit-circuitpython-stm32f4_discovery-pl-5.3.0-rc.0.bin"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/pt_BR/adafruit-circuitpython-stm32f4_discovery-pt_BR-5.3.0-rc.0.bin"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/zh_Latn_pinyin/adafruit-circuitpython-stm32f4_discovery-zh_Latn_pinyin-5.3.0-rc.0.bin"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -10830,55 +11404,109 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/ID/adafruit-circuitpython-stm32f4_discovery-ID-5.4.0-beta.0.bin"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/de_DE/adafruit-circuitpython-stm32f4_discovery-de_DE-5.4.0-beta.0.bin"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/en_US/adafruit-circuitpython-stm32f4_discovery-en_US-5.4.0-beta.0.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/en_x_pirate/adafruit-circuitpython-stm32f4_discovery-en_x_pirate-5.4.0-beta.0.bin"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/es/adafruit-circuitpython-stm32f4_discovery-es-5.4.0-beta.0.bin"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/fil/adafruit-circuitpython-stm32f4_discovery-fil-5.4.0-beta.0.bin"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/fr/adafruit-circuitpython-stm32f4_discovery-fr-5.4.0-beta.0.bin"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/it_IT/adafruit-circuitpython-stm32f4_discovery-it_IT-5.4.0-beta.0.bin"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/ko/adafruit-circuitpython-stm32f4_discovery-ko-5.4.0-beta.0.bin"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/pl/adafruit-circuitpython-stm32f4_discovery-pl-5.4.0-beta.0.bin"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/pt_BR/adafruit-circuitpython-stm32f4_discovery-pt_BR-5.4.0-beta.0.bin"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/sv/adafruit-circuitpython-stm32f4_discovery-sv-5.4.0-beta.0.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/zh_Latn_pinyin/adafruit-circuitpython-stm32f4_discovery-zh_Latn_pinyin-5.4.0-beta.0.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 17,
-        "id": "stringcar_m0_express",
+        "downloads": 0,
+        "id": "stm32f746g_discovery",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/ID/adafruit-circuitpython-stringcar_m0_express-ID-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/ID/adafruit-circuitpython-stm32f746g_discovery-ID-5.4.0-beta.0.bin"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/de_DE/adafruit-circuitpython-stringcar_m0_express-de_DE-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/de_DE/adafruit-circuitpython-stm32f746g_discovery-de_DE-5.4.0-beta.0.bin"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/en_US/adafruit-circuitpython-stringcar_m0_express-en_US-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/en_US/adafruit-circuitpython-stm32f746g_discovery-en_US-5.4.0-beta.0.bin"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/en_x_pirate/adafruit-circuitpython-stringcar_m0_express-en_x_pirate-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/en_x_pirate/adafruit-circuitpython-stm32f746g_discovery-en_x_pirate-5.4.0-beta.0.bin"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/es/adafruit-circuitpython-stringcar_m0_express-es-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/es/adafruit-circuitpython-stm32f746g_discovery-es-5.4.0-beta.0.bin"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/fil/adafruit-circuitpython-stringcar_m0_express-fil-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/fil/adafruit-circuitpython-stm32f746g_discovery-fil-5.4.0-beta.0.bin"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/fr/adafruit-circuitpython-stringcar_m0_express-fr-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/fr/adafruit-circuitpython-stm32f746g_discovery-fr-5.4.0-beta.0.bin"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/it_IT/adafruit-circuitpython-stringcar_m0_express-it_IT-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/it_IT/adafruit-circuitpython-stm32f746g_discovery-it_IT-5.4.0-beta.0.bin"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/ko/adafruit-circuitpython-stringcar_m0_express-ko-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/ko/adafruit-circuitpython-stm32f746g_discovery-ko-5.4.0-beta.0.bin"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/pl/adafruit-circuitpython-stringcar_m0_express-pl-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/pl/adafruit-circuitpython-stm32f746g_discovery-pl-5.4.0-beta.0.bin"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/pt_BR/adafruit-circuitpython-stringcar_m0_express-pt_BR-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/pt_BR/adafruit-circuitpython-stm32f746g_discovery-pt_BR-5.4.0-beta.0.bin"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/sv/adafruit-circuitpython-stm32f746g_discovery-sv-5.4.0-beta.0.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/zh_Latn_pinyin/adafruit-circuitpython-stringcar_m0_express-zh_Latn_pinyin-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/zh_Latn_pinyin/adafruit-circuitpython-stm32f746g_discovery-zh_Latn_pinyin-5.4.0-beta.0.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.3.0-rc.0"
-            },
+                "version": "5.4.0-beta.0"
+            }
+        ]
+    },
+    {
+        "downloads": 0,
+        "id": "stringcar_m0_express",
+        "versions": [
             {
                 "files": {
                     "ID": [
@@ -10920,67 +11548,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/ID/adafruit-circuitpython-stringcar_m0_express-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/de_DE/adafruit-circuitpython-stringcar_m0_express-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/en_US/adafruit-circuitpython-stringcar_m0_express-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/en_x_pirate/adafruit-circuitpython-stringcar_m0_express-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/es/adafruit-circuitpython-stringcar_m0_express-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/fil/adafruit-circuitpython-stringcar_m0_express-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/fr/adafruit-circuitpython-stringcar_m0_express-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/it_IT/adafruit-circuitpython-stringcar_m0_express-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/ko/adafruit-circuitpython-stringcar_m0_express-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/pl/adafruit-circuitpython-stringcar_m0_express-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/pt_BR/adafruit-circuitpython-stringcar_m0_express-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/sv/adafruit-circuitpython-stringcar_m0_express-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/zh_Latn_pinyin/adafruit-circuitpython-stringcar_m0_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 112,
+        "downloads": 0,
         "id": "teensy40",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/teensy40/ID/adafruit-circuitpython-teensy40-ID-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/ID/adafruit-circuitpython-teensy40-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/teensy40/de_DE/adafruit-circuitpython-teensy40-de_DE-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/de_DE/adafruit-circuitpython-teensy40-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/teensy40/en_US/adafruit-circuitpython-teensy40-en_US-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/en_US/adafruit-circuitpython-teensy40-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/teensy40/en_x_pirate/adafruit-circuitpython-teensy40-en_x_pirate-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/en_x_pirate/adafruit-circuitpython-teensy40-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/teensy40/es/adafruit-circuitpython-teensy40-es-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/es/adafruit-circuitpython-teensy40-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/teensy40/fil/adafruit-circuitpython-teensy40-fil-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/fil/adafruit-circuitpython-teensy40-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/teensy40/fr/adafruit-circuitpython-teensy40-fr-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/fr/adafruit-circuitpython-teensy40-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/teensy40/it_IT/adafruit-circuitpython-teensy40-it_IT-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/it_IT/adafruit-circuitpython-teensy40-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/teensy40/ko/adafruit-circuitpython-teensy40-ko-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/ko/adafruit-circuitpython-teensy40-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/teensy40/pl/adafruit-circuitpython-teensy40-pl-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/pl/adafruit-circuitpython-teensy40-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/teensy40/pt_BR/adafruit-circuitpython-teensy40-pt_BR-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/pt_BR/adafruit-circuitpython-teensy40-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/teensy40/zh_Latn_pinyin/adafruit-circuitpython-teensy40-zh_Latn_pinyin-5.3.0-rc.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/zh_Latn_pinyin/adafruit-circuitpython-teensy40-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -11034,55 +11653,135 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/teensy40/ID/adafruit-circuitpython-teensy40-ID-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/ID/adafruit-circuitpython-teensy40-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/teensy40/de_DE/adafruit-circuitpython-teensy40-de_DE-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/de_DE/adafruit-circuitpython-teensy40-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/teensy40/en_US/adafruit-circuitpython-teensy40-en_US-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/en_US/adafruit-circuitpython-teensy40-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/teensy40/en_x_pirate/adafruit-circuitpython-teensy40-en_x_pirate-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/en_x_pirate/adafruit-circuitpython-teensy40-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/teensy40/es/adafruit-circuitpython-teensy40-es-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/es/adafruit-circuitpython-teensy40-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/teensy40/fil/adafruit-circuitpython-teensy40-fil-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/fil/adafruit-circuitpython-teensy40-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/teensy40/fr/adafruit-circuitpython-teensy40-fr-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/fr/adafruit-circuitpython-teensy40-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/teensy40/it_IT/adafruit-circuitpython-teensy40-it_IT-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/it_IT/adafruit-circuitpython-teensy40-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/teensy40/ko/adafruit-circuitpython-teensy40-ko-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/ko/adafruit-circuitpython-teensy40-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/teensy40/pl/adafruit-circuitpython-teensy40-pl-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/pl/adafruit-circuitpython-teensy40-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/teensy40/pt_BR/adafruit-circuitpython-teensy40-pt_BR-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/pt_BR/adafruit-circuitpython-teensy40-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/teensy40/sv/adafruit-circuitpython-teensy40-sv-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/sv/adafruit-circuitpython-teensy40-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/teensy40/zh_Latn_pinyin/adafruit-circuitpython-teensy40-zh_Latn_pinyin-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/zh_Latn_pinyin/adafruit-circuitpython-teensy40-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 31,
-        "id": "teknikio_bluebird",
+        "downloads": 0,
+        "id": "teensy41",
         "versions": [
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/ID/adafruit-circuitpython-teknikio_bluebird-ID-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy41/ID/adafruit-circuitpython-teensy41-ID-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy41/ID/adafruit-circuitpython-teensy41-ID-5.4.0-beta.0.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/de_DE/adafruit-circuitpython-teknikio_bluebird-de_DE-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy41/de_DE/adafruit-circuitpython-teensy41-de_DE-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy41/de_DE/adafruit-circuitpython-teensy41-de_DE-5.4.0-beta.0.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/en_US/adafruit-circuitpython-teknikio_bluebird-en_US-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy41/en_US/adafruit-circuitpython-teensy41-en_US-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy41/en_US/adafruit-circuitpython-teensy41-en_US-5.4.0-beta.0.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/en_x_pirate/adafruit-circuitpython-teknikio_bluebird-en_x_pirate-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy41/en_x_pirate/adafruit-circuitpython-teensy41-en_x_pirate-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy41/en_x_pirate/adafruit-circuitpython-teensy41-en_x_pirate-5.4.0-beta.0.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/es/adafruit-circuitpython-teknikio_bluebird-es-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy41/es/adafruit-circuitpython-teensy41-es-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy41/es/adafruit-circuitpython-teensy41-es-5.4.0-beta.0.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/fil/adafruit-circuitpython-teknikio_bluebird-fil-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy41/fil/adafruit-circuitpython-teensy41-fil-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy41/fil/adafruit-circuitpython-teensy41-fil-5.4.0-beta.0.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/fr/adafruit-circuitpython-teknikio_bluebird-fr-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy41/fr/adafruit-circuitpython-teensy41-fr-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy41/fr/adafruit-circuitpython-teensy41-fr-5.4.0-beta.0.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/it_IT/adafruit-circuitpython-teknikio_bluebird-it_IT-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy41/it_IT/adafruit-circuitpython-teensy41-it_IT-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy41/it_IT/adafruit-circuitpython-teensy41-it_IT-5.4.0-beta.0.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/ko/adafruit-circuitpython-teknikio_bluebird-ko-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy41/ko/adafruit-circuitpython-teensy41-ko-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy41/ko/adafruit-circuitpython-teensy41-ko-5.4.0-beta.0.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/pl/adafruit-circuitpython-teknikio_bluebird-pl-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy41/pl/adafruit-circuitpython-teensy41-pl-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy41/pl/adafruit-circuitpython-teensy41-pl-5.4.0-beta.0.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/pt_BR/adafruit-circuitpython-teknikio_bluebird-pt_BR-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy41/pt_BR/adafruit-circuitpython-teensy41-pt_BR-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy41/pt_BR/adafruit-circuitpython-teensy41-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/teensy41/sv/adafruit-circuitpython-teensy41-sv-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy41/sv/adafruit-circuitpython-teensy41-sv-5.4.0-beta.0.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/zh_Latn_pinyin/adafruit-circuitpython-teknikio_bluebird-zh_Latn_pinyin-5.3.0-rc.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy41/zh_Latn_pinyin/adafruit-circuitpython-teensy41-zh_Latn_pinyin-5.4.0-beta.0.hex",
+                        "https://downloads.circuitpython.org/bin/teensy41/zh_Latn_pinyin/adafruit-circuitpython-teensy41-zh_Latn_pinyin-5.4.0-beta.0.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.3.0-rc.0"
-            },
+                "version": "5.4.0-beta.0"
+            }
+        ]
+    },
+    {
+        "downloads": 0,
+        "id": "teknikio_bluebird",
+        "versions": [
             {
                 "files": {
                     "ID": [
@@ -11124,55 +11823,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/ID/adafruit-circuitpython-teknikio_bluebird-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/de_DE/adafruit-circuitpython-teknikio_bluebird-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/en_US/adafruit-circuitpython-teknikio_bluebird-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/en_x_pirate/adafruit-circuitpython-teknikio_bluebird-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/es/adafruit-circuitpython-teknikio_bluebird-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/fil/adafruit-circuitpython-teknikio_bluebird-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/fr/adafruit-circuitpython-teknikio_bluebird-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/it_IT/adafruit-circuitpython-teknikio_bluebird-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/ko/adafruit-circuitpython-teknikio_bluebird-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/pl/adafruit-circuitpython-teknikio_bluebird-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/pt_BR/adafruit-circuitpython-teknikio_bluebird-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/sv/adafruit-circuitpython-teknikio_bluebird-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/zh_Latn_pinyin/adafruit-circuitpython-teknikio_bluebird-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 1,
+        "downloads": 0,
         "id": "thunderpack",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/thunderpack/ID/adafruit-circuitpython-thunderpack-ID-5.3.0-rc.0.bin"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/thunderpack/de_DE/adafruit-circuitpython-thunderpack-de_DE-5.3.0-rc.0.bin"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/thunderpack/en_US/adafruit-circuitpython-thunderpack-en_US-5.3.0-rc.0.bin"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/thunderpack/en_x_pirate/adafruit-circuitpython-thunderpack-en_x_pirate-5.3.0-rc.0.bin"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/thunderpack/es/adafruit-circuitpython-thunderpack-es-5.3.0-rc.0.bin"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/thunderpack/fil/adafruit-circuitpython-thunderpack-fil-5.3.0-rc.0.bin"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/thunderpack/fr/adafruit-circuitpython-thunderpack-fr-5.3.0-rc.0.bin"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/thunderpack/it_IT/adafruit-circuitpython-thunderpack-it_IT-5.3.0-rc.0.bin"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/thunderpack/ko/adafruit-circuitpython-thunderpack-ko-5.3.0-rc.0.bin"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/thunderpack/pl/adafruit-circuitpython-thunderpack-pl-5.3.0-rc.0.bin"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/thunderpack/pt_BR/adafruit-circuitpython-thunderpack-pt_BR-5.3.0-rc.0.bin"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/thunderpack/zh_Latn_pinyin/adafruit-circuitpython-thunderpack-zh_Latn_pinyin-5.3.0-rc.0.bin"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -11214,55 +11916,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/thunderpack/ID/adafruit-circuitpython-thunderpack-ID-5.4.0-beta.0.bin"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/thunderpack/de_DE/adafruit-circuitpython-thunderpack-de_DE-5.4.0-beta.0.bin"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/thunderpack/en_US/adafruit-circuitpython-thunderpack-en_US-5.4.0-beta.0.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/thunderpack/en_x_pirate/adafruit-circuitpython-thunderpack-en_x_pirate-5.4.0-beta.0.bin"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/thunderpack/es/adafruit-circuitpython-thunderpack-es-5.4.0-beta.0.bin"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/thunderpack/fil/adafruit-circuitpython-thunderpack-fil-5.4.0-beta.0.bin"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/thunderpack/fr/adafruit-circuitpython-thunderpack-fr-5.4.0-beta.0.bin"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/thunderpack/it_IT/adafruit-circuitpython-thunderpack-it_IT-5.4.0-beta.0.bin"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/thunderpack/ko/adafruit-circuitpython-thunderpack-ko-5.4.0-beta.0.bin"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/thunderpack/pl/adafruit-circuitpython-thunderpack-pl-5.4.0-beta.0.bin"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/thunderpack/pt_BR/adafruit-circuitpython-thunderpack-pt_BR-5.4.0-beta.0.bin"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/thunderpack/sv/adafruit-circuitpython-thunderpack-sv-5.4.0-beta.0.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/thunderpack/zh_Latn_pinyin/adafruit-circuitpython-thunderpack-zh_Latn_pinyin-5.4.0-beta.0.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 117,
+        "downloads": 0,
         "id": "trellis_m4_express",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/ID/adafruit-circuitpython-trellis_m4_express-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/de_DE/adafruit-circuitpython-trellis_m4_express-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/en_US/adafruit-circuitpython-trellis_m4_express-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/en_x_pirate/adafruit-circuitpython-trellis_m4_express-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/es/adafruit-circuitpython-trellis_m4_express-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/fil/adafruit-circuitpython-trellis_m4_express-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/fr/adafruit-circuitpython-trellis_m4_express-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/it_IT/adafruit-circuitpython-trellis_m4_express-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/ko/adafruit-circuitpython-trellis_m4_express-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/pl/adafruit-circuitpython-trellis_m4_express-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/pt_BR/adafruit-circuitpython-trellis_m4_express-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/zh_Latn_pinyin/adafruit-circuitpython-trellis_m4_express-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -11304,55 +12009,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/ID/adafruit-circuitpython-trellis_m4_express-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/de_DE/adafruit-circuitpython-trellis_m4_express-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/en_US/adafruit-circuitpython-trellis_m4_express-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/en_x_pirate/adafruit-circuitpython-trellis_m4_express-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/es/adafruit-circuitpython-trellis_m4_express-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/fil/adafruit-circuitpython-trellis_m4_express-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/fr/adafruit-circuitpython-trellis_m4_express-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/it_IT/adafruit-circuitpython-trellis_m4_express-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/ko/adafruit-circuitpython-trellis_m4_express-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/pl/adafruit-circuitpython-trellis_m4_express-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/pt_BR/adafruit-circuitpython-trellis_m4_express-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/sv/adafruit-circuitpython-trellis_m4_express-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/zh_Latn_pinyin/adafruit-circuitpython-trellis_m4_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 276,
+        "downloads": 0,
         "id": "trinket_m0",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/ID/adafruit-circuitpython-trinket_m0-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/de_DE/adafruit-circuitpython-trinket_m0-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/en_US/adafruit-circuitpython-trinket_m0-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/en_x_pirate/adafruit-circuitpython-trinket_m0-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/es/adafruit-circuitpython-trinket_m0-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/fil/adafruit-circuitpython-trinket_m0-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/fr/adafruit-circuitpython-trinket_m0-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/it_IT/adafruit-circuitpython-trinket_m0-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/ko/adafruit-circuitpython-trinket_m0-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/pl/adafruit-circuitpython-trinket_m0-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/pt_BR/adafruit-circuitpython-trinket_m0-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/zh_Latn_pinyin/adafruit-circuitpython-trinket_m0-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -11394,55 +12102,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0/ID/adafruit-circuitpython-trinket_m0-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0/de_DE/adafruit-circuitpython-trinket_m0-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0/en_US/adafruit-circuitpython-trinket_m0-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0/en_x_pirate/adafruit-circuitpython-trinket_m0-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0/es/adafruit-circuitpython-trinket_m0-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0/fil/adafruit-circuitpython-trinket_m0-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0/fr/adafruit-circuitpython-trinket_m0-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0/it_IT/adafruit-circuitpython-trinket_m0-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0/ko/adafruit-circuitpython-trinket_m0-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0/pl/adafruit-circuitpython-trinket_m0-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0/pt_BR/adafruit-circuitpython-trinket_m0-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0/sv/adafruit-circuitpython-trinket_m0-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0/zh_Latn_pinyin/adafruit-circuitpython-trinket_m0-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 17,
+        "downloads": 0,
         "id": "trinket_m0_haxpress",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/ID/adafruit-circuitpython-trinket_m0_haxpress-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/de_DE/adafruit-circuitpython-trinket_m0_haxpress-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/en_US/adafruit-circuitpython-trinket_m0_haxpress-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/en_x_pirate/adafruit-circuitpython-trinket_m0_haxpress-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/es/adafruit-circuitpython-trinket_m0_haxpress-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/fil/adafruit-circuitpython-trinket_m0_haxpress-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/fr/adafruit-circuitpython-trinket_m0_haxpress-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/it_IT/adafruit-circuitpython-trinket_m0_haxpress-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/ko/adafruit-circuitpython-trinket_m0_haxpress-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/pl/adafruit-circuitpython-trinket_m0_haxpress-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/pt_BR/adafruit-circuitpython-trinket_m0_haxpress-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/zh_Latn_pinyin/adafruit-circuitpython-trinket_m0_haxpress-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -11484,55 +12195,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/ID/adafruit-circuitpython-trinket_m0_haxpress-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/de_DE/adafruit-circuitpython-trinket_m0_haxpress-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/en_US/adafruit-circuitpython-trinket_m0_haxpress-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/en_x_pirate/adafruit-circuitpython-trinket_m0_haxpress-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/es/adafruit-circuitpython-trinket_m0_haxpress-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/fil/adafruit-circuitpython-trinket_m0_haxpress-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/fr/adafruit-circuitpython-trinket_m0_haxpress-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/it_IT/adafruit-circuitpython-trinket_m0_haxpress-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/ko/adafruit-circuitpython-trinket_m0_haxpress-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/pl/adafruit-circuitpython-trinket_m0_haxpress-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/pt_BR/adafruit-circuitpython-trinket_m0_haxpress-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/sv/adafruit-circuitpython-trinket_m0_haxpress-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/zh_Latn_pinyin/adafruit-circuitpython-trinket_m0_haxpress-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 12,
+        "downloads": 0,
         "id": "uartlogger2",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/uartlogger2/ID/adafruit-circuitpython-uartlogger2-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/uartlogger2/de_DE/adafruit-circuitpython-uartlogger2-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/uartlogger2/en_US/adafruit-circuitpython-uartlogger2-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/uartlogger2/en_x_pirate/adafruit-circuitpython-uartlogger2-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/uartlogger2/es/adafruit-circuitpython-uartlogger2-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/uartlogger2/fil/adafruit-circuitpython-uartlogger2-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/uartlogger2/fr/adafruit-circuitpython-uartlogger2-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/uartlogger2/it_IT/adafruit-circuitpython-uartlogger2-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/uartlogger2/ko/adafruit-circuitpython-uartlogger2-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/uartlogger2/pl/adafruit-circuitpython-uartlogger2-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/uartlogger2/pt_BR/adafruit-circuitpython-uartlogger2-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/uartlogger2/zh_Latn_pinyin/adafruit-circuitpython-uartlogger2-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -11574,55 +12288,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/uartlogger2/ID/adafruit-circuitpython-uartlogger2-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/uartlogger2/de_DE/adafruit-circuitpython-uartlogger2-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/uartlogger2/en_US/adafruit-circuitpython-uartlogger2-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/uartlogger2/en_x_pirate/adafruit-circuitpython-uartlogger2-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/uartlogger2/es/adafruit-circuitpython-uartlogger2-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/uartlogger2/fil/adafruit-circuitpython-uartlogger2-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/uartlogger2/fr/adafruit-circuitpython-uartlogger2-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/uartlogger2/it_IT/adafruit-circuitpython-uartlogger2-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/uartlogger2/ko/adafruit-circuitpython-uartlogger2-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/uartlogger2/pl/adafruit-circuitpython-uartlogger2-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/uartlogger2/pt_BR/adafruit-circuitpython-uartlogger2-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/uartlogger2/sv/adafruit-circuitpython-uartlogger2-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/uartlogger2/zh_Latn_pinyin/adafruit-circuitpython-uartlogger2-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 44,
+        "downloads": 0,
         "id": "uchip",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/uchip/ID/adafruit-circuitpython-uchip-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/uchip/de_DE/adafruit-circuitpython-uchip-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/uchip/en_US/adafruit-circuitpython-uchip-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/uchip/en_x_pirate/adafruit-circuitpython-uchip-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/uchip/es/adafruit-circuitpython-uchip-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/uchip/fil/adafruit-circuitpython-uchip-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/uchip/fr/adafruit-circuitpython-uchip-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/uchip/it_IT/adafruit-circuitpython-uchip-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/uchip/ko/adafruit-circuitpython-uchip-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/uchip/pl/adafruit-circuitpython-uchip-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/uchip/pt_BR/adafruit-circuitpython-uchip-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/uchip/zh_Latn_pinyin/adafruit-circuitpython-uchip-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -11664,55 +12381,71 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/uchip/ID/adafruit-circuitpython-uchip-ID-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/uchip/ID/adafruit-circuitpython-uchip-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/uchip/de_DE/adafruit-circuitpython-uchip-de_DE-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/uchip/de_DE/adafruit-circuitpython-uchip-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/uchip/en_US/adafruit-circuitpython-uchip-en_US-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/uchip/en_US/adafruit-circuitpython-uchip-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/uchip/en_x_pirate/adafruit-circuitpython-uchip-en_x_pirate-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/uchip/en_x_pirate/adafruit-circuitpython-uchip-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/uchip/es/adafruit-circuitpython-uchip-es-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/uchip/es/adafruit-circuitpython-uchip-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/uchip/fil/adafruit-circuitpython-uchip-fil-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/uchip/fil/adafruit-circuitpython-uchip-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/uchip/fr/adafruit-circuitpython-uchip-fr-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/uchip/fr/adafruit-circuitpython-uchip-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/uchip/it_IT/adafruit-circuitpython-uchip-it_IT-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/uchip/it_IT/adafruit-circuitpython-uchip-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/uchip/ko/adafruit-circuitpython-uchip-ko-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/uchip/ko/adafruit-circuitpython-uchip-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/uchip/pl/adafruit-circuitpython-uchip-pl-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/uchip/pl/adafruit-circuitpython-uchip-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/uchip/pt_BR/adafruit-circuitpython-uchip-pt_BR-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/uchip/pt_BR/adafruit-circuitpython-uchip-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/uchip/sv/adafruit-circuitpython-uchip-sv-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/uchip/sv/adafruit-circuitpython-uchip-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/uchip/zh_Latn_pinyin/adafruit-circuitpython-uchip-zh_Latn_pinyin-5.4.0-beta.0.bin",
+                        "https://downloads.circuitpython.org/bin/uchip/zh_Latn_pinyin/adafruit-circuitpython-uchip-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 13,
+        "downloads": 0,
         "id": "ugame10",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/ugame10/ID/adafruit-circuitpython-ugame10-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/ugame10/de_DE/adafruit-circuitpython-ugame10-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/ugame10/en_US/adafruit-circuitpython-ugame10-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/ugame10/en_x_pirate/adafruit-circuitpython-ugame10-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/ugame10/es/adafruit-circuitpython-ugame10-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/ugame10/fil/adafruit-circuitpython-ugame10-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/ugame10/fr/adafruit-circuitpython-ugame10-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/ugame10/it_IT/adafruit-circuitpython-ugame10-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/ugame10/ko/adafruit-circuitpython-ugame10-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/ugame10/pl/adafruit-circuitpython-ugame10-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/ugame10/pt_BR/adafruit-circuitpython-ugame10-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/ugame10/zh_Latn_pinyin/adafruit-circuitpython-ugame10-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -11754,55 +12487,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/ugame10/ID/adafruit-circuitpython-ugame10-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/ugame10/de_DE/adafruit-circuitpython-ugame10-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/ugame10/en_US/adafruit-circuitpython-ugame10-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/ugame10/en_x_pirate/adafruit-circuitpython-ugame10-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/ugame10/es/adafruit-circuitpython-ugame10-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/ugame10/fil/adafruit-circuitpython-ugame10-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/ugame10/fr/adafruit-circuitpython-ugame10-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/ugame10/it_IT/adafruit-circuitpython-ugame10-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/ugame10/ko/adafruit-circuitpython-ugame10-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/ugame10/pl/adafruit-circuitpython-ugame10-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/ugame10/pt_BR/adafruit-circuitpython-ugame10-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/ugame10/sv/adafruit-circuitpython-ugame10-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/ugame10/zh_Latn_pinyin/adafruit-circuitpython-ugame10-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 44,
+        "downloads": 0,
         "id": "winterbloom_big_honking_button",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/ID/adafruit-circuitpython-winterbloom_big_honking_button-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/de_DE/adafruit-circuitpython-winterbloom_big_honking_button-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/en_US/adafruit-circuitpython-winterbloom_big_honking_button-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/en_x_pirate/adafruit-circuitpython-winterbloom_big_honking_button-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/es/adafruit-circuitpython-winterbloom_big_honking_button-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/fil/adafruit-circuitpython-winterbloom_big_honking_button-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/fr/adafruit-circuitpython-winterbloom_big_honking_button-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/it_IT/adafruit-circuitpython-winterbloom_big_honking_button-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/ko/adafruit-circuitpython-winterbloom_big_honking_button-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/pl/adafruit-circuitpython-winterbloom_big_honking_button-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/pt_BR/adafruit-circuitpython-winterbloom_big_honking_button-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/zh_Latn_pinyin/adafruit-circuitpython-winterbloom_big_honking_button-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -11844,55 +12580,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/ID/adafruit-circuitpython-winterbloom_big_honking_button-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/de_DE/adafruit-circuitpython-winterbloom_big_honking_button-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/en_US/adafruit-circuitpython-winterbloom_big_honking_button-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/en_x_pirate/adafruit-circuitpython-winterbloom_big_honking_button-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/es/adafruit-circuitpython-winterbloom_big_honking_button-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/fil/adafruit-circuitpython-winterbloom_big_honking_button-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/fr/adafruit-circuitpython-winterbloom_big_honking_button-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/it_IT/adafruit-circuitpython-winterbloom_big_honking_button-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/ko/adafruit-circuitpython-winterbloom_big_honking_button-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/pl/adafruit-circuitpython-winterbloom_big_honking_button-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/pt_BR/adafruit-circuitpython-winterbloom_big_honking_button-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/sv/adafruit-circuitpython-winterbloom_big_honking_button-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/zh_Latn_pinyin/adafruit-circuitpython-winterbloom_big_honking_button-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 30,
+        "downloads": 0,
         "id": "winterbloom_sol",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/ID/adafruit-circuitpython-winterbloom_sol-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/de_DE/adafruit-circuitpython-winterbloom_sol-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/en_US/adafruit-circuitpython-winterbloom_sol-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/en_x_pirate/adafruit-circuitpython-winterbloom_sol-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/es/adafruit-circuitpython-winterbloom_sol-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/fil/adafruit-circuitpython-winterbloom_sol-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/fr/adafruit-circuitpython-winterbloom_sol-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/it_IT/adafruit-circuitpython-winterbloom_sol-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/ko/adafruit-circuitpython-winterbloom_sol-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/pl/adafruit-circuitpython-winterbloom_sol-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/pt_BR/adafruit-circuitpython-winterbloom_sol-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/zh_Latn_pinyin/adafruit-circuitpython-winterbloom_sol-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -11934,55 +12673,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/ID/adafruit-circuitpython-winterbloom_sol-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/de_DE/adafruit-circuitpython-winterbloom_sol-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/en_US/adafruit-circuitpython-winterbloom_sol-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/en_x_pirate/adafruit-circuitpython-winterbloom_sol-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/es/adafruit-circuitpython-winterbloom_sol-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/fil/adafruit-circuitpython-winterbloom_sol-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/fr/adafruit-circuitpython-winterbloom_sol-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/it_IT/adafruit-circuitpython-winterbloom_sol-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/ko/adafruit-circuitpython-winterbloom_sol-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/pl/adafruit-circuitpython-winterbloom_sol-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/pt_BR/adafruit-circuitpython-winterbloom_sol-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/sv/adafruit-circuitpython-winterbloom_sol-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/zh_Latn_pinyin/adafruit-circuitpython-winterbloom_sol-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 23,
+        "downloads": 0,
         "id": "xinabox_cc03",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/ID/adafruit-circuitpython-xinabox_cc03-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/de_DE/adafruit-circuitpython-xinabox_cc03-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/en_US/adafruit-circuitpython-xinabox_cc03-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/en_x_pirate/adafruit-circuitpython-xinabox_cc03-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/es/adafruit-circuitpython-xinabox_cc03-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/fil/adafruit-circuitpython-xinabox_cc03-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/fr/adafruit-circuitpython-xinabox_cc03-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/it_IT/adafruit-circuitpython-xinabox_cc03-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/ko/adafruit-circuitpython-xinabox_cc03-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/pl/adafruit-circuitpython-xinabox_cc03-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/pt_BR/adafruit-circuitpython-xinabox_cc03-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/zh_Latn_pinyin/adafruit-circuitpython-xinabox_cc03-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -12024,55 +12766,58 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/ID/adafruit-circuitpython-xinabox_cc03-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/de_DE/adafruit-circuitpython-xinabox_cc03-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/en_US/adafruit-circuitpython-xinabox_cc03-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/en_x_pirate/adafruit-circuitpython-xinabox_cc03-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/es/adafruit-circuitpython-xinabox_cc03-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/fil/adafruit-circuitpython-xinabox_cc03-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/fr/adafruit-circuitpython-xinabox_cc03-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/it_IT/adafruit-circuitpython-xinabox_cc03-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/ko/adafruit-circuitpython-xinabox_cc03-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/pl/adafruit-circuitpython-xinabox_cc03-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/pt_BR/adafruit-circuitpython-xinabox_cc03-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/sv/adafruit-circuitpython-xinabox_cc03-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/zh_Latn_pinyin/adafruit-circuitpython-xinabox_cc03-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     },
     {
-        "downloads": 24,
+        "downloads": 0,
         "id": "xinabox_cs11",
         "versions": [
-            {
-                "files": {
-                    "ID": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/ID/adafruit-circuitpython-xinabox_cs11-ID-5.3.0-rc.0.uf2"
-                    ],
-                    "de_DE": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/de_DE/adafruit-circuitpython-xinabox_cs11-de_DE-5.3.0-rc.0.uf2"
-                    ],
-                    "en_US": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/en_US/adafruit-circuitpython-xinabox_cs11-en_US-5.3.0-rc.0.uf2"
-                    ],
-                    "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/en_x_pirate/adafruit-circuitpython-xinabox_cs11-en_x_pirate-5.3.0-rc.0.uf2"
-                    ],
-                    "es": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/es/adafruit-circuitpython-xinabox_cs11-es-5.3.0-rc.0.uf2"
-                    ],
-                    "fil": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/fil/adafruit-circuitpython-xinabox_cs11-fil-5.3.0-rc.0.uf2"
-                    ],
-                    "fr": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/fr/adafruit-circuitpython-xinabox_cs11-fr-5.3.0-rc.0.uf2"
-                    ],
-                    "it_IT": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/it_IT/adafruit-circuitpython-xinabox_cs11-it_IT-5.3.0-rc.0.uf2"
-                    ],
-                    "ko": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/ko/adafruit-circuitpython-xinabox_cs11-ko-5.3.0-rc.0.uf2"
-                    ],
-                    "pl": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/pl/adafruit-circuitpython-xinabox_cs11-pl-5.3.0-rc.0.uf2"
-                    ],
-                    "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/pt_BR/adafruit-circuitpython-xinabox_cs11-pt_BR-5.3.0-rc.0.uf2"
-                    ],
-                    "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/zh_Latn_pinyin/adafruit-circuitpython-xinabox_cs11-zh_Latn_pinyin-5.3.0-rc.0.uf2"
-                    ]
-                },
-                "stable": false,
-                "version": "5.3.0-rc.0"
-            },
             {
                 "files": {
                     "ID": [
@@ -12114,6 +12859,51 @@
                 },
                 "stable": true,
                 "version": "5.3.0"
+            },
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/ID/adafruit-circuitpython-xinabox_cs11-ID-5.4.0-beta.0.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/de_DE/adafruit-circuitpython-xinabox_cs11-de_DE-5.4.0-beta.0.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/en_US/adafruit-circuitpython-xinabox_cs11-en_US-5.4.0-beta.0.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/en_x_pirate/adafruit-circuitpython-xinabox_cs11-en_x_pirate-5.4.0-beta.0.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/es/adafruit-circuitpython-xinabox_cs11-es-5.4.0-beta.0.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/fil/adafruit-circuitpython-xinabox_cs11-fil-5.4.0-beta.0.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/fr/adafruit-circuitpython-xinabox_cs11-fr-5.4.0-beta.0.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/it_IT/adafruit-circuitpython-xinabox_cs11-it_IT-5.4.0-beta.0.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/ko/adafruit-circuitpython-xinabox_cs11-ko-5.4.0-beta.0.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/pl/adafruit-circuitpython-xinabox_cs11-pl-5.4.0-beta.0.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/pt_BR/adafruit-circuitpython-xinabox_cs11-pt_BR-5.4.0-beta.0.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/sv/adafruit-circuitpython-xinabox_cs11-sv-5.4.0-beta.0.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/zh_Latn_pinyin/adafruit-circuitpython-xinabox_cs11-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.0"
             }
         ]
     }

--- a/_data/files.json
+++ b/_data/files.json
@@ -1,6 +1,6 @@
 [
     {
-        "downloads": 0,
+        "downloads": 46,
         "id": "8086_commander",
         "versions": [
             {
@@ -93,7 +93,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 25,
         "id": "TG-Watch02A",
         "versions": [
             {
@@ -186,7 +186,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 19,
         "id": "aramcon_badge_2019",
         "versions": [
             {
@@ -279,7 +279,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 5,
         "id": "arduino_mkr1300",
         "versions": [
             {
@@ -397,7 +397,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 7,
         "id": "arduino_mkrzero",
         "versions": [
             {
@@ -515,7 +515,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 57,
         "id": "arduino_nano_33_ble",
         "versions": [
             {
@@ -608,7 +608,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 16,
         "id": "arduino_nano_33_iot",
         "versions": [
             {
@@ -726,7 +726,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 26,
         "id": "arduino_zero",
         "versions": [
             {
@@ -844,7 +844,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 15,
         "id": "bast_pro_mini_m0",
         "versions": [
             {
@@ -937,7 +937,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 29,
         "id": "bdmicro_vina_m0",
         "versions": [
             {
@@ -1030,7 +1030,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 28,
         "id": "capablerobot_usbhub",
         "versions": [
             {
@@ -1123,7 +1123,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 30,
         "id": "catwan_usbstick",
         "versions": [
             {
@@ -1216,7 +1216,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 36,
         "id": "circuitbrains_basic_m0",
         "versions": [
             {
@@ -1309,7 +1309,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 45,
         "id": "circuitbrains_deluxe_m4",
         "versions": [
             {
@@ -1402,7 +1402,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 127,
         "id": "circuitplayground_bluefruit",
         "versions": [
             {
@@ -1495,7 +1495,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 317,
         "id": "circuitplayground_express",
         "versions": [
             {
@@ -1588,7 +1588,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 29,
         "id": "circuitplayground_express_4h",
         "versions": [
             {
@@ -1681,7 +1681,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 42,
         "id": "circuitplayground_express_crickit",
         "versions": [
             {
@@ -1774,7 +1774,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 32,
         "id": "circuitplayground_express_digikey_pycon2019",
         "versions": [
             {
@@ -1867,7 +1867,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 40,
         "id": "circuitplayground_express_displayio",
         "versions": [
             {
@@ -1960,7 +1960,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 87,
         "id": "clue_nrf52840_express",
         "versions": [
             {
@@ -2053,7 +2053,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 14,
         "id": "cp32-m4",
         "versions": [
             {
@@ -2146,7 +2146,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 1,
         "id": "datalore_ip_m4",
         "versions": [
             {
@@ -2239,7 +2239,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 29,
         "id": "datum_distance",
         "versions": [
             {
@@ -2332,7 +2332,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 28,
         "id": "datum_imu",
         "versions": [
             {
@@ -2425,7 +2425,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 6,
         "id": "datum_light",
         "versions": [
             {
@@ -2518,7 +2518,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 29,
         "id": "datum_weather",
         "versions": [
             {
@@ -2611,7 +2611,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 54,
         "id": "edgebadge",
         "versions": [
             {
@@ -2704,7 +2704,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 37,
         "id": "electronut_labs_blip",
         "versions": [
             {
@@ -2797,7 +2797,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 30,
         "id": "electronut_labs_papyr",
         "versions": [
             {
@@ -2890,7 +2890,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 14,
         "id": "escornabot_makech",
         "versions": [
             {
@@ -2983,7 +2983,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 8,
         "id": "espruino_pico",
         "versions": [
             {
@@ -3076,7 +3076,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 7,
         "id": "espruino_wifi",
         "versions": [
             {
@@ -3169,7 +3169,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 39,
         "id": "feather_bluefruit_sense",
         "versions": [
             {
@@ -3262,7 +3262,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 37,
         "id": "feather_m0_adalogger",
         "versions": [
             {
@@ -3380,7 +3380,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 32,
         "id": "feather_m0_basic",
         "versions": [
             {
@@ -3498,7 +3498,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 97,
         "id": "feather_m0_express",
         "versions": [
             {
@@ -3591,7 +3591,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 6,
         "id": "feather_m0_express_crickit",
         "versions": [
             {
@@ -3684,7 +3684,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 20,
         "id": "feather_m0_rfm69",
         "versions": [
             {
@@ -3802,7 +3802,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 19,
         "id": "feather_m0_rfm9x",
         "versions": [
             {
@@ -3920,7 +3920,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 13,
         "id": "feather_m0_supersized",
         "versions": [
             {
@@ -4013,7 +4013,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 201,
         "id": "feather_m4_express",
         "versions": [
             {
@@ -4106,7 +4106,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 13,
         "id": "feather_m7_1011",
         "versions": [
             {
@@ -4224,7 +4224,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 9,
         "id": "feather_mimxrt1011",
         "versions": [
             {
@@ -4342,7 +4342,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 10,
         "id": "feather_mimxrt1062",
         "versions": [
             {
@@ -4460,7 +4460,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 86,
         "id": "feather_nrf52840_express",
         "versions": [
             {
@@ -4553,7 +4553,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 27,
         "id": "feather_radiofruit_zigbee",
         "versions": [
             {
@@ -4646,7 +4646,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 47,
         "id": "feather_stm32f405_express",
         "versions": [
             {
@@ -4739,7 +4739,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 39,
         "id": "fomu",
         "versions": [
             {
@@ -4837,7 +4837,7 @@
         "versions": []
     },
     {
-        "downloads": 0,
+        "downloads": 74,
         "id": "gemma_m0",
         "versions": [
             {
@@ -4930,7 +4930,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 28,
         "id": "gemma_m0_pycon2018",
         "versions": [
             {
@@ -5023,7 +5023,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 61,
         "id": "grandcentral_m4_express",
         "versions": [
             {
@@ -5116,7 +5116,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 44,
         "id": "hallowing_m0_express",
         "versions": [
             {
@@ -5209,7 +5209,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 38,
         "id": "hallowing_m4_express",
         "versions": [
             {
@@ -5302,7 +5302,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 11,
         "id": "imxrt1010_evk",
         "versions": [
             {
@@ -5420,7 +5420,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 4,
         "id": "imxrt1020_evk",
         "versions": [
             {
@@ -5538,7 +5538,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 9,
         "id": "imxrt1060_evk",
         "versions": [
             {
@@ -5656,7 +5656,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 57,
         "id": "itsybitsy_m0_express",
         "versions": [
             {
@@ -5749,7 +5749,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 122,
         "id": "itsybitsy_m4_express",
         "versions": [
             {
@@ -5842,7 +5842,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 70,
         "id": "itsybitsy_nrf52840_express",
         "versions": [
             {
@@ -5935,7 +5935,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 49,
         "id": "kicksat-sprite",
         "versions": [
             {
@@ -6028,7 +6028,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 26,
         "id": "makerdiary_nrf52840_mdk",
         "versions": [
             {
@@ -6121,7 +6121,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 40,
         "id": "makerdiary_nrf52840_mdk_usb_dongle",
         "versions": [
             {
@@ -6214,7 +6214,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 9,
         "id": "meowbit_v121",
         "versions": [
             {
@@ -6307,7 +6307,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 27,
         "id": "meowmeow",
         "versions": [
             {
@@ -6400,7 +6400,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 83,
         "id": "metro_m0_express",
         "versions": [
             {
@@ -6493,7 +6493,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 46,
         "id": "metro_m4_airlift_lite",
         "versions": [
             {
@@ -6586,7 +6586,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 47,
         "id": "metro_m4_express",
         "versions": [
             {
@@ -6679,7 +6679,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 29,
         "id": "metro_nrf52840_express",
         "versions": [
             {
@@ -6772,7 +6772,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 25,
         "id": "mini_sam_m4",
         "versions": [
             {
@@ -6865,7 +6865,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 56,
         "id": "monster_m4sk",
         "versions": [
             {
@@ -6958,7 +6958,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 26,
         "id": "ndgarage_ndbit6",
         "versions": [
             {
@@ -7051,7 +7051,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 44,
         "id": "nfc_copy_cat",
         "versions": [
             {
@@ -7381,7 +7381,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 58,
         "id": "ohs2020_badge",
         "versions": [
             {
@@ -7474,7 +7474,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 31,
         "id": "openbook_m4",
         "versions": [
             {
@@ -7618,7 +7618,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 27,
         "id": "particle_argon",
         "versions": [
             {
@@ -7804,7 +7804,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 32,
         "id": "particle_xenon",
         "versions": [
             {
@@ -7902,7 +7902,7 @@
         "versions": []
     },
     {
-        "downloads": 0,
+        "downloads": 9,
         "id": "pca10056",
         "versions": [
             {
@@ -8020,7 +8020,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 19,
         "id": "pca10059",
         "versions": [
             {
@@ -8189,7 +8189,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 29,
         "id": "pewpew10",
         "versions": [
             {
@@ -8282,7 +8282,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 16,
         "id": "pewpew13",
         "versions": [
             {
@@ -8375,7 +8375,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 26,
         "id": "pewpew_m4",
         "versions": [
             {
@@ -8468,7 +8468,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 27,
         "id": "pirkey_m0",
         "versions": [
             {
@@ -8612,7 +8612,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 3,
         "id": "pyb_nano_v2",
         "versions": [
             {
@@ -8705,7 +8705,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 52,
         "id": "pybadge",
         "versions": [
             {
@@ -8798,7 +8798,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 16,
         "id": "pybadge_airlift",
         "versions": [
             {
@@ -8891,7 +8891,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 34,
         "id": "pyboard_v11",
         "versions": [
             {
@@ -8984,7 +8984,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 35,
         "id": "pycubed",
         "versions": [
             {
@@ -9077,7 +9077,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 67,
         "id": "pygamer",
         "versions": [
             {
@@ -9170,7 +9170,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 28,
         "id": "pygamer_advance",
         "versions": [
             {
@@ -9263,7 +9263,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 183,
         "id": "pyportal",
         "versions": [
             {
@@ -9356,7 +9356,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 14,
         "id": "pyportal_pynt",
         "versions": [
             {
@@ -9449,7 +9449,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 41,
         "id": "pyportal_titano",
         "versions": [
             {
@@ -9542,7 +9542,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 41,
         "id": "pyruler",
         "versions": [
             {
@@ -9635,7 +9635,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 34,
         "id": "robohatmm1_m4",
         "versions": [
             {
@@ -9728,7 +9728,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 28,
         "id": "sam32",
         "versions": [
             {
@@ -9821,7 +9821,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 49,
         "id": "seeeduino_xiao",
         "versions": [
             {
@@ -9914,7 +9914,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 55,
         "id": "serpente",
         "versions": [
             {
@@ -10007,7 +10007,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 4,
         "id": "shirtty",
         "versions": [
             {
@@ -10151,7 +10151,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 29,
         "id": "snekboard",
         "versions": [
             {
@@ -10244,7 +10244,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 28,
         "id": "sparkfun_lumidrive",
         "versions": [
             {
@@ -10337,7 +10337,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 31,
         "id": "sparkfun_nrf52840_mini",
         "versions": [
             {
@@ -10430,7 +10430,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 38,
         "id": "sparkfun_qwiic_micro_no_flash",
         "versions": [
             {
@@ -10523,7 +10523,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 3,
         "id": "sparkfun_qwiic_micro_with_flash",
         "versions": [
             {
@@ -10616,7 +10616,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 29,
         "id": "sparkfun_redboard_turbo",
         "versions": [
             {
@@ -10709,7 +10709,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 7,
         "id": "sparkfun_samd21_dev",
         "versions": [
             {
@@ -10802,7 +10802,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 31,
         "id": "sparkfun_samd21_mini",
         "versions": [
             {
@@ -10895,7 +10895,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 42,
         "id": "sparkfun_samd51_thing_plus",
         "versions": [
             {
@@ -10988,7 +10988,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 54,
         "id": "spresense",
         "versions": [
             {
@@ -11081,7 +11081,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 34,
         "id": "stm32f411ce_blackpill",
         "versions": [
             {
@@ -11174,7 +11174,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 23,
         "id": "stm32f411ve_discovery",
         "versions": [
             {
@@ -11267,7 +11267,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 20,
         "id": "stm32f412zg_discovery",
         "versions": [
             {
@@ -11360,7 +11360,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 26,
         "id": "stm32f4_discovery",
         "versions": [
             {
@@ -11504,7 +11504,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 31,
         "id": "stringcar_m0_express",
         "versions": [
             {
@@ -11597,7 +11597,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 55,
         "id": "teensy40",
         "versions": [
             {
@@ -11779,7 +11779,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 27,
         "id": "teknikio_bluebird",
         "versions": [
             {
@@ -11872,7 +11872,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 15,
         "id": "thunderpack",
         "versions": [
             {
@@ -11965,7 +11965,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 94,
         "id": "trellis_m4_express",
         "versions": [
             {
@@ -12058,7 +12058,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 150,
         "id": "trinket_m0",
         "versions": [
             {
@@ -12151,7 +12151,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 1,
         "id": "trinket_m0_haxpress",
         "versions": [
             {
@@ -12337,7 +12337,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 29,
         "id": "uchip",
         "versions": [
             {
@@ -12443,7 +12443,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 24,
         "id": "ugame10",
         "versions": [
             {
@@ -12536,7 +12536,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 39,
         "id": "winterbloom_big_honking_button",
         "versions": [
             {
@@ -12629,7 +12629,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 45,
         "id": "winterbloom_sol",
         "versions": [
             {
@@ -12722,7 +12722,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 1,
         "id": "xinabox_cc03",
         "versions": [
             {
@@ -12815,7 +12815,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 38,
         "id": "xinabox_cs11",
         "versions": [
             {


### PR DESCRIPTION
Automated website update for release 5.4.0-beta.0 by Blinka.

New boards:
* simmel
* pitaya_go
* pca10100
* openmv_h7
* nucleo_f746zg
* stm32f746g_discovery
* teensy41

New languages:
* sv
