### PR TITLE
contributing: Add weblate

### DIFF
--- a/_layouts/contributing.html
+++ b/_layouts/contributing.html
@@ -23,6 +23,9 @@ layout: default
       Have an idea for a new driver or library?
       <a href="https://github.com/adafruit/circuitpython/issues">File an issue on the CircuitPython repo!</a>
     </p>
+    <p>
+      Contribute localizations (translations) of CircuitPython using <a href="https://hosted.weblate.org/engage/circuitpython/">Weblate</a>.
+    </p>
     <h2>Current Status for {{ site.data.libraries.updated_at | date: "%a, %b %d, %Y" }}</h2>
 
     {% assign current = page.url | downcase | split: '/' %}
@@ -39,6 +42,10 @@ layout: default
         <a href="/contributing/library-infrastructure-issues" {% if
            current[2] ==
         'library-infrastructure-issues' %}class='active'{% endif %}>Library Infrastructure Issues</a>
+      </li>
+      <li>
+        <a href="/contributing/weblate" {% if current[2] ==
+        'weblate' %}class='active'{% endif %}>Localization</a>
       </li>
     </ul>
     <div class="clear"></div>

--- a/contributing/weblate.html
+++ b/contributing/weblate.html
@@ -1,0 +1,24 @@
+---
+layout: contributing
+title: Contributing - Localization
+permalink: /contributing/weblate
+---
+
+<h2>Translation with Weblate</h2>
+<div class="weblate">
+  <a href="https://hosted.weblate.org/engage/circuitpython/?utm_source=widget">
+    <img src="https://hosted.weblate.org/widgets/circuitpython/-/multi-auto.svg" alt="Translation status" />
+  </a>
+</div>
+<p>
+  Contribute to CircuitPython by localizing (translating) its control and error messages into other
+  languages. With the help of fellow open source project <a href="https://weblate.org/">Weblate</a>,
+  we're making it even easier to add or improve translations.
+</p>
+<p>
+  On <a href="https://hosted.weblate.org/projects/circuitpython/main/"
+  >hosted.weblate.org</a>, you can sign in with an existing account such as
+  Github, Google or Facebook and start contributing through a simple web interface. No forks or pull
+  requests needed!  As always, if you run into trouble join us on <a
+  href="https://adafru.it/discord">Discord</a>, we're here to help.
+</p>

--- a/contributing/weblate.html
+++ b/contributing/weblate.html
@@ -9,6 +9,9 @@ permalink: /contributing/weblate
   <a href="https://hosted.weblate.org/engage/circuitpython/?utm_source=widget">
     <img src="https://hosted.weblate.org/widgets/circuitpython/-/multi-auto.svg" alt="Translation status" />
   </a>
+  <a href="https://hosted.weblate.org/engage/circuitpython/?utm_source=widget">
+    <img src="https://hosted.weblate.org/widgets/circuitpython/-/287x66-grey.png" alt="Translation status" />
+  </a>
 </div>
 <p>
   Contribute to CircuitPython by localizing (translating) its control and error messages into other


### PR DESCRIPTION
It looks roughly like this:

![Screenshot_2020-05-16_17-54-51](https://user-images.githubusercontent.com/1517291/82131766-5d0d4880-979e-11ea-9a55-7077962f3288.png)

There are other widgets we could choose instead:
https://hosted.weblate.org/widgets/circuitpython/
