### PR TITLE
Automated website update for release 5.4.0-beta.1

### DIFF
--- a/_board/circuitbrains_basic_m0.md
+++ b/_board/circuitbrains_basic_m0.md
@@ -14,6 +14,8 @@ download_instructions: ""
 
 CircuitPython on an ARM Cortex M0 in 1 square inch! This "Just Add Solder" castellated module is perfect for incorporating into your own project. The CircuitBrains Basic board footprint is small enough to fit into narrow spaces and wearable projects.
 
+**NOTE:** This board does not have a USB connector for the native USB. Native USB is broken out on the header/castellations and therefore requires a non-standard USB connection such as mounting to a motherboard PCB.
+
 ## Technical Specs
 
 - Dimensions: 25 x 25 x 3.5 millimeters / 1 x 1 x 0.15 inches

--- a/_board/circuitbrains_deluxe_m4.md
+++ b/_board/circuitbrains_deluxe_m4.md
@@ -14,6 +14,8 @@ download_instructions: ""
 
 CircuitPython on an ARM Cortex M4 in almost 1 square inch! This "Just Add Solder" castellated module is perfect for incorporating into your own project. The CircuitBrains Deluxe board footprint is small enough to fit into narrow spaces and wearable projects.
 
+**NOTE:** This board does not have a USB connector for the native USB. Native USB is broken out on the header/castellations and therefore requires a non-standard USB connection such as mounting to a motherboard PCB.
+
 ## Technical Specs
 
 - Dimensions: 29 x 29 x 3.5 millimeters / 1.15 x 1.15 x 0.15 inches

--- a/_board/espressif_saola_1_wroom.md
+++ b/_board/espressif_saola_1_wroom.md
@@ -1,8 +1,8 @@
 ---
 layout: download
-board_id: "espressif_saola_1_wrover"
-title: "Saola 1 w/WROVER Download"
-name: "Saola 1 w/WROVER"
+board_id: "espressif_saola_1_wroom"
+title: "Saola 1 w/WROOM Download"
+name: "Saola 1 w/WROOM"
 manufacturer: "Espressif"
 board_url: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-saola-1-v1.2.html"
 board_image: "unknown.jpg"

--- a/_board/espressif_saola_1_wroom.md
+++ b/_board/espressif_saola_1_wroom.md
@@ -1,0 +1,21 @@
+---
+layout: download
+board_id: "espressif_saola_1_wrover"
+title: "Saola 1 w/WROVER Download"
+name: "Saola 1 w/WROVER"
+manufacturer: "Espressif"
+board_url: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-saola-1-v1.2.html"
+board_image: "unknown.jpg"
+date_added: 2020-05-15
+---
+
+This is the Saola dev board with a WROOM ESP32-S2 module.
+
+**NOTE:** This board does not have a USB connector for the native USB. Native USB is broken out on the header and therefore requires a non-standard USB connection such as [a breakout cable](https://www.adafruit.com/product/4448).
+
+## Learn More
+* [User Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-saola-1-v1.2.html)
+
+## Contribute
+
+Have some info to add for this board? Edit the source for this page [here](https://github.com/adafruit/circuitpython-org/edit/master/_board/{{ page.board_id }}.md).

--- a/_board/espressif_saola_1_wrover.md
+++ b/_board/espressif_saola_1_wrover.md
@@ -1,0 +1,21 @@
+---
+layout: download
+board_id: "espressif_saola_1_wrover"
+title: "Saola 1 w/WROVER Download"
+name: "Saola 1 w/WROVER"
+manufacturer: "Espressif"
+board_url: "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-saola-1-v1.2.html"
+board_image: "unknown.jpg"
+date_added: 2020-05-15
+---
+
+This is the Saola dev board with a WROVER ESP32-S2 module. The module includes 2MB PSRAM.
+
+**NOTE:** This board does not have a USB connector for the native USB. Native USB is broken out on the header and therefore requires a non-standard USB connection such as [a breakout cable](https://www.adafruit.com/product/4448).
+
+## Learn More
+* [User Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-saola-1-v1.2.html)
+
+## Contribute
+
+Have some info to add for this board? Edit the source for this page [here](https://github.com/adafruit/circuitpython-org/edit/master/_board/{{ page.board_id }}.md).

--- a/_board/fluff_m0.md
+++ b/_board/fluff_m0.md
@@ -1,0 +1,16 @@
+---
+layout: download
+board_id: "fluff_m0"
+title: "Fluff M0 Download"
+name: "Fluff M0"
+manufacturer: "Radomir Dopieralski"
+board_url: "https://hackaday.io/project/171381-fluff-m0"
+board_image: "unknown.jpg"
+date_added: 2020-5-22
+---
+
+[Hackaday.io](https://hackaday.io/project/171381-fluff-m0)
+
+## Contribute
+
+Have some info to add for this board? Edit the source for this page [here](https://github.com/adafruit/circuitpython-org/edit/master/_board/{{ page.board_id }}.md).

--- a/_board/nice_nano.md
+++ b/_board/nice_nano.md
@@ -1,0 +1,17 @@
+---
+layout: download
+board_id: "nice_nano"
+title: "nice!nano Download"
+name: "Nice!Nano"
+manufacturer: "Nice Keyboards"
+board_url: "https://docs.nicekeyboards.com/#/nice!nano/"
+board_image: "unknown.jpg"
+date_added: 2020-06-05
+---
+
+## Learn More
+* [Nice Keyboards](https://docs.nicekeyboards.com/#/nice!nano/)
+
+## Contribute
+
+Have some info to add for this board? Edit the source for this page [here](https://github.com/adafruit/circuitpython-org/edit/master/_board/{{ page.board_id }}.md).

--- a/_board/pycubed_mram.md
+++ b/_board/pycubed_mram.md
@@ -1,0 +1,24 @@
+---
+layout: download
+board_id: "pycubed_mram"
+title: "PyCubed w/MRAM Download"
+name: "PyCubed w/MRAM"
+manufacturer: "Robot Exploration Lab"
+board_url: "https://rexlab.stanford.edu/projects/pycubed.html"
+board_image: "pycubed.jpg"
+date_added: 2020-4-07
+features:
+---
+
+The hardware and software pitfalls associated with satellite development greatly contribute to the nearly 60% failure rates of initial CubeSat missions. As the role of small satellites in commercial and scientific endeavors evolves beyond an “engineering exercise,” basic aspects of the spacecraft design must be matured and made widely available in order to continue advancing this valuable technology for Space exploration.
+
+PyCubed: an open-source, radiation-tested CubeSat framework that cost-effectively integrates ADCS, TT&C, C&DH, and EPS into a single PC104-compatible module programmable entirely in Python. PyRCubed addresses many hardware-related failure modes of CubeSats through component and system-level radiation testing, in-depth design and qualification documentation, and on-orbit flight performance from an ongoing LEO mission (KickSat-2). The challenge of mission-ready software development is also mitigated through low-level implementation of the Python programming language via CircuitPython.
+
+This version uses magnetic RAM (MRAM) instead of flash memory.
+
+## Learn More
+* [Github](https://github.com/PyCubed)
+
+## Contribute
+
+Have some info to add for this board? Edit the source for this page [here](https://github.com/adafruit/circuitpython-org/edit/master/_board/{{ page.board_id }}.md).

--- a/_board/simmel.md
+++ b/_board/simmel.md
@@ -6,7 +6,7 @@ name: "Simmel Board"
 manufacturer: "Simmel Project"
 board_url: "https://github.com/simmel-project/frontpage"
 board_image: "simmel.jpg"
-date_added: 2019-04-29
+date_added: 2020-04-29
 ---
 
 Simmel is a platform that enables COVID-19 contact tracing while preserving user privacy. It is a wearable hardware beacon and scanner which can broadcast and record randomized user IDs. Contacts are stored within the wearable device, so you retain full control of your trace history until you choose to share it.

--- a/_data/files.json
+++ b/_data/files.json
@@ -1,6 +1,6 @@
 [
     {
-        "downloads": 0,
+        "downloads": 29,
         "id": "8086_commander",
         "versions": [
             {
@@ -99,7 +99,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 15,
         "id": "TG-Watch02A",
         "versions": [
             {
@@ -255,7 +255,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 41,
         "id": "aramcon_badge_2019",
         "versions": [
             {
@@ -354,7 +354,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 31,
         "id": "arduino_mkr1300",
         "versions": [
             {
@@ -480,7 +480,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 32,
         "id": "arduino_mkrzero",
         "versions": [
             {
@@ -606,7 +606,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 76,
         "id": "arduino_nano_33_ble",
         "versions": [
             {
@@ -705,7 +705,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 39,
         "id": "arduino_nano_33_iot",
         "versions": [
             {
@@ -831,7 +831,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 79,
         "id": "arduino_zero",
         "versions": [
             {
@@ -957,7 +957,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 7,
         "id": "bast_pro_mini_m0",
         "versions": [
             {
@@ -1056,7 +1056,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 55,
         "id": "bdmicro_vina_m0",
         "versions": [
             {
@@ -1155,7 +1155,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 40,
         "id": "capablerobot_usbhub",
         "versions": [
             {
@@ -1254,7 +1254,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 23,
         "id": "catwan_usbstick",
         "versions": [
             {
@@ -1353,7 +1353,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 51,
         "id": "circuitbrains_basic_m0",
         "versions": [
             {
@@ -1452,7 +1452,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 43,
         "id": "circuitbrains_deluxe_m4",
         "versions": [
             {
@@ -1551,7 +1551,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 230,
         "id": "circuitplayground_bluefruit",
         "versions": [
             {
@@ -1650,7 +1650,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 640,
         "id": "circuitplayground_express",
         "versions": [
             {
@@ -1749,7 +1749,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 32,
         "id": "circuitplayground_express_4h",
         "versions": [
             {
@@ -1848,7 +1848,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 66,
         "id": "circuitplayground_express_crickit",
         "versions": [
             {
@@ -1947,7 +1947,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 29,
         "id": "circuitplayground_express_digikey_pycon2019",
         "versions": [
             {
@@ -2046,7 +2046,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 42,
         "id": "circuitplayground_express_displayio",
         "versions": [
             {
@@ -2145,7 +2145,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 178,
         "id": "clue_nrf52840_express",
         "versions": [
             {
@@ -2244,7 +2244,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 7,
         "id": "cp32-m4",
         "versions": [
             {
@@ -2343,7 +2343,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 5,
         "id": "datalore_ip_m4",
         "versions": [
             {
@@ -2442,7 +2442,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 42,
         "id": "datum_distance",
         "versions": [
             {
@@ -2541,7 +2541,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 37,
         "id": "datum_imu",
         "versions": [
             {
@@ -2640,7 +2640,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 13,
         "id": "datum_light",
         "versions": [
             {
@@ -2739,7 +2739,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 35,
         "id": "datum_weather",
         "versions": [
             {
@@ -2838,7 +2838,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 66,
         "id": "edgebadge",
         "versions": [
             {
@@ -2937,7 +2937,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 30,
         "id": "electronut_labs_blip",
         "versions": [
             {
@@ -3036,7 +3036,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 39,
         "id": "electronut_labs_papyr",
         "versions": [
             {
@@ -3135,7 +3135,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 14,
         "id": "escornabot_makech",
         "versions": [
             {
@@ -3348,7 +3348,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 14,
         "id": "espruino_pico",
         "versions": [
             {
@@ -3447,7 +3447,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 16,
         "id": "espruino_wifi",
         "versions": [
             {
@@ -3546,7 +3546,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 51,
         "id": "feather_bluefruit_sense",
         "versions": [
             {
@@ -3645,7 +3645,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 77,
         "id": "feather_m0_adalogger",
         "versions": [
             {
@@ -3771,7 +3771,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 75,
         "id": "feather_m0_basic",
         "versions": [
             {
@@ -3897,7 +3897,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 202,
         "id": "feather_m0_express",
         "versions": [
             {
@@ -3996,7 +3996,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 18,
         "id": "feather_m0_express_crickit",
         "versions": [
             {
@@ -4095,7 +4095,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 36,
         "id": "feather_m0_rfm69",
         "versions": [
             {
@@ -4221,7 +4221,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 65,
         "id": "feather_m0_rfm9x",
         "versions": [
             {
@@ -4347,7 +4347,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 36,
         "id": "feather_m0_supersized",
         "versions": [
             {
@@ -4446,7 +4446,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 365,
         "id": "feather_m4_express",
         "versions": [
             {
@@ -4545,7 +4545,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 24,
         "id": "feather_m7_1011",
         "versions": [
             {
@@ -4671,7 +4671,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 21,
         "id": "feather_mimxrt1011",
         "versions": [
             {
@@ -4797,7 +4797,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 27,
         "id": "feather_mimxrt1062",
         "versions": [
             {
@@ -4923,7 +4923,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 155,
         "id": "feather_nrf52840_express",
         "versions": [
             {
@@ -5022,7 +5022,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 18,
         "id": "feather_radiofruit_zigbee",
         "versions": [
             {
@@ -5121,7 +5121,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 69,
         "id": "feather_stm32f405_express",
         "versions": [
             {
@@ -5277,7 +5277,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 38,
         "id": "fomu",
         "versions": [
             {
@@ -5381,7 +5381,7 @@
         "versions": []
     },
     {
-        "downloads": 0,
+        "downloads": 122,
         "id": "gemma_m0",
         "versions": [
             {
@@ -5480,7 +5480,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 35,
         "id": "gemma_m0_pycon2018",
         "versions": [
             {
@@ -5579,7 +5579,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 105,
         "id": "grandcentral_m4_express",
         "versions": [
             {
@@ -5678,7 +5678,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 45,
         "id": "hallowing_m0_express",
         "versions": [
             {
@@ -5777,7 +5777,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 35,
         "id": "hallowing_m4_express",
         "versions": [
             {
@@ -5933,7 +5933,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 31,
         "id": "imxrt1010_evk",
         "versions": [
             {
@@ -6059,7 +6059,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 31,
         "id": "imxrt1020_evk",
         "versions": [
             {
@@ -6185,7 +6185,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 36,
         "id": "imxrt1060_evk",
         "versions": [
             {
@@ -6311,7 +6311,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 111,
         "id": "itsybitsy_m0_express",
         "versions": [
             {
@@ -6410,7 +6410,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 210,
         "id": "itsybitsy_m4_express",
         "versions": [
             {
@@ -6509,7 +6509,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 116,
         "id": "itsybitsy_nrf52840_express",
         "versions": [
             {
@@ -6608,7 +6608,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 50,
         "id": "kicksat-sprite",
         "versions": [
             {
@@ -6707,7 +6707,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 26,
         "id": "makerdiary_nrf52840_mdk",
         "versions": [
             {
@@ -6806,7 +6806,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 63,
         "id": "makerdiary_nrf52840_mdk_usb_dongle",
         "versions": [
             {
@@ -6920,7 +6920,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 25,
         "id": "meowbit_v121",
         "versions": [
             {
@@ -7019,7 +7019,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 27,
         "id": "meowmeow",
         "versions": [
             {
@@ -7118,7 +7118,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 149,
         "id": "metro_m0_express",
         "versions": [
             {
@@ -7217,7 +7217,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 84,
         "id": "metro_m4_airlift_lite",
         "versions": [
             {
@@ -7316,7 +7316,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 90,
         "id": "metro_m4_express",
         "versions": [
             {
@@ -7415,7 +7415,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 32,
         "id": "metro_nrf52840_express",
         "versions": [
             {
@@ -7514,7 +7514,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 24,
         "id": "mini_sam_m4",
         "versions": [
             {
@@ -7613,7 +7613,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 62,
         "id": "monster_m4sk",
         "versions": [
             {
@@ -7712,7 +7712,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 33,
         "id": "ndgarage_ndbit6",
         "versions": [
             {
@@ -7811,7 +7811,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 38,
         "id": "nfc_copy_cat",
         "versions": [
             {
@@ -7967,7 +7967,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 12,
         "id": "nucleo_f746zg",
         "versions": [
             {
@@ -8024,7 +8024,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 31,
         "id": "nucleo_f767zi",
         "versions": [
             {
@@ -8123,7 +8123,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 33,
         "id": "nucleo_h743zi_2",
         "versions": [
             {
@@ -8222,7 +8222,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 44,
         "id": "ohs2020_badge",
         "versions": [
             {
@@ -8321,7 +8321,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 53,
         "id": "openbook_m4",
         "versions": [
             {
@@ -8420,7 +8420,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 7,
         "id": "openmv_h7",
         "versions": [
             {
@@ -8477,7 +8477,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 43,
         "id": "particle_argon",
         "versions": [
             {
@@ -8576,7 +8576,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 12,
         "id": "particle_boron",
         "versions": [
             {
@@ -8675,7 +8675,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 76,
         "id": "particle_xenon",
         "versions": [
             {
@@ -8779,7 +8779,7 @@
         "versions": []
     },
     {
-        "downloads": 0,
+        "downloads": 40,
         "id": "pca10056",
         "versions": [
             {
@@ -8905,7 +8905,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 66,
         "id": "pca10059",
         "versions": [
             {
@@ -9031,7 +9031,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 19,
         "id": "pca10100",
         "versions": [
             {
@@ -9088,7 +9088,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 32,
         "id": "pewpew10",
         "versions": [
             {
@@ -9187,7 +9187,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 5,
         "id": "pewpew13",
         "versions": [
             {
@@ -9286,7 +9286,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 27,
         "id": "pewpew_m4",
         "versions": [
             {
@@ -9385,7 +9385,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 35,
         "id": "pirkey_m0",
         "versions": [
             {
@@ -9484,7 +9484,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 18,
         "id": "pitaya_go",
         "versions": [
             {
@@ -9541,7 +9541,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 9,
         "id": "pyb_nano_v2",
         "versions": [
             {
@@ -9640,7 +9640,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 119,
         "id": "pybadge",
         "versions": [
             {
@@ -9739,7 +9739,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 42,
         "id": "pybadge_airlift",
         "versions": [
             {
@@ -9838,7 +9838,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 50,
         "id": "pyboard_v11",
         "versions": [
             {
@@ -9937,7 +9937,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 36,
         "id": "pycubed",
         "versions": [
             {
@@ -10093,7 +10093,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 113,
         "id": "pygamer",
         "versions": [
             {
@@ -10192,7 +10192,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 22,
         "id": "pygamer_advance",
         "versions": [
             {
@@ -10291,7 +10291,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 299,
         "id": "pyportal",
         "versions": [
             {
@@ -10390,7 +10390,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 56,
         "id": "pyportal_pynt",
         "versions": [
             {
@@ -10489,7 +10489,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 61,
         "id": "pyportal_titano",
         "versions": [
             {
@@ -10588,7 +10588,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 56,
         "id": "pyruler",
         "versions": [
             {
@@ -10687,7 +10687,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 26,
         "id": "robohatmm1_m4",
         "versions": [
             {
@@ -10786,7 +10786,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 43,
         "id": "sam32",
         "versions": [
             {
@@ -10885,7 +10885,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 95,
         "id": "seeeduino_xiao",
         "versions": [
             {
@@ -10984,7 +10984,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 63,
         "id": "serpente",
         "versions": [
             {
@@ -11083,7 +11083,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 36,
         "id": "shirtty",
         "versions": [
             {
@@ -11182,7 +11182,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 21,
         "id": "simmel",
         "versions": [
             {
@@ -11239,7 +11239,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 30,
         "id": "snekboard",
         "versions": [
             {
@@ -11338,7 +11338,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 37,
         "id": "sparkfun_lumidrive",
         "versions": [
             {
@@ -11437,7 +11437,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 39,
         "id": "sparkfun_nrf52840_mini",
         "versions": [
             {
@@ -11536,7 +11536,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 47,
         "id": "sparkfun_qwiic_micro_no_flash",
         "versions": [
             {
@@ -11635,7 +11635,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 34,
         "id": "sparkfun_qwiic_micro_with_flash",
         "versions": [
             {
@@ -11734,7 +11734,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 33,
         "id": "sparkfun_redboard_turbo",
         "versions": [
             {
@@ -11833,7 +11833,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 17,
         "id": "sparkfun_samd21_dev",
         "versions": [
             {
@@ -11932,7 +11932,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 31,
         "id": "sparkfun_samd21_mini",
         "versions": [
             {
@@ -12031,7 +12031,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 48,
         "id": "sparkfun_samd51_thing_plus",
         "versions": [
             {
@@ -12130,7 +12130,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 77,
         "id": "spresense",
         "versions": [
             {
@@ -12229,7 +12229,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 60,
         "id": "stm32f411ce_blackpill",
         "versions": [
             {
@@ -12328,7 +12328,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 33,
         "id": "stm32f411ve_discovery",
         "versions": [
             {
@@ -12427,7 +12427,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 24,
         "id": "stm32f412zg_discovery",
         "versions": [
             {
@@ -12526,7 +12526,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 57,
         "id": "stm32f4_discovery",
         "versions": [
             {
@@ -12625,7 +12625,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 11,
         "id": "stm32f746g_discovery",
         "versions": [
             {
@@ -12682,7 +12682,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 23,
         "id": "stringcar_m0_express",
         "versions": [
             {
@@ -12781,7 +12781,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 128,
         "id": "teensy40",
         "versions": [
             {
@@ -12907,7 +12907,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 39,
         "id": "teensy41",
         "versions": [
             {
@@ -12979,7 +12979,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 34,
         "id": "teknikio_bluebird",
         "versions": [
             {
@@ -13078,7 +13078,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 18,
         "id": "thunderpack",
         "versions": [
             {
@@ -13177,7 +13177,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 118,
         "id": "trellis_m4_express",
         "versions": [
             {
@@ -13276,7 +13276,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 308,
         "id": "trinket_m0",
         "versions": [
             {
@@ -13375,7 +13375,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 10,
         "id": "trinket_m0_haxpress",
         "versions": [
             {
@@ -13474,7 +13474,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 4,
         "id": "uartlogger2",
         "versions": [
             {
@@ -13573,7 +13573,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 36,
         "id": "uchip",
         "versions": [
             {
@@ -13687,7 +13687,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 35,
         "id": "ugame10",
         "versions": [
             {
@@ -13786,7 +13786,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 29,
         "id": "winterbloom_big_honking_button",
         "versions": [
             {
@@ -13885,7 +13885,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 46,
         "id": "winterbloom_sol",
         "versions": [
             {
@@ -13984,7 +13984,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 35,
         "id": "xinabox_cc03",
         "versions": [
             {
@@ -14083,7 +14083,7 @@
         ]
     },
     {
-        "downloads": 0,
+        "downloads": 56,
         "id": "xinabox_cs11",
         "versions": [
             {

--- a/_data/files.json
+++ b/_data/files.json
@@ -1,6 +1,6 @@
 [
     {
-        "downloads": 46,
+        "downloads": 0,
         "id": "8086_commander",
         "versions": [
             {
@@ -48,52 +48,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/8086_commander/ID/adafruit-circuitpython-8086_commander-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/8086_commander/ID/adafruit-circuitpython-8086_commander-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/8086_commander/cs/adafruit-circuitpython-8086_commander-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/8086_commander/de_DE/adafruit-circuitpython-8086_commander-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/8086_commander/de_DE/adafruit-circuitpython-8086_commander-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/8086_commander/en_US/adafruit-circuitpython-8086_commander-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/8086_commander/en_US/adafruit-circuitpython-8086_commander-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/8086_commander/en_x_pirate/adafruit-circuitpython-8086_commander-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/8086_commander/en_x_pirate/adafruit-circuitpython-8086_commander-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/8086_commander/es/adafruit-circuitpython-8086_commander-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/8086_commander/es/adafruit-circuitpython-8086_commander-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/8086_commander/fil/adafruit-circuitpython-8086_commander-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/8086_commander/fil/adafruit-circuitpython-8086_commander-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/8086_commander/fr/adafruit-circuitpython-8086_commander-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/8086_commander/fr/adafruit-circuitpython-8086_commander-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/8086_commander/it_IT/adafruit-circuitpython-8086_commander-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/8086_commander/it_IT/adafruit-circuitpython-8086_commander-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/8086_commander/ko/adafruit-circuitpython-8086_commander-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/8086_commander/ko/adafruit-circuitpython-8086_commander-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/8086_commander/nl/adafruit-circuitpython-8086_commander-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/8086_commander/pl/adafruit-circuitpython-8086_commander-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/8086_commander/pl/adafruit-circuitpython-8086_commander-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/8086_commander/pt_BR/adafruit-circuitpython-8086_commander-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/8086_commander/pt_BR/adafruit-circuitpython-8086_commander-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/8086_commander/sv/adafruit-circuitpython-8086_commander-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/8086_commander/sv/adafruit-circuitpython-8086_commander-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/8086_commander/zh_Latn_pinyin/adafruit-circuitpython-8086_commander-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/8086_commander/zh_Latn_pinyin/adafruit-circuitpython-8086_commander-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 25,
+        "downloads": 0,
         "id": "TG-Watch02A",
         "versions": [
             {
@@ -141,52 +147,115 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/TG-Watch02A/ID/adafruit-circuitpython-TG-Watch02A-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/ID/adafruit-circuitpython-TG-Watch02A-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/cs/adafruit-circuitpython-TG-Watch02A-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/TG-Watch02A/de_DE/adafruit-circuitpython-TG-Watch02A-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/de_DE/adafruit-circuitpython-TG-Watch02A-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/TG-Watch02A/en_US/adafruit-circuitpython-TG-Watch02A-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/en_US/adafruit-circuitpython-TG-Watch02A-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/TG-Watch02A/en_x_pirate/adafruit-circuitpython-TG-Watch02A-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/en_x_pirate/adafruit-circuitpython-TG-Watch02A-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/TG-Watch02A/es/adafruit-circuitpython-TG-Watch02A-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/es/adafruit-circuitpython-TG-Watch02A-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/TG-Watch02A/fil/adafruit-circuitpython-TG-Watch02A-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/fil/adafruit-circuitpython-TG-Watch02A-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/TG-Watch02A/fr/adafruit-circuitpython-TG-Watch02A-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/fr/adafruit-circuitpython-TG-Watch02A-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/TG-Watch02A/it_IT/adafruit-circuitpython-TG-Watch02A-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/it_IT/adafruit-circuitpython-TG-Watch02A-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/TG-Watch02A/ko/adafruit-circuitpython-TG-Watch02A-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/ko/adafruit-circuitpython-TG-Watch02A-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/nl/adafruit-circuitpython-TG-Watch02A-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/TG-Watch02A/pl/adafruit-circuitpython-TG-Watch02A-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/pl/adafruit-circuitpython-TG-Watch02A-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/TG-Watch02A/pt_BR/adafruit-circuitpython-TG-Watch02A-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/pt_BR/adafruit-circuitpython-TG-Watch02A-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/TG-Watch02A/sv/adafruit-circuitpython-TG-Watch02A-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/sv/adafruit-circuitpython-TG-Watch02A-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/TG-Watch02A/zh_Latn_pinyin/adafruit-circuitpython-TG-Watch02A-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/TG-Watch02A/zh_Latn_pinyin/adafruit-circuitpython-TG-Watch02A-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 19,
+        "downloads": 0,
+        "id": "aloriumtech_evo_m51",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/aloriumtech_evo_m51/ID/adafruit-circuitpython-aloriumtech_evo_m51-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/aloriumtech_evo_m51/cs/adafruit-circuitpython-aloriumtech_evo_m51-cs-5.4.0-beta.1.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/aloriumtech_evo_m51/de_DE/adafruit-circuitpython-aloriumtech_evo_m51-de_DE-5.4.0-beta.1.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/aloriumtech_evo_m51/en_US/adafruit-circuitpython-aloriumtech_evo_m51-en_US-5.4.0-beta.1.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/aloriumtech_evo_m51/en_x_pirate/adafruit-circuitpython-aloriumtech_evo_m51-en_x_pirate-5.4.0-beta.1.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/aloriumtech_evo_m51/es/adafruit-circuitpython-aloriumtech_evo_m51-es-5.4.0-beta.1.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/aloriumtech_evo_m51/fil/adafruit-circuitpython-aloriumtech_evo_m51-fil-5.4.0-beta.1.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/aloriumtech_evo_m51/fr/adafruit-circuitpython-aloriumtech_evo_m51-fr-5.4.0-beta.1.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/aloriumtech_evo_m51/it_IT/adafruit-circuitpython-aloriumtech_evo_m51-it_IT-5.4.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/aloriumtech_evo_m51/ko/adafruit-circuitpython-aloriumtech_evo_m51-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/aloriumtech_evo_m51/nl/adafruit-circuitpython-aloriumtech_evo_m51-nl-5.4.0-beta.1.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/aloriumtech_evo_m51/pl/adafruit-circuitpython-aloriumtech_evo_m51-pl-5.4.0-beta.1.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/aloriumtech_evo_m51/pt_BR/adafruit-circuitpython-aloriumtech_evo_m51-pt_BR-5.4.0-beta.1.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/aloriumtech_evo_m51/sv/adafruit-circuitpython-aloriumtech_evo_m51-sv-5.4.0-beta.1.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/aloriumtech_evo_m51/zh_Latn_pinyin/adafruit-circuitpython-aloriumtech_evo_m51-zh_Latn_pinyin-5.4.0-beta.1.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.1"
+            }
+        ]
+    },
+    {
+        "downloads": 0,
         "id": "aramcon_badge_2019",
         "versions": [
             {
@@ -234,52 +303,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/ID/adafruit-circuitpython-aramcon_badge_2019-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/ID/adafruit-circuitpython-aramcon_badge_2019-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/cs/adafruit-circuitpython-aramcon_badge_2019-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/de_DE/adafruit-circuitpython-aramcon_badge_2019-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/de_DE/adafruit-circuitpython-aramcon_badge_2019-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/en_US/adafruit-circuitpython-aramcon_badge_2019-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/en_US/adafruit-circuitpython-aramcon_badge_2019-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/en_x_pirate/adafruit-circuitpython-aramcon_badge_2019-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/en_x_pirate/adafruit-circuitpython-aramcon_badge_2019-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/es/adafruit-circuitpython-aramcon_badge_2019-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/es/adafruit-circuitpython-aramcon_badge_2019-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/fil/adafruit-circuitpython-aramcon_badge_2019-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/fil/adafruit-circuitpython-aramcon_badge_2019-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/fr/adafruit-circuitpython-aramcon_badge_2019-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/fr/adafruit-circuitpython-aramcon_badge_2019-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/it_IT/adafruit-circuitpython-aramcon_badge_2019-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/it_IT/adafruit-circuitpython-aramcon_badge_2019-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/ko/adafruit-circuitpython-aramcon_badge_2019-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/ko/adafruit-circuitpython-aramcon_badge_2019-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/nl/adafruit-circuitpython-aramcon_badge_2019-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/pl/adafruit-circuitpython-aramcon_badge_2019-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/pl/adafruit-circuitpython-aramcon_badge_2019-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/pt_BR/adafruit-circuitpython-aramcon_badge_2019-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/pt_BR/adafruit-circuitpython-aramcon_badge_2019-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/sv/adafruit-circuitpython-aramcon_badge_2019-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/sv/adafruit-circuitpython-aramcon_badge_2019-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/zh_Latn_pinyin/adafruit-circuitpython-aramcon_badge_2019-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/aramcon_badge_2019/zh_Latn_pinyin/adafruit-circuitpython-aramcon_badge_2019-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 5,
+        "downloads": 0,
         "id": "arduino_mkr1300",
         "versions": [
             {
@@ -339,65 +414,73 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/ID/adafruit-circuitpython-arduino_mkr1300-ID-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/ID/adafruit-circuitpython-arduino_mkr1300-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/ID/adafruit-circuitpython-arduino_mkr1300-ID-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/ID/adafruit-circuitpython-arduino_mkr1300-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/cs/adafruit-circuitpython-arduino_mkr1300-cs-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/cs/adafruit-circuitpython-arduino_mkr1300-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/de_DE/adafruit-circuitpython-arduino_mkr1300-de_DE-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/de_DE/adafruit-circuitpython-arduino_mkr1300-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/de_DE/adafruit-circuitpython-arduino_mkr1300-de_DE-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/de_DE/adafruit-circuitpython-arduino_mkr1300-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/en_US/adafruit-circuitpython-arduino_mkr1300-en_US-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/en_US/adafruit-circuitpython-arduino_mkr1300-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/en_US/adafruit-circuitpython-arduino_mkr1300-en_US-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/en_US/adafruit-circuitpython-arduino_mkr1300-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/en_x_pirate/adafruit-circuitpython-arduino_mkr1300-en_x_pirate-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/en_x_pirate/adafruit-circuitpython-arduino_mkr1300-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/en_x_pirate/adafruit-circuitpython-arduino_mkr1300-en_x_pirate-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/en_x_pirate/adafruit-circuitpython-arduino_mkr1300-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/es/adafruit-circuitpython-arduino_mkr1300-es-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/es/adafruit-circuitpython-arduino_mkr1300-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/es/adafruit-circuitpython-arduino_mkr1300-es-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/es/adafruit-circuitpython-arduino_mkr1300-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/fil/adafruit-circuitpython-arduino_mkr1300-fil-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/fil/adafruit-circuitpython-arduino_mkr1300-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/fil/adafruit-circuitpython-arduino_mkr1300-fil-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/fil/adafruit-circuitpython-arduino_mkr1300-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/fr/adafruit-circuitpython-arduino_mkr1300-fr-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/fr/adafruit-circuitpython-arduino_mkr1300-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/fr/adafruit-circuitpython-arduino_mkr1300-fr-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/fr/adafruit-circuitpython-arduino_mkr1300-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/it_IT/adafruit-circuitpython-arduino_mkr1300-it_IT-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/it_IT/adafruit-circuitpython-arduino_mkr1300-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/it_IT/adafruit-circuitpython-arduino_mkr1300-it_IT-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/it_IT/adafruit-circuitpython-arduino_mkr1300-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/ko/adafruit-circuitpython-arduino_mkr1300-ko-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/ko/adafruit-circuitpython-arduino_mkr1300-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/ko/adafruit-circuitpython-arduino_mkr1300-ko-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/ko/adafruit-circuitpython-arduino_mkr1300-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/nl/adafruit-circuitpython-arduino_mkr1300-nl-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/nl/adafruit-circuitpython-arduino_mkr1300-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/pl/adafruit-circuitpython-arduino_mkr1300-pl-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/pl/adafruit-circuitpython-arduino_mkr1300-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/pl/adafruit-circuitpython-arduino_mkr1300-pl-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/pl/adafruit-circuitpython-arduino_mkr1300-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/pt_BR/adafruit-circuitpython-arduino_mkr1300-pt_BR-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/pt_BR/adafruit-circuitpython-arduino_mkr1300-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/pt_BR/adafruit-circuitpython-arduino_mkr1300-pt_BR-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/pt_BR/adafruit-circuitpython-arduino_mkr1300-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/sv/adafruit-circuitpython-arduino_mkr1300-sv-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/sv/adafruit-circuitpython-arduino_mkr1300-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/sv/adafruit-circuitpython-arduino_mkr1300-sv-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/sv/adafruit-circuitpython-arduino_mkr1300-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/zh_Latn_pinyin/adafruit-circuitpython-arduino_mkr1300-zh_Latn_pinyin-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/zh_Latn_pinyin/adafruit-circuitpython-arduino_mkr1300-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/zh_Latn_pinyin/adafruit-circuitpython-arduino_mkr1300-zh_Latn_pinyin-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkr1300/zh_Latn_pinyin/adafruit-circuitpython-arduino_mkr1300-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 7,
+        "downloads": 0,
         "id": "arduino_mkrzero",
         "versions": [
             {
@@ -457,65 +540,73 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/ID/adafruit-circuitpython-arduino_mkrzero-ID-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/ID/adafruit-circuitpython-arduino_mkrzero-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/ID/adafruit-circuitpython-arduino_mkrzero-ID-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/ID/adafruit-circuitpython-arduino_mkrzero-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/cs/adafruit-circuitpython-arduino_mkrzero-cs-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/cs/adafruit-circuitpython-arduino_mkrzero-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/de_DE/adafruit-circuitpython-arduino_mkrzero-de_DE-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/de_DE/adafruit-circuitpython-arduino_mkrzero-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/de_DE/adafruit-circuitpython-arduino_mkrzero-de_DE-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/de_DE/adafruit-circuitpython-arduino_mkrzero-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/en_US/adafruit-circuitpython-arduino_mkrzero-en_US-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/en_US/adafruit-circuitpython-arduino_mkrzero-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/en_US/adafruit-circuitpython-arduino_mkrzero-en_US-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/en_US/adafruit-circuitpython-arduino_mkrzero-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/en_x_pirate/adafruit-circuitpython-arduino_mkrzero-en_x_pirate-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/en_x_pirate/adafruit-circuitpython-arduino_mkrzero-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/en_x_pirate/adafruit-circuitpython-arduino_mkrzero-en_x_pirate-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/en_x_pirate/adafruit-circuitpython-arduino_mkrzero-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/es/adafruit-circuitpython-arduino_mkrzero-es-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/es/adafruit-circuitpython-arduino_mkrzero-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/es/adafruit-circuitpython-arduino_mkrzero-es-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/es/adafruit-circuitpython-arduino_mkrzero-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/fil/adafruit-circuitpython-arduino_mkrzero-fil-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/fil/adafruit-circuitpython-arduino_mkrzero-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/fil/adafruit-circuitpython-arduino_mkrzero-fil-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/fil/adafruit-circuitpython-arduino_mkrzero-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/fr/adafruit-circuitpython-arduino_mkrzero-fr-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/fr/adafruit-circuitpython-arduino_mkrzero-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/fr/adafruit-circuitpython-arduino_mkrzero-fr-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/fr/adafruit-circuitpython-arduino_mkrzero-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/it_IT/adafruit-circuitpython-arduino_mkrzero-it_IT-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/it_IT/adafruit-circuitpython-arduino_mkrzero-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/it_IT/adafruit-circuitpython-arduino_mkrzero-it_IT-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/it_IT/adafruit-circuitpython-arduino_mkrzero-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/ko/adafruit-circuitpython-arduino_mkrzero-ko-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/ko/adafruit-circuitpython-arduino_mkrzero-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/ko/adafruit-circuitpython-arduino_mkrzero-ko-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/ko/adafruit-circuitpython-arduino_mkrzero-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/nl/adafruit-circuitpython-arduino_mkrzero-nl-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/nl/adafruit-circuitpython-arduino_mkrzero-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/pl/adafruit-circuitpython-arduino_mkrzero-pl-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/pl/adafruit-circuitpython-arduino_mkrzero-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/pl/adafruit-circuitpython-arduino_mkrzero-pl-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/pl/adafruit-circuitpython-arduino_mkrzero-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/pt_BR/adafruit-circuitpython-arduino_mkrzero-pt_BR-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/pt_BR/adafruit-circuitpython-arduino_mkrzero-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/pt_BR/adafruit-circuitpython-arduino_mkrzero-pt_BR-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/pt_BR/adafruit-circuitpython-arduino_mkrzero-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/sv/adafruit-circuitpython-arduino_mkrzero-sv-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/sv/adafruit-circuitpython-arduino_mkrzero-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/sv/adafruit-circuitpython-arduino_mkrzero-sv-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/sv/adafruit-circuitpython-arduino_mkrzero-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/zh_Latn_pinyin/adafruit-circuitpython-arduino_mkrzero-zh_Latn_pinyin-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/zh_Latn_pinyin/adafruit-circuitpython-arduino_mkrzero-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/zh_Latn_pinyin/adafruit-circuitpython-arduino_mkrzero-zh_Latn_pinyin-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_mkrzero/zh_Latn_pinyin/adafruit-circuitpython-arduino_mkrzero-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 57,
+        "downloads": 0,
         "id": "arduino_nano_33_ble",
         "versions": [
             {
@@ -563,52 +654,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/ID/adafruit-circuitpython-arduino_nano_33_ble-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/ID/adafruit-circuitpython-arduino_nano_33_ble-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/cs/adafruit-circuitpython-arduino_nano_33_ble-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/de_DE/adafruit-circuitpython-arduino_nano_33_ble-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/de_DE/adafruit-circuitpython-arduino_nano_33_ble-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/en_US/adafruit-circuitpython-arduino_nano_33_ble-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/en_US/adafruit-circuitpython-arduino_nano_33_ble-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/en_x_pirate/adafruit-circuitpython-arduino_nano_33_ble-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/en_x_pirate/adafruit-circuitpython-arduino_nano_33_ble-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/es/adafruit-circuitpython-arduino_nano_33_ble-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/es/adafruit-circuitpython-arduino_nano_33_ble-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/fil/adafruit-circuitpython-arduino_nano_33_ble-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/fil/adafruit-circuitpython-arduino_nano_33_ble-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/fr/adafruit-circuitpython-arduino_nano_33_ble-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/fr/adafruit-circuitpython-arduino_nano_33_ble-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/it_IT/adafruit-circuitpython-arduino_nano_33_ble-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/it_IT/adafruit-circuitpython-arduino_nano_33_ble-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/ko/adafruit-circuitpython-arduino_nano_33_ble-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/ko/adafruit-circuitpython-arduino_nano_33_ble-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/nl/adafruit-circuitpython-arduino_nano_33_ble-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/pl/adafruit-circuitpython-arduino_nano_33_ble-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/pl/adafruit-circuitpython-arduino_nano_33_ble-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/pt_BR/adafruit-circuitpython-arduino_nano_33_ble-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/pt_BR/adafruit-circuitpython-arduino_nano_33_ble-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/sv/adafruit-circuitpython-arduino_nano_33_ble-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/sv/adafruit-circuitpython-arduino_nano_33_ble-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/zh_Latn_pinyin/adafruit-circuitpython-arduino_nano_33_ble-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_ble/zh_Latn_pinyin/adafruit-circuitpython-arduino_nano_33_ble-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 16,
+        "downloads": 0,
         "id": "arduino_nano_33_iot",
         "versions": [
             {
@@ -668,65 +765,73 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/ID/adafruit-circuitpython-arduino_nano_33_iot-ID-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/ID/adafruit-circuitpython-arduino_nano_33_iot-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/ID/adafruit-circuitpython-arduino_nano_33_iot-ID-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/ID/adafruit-circuitpython-arduino_nano_33_iot-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/cs/adafruit-circuitpython-arduino_nano_33_iot-cs-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/cs/adafruit-circuitpython-arduino_nano_33_iot-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/de_DE/adafruit-circuitpython-arduino_nano_33_iot-de_DE-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/de_DE/adafruit-circuitpython-arduino_nano_33_iot-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/de_DE/adafruit-circuitpython-arduino_nano_33_iot-de_DE-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/de_DE/adafruit-circuitpython-arduino_nano_33_iot-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/en_US/adafruit-circuitpython-arduino_nano_33_iot-en_US-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/en_US/adafruit-circuitpython-arduino_nano_33_iot-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/en_US/adafruit-circuitpython-arduino_nano_33_iot-en_US-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/en_US/adafruit-circuitpython-arduino_nano_33_iot-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/en_x_pirate/adafruit-circuitpython-arduino_nano_33_iot-en_x_pirate-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/en_x_pirate/adafruit-circuitpython-arduino_nano_33_iot-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/en_x_pirate/adafruit-circuitpython-arduino_nano_33_iot-en_x_pirate-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/en_x_pirate/adafruit-circuitpython-arduino_nano_33_iot-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/es/adafruit-circuitpython-arduino_nano_33_iot-es-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/es/adafruit-circuitpython-arduino_nano_33_iot-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/es/adafruit-circuitpython-arduino_nano_33_iot-es-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/es/adafruit-circuitpython-arduino_nano_33_iot-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/fil/adafruit-circuitpython-arduino_nano_33_iot-fil-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/fil/adafruit-circuitpython-arduino_nano_33_iot-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/fil/adafruit-circuitpython-arduino_nano_33_iot-fil-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/fil/adafruit-circuitpython-arduino_nano_33_iot-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/fr/adafruit-circuitpython-arduino_nano_33_iot-fr-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/fr/adafruit-circuitpython-arduino_nano_33_iot-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/fr/adafruit-circuitpython-arduino_nano_33_iot-fr-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/fr/adafruit-circuitpython-arduino_nano_33_iot-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/it_IT/adafruit-circuitpython-arduino_nano_33_iot-it_IT-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/it_IT/adafruit-circuitpython-arduino_nano_33_iot-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/it_IT/adafruit-circuitpython-arduino_nano_33_iot-it_IT-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/it_IT/adafruit-circuitpython-arduino_nano_33_iot-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/ko/adafruit-circuitpython-arduino_nano_33_iot-ko-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/ko/adafruit-circuitpython-arduino_nano_33_iot-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/ko/adafruit-circuitpython-arduino_nano_33_iot-ko-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/ko/adafruit-circuitpython-arduino_nano_33_iot-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/nl/adafruit-circuitpython-arduino_nano_33_iot-nl-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/nl/adafruit-circuitpython-arduino_nano_33_iot-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/pl/adafruit-circuitpython-arduino_nano_33_iot-pl-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/pl/adafruit-circuitpython-arduino_nano_33_iot-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/pl/adafruit-circuitpython-arduino_nano_33_iot-pl-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/pl/adafruit-circuitpython-arduino_nano_33_iot-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/pt_BR/adafruit-circuitpython-arduino_nano_33_iot-pt_BR-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/pt_BR/adafruit-circuitpython-arduino_nano_33_iot-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/pt_BR/adafruit-circuitpython-arduino_nano_33_iot-pt_BR-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/pt_BR/adafruit-circuitpython-arduino_nano_33_iot-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/sv/adafruit-circuitpython-arduino_nano_33_iot-sv-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/sv/adafruit-circuitpython-arduino_nano_33_iot-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/sv/adafruit-circuitpython-arduino_nano_33_iot-sv-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/sv/adafruit-circuitpython-arduino_nano_33_iot-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/zh_Latn_pinyin/adafruit-circuitpython-arduino_nano_33_iot-zh_Latn_pinyin-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/zh_Latn_pinyin/adafruit-circuitpython-arduino_nano_33_iot-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/zh_Latn_pinyin/adafruit-circuitpython-arduino_nano_33_iot-zh_Latn_pinyin-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_nano_33_iot/zh_Latn_pinyin/adafruit-circuitpython-arduino_nano_33_iot-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 26,
+        "downloads": 0,
         "id": "arduino_zero",
         "versions": [
             {
@@ -786,65 +891,73 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/ID/adafruit-circuitpython-arduino_zero-ID-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/ID/adafruit-circuitpython-arduino_zero-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_zero/ID/adafruit-circuitpython-arduino_zero-ID-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/ID/adafruit-circuitpython-arduino_zero-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/arduino_zero/cs/adafruit-circuitpython-arduino_zero-cs-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/cs/adafruit-circuitpython-arduino_zero-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/de_DE/adafruit-circuitpython-arduino_zero-de_DE-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/de_DE/adafruit-circuitpython-arduino_zero-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_zero/de_DE/adafruit-circuitpython-arduino_zero-de_DE-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/de_DE/adafruit-circuitpython-arduino_zero-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/en_US/adafruit-circuitpython-arduino_zero-en_US-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/en_US/adafruit-circuitpython-arduino_zero-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_zero/en_US/adafruit-circuitpython-arduino_zero-en_US-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/en_US/adafruit-circuitpython-arduino_zero-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/en_x_pirate/adafruit-circuitpython-arduino_zero-en_x_pirate-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/en_x_pirate/adafruit-circuitpython-arduino_zero-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_zero/en_x_pirate/adafruit-circuitpython-arduino_zero-en_x_pirate-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/en_x_pirate/adafruit-circuitpython-arduino_zero-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/es/adafruit-circuitpython-arduino_zero-es-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/es/adafruit-circuitpython-arduino_zero-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_zero/es/adafruit-circuitpython-arduino_zero-es-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/es/adafruit-circuitpython-arduino_zero-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/fil/adafruit-circuitpython-arduino_zero-fil-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/fil/adafruit-circuitpython-arduino_zero-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_zero/fil/adafruit-circuitpython-arduino_zero-fil-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/fil/adafruit-circuitpython-arduino_zero-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/fr/adafruit-circuitpython-arduino_zero-fr-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/fr/adafruit-circuitpython-arduino_zero-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_zero/fr/adafruit-circuitpython-arduino_zero-fr-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/fr/adafruit-circuitpython-arduino_zero-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/it_IT/adafruit-circuitpython-arduino_zero-it_IT-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/it_IT/adafruit-circuitpython-arduino_zero-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_zero/it_IT/adafruit-circuitpython-arduino_zero-it_IT-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/it_IT/adafruit-circuitpython-arduino_zero-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/ko/adafruit-circuitpython-arduino_zero-ko-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/ko/adafruit-circuitpython-arduino_zero-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_zero/ko/adafruit-circuitpython-arduino_zero-ko-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/ko/adafruit-circuitpython-arduino_zero-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/arduino_zero/nl/adafruit-circuitpython-arduino_zero-nl-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/nl/adafruit-circuitpython-arduino_zero-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/pl/adafruit-circuitpython-arduino_zero-pl-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/pl/adafruit-circuitpython-arduino_zero-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_zero/pl/adafruit-circuitpython-arduino_zero-pl-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/pl/adafruit-circuitpython-arduino_zero-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/pt_BR/adafruit-circuitpython-arduino_zero-pt_BR-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/pt_BR/adafruit-circuitpython-arduino_zero-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_zero/pt_BR/adafruit-circuitpython-arduino_zero-pt_BR-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/pt_BR/adafruit-circuitpython-arduino_zero-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/sv/adafruit-circuitpython-arduino_zero-sv-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/sv/adafruit-circuitpython-arduino_zero-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_zero/sv/adafruit-circuitpython-arduino_zero-sv-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/sv/adafruit-circuitpython-arduino_zero-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/arduino_zero/zh_Latn_pinyin/adafruit-circuitpython-arduino_zero-zh_Latn_pinyin-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/arduino_zero/zh_Latn_pinyin/adafruit-circuitpython-arduino_zero-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/arduino_zero/zh_Latn_pinyin/adafruit-circuitpython-arduino_zero-zh_Latn_pinyin-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/arduino_zero/zh_Latn_pinyin/adafruit-circuitpython-arduino_zero-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 15,
+        "downloads": 0,
         "id": "bast_pro_mini_m0",
         "versions": [
             {
@@ -892,52 +1005,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/ID/adafruit-circuitpython-bast_pro_mini_m0-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/ID/adafruit-circuitpython-bast_pro_mini_m0-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/cs/adafruit-circuitpython-bast_pro_mini_m0-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/de_DE/adafruit-circuitpython-bast_pro_mini_m0-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/de_DE/adafruit-circuitpython-bast_pro_mini_m0-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/en_US/adafruit-circuitpython-bast_pro_mini_m0-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/en_US/adafruit-circuitpython-bast_pro_mini_m0-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/en_x_pirate/adafruit-circuitpython-bast_pro_mini_m0-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/en_x_pirate/adafruit-circuitpython-bast_pro_mini_m0-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/es/adafruit-circuitpython-bast_pro_mini_m0-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/es/adafruit-circuitpython-bast_pro_mini_m0-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/fil/adafruit-circuitpython-bast_pro_mini_m0-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/fil/adafruit-circuitpython-bast_pro_mini_m0-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/fr/adafruit-circuitpython-bast_pro_mini_m0-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/fr/adafruit-circuitpython-bast_pro_mini_m0-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/it_IT/adafruit-circuitpython-bast_pro_mini_m0-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/it_IT/adafruit-circuitpython-bast_pro_mini_m0-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/ko/adafruit-circuitpython-bast_pro_mini_m0-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/ko/adafruit-circuitpython-bast_pro_mini_m0-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/nl/adafruit-circuitpython-bast_pro_mini_m0-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/pl/adafruit-circuitpython-bast_pro_mini_m0-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/pl/adafruit-circuitpython-bast_pro_mini_m0-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/pt_BR/adafruit-circuitpython-bast_pro_mini_m0-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/pt_BR/adafruit-circuitpython-bast_pro_mini_m0-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/sv/adafruit-circuitpython-bast_pro_mini_m0-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/sv/adafruit-circuitpython-bast_pro_mini_m0-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/zh_Latn_pinyin/adafruit-circuitpython-bast_pro_mini_m0-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/bast_pro_mini_m0/zh_Latn_pinyin/adafruit-circuitpython-bast_pro_mini_m0-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 29,
+        "downloads": 0,
         "id": "bdmicro_vina_m0",
         "versions": [
             {
@@ -985,52 +1104,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/ID/adafruit-circuitpython-bdmicro_vina_m0-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/ID/adafruit-circuitpython-bdmicro_vina_m0-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/cs/adafruit-circuitpython-bdmicro_vina_m0-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/de_DE/adafruit-circuitpython-bdmicro_vina_m0-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/de_DE/adafruit-circuitpython-bdmicro_vina_m0-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/en_US/adafruit-circuitpython-bdmicro_vina_m0-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/en_US/adafruit-circuitpython-bdmicro_vina_m0-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/en_x_pirate/adafruit-circuitpython-bdmicro_vina_m0-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/en_x_pirate/adafruit-circuitpython-bdmicro_vina_m0-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/es/adafruit-circuitpython-bdmicro_vina_m0-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/es/adafruit-circuitpython-bdmicro_vina_m0-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/fil/adafruit-circuitpython-bdmicro_vina_m0-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/fil/adafruit-circuitpython-bdmicro_vina_m0-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/fr/adafruit-circuitpython-bdmicro_vina_m0-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/fr/adafruit-circuitpython-bdmicro_vina_m0-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/it_IT/adafruit-circuitpython-bdmicro_vina_m0-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/it_IT/adafruit-circuitpython-bdmicro_vina_m0-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/ko/adafruit-circuitpython-bdmicro_vina_m0-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/ko/adafruit-circuitpython-bdmicro_vina_m0-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/nl/adafruit-circuitpython-bdmicro_vina_m0-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/pl/adafruit-circuitpython-bdmicro_vina_m0-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/pl/adafruit-circuitpython-bdmicro_vina_m0-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/pt_BR/adafruit-circuitpython-bdmicro_vina_m0-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/pt_BR/adafruit-circuitpython-bdmicro_vina_m0-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/sv/adafruit-circuitpython-bdmicro_vina_m0-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/sv/adafruit-circuitpython-bdmicro_vina_m0-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/zh_Latn_pinyin/adafruit-circuitpython-bdmicro_vina_m0-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/bdmicro_vina_m0/zh_Latn_pinyin/adafruit-circuitpython-bdmicro_vina_m0-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 28,
+        "downloads": 0,
         "id": "capablerobot_usbhub",
         "versions": [
             {
@@ -1078,52 +1203,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/ID/adafruit-circuitpython-capablerobot_usbhub-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/ID/adafruit-circuitpython-capablerobot_usbhub-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/cs/adafruit-circuitpython-capablerobot_usbhub-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/de_DE/adafruit-circuitpython-capablerobot_usbhub-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/de_DE/adafruit-circuitpython-capablerobot_usbhub-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/en_US/adafruit-circuitpython-capablerobot_usbhub-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/en_US/adafruit-circuitpython-capablerobot_usbhub-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/en_x_pirate/adafruit-circuitpython-capablerobot_usbhub-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/en_x_pirate/adafruit-circuitpython-capablerobot_usbhub-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/es/adafruit-circuitpython-capablerobot_usbhub-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/es/adafruit-circuitpython-capablerobot_usbhub-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/fil/adafruit-circuitpython-capablerobot_usbhub-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/fil/adafruit-circuitpython-capablerobot_usbhub-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/fr/adafruit-circuitpython-capablerobot_usbhub-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/fr/adafruit-circuitpython-capablerobot_usbhub-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/it_IT/adafruit-circuitpython-capablerobot_usbhub-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/it_IT/adafruit-circuitpython-capablerobot_usbhub-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/ko/adafruit-circuitpython-capablerobot_usbhub-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/ko/adafruit-circuitpython-capablerobot_usbhub-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/nl/adafruit-circuitpython-capablerobot_usbhub-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/pl/adafruit-circuitpython-capablerobot_usbhub-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/pl/adafruit-circuitpython-capablerobot_usbhub-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/pt_BR/adafruit-circuitpython-capablerobot_usbhub-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/pt_BR/adafruit-circuitpython-capablerobot_usbhub-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/sv/adafruit-circuitpython-capablerobot_usbhub-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/sv/adafruit-circuitpython-capablerobot_usbhub-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/zh_Latn_pinyin/adafruit-circuitpython-capablerobot_usbhub-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/capablerobot_usbhub/zh_Latn_pinyin/adafruit-circuitpython-capablerobot_usbhub-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 30,
+        "downloads": 0,
         "id": "catwan_usbstick",
         "versions": [
             {
@@ -1171,52 +1302,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/ID/adafruit-circuitpython-catwan_usbstick-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/ID/adafruit-circuitpython-catwan_usbstick-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/cs/adafruit-circuitpython-catwan_usbstick-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/de_DE/adafruit-circuitpython-catwan_usbstick-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/de_DE/adafruit-circuitpython-catwan_usbstick-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/en_US/adafruit-circuitpython-catwan_usbstick-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/en_US/adafruit-circuitpython-catwan_usbstick-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/en_x_pirate/adafruit-circuitpython-catwan_usbstick-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/en_x_pirate/adafruit-circuitpython-catwan_usbstick-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/es/adafruit-circuitpython-catwan_usbstick-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/es/adafruit-circuitpython-catwan_usbstick-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/fil/adafruit-circuitpython-catwan_usbstick-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/fil/adafruit-circuitpython-catwan_usbstick-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/fr/adafruit-circuitpython-catwan_usbstick-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/fr/adafruit-circuitpython-catwan_usbstick-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/it_IT/adafruit-circuitpython-catwan_usbstick-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/it_IT/adafruit-circuitpython-catwan_usbstick-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/ko/adafruit-circuitpython-catwan_usbstick-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/ko/adafruit-circuitpython-catwan_usbstick-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/nl/adafruit-circuitpython-catwan_usbstick-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/pl/adafruit-circuitpython-catwan_usbstick-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/pl/adafruit-circuitpython-catwan_usbstick-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/pt_BR/adafruit-circuitpython-catwan_usbstick-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/pt_BR/adafruit-circuitpython-catwan_usbstick-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/sv/adafruit-circuitpython-catwan_usbstick-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/sv/adafruit-circuitpython-catwan_usbstick-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/catwan_usbstick/zh_Latn_pinyin/adafruit-circuitpython-catwan_usbstick-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/catwan_usbstick/zh_Latn_pinyin/adafruit-circuitpython-catwan_usbstick-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 36,
+        "downloads": 0,
         "id": "circuitbrains_basic_m0",
         "versions": [
             {
@@ -1264,52 +1401,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/ID/adafruit-circuitpython-circuitbrains_basic_m0-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/ID/adafruit-circuitpython-circuitbrains_basic_m0-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/cs/adafruit-circuitpython-circuitbrains_basic_m0-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/de_DE/adafruit-circuitpython-circuitbrains_basic_m0-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/de_DE/adafruit-circuitpython-circuitbrains_basic_m0-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/en_US/adafruit-circuitpython-circuitbrains_basic_m0-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/en_US/adafruit-circuitpython-circuitbrains_basic_m0-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/en_x_pirate/adafruit-circuitpython-circuitbrains_basic_m0-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/en_x_pirate/adafruit-circuitpython-circuitbrains_basic_m0-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/es/adafruit-circuitpython-circuitbrains_basic_m0-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/es/adafruit-circuitpython-circuitbrains_basic_m0-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/fil/adafruit-circuitpython-circuitbrains_basic_m0-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/fil/adafruit-circuitpython-circuitbrains_basic_m0-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/fr/adafruit-circuitpython-circuitbrains_basic_m0-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/fr/adafruit-circuitpython-circuitbrains_basic_m0-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/it_IT/adafruit-circuitpython-circuitbrains_basic_m0-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/it_IT/adafruit-circuitpython-circuitbrains_basic_m0-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/ko/adafruit-circuitpython-circuitbrains_basic_m0-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/ko/adafruit-circuitpython-circuitbrains_basic_m0-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/nl/adafruit-circuitpython-circuitbrains_basic_m0-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/pl/adafruit-circuitpython-circuitbrains_basic_m0-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/pl/adafruit-circuitpython-circuitbrains_basic_m0-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/pt_BR/adafruit-circuitpython-circuitbrains_basic_m0-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/pt_BR/adafruit-circuitpython-circuitbrains_basic_m0-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/sv/adafruit-circuitpython-circuitbrains_basic_m0-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/sv/adafruit-circuitpython-circuitbrains_basic_m0-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/zh_Latn_pinyin/adafruit-circuitpython-circuitbrains_basic_m0-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitbrains_basic_m0/zh_Latn_pinyin/adafruit-circuitpython-circuitbrains_basic_m0-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 45,
+        "downloads": 0,
         "id": "circuitbrains_deluxe_m4",
         "versions": [
             {
@@ -1357,52 +1500,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/ID/adafruit-circuitpython-circuitbrains_deluxe_m4-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/ID/adafruit-circuitpython-circuitbrains_deluxe_m4-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/cs/adafruit-circuitpython-circuitbrains_deluxe_m4-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/de_DE/adafruit-circuitpython-circuitbrains_deluxe_m4-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/de_DE/adafruit-circuitpython-circuitbrains_deluxe_m4-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/en_US/adafruit-circuitpython-circuitbrains_deluxe_m4-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/en_US/adafruit-circuitpython-circuitbrains_deluxe_m4-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/en_x_pirate/adafruit-circuitpython-circuitbrains_deluxe_m4-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/en_x_pirate/adafruit-circuitpython-circuitbrains_deluxe_m4-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/es/adafruit-circuitpython-circuitbrains_deluxe_m4-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/es/adafruit-circuitpython-circuitbrains_deluxe_m4-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/fil/adafruit-circuitpython-circuitbrains_deluxe_m4-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/fil/adafruit-circuitpython-circuitbrains_deluxe_m4-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/fr/adafruit-circuitpython-circuitbrains_deluxe_m4-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/fr/adafruit-circuitpython-circuitbrains_deluxe_m4-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/it_IT/adafruit-circuitpython-circuitbrains_deluxe_m4-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/it_IT/adafruit-circuitpython-circuitbrains_deluxe_m4-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/ko/adafruit-circuitpython-circuitbrains_deluxe_m4-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/ko/adafruit-circuitpython-circuitbrains_deluxe_m4-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/nl/adafruit-circuitpython-circuitbrains_deluxe_m4-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/pl/adafruit-circuitpython-circuitbrains_deluxe_m4-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/pl/adafruit-circuitpython-circuitbrains_deluxe_m4-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/pt_BR/adafruit-circuitpython-circuitbrains_deluxe_m4-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/pt_BR/adafruit-circuitpython-circuitbrains_deluxe_m4-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/sv/adafruit-circuitpython-circuitbrains_deluxe_m4-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/sv/adafruit-circuitpython-circuitbrains_deluxe_m4-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/zh_Latn_pinyin/adafruit-circuitpython-circuitbrains_deluxe_m4-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitbrains_deluxe_m4/zh_Latn_pinyin/adafruit-circuitpython-circuitbrains_deluxe_m4-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 127,
+        "downloads": 0,
         "id": "circuitplayground_bluefruit",
         "versions": [
             {
@@ -1450,52 +1599,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/ID/adafruit-circuitpython-circuitplayground_bluefruit-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/ID/adafruit-circuitpython-circuitplayground_bluefruit-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/cs/adafruit-circuitpython-circuitplayground_bluefruit-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/de_DE/adafruit-circuitpython-circuitplayground_bluefruit-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/de_DE/adafruit-circuitpython-circuitplayground_bluefruit-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/en_US/adafruit-circuitpython-circuitplayground_bluefruit-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/en_US/adafruit-circuitpython-circuitplayground_bluefruit-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/en_x_pirate/adafruit-circuitpython-circuitplayground_bluefruit-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/en_x_pirate/adafruit-circuitpython-circuitplayground_bluefruit-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/es/adafruit-circuitpython-circuitplayground_bluefruit-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/es/adafruit-circuitpython-circuitplayground_bluefruit-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/fil/adafruit-circuitpython-circuitplayground_bluefruit-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/fil/adafruit-circuitpython-circuitplayground_bluefruit-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/fr/adafruit-circuitpython-circuitplayground_bluefruit-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/fr/adafruit-circuitpython-circuitplayground_bluefruit-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/it_IT/adafruit-circuitpython-circuitplayground_bluefruit-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/it_IT/adafruit-circuitpython-circuitplayground_bluefruit-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/ko/adafruit-circuitpython-circuitplayground_bluefruit-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/ko/adafruit-circuitpython-circuitplayground_bluefruit-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/nl/adafruit-circuitpython-circuitplayground_bluefruit-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/pl/adafruit-circuitpython-circuitplayground_bluefruit-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/pl/adafruit-circuitpython-circuitplayground_bluefruit-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/pt_BR/adafruit-circuitpython-circuitplayground_bluefruit-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/pt_BR/adafruit-circuitpython-circuitplayground_bluefruit-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/sv/adafruit-circuitpython-circuitplayground_bluefruit-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/sv/adafruit-circuitpython-circuitplayground_bluefruit-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_bluefruit-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_bluefruit/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_bluefruit-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 317,
+        "downloads": 0,
         "id": "circuitplayground_express",
         "versions": [
             {
@@ -1543,52 +1698,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/ID/adafruit-circuitpython-circuitplayground_express-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/ID/adafruit-circuitpython-circuitplayground_express-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/cs/adafruit-circuitpython-circuitplayground_express-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/de_DE/adafruit-circuitpython-circuitplayground_express-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/de_DE/adafruit-circuitpython-circuitplayground_express-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/en_US/adafruit-circuitpython-circuitplayground_express-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/en_US/adafruit-circuitpython-circuitplayground_express-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/en_x_pirate/adafruit-circuitpython-circuitplayground_express-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/en_x_pirate/adafruit-circuitpython-circuitplayground_express-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/es/adafruit-circuitpython-circuitplayground_express-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/es/adafruit-circuitpython-circuitplayground_express-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/fil/adafruit-circuitpython-circuitplayground_express-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/fil/adafruit-circuitpython-circuitplayground_express-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/fr/adafruit-circuitpython-circuitplayground_express-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/fr/adafruit-circuitpython-circuitplayground_express-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/it_IT/adafruit-circuitpython-circuitplayground_express-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/it_IT/adafruit-circuitpython-circuitplayground_express-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/ko/adafruit-circuitpython-circuitplayground_express-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/ko/adafruit-circuitpython-circuitplayground_express-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/nl/adafruit-circuitpython-circuitplayground_express-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/pl/adafruit-circuitpython-circuitplayground_express-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/pl/adafruit-circuitpython-circuitplayground_express-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/pt_BR/adafruit-circuitpython-circuitplayground_express-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/pt_BR/adafruit-circuitpython-circuitplayground_express-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/sv/adafruit-circuitpython-circuitplayground_express-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/sv/adafruit-circuitpython-circuitplayground_express-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_express-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 29,
+        "downloads": 0,
         "id": "circuitplayground_express_4h",
         "versions": [
             {
@@ -1636,52 +1797,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/ID/adafruit-circuitpython-circuitplayground_express_4h-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/ID/adafruit-circuitpython-circuitplayground_express_4h-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/cs/adafruit-circuitpython-circuitplayground_express_4h-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/de_DE/adafruit-circuitpython-circuitplayground_express_4h-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/de_DE/adafruit-circuitpython-circuitplayground_express_4h-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/en_US/adafruit-circuitpython-circuitplayground_express_4h-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/en_US/adafruit-circuitpython-circuitplayground_express_4h-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/en_x_pirate/adafruit-circuitpython-circuitplayground_express_4h-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/en_x_pirate/adafruit-circuitpython-circuitplayground_express_4h-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/es/adafruit-circuitpython-circuitplayground_express_4h-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/es/adafruit-circuitpython-circuitplayground_express_4h-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/fil/adafruit-circuitpython-circuitplayground_express_4h-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/fil/adafruit-circuitpython-circuitplayground_express_4h-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/fr/adafruit-circuitpython-circuitplayground_express_4h-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/fr/adafruit-circuitpython-circuitplayground_express_4h-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/it_IT/adafruit-circuitpython-circuitplayground_express_4h-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/it_IT/adafruit-circuitpython-circuitplayground_express_4h-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/ko/adafruit-circuitpython-circuitplayground_express_4h-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/ko/adafruit-circuitpython-circuitplayground_express_4h-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/nl/adafruit-circuitpython-circuitplayground_express_4h-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/pl/adafruit-circuitpython-circuitplayground_express_4h-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/pl/adafruit-circuitpython-circuitplayground_express_4h-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/pt_BR/adafruit-circuitpython-circuitplayground_express_4h-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/pt_BR/adafruit-circuitpython-circuitplayground_express_4h-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/sv/adafruit-circuitpython-circuitplayground_express_4h-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/sv/adafruit-circuitpython-circuitplayground_express_4h-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_express_4h-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_4h/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_express_4h-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 42,
+        "downloads": 0,
         "id": "circuitplayground_express_crickit",
         "versions": [
             {
@@ -1729,52 +1896,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/ID/adafruit-circuitpython-circuitplayground_express_crickit-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/ID/adafruit-circuitpython-circuitplayground_express_crickit-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/cs/adafruit-circuitpython-circuitplayground_express_crickit-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/de_DE/adafruit-circuitpython-circuitplayground_express_crickit-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/de_DE/adafruit-circuitpython-circuitplayground_express_crickit-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/en_US/adafruit-circuitpython-circuitplayground_express_crickit-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/en_US/adafruit-circuitpython-circuitplayground_express_crickit-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/en_x_pirate/adafruit-circuitpython-circuitplayground_express_crickit-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/en_x_pirate/adafruit-circuitpython-circuitplayground_express_crickit-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/es/adafruit-circuitpython-circuitplayground_express_crickit-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/es/adafruit-circuitpython-circuitplayground_express_crickit-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/fil/adafruit-circuitpython-circuitplayground_express_crickit-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/fil/adafruit-circuitpython-circuitplayground_express_crickit-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/fr/adafruit-circuitpython-circuitplayground_express_crickit-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/fr/adafruit-circuitpython-circuitplayground_express_crickit-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/it_IT/adafruit-circuitpython-circuitplayground_express_crickit-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/it_IT/adafruit-circuitpython-circuitplayground_express_crickit-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/ko/adafruit-circuitpython-circuitplayground_express_crickit-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/ko/adafruit-circuitpython-circuitplayground_express_crickit-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/nl/adafruit-circuitpython-circuitplayground_express_crickit-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/pl/adafruit-circuitpython-circuitplayground_express_crickit-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/pl/adafruit-circuitpython-circuitplayground_express_crickit-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/pt_BR/adafruit-circuitpython-circuitplayground_express_crickit-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/pt_BR/adafruit-circuitpython-circuitplayground_express_crickit-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/sv/adafruit-circuitpython-circuitplayground_express_crickit-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/sv/adafruit-circuitpython-circuitplayground_express_crickit-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_express_crickit-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_crickit/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_express_crickit-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 32,
+        "downloads": 0,
         "id": "circuitplayground_express_digikey_pycon2019",
         "versions": [
             {
@@ -1822,52 +1995,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/ID/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/ID/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/cs/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/de_DE/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/de_DE/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/en_US/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/en_US/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/en_x_pirate/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/en_x_pirate/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/es/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/es/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/fil/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/fil/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/fr/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/fr/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/it_IT/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/it_IT/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/ko/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/ko/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/nl/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/pl/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/pl/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/pt_BR/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/pt_BR/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/sv/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/sv/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_digikey_pycon2019/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_express_digikey_pycon2019-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 40,
+        "downloads": 0,
         "id": "circuitplayground_express_displayio",
         "versions": [
             {
@@ -1915,52 +2094,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/ID/adafruit-circuitpython-circuitplayground_express_displayio-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/ID/adafruit-circuitpython-circuitplayground_express_displayio-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/cs/adafruit-circuitpython-circuitplayground_express_displayio-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/de_DE/adafruit-circuitpython-circuitplayground_express_displayio-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/de_DE/adafruit-circuitpython-circuitplayground_express_displayio-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/en_US/adafruit-circuitpython-circuitplayground_express_displayio-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/en_US/adafruit-circuitpython-circuitplayground_express_displayio-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/en_x_pirate/adafruit-circuitpython-circuitplayground_express_displayio-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/en_x_pirate/adafruit-circuitpython-circuitplayground_express_displayio-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/es/adafruit-circuitpython-circuitplayground_express_displayio-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/es/adafruit-circuitpython-circuitplayground_express_displayio-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/fil/adafruit-circuitpython-circuitplayground_express_displayio-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/fil/adafruit-circuitpython-circuitplayground_express_displayio-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/fr/adafruit-circuitpython-circuitplayground_express_displayio-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/fr/adafruit-circuitpython-circuitplayground_express_displayio-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/it_IT/adafruit-circuitpython-circuitplayground_express_displayio-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/it_IT/adafruit-circuitpython-circuitplayground_express_displayio-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/ko/adafruit-circuitpython-circuitplayground_express_displayio-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/ko/adafruit-circuitpython-circuitplayground_express_displayio-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/nl/adafruit-circuitpython-circuitplayground_express_displayio-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/pl/adafruit-circuitpython-circuitplayground_express_displayio-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/pl/adafruit-circuitpython-circuitplayground_express_displayio-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/pt_BR/adafruit-circuitpython-circuitplayground_express_displayio-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/pt_BR/adafruit-circuitpython-circuitplayground_express_displayio-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/sv/adafruit-circuitpython-circuitplayground_express_displayio-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/sv/adafruit-circuitpython-circuitplayground_express_displayio-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_express_displayio-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/circuitplayground_express_displayio/zh_Latn_pinyin/adafruit-circuitpython-circuitplayground_express_displayio-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 87,
+        "downloads": 0,
         "id": "clue_nrf52840_express",
         "versions": [
             {
@@ -2008,52 +2193,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/ID/adafruit-circuitpython-clue_nrf52840_express-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/ID/adafruit-circuitpython-clue_nrf52840_express-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/cs/adafruit-circuitpython-clue_nrf52840_express-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/de_DE/adafruit-circuitpython-clue_nrf52840_express-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/de_DE/adafruit-circuitpython-clue_nrf52840_express-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/en_US/adafruit-circuitpython-clue_nrf52840_express-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/en_US/adafruit-circuitpython-clue_nrf52840_express-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/en_x_pirate/adafruit-circuitpython-clue_nrf52840_express-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/en_x_pirate/adafruit-circuitpython-clue_nrf52840_express-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/es/adafruit-circuitpython-clue_nrf52840_express-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/es/adafruit-circuitpython-clue_nrf52840_express-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/fil/adafruit-circuitpython-clue_nrf52840_express-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/fil/adafruit-circuitpython-clue_nrf52840_express-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/fr/adafruit-circuitpython-clue_nrf52840_express-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/fr/adafruit-circuitpython-clue_nrf52840_express-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/it_IT/adafruit-circuitpython-clue_nrf52840_express-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/it_IT/adafruit-circuitpython-clue_nrf52840_express-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/ko/adafruit-circuitpython-clue_nrf52840_express-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/ko/adafruit-circuitpython-clue_nrf52840_express-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/nl/adafruit-circuitpython-clue_nrf52840_express-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/pl/adafruit-circuitpython-clue_nrf52840_express-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/pl/adafruit-circuitpython-clue_nrf52840_express-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/pt_BR/adafruit-circuitpython-clue_nrf52840_express-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/pt_BR/adafruit-circuitpython-clue_nrf52840_express-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/sv/adafruit-circuitpython-clue_nrf52840_express-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/sv/adafruit-circuitpython-clue_nrf52840_express-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/zh_Latn_pinyin/adafruit-circuitpython-clue_nrf52840_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/clue_nrf52840_express/zh_Latn_pinyin/adafruit-circuitpython-clue_nrf52840_express-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 14,
+        "downloads": 0,
         "id": "cp32-m4",
         "versions": [
             {
@@ -2101,52 +2292,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/ID/adafruit-circuitpython-cp32-m4-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/cp32-m4/ID/adafruit-circuitpython-cp32-m4-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/cp32-m4/cs/adafruit-circuitpython-cp32-m4-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/de_DE/adafruit-circuitpython-cp32-m4-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/cp32-m4/de_DE/adafruit-circuitpython-cp32-m4-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/en_US/adafruit-circuitpython-cp32-m4-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/cp32-m4/en_US/adafruit-circuitpython-cp32-m4-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/en_x_pirate/adafruit-circuitpython-cp32-m4-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/cp32-m4/en_x_pirate/adafruit-circuitpython-cp32-m4-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/es/adafruit-circuitpython-cp32-m4-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/cp32-m4/es/adafruit-circuitpython-cp32-m4-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/fil/adafruit-circuitpython-cp32-m4-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/cp32-m4/fil/adafruit-circuitpython-cp32-m4-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/fr/adafruit-circuitpython-cp32-m4-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/cp32-m4/fr/adafruit-circuitpython-cp32-m4-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/it_IT/adafruit-circuitpython-cp32-m4-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/cp32-m4/it_IT/adafruit-circuitpython-cp32-m4-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/ko/adafruit-circuitpython-cp32-m4-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/cp32-m4/ko/adafruit-circuitpython-cp32-m4-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/cp32-m4/nl/adafruit-circuitpython-cp32-m4-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/pl/adafruit-circuitpython-cp32-m4-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/cp32-m4/pl/adafruit-circuitpython-cp32-m4-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/pt_BR/adafruit-circuitpython-cp32-m4-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/cp32-m4/pt_BR/adafruit-circuitpython-cp32-m4-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/sv/adafruit-circuitpython-cp32-m4-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/cp32-m4/sv/adafruit-circuitpython-cp32-m4-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/cp32-m4/zh_Latn_pinyin/adafruit-circuitpython-cp32-m4-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/cp32-m4/zh_Latn_pinyin/adafruit-circuitpython-cp32-m4-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 1,
+        "downloads": 0,
         "id": "datalore_ip_m4",
         "versions": [
             {
@@ -2194,52 +2391,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/ID/adafruit-circuitpython-datalore_ip_m4-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/ID/adafruit-circuitpython-datalore_ip_m4-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/cs/adafruit-circuitpython-datalore_ip_m4-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/de_DE/adafruit-circuitpython-datalore_ip_m4-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/de_DE/adafruit-circuitpython-datalore_ip_m4-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/en_US/adafruit-circuitpython-datalore_ip_m4-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/en_US/adafruit-circuitpython-datalore_ip_m4-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/en_x_pirate/adafruit-circuitpython-datalore_ip_m4-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/en_x_pirate/adafruit-circuitpython-datalore_ip_m4-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/es/adafruit-circuitpython-datalore_ip_m4-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/es/adafruit-circuitpython-datalore_ip_m4-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/fil/adafruit-circuitpython-datalore_ip_m4-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/fil/adafruit-circuitpython-datalore_ip_m4-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/fr/adafruit-circuitpython-datalore_ip_m4-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/fr/adafruit-circuitpython-datalore_ip_m4-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/it_IT/adafruit-circuitpython-datalore_ip_m4-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/it_IT/adafruit-circuitpython-datalore_ip_m4-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/ko/adafruit-circuitpython-datalore_ip_m4-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/ko/adafruit-circuitpython-datalore_ip_m4-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/nl/adafruit-circuitpython-datalore_ip_m4-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/pl/adafruit-circuitpython-datalore_ip_m4-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/pl/adafruit-circuitpython-datalore_ip_m4-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/pt_BR/adafruit-circuitpython-datalore_ip_m4-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/pt_BR/adafruit-circuitpython-datalore_ip_m4-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/sv/adafruit-circuitpython-datalore_ip_m4-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/sv/adafruit-circuitpython-datalore_ip_m4-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/zh_Latn_pinyin/adafruit-circuitpython-datalore_ip_m4-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datalore_ip_m4/zh_Latn_pinyin/adafruit-circuitpython-datalore_ip_m4-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 29,
+        "downloads": 0,
         "id": "datum_distance",
         "versions": [
             {
@@ -2287,52 +2490,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/ID/adafruit-circuitpython-datum_distance-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_distance/ID/adafruit-circuitpython-datum_distance-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/datum_distance/cs/adafruit-circuitpython-datum_distance-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/de_DE/adafruit-circuitpython-datum_distance-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_distance/de_DE/adafruit-circuitpython-datum_distance-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/en_US/adafruit-circuitpython-datum_distance-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_distance/en_US/adafruit-circuitpython-datum_distance-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/en_x_pirate/adafruit-circuitpython-datum_distance-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_distance/en_x_pirate/adafruit-circuitpython-datum_distance-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/es/adafruit-circuitpython-datum_distance-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_distance/es/adafruit-circuitpython-datum_distance-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/fil/adafruit-circuitpython-datum_distance-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_distance/fil/adafruit-circuitpython-datum_distance-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/fr/adafruit-circuitpython-datum_distance-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_distance/fr/adafruit-circuitpython-datum_distance-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/it_IT/adafruit-circuitpython-datum_distance-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_distance/it_IT/adafruit-circuitpython-datum_distance-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/ko/adafruit-circuitpython-datum_distance-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_distance/ko/adafruit-circuitpython-datum_distance-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/datum_distance/nl/adafruit-circuitpython-datum_distance-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/pl/adafruit-circuitpython-datum_distance-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_distance/pl/adafruit-circuitpython-datum_distance-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/pt_BR/adafruit-circuitpython-datum_distance-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_distance/pt_BR/adafruit-circuitpython-datum_distance-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/sv/adafruit-circuitpython-datum_distance-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_distance/sv/adafruit-circuitpython-datum_distance-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/datum_distance/zh_Latn_pinyin/adafruit-circuitpython-datum_distance-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_distance/zh_Latn_pinyin/adafruit-circuitpython-datum_distance-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 28,
+        "downloads": 0,
         "id": "datum_imu",
         "versions": [
             {
@@ -2380,52 +2589,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/ID/adafruit-circuitpython-datum_imu-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_imu/ID/adafruit-circuitpython-datum_imu-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/datum_imu/cs/adafruit-circuitpython-datum_imu-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/de_DE/adafruit-circuitpython-datum_imu-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_imu/de_DE/adafruit-circuitpython-datum_imu-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/en_US/adafruit-circuitpython-datum_imu-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_imu/en_US/adafruit-circuitpython-datum_imu-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/en_x_pirate/adafruit-circuitpython-datum_imu-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_imu/en_x_pirate/adafruit-circuitpython-datum_imu-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/es/adafruit-circuitpython-datum_imu-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_imu/es/adafruit-circuitpython-datum_imu-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/fil/adafruit-circuitpython-datum_imu-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_imu/fil/adafruit-circuitpython-datum_imu-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/fr/adafruit-circuitpython-datum_imu-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_imu/fr/adafruit-circuitpython-datum_imu-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/it_IT/adafruit-circuitpython-datum_imu-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_imu/it_IT/adafruit-circuitpython-datum_imu-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/ko/adafruit-circuitpython-datum_imu-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_imu/ko/adafruit-circuitpython-datum_imu-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/datum_imu/nl/adafruit-circuitpython-datum_imu-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/pl/adafruit-circuitpython-datum_imu-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_imu/pl/adafruit-circuitpython-datum_imu-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/pt_BR/adafruit-circuitpython-datum_imu-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_imu/pt_BR/adafruit-circuitpython-datum_imu-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/sv/adafruit-circuitpython-datum_imu-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_imu/sv/adafruit-circuitpython-datum_imu-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/datum_imu/zh_Latn_pinyin/adafruit-circuitpython-datum_imu-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_imu/zh_Latn_pinyin/adafruit-circuitpython-datum_imu-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 6,
+        "downloads": 0,
         "id": "datum_light",
         "versions": [
             {
@@ -2473,52 +2688,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/datum_light/ID/adafruit-circuitpython-datum_light-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_light/ID/adafruit-circuitpython-datum_light-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/datum_light/cs/adafruit-circuitpython-datum_light-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/datum_light/de_DE/adafruit-circuitpython-datum_light-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_light/de_DE/adafruit-circuitpython-datum_light-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/datum_light/en_US/adafruit-circuitpython-datum_light-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_light/en_US/adafruit-circuitpython-datum_light-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/datum_light/en_x_pirate/adafruit-circuitpython-datum_light-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_light/en_x_pirate/adafruit-circuitpython-datum_light-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/datum_light/es/adafruit-circuitpython-datum_light-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_light/es/adafruit-circuitpython-datum_light-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/datum_light/fil/adafruit-circuitpython-datum_light-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_light/fil/adafruit-circuitpython-datum_light-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/datum_light/fr/adafruit-circuitpython-datum_light-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_light/fr/adafruit-circuitpython-datum_light-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/datum_light/it_IT/adafruit-circuitpython-datum_light-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_light/it_IT/adafruit-circuitpython-datum_light-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/datum_light/ko/adafruit-circuitpython-datum_light-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_light/ko/adafruit-circuitpython-datum_light-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/datum_light/nl/adafruit-circuitpython-datum_light-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/datum_light/pl/adafruit-circuitpython-datum_light-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_light/pl/adafruit-circuitpython-datum_light-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/datum_light/pt_BR/adafruit-circuitpython-datum_light-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_light/pt_BR/adafruit-circuitpython-datum_light-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/datum_light/sv/adafruit-circuitpython-datum_light-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_light/sv/adafruit-circuitpython-datum_light-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/datum_light/zh_Latn_pinyin/adafruit-circuitpython-datum_light-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_light/zh_Latn_pinyin/adafruit-circuitpython-datum_light-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 29,
+        "downloads": 0,
         "id": "datum_weather",
         "versions": [
             {
@@ -2566,52 +2787,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/ID/adafruit-circuitpython-datum_weather-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_weather/ID/adafruit-circuitpython-datum_weather-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/datum_weather/cs/adafruit-circuitpython-datum_weather-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/de_DE/adafruit-circuitpython-datum_weather-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_weather/de_DE/adafruit-circuitpython-datum_weather-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/en_US/adafruit-circuitpython-datum_weather-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_weather/en_US/adafruit-circuitpython-datum_weather-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/en_x_pirate/adafruit-circuitpython-datum_weather-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_weather/en_x_pirate/adafruit-circuitpython-datum_weather-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/es/adafruit-circuitpython-datum_weather-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_weather/es/adafruit-circuitpython-datum_weather-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/fil/adafruit-circuitpython-datum_weather-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_weather/fil/adafruit-circuitpython-datum_weather-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/fr/adafruit-circuitpython-datum_weather-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_weather/fr/adafruit-circuitpython-datum_weather-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/it_IT/adafruit-circuitpython-datum_weather-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_weather/it_IT/adafruit-circuitpython-datum_weather-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/ko/adafruit-circuitpython-datum_weather-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_weather/ko/adafruit-circuitpython-datum_weather-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/datum_weather/nl/adafruit-circuitpython-datum_weather-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/pl/adafruit-circuitpython-datum_weather-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_weather/pl/adafruit-circuitpython-datum_weather-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/pt_BR/adafruit-circuitpython-datum_weather-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_weather/pt_BR/adafruit-circuitpython-datum_weather-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/sv/adafruit-circuitpython-datum_weather-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_weather/sv/adafruit-circuitpython-datum_weather-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/datum_weather/zh_Latn_pinyin/adafruit-circuitpython-datum_weather-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/datum_weather/zh_Latn_pinyin/adafruit-circuitpython-datum_weather-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 54,
+        "downloads": 0,
         "id": "edgebadge",
         "versions": [
             {
@@ -2659,52 +2886,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/ID/adafruit-circuitpython-edgebadge-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/edgebadge/ID/adafruit-circuitpython-edgebadge-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/edgebadge/cs/adafruit-circuitpython-edgebadge-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/de_DE/adafruit-circuitpython-edgebadge-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/edgebadge/de_DE/adafruit-circuitpython-edgebadge-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/en_US/adafruit-circuitpython-edgebadge-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/edgebadge/en_US/adafruit-circuitpython-edgebadge-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/en_x_pirate/adafruit-circuitpython-edgebadge-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/edgebadge/en_x_pirate/adafruit-circuitpython-edgebadge-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/es/adafruit-circuitpython-edgebadge-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/edgebadge/es/adafruit-circuitpython-edgebadge-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/fil/adafruit-circuitpython-edgebadge-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/edgebadge/fil/adafruit-circuitpython-edgebadge-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/fr/adafruit-circuitpython-edgebadge-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/edgebadge/fr/adafruit-circuitpython-edgebadge-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/it_IT/adafruit-circuitpython-edgebadge-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/edgebadge/it_IT/adafruit-circuitpython-edgebadge-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/ko/adafruit-circuitpython-edgebadge-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/edgebadge/ko/adafruit-circuitpython-edgebadge-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/edgebadge/nl/adafruit-circuitpython-edgebadge-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/pl/adafruit-circuitpython-edgebadge-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/edgebadge/pl/adafruit-circuitpython-edgebadge-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/pt_BR/adafruit-circuitpython-edgebadge-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/edgebadge/pt_BR/adafruit-circuitpython-edgebadge-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/sv/adafruit-circuitpython-edgebadge-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/edgebadge/sv/adafruit-circuitpython-edgebadge-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/edgebadge/zh_Latn_pinyin/adafruit-circuitpython-edgebadge-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/edgebadge/zh_Latn_pinyin/adafruit-circuitpython-edgebadge-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 37,
+        "downloads": 0,
         "id": "electronut_labs_blip",
         "versions": [
             {
@@ -2752,52 +2985,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/ID/adafruit-circuitpython-electronut_labs_blip-ID-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/ID/adafruit-circuitpython-electronut_labs_blip-ID-5.4.0-beta.1.hex"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/cs/adafruit-circuitpython-electronut_labs_blip-cs-5.4.0-beta.1.hex"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/de_DE/adafruit-circuitpython-electronut_labs_blip-de_DE-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/de_DE/adafruit-circuitpython-electronut_labs_blip-de_DE-5.4.0-beta.1.hex"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/en_US/adafruit-circuitpython-electronut_labs_blip-en_US-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/en_US/adafruit-circuitpython-electronut_labs_blip-en_US-5.4.0-beta.1.hex"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/en_x_pirate/adafruit-circuitpython-electronut_labs_blip-en_x_pirate-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/en_x_pirate/adafruit-circuitpython-electronut_labs_blip-en_x_pirate-5.4.0-beta.1.hex"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/es/adafruit-circuitpython-electronut_labs_blip-es-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/es/adafruit-circuitpython-electronut_labs_blip-es-5.4.0-beta.1.hex"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/fil/adafruit-circuitpython-electronut_labs_blip-fil-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/fil/adafruit-circuitpython-electronut_labs_blip-fil-5.4.0-beta.1.hex"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/fr/adafruit-circuitpython-electronut_labs_blip-fr-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/fr/adafruit-circuitpython-electronut_labs_blip-fr-5.4.0-beta.1.hex"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/it_IT/adafruit-circuitpython-electronut_labs_blip-it_IT-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/it_IT/adafruit-circuitpython-electronut_labs_blip-it_IT-5.4.0-beta.1.hex"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/ko/adafruit-circuitpython-electronut_labs_blip-ko-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/ko/adafruit-circuitpython-electronut_labs_blip-ko-5.4.0-beta.1.hex"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/nl/adafruit-circuitpython-electronut_labs_blip-nl-5.4.0-beta.1.hex"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/pl/adafruit-circuitpython-electronut_labs_blip-pl-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/pl/adafruit-circuitpython-electronut_labs_blip-pl-5.4.0-beta.1.hex"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/pt_BR/adafruit-circuitpython-electronut_labs_blip-pt_BR-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/pt_BR/adafruit-circuitpython-electronut_labs_blip-pt_BR-5.4.0-beta.1.hex"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/sv/adafruit-circuitpython-electronut_labs_blip-sv-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/sv/adafruit-circuitpython-electronut_labs_blip-sv-5.4.0-beta.1.hex"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/zh_Latn_pinyin/adafruit-circuitpython-electronut_labs_blip-zh_Latn_pinyin-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/electronut_labs_blip/zh_Latn_pinyin/adafruit-circuitpython-electronut_labs_blip-zh_Latn_pinyin-5.4.0-beta.1.hex"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 30,
+        "downloads": 0,
         "id": "electronut_labs_papyr",
         "versions": [
             {
@@ -2845,52 +3084,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/ID/adafruit-circuitpython-electronut_labs_papyr-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/ID/adafruit-circuitpython-electronut_labs_papyr-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/cs/adafruit-circuitpython-electronut_labs_papyr-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/de_DE/adafruit-circuitpython-electronut_labs_papyr-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/de_DE/adafruit-circuitpython-electronut_labs_papyr-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/en_US/adafruit-circuitpython-electronut_labs_papyr-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/en_US/adafruit-circuitpython-electronut_labs_papyr-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/en_x_pirate/adafruit-circuitpython-electronut_labs_papyr-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/en_x_pirate/adafruit-circuitpython-electronut_labs_papyr-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/es/adafruit-circuitpython-electronut_labs_papyr-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/es/adafruit-circuitpython-electronut_labs_papyr-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/fil/adafruit-circuitpython-electronut_labs_papyr-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/fil/adafruit-circuitpython-electronut_labs_papyr-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/fr/adafruit-circuitpython-electronut_labs_papyr-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/fr/adafruit-circuitpython-electronut_labs_papyr-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/it_IT/adafruit-circuitpython-electronut_labs_papyr-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/it_IT/adafruit-circuitpython-electronut_labs_papyr-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/ko/adafruit-circuitpython-electronut_labs_papyr-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/ko/adafruit-circuitpython-electronut_labs_papyr-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/nl/adafruit-circuitpython-electronut_labs_papyr-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/pl/adafruit-circuitpython-electronut_labs_papyr-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/pl/adafruit-circuitpython-electronut_labs_papyr-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/pt_BR/adafruit-circuitpython-electronut_labs_papyr-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/pt_BR/adafruit-circuitpython-electronut_labs_papyr-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/sv/adafruit-circuitpython-electronut_labs_papyr-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/sv/adafruit-circuitpython-electronut_labs_papyr-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/zh_Latn_pinyin/adafruit-circuitpython-electronut_labs_papyr-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/electronut_labs_papyr/zh_Latn_pinyin/adafruit-circuitpython-electronut_labs_papyr-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 14,
+        "downloads": 0,
         "id": "escornabot_makech",
         "versions": [
             {
@@ -2938,52 +3183,172 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/ID/adafruit-circuitpython-escornabot_makech-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/ID/adafruit-circuitpython-escornabot_makech-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/cs/adafruit-circuitpython-escornabot_makech-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/de_DE/adafruit-circuitpython-escornabot_makech-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/de_DE/adafruit-circuitpython-escornabot_makech-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/en_US/adafruit-circuitpython-escornabot_makech-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/en_US/adafruit-circuitpython-escornabot_makech-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/en_x_pirate/adafruit-circuitpython-escornabot_makech-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/en_x_pirate/adafruit-circuitpython-escornabot_makech-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/es/adafruit-circuitpython-escornabot_makech-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/es/adafruit-circuitpython-escornabot_makech-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/fil/adafruit-circuitpython-escornabot_makech-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/fil/adafruit-circuitpython-escornabot_makech-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/fr/adafruit-circuitpython-escornabot_makech-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/fr/adafruit-circuitpython-escornabot_makech-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/it_IT/adafruit-circuitpython-escornabot_makech-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/it_IT/adafruit-circuitpython-escornabot_makech-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/ko/adafruit-circuitpython-escornabot_makech-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/ko/adafruit-circuitpython-escornabot_makech-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/nl/adafruit-circuitpython-escornabot_makech-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/pl/adafruit-circuitpython-escornabot_makech-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/pl/adafruit-circuitpython-escornabot_makech-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/pt_BR/adafruit-circuitpython-escornabot_makech-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/pt_BR/adafruit-circuitpython-escornabot_makech-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/sv/adafruit-circuitpython-escornabot_makech-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/sv/adafruit-circuitpython-escornabot_makech-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/escornabot_makech/zh_Latn_pinyin/adafruit-circuitpython-escornabot_makech-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/escornabot_makech/zh_Latn_pinyin/adafruit-circuitpython-escornabot_makech-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 8,
+        "downloads": 0,
+        "id": "espressif_saola_1_wroom",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/espressif_saola_1_wroom/ID/adafruit-circuitpython-espressif_saola_1_wroom-ID-5.4.0-beta.1.bin"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/espressif_saola_1_wroom/cs/adafruit-circuitpython-espressif_saola_1_wroom-cs-5.4.0-beta.1.bin"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/espressif_saola_1_wroom/de_DE/adafruit-circuitpython-espressif_saola_1_wroom-de_DE-5.4.0-beta.1.bin"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/espressif_saola_1_wroom/en_US/adafruit-circuitpython-espressif_saola_1_wroom-en_US-5.4.0-beta.1.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/espressif_saola_1_wroom/en_x_pirate/adafruit-circuitpython-espressif_saola_1_wroom-en_x_pirate-5.4.0-beta.1.bin"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/espressif_saola_1_wroom/es/adafruit-circuitpython-espressif_saola_1_wroom-es-5.4.0-beta.1.bin"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/espressif_saola_1_wroom/fil/adafruit-circuitpython-espressif_saola_1_wroom-fil-5.4.0-beta.1.bin"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/espressif_saola_1_wroom/fr/adafruit-circuitpython-espressif_saola_1_wroom-fr-5.4.0-beta.1.bin"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/espressif_saola_1_wroom/it_IT/adafruit-circuitpython-espressif_saola_1_wroom-it_IT-5.4.0-beta.1.bin"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/espressif_saola_1_wroom/ko/adafruit-circuitpython-espressif_saola_1_wroom-ko-5.4.0-beta.1.bin"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/espressif_saola_1_wroom/nl/adafruit-circuitpython-espressif_saola_1_wroom-nl-5.4.0-beta.1.bin"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/espressif_saola_1_wroom/pl/adafruit-circuitpython-espressif_saola_1_wroom-pl-5.4.0-beta.1.bin"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/espressif_saola_1_wroom/pt_BR/adafruit-circuitpython-espressif_saola_1_wroom-pt_BR-5.4.0-beta.1.bin"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/espressif_saola_1_wroom/sv/adafruit-circuitpython-espressif_saola_1_wroom-sv-5.4.0-beta.1.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/espressif_saola_1_wroom/zh_Latn_pinyin/adafruit-circuitpython-espressif_saola_1_wroom-zh_Latn_pinyin-5.4.0-beta.1.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.1"
+            }
+        ]
+    },
+    {
+        "downloads": 0,
+        "id": "espressif_saola_1_wrover",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/espressif_saola_1_wrover/ID/adafruit-circuitpython-espressif_saola_1_wrover-ID-5.4.0-beta.1.bin"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/espressif_saola_1_wrover/cs/adafruit-circuitpython-espressif_saola_1_wrover-cs-5.4.0-beta.1.bin"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/espressif_saola_1_wrover/de_DE/adafruit-circuitpython-espressif_saola_1_wrover-de_DE-5.4.0-beta.1.bin"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/espressif_saola_1_wrover/en_US/adafruit-circuitpython-espressif_saola_1_wrover-en_US-5.4.0-beta.1.bin"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/espressif_saola_1_wrover/en_x_pirate/adafruit-circuitpython-espressif_saola_1_wrover-en_x_pirate-5.4.0-beta.1.bin"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/espressif_saola_1_wrover/es/adafruit-circuitpython-espressif_saola_1_wrover-es-5.4.0-beta.1.bin"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/espressif_saola_1_wrover/fil/adafruit-circuitpython-espressif_saola_1_wrover-fil-5.4.0-beta.1.bin"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/espressif_saola_1_wrover/fr/adafruit-circuitpython-espressif_saola_1_wrover-fr-5.4.0-beta.1.bin"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/espressif_saola_1_wrover/it_IT/adafruit-circuitpython-espressif_saola_1_wrover-it_IT-5.4.0-beta.1.bin"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/espressif_saola_1_wrover/ko/adafruit-circuitpython-espressif_saola_1_wrover-ko-5.4.0-beta.1.bin"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/espressif_saola_1_wrover/nl/adafruit-circuitpython-espressif_saola_1_wrover-nl-5.4.0-beta.1.bin"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/espressif_saola_1_wrover/pl/adafruit-circuitpython-espressif_saola_1_wrover-pl-5.4.0-beta.1.bin"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/espressif_saola_1_wrover/pt_BR/adafruit-circuitpython-espressif_saola_1_wrover-pt_BR-5.4.0-beta.1.bin"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/espressif_saola_1_wrover/sv/adafruit-circuitpython-espressif_saola_1_wrover-sv-5.4.0-beta.1.bin"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/espressif_saola_1_wrover/zh_Latn_pinyin/adafruit-circuitpython-espressif_saola_1_wrover-zh_Latn_pinyin-5.4.0-beta.1.bin"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.1"
+            }
+        ]
+    },
+    {
+        "downloads": 0,
         "id": "espruino_pico",
         "versions": [
             {
@@ -3031,52 +3396,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/ID/adafruit-circuitpython-espruino_pico-ID-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/espruino_pico/ID/adafruit-circuitpython-espruino_pico-ID-5.4.0-beta.1.bin"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/espruino_pico/cs/adafruit-circuitpython-espruino_pico-cs-5.4.0-beta.1.bin"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/de_DE/adafruit-circuitpython-espruino_pico-de_DE-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/espruino_pico/de_DE/adafruit-circuitpython-espruino_pico-de_DE-5.4.0-beta.1.bin"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/en_US/adafruit-circuitpython-espruino_pico-en_US-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/espruino_pico/en_US/adafruit-circuitpython-espruino_pico-en_US-5.4.0-beta.1.bin"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/en_x_pirate/adafruit-circuitpython-espruino_pico-en_x_pirate-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/espruino_pico/en_x_pirate/adafruit-circuitpython-espruino_pico-en_x_pirate-5.4.0-beta.1.bin"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/es/adafruit-circuitpython-espruino_pico-es-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/espruino_pico/es/adafruit-circuitpython-espruino_pico-es-5.4.0-beta.1.bin"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/fil/adafruit-circuitpython-espruino_pico-fil-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/espruino_pico/fil/adafruit-circuitpython-espruino_pico-fil-5.4.0-beta.1.bin"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/fr/adafruit-circuitpython-espruino_pico-fr-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/espruino_pico/fr/adafruit-circuitpython-espruino_pico-fr-5.4.0-beta.1.bin"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/it_IT/adafruit-circuitpython-espruino_pico-it_IT-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/espruino_pico/it_IT/adafruit-circuitpython-espruino_pico-it_IT-5.4.0-beta.1.bin"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/ko/adafruit-circuitpython-espruino_pico-ko-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/espruino_pico/ko/adafruit-circuitpython-espruino_pico-ko-5.4.0-beta.1.bin"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/espruino_pico/nl/adafruit-circuitpython-espruino_pico-nl-5.4.0-beta.1.bin"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/pl/adafruit-circuitpython-espruino_pico-pl-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/espruino_pico/pl/adafruit-circuitpython-espruino_pico-pl-5.4.0-beta.1.bin"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/pt_BR/adafruit-circuitpython-espruino_pico-pt_BR-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/espruino_pico/pt_BR/adafruit-circuitpython-espruino_pico-pt_BR-5.4.0-beta.1.bin"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/sv/adafruit-circuitpython-espruino_pico-sv-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/espruino_pico/sv/adafruit-circuitpython-espruino_pico-sv-5.4.0-beta.1.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/espruino_pico/zh_Latn_pinyin/adafruit-circuitpython-espruino_pico-zh_Latn_pinyin-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/espruino_pico/zh_Latn_pinyin/adafruit-circuitpython-espruino_pico-zh_Latn_pinyin-5.4.0-beta.1.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 7,
+        "downloads": 0,
         "id": "espruino_wifi",
         "versions": [
             {
@@ -3124,52 +3495,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/ID/adafruit-circuitpython-espruino_wifi-ID-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/ID/adafruit-circuitpython-espruino_wifi-ID-5.4.0-beta.1.bin"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/cs/adafruit-circuitpython-espruino_wifi-cs-5.4.0-beta.1.bin"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/de_DE/adafruit-circuitpython-espruino_wifi-de_DE-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/de_DE/adafruit-circuitpython-espruino_wifi-de_DE-5.4.0-beta.1.bin"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/en_US/adafruit-circuitpython-espruino_wifi-en_US-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/en_US/adafruit-circuitpython-espruino_wifi-en_US-5.4.0-beta.1.bin"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/en_x_pirate/adafruit-circuitpython-espruino_wifi-en_x_pirate-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/en_x_pirate/adafruit-circuitpython-espruino_wifi-en_x_pirate-5.4.0-beta.1.bin"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/es/adafruit-circuitpython-espruino_wifi-es-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/es/adafruit-circuitpython-espruino_wifi-es-5.4.0-beta.1.bin"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/fil/adafruit-circuitpython-espruino_wifi-fil-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/fil/adafruit-circuitpython-espruino_wifi-fil-5.4.0-beta.1.bin"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/fr/adafruit-circuitpython-espruino_wifi-fr-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/fr/adafruit-circuitpython-espruino_wifi-fr-5.4.0-beta.1.bin"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/it_IT/adafruit-circuitpython-espruino_wifi-it_IT-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/it_IT/adafruit-circuitpython-espruino_wifi-it_IT-5.4.0-beta.1.bin"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/ko/adafruit-circuitpython-espruino_wifi-ko-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/ko/adafruit-circuitpython-espruino_wifi-ko-5.4.0-beta.1.bin"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/nl/adafruit-circuitpython-espruino_wifi-nl-5.4.0-beta.1.bin"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/pl/adafruit-circuitpython-espruino_wifi-pl-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/pl/adafruit-circuitpython-espruino_wifi-pl-5.4.0-beta.1.bin"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/pt_BR/adafruit-circuitpython-espruino_wifi-pt_BR-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/pt_BR/adafruit-circuitpython-espruino_wifi-pt_BR-5.4.0-beta.1.bin"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/sv/adafruit-circuitpython-espruino_wifi-sv-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/sv/adafruit-circuitpython-espruino_wifi-sv-5.4.0-beta.1.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/espruino_wifi/zh_Latn_pinyin/adafruit-circuitpython-espruino_wifi-zh_Latn_pinyin-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/espruino_wifi/zh_Latn_pinyin/adafruit-circuitpython-espruino_wifi-zh_Latn_pinyin-5.4.0-beta.1.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 39,
+        "downloads": 0,
         "id": "feather_bluefruit_sense",
         "versions": [
             {
@@ -3217,52 +3594,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/ID/adafruit-circuitpython-feather_bluefruit_sense-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/ID/adafruit-circuitpython-feather_bluefruit_sense-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/cs/adafruit-circuitpython-feather_bluefruit_sense-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/de_DE/adafruit-circuitpython-feather_bluefruit_sense-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/de_DE/adafruit-circuitpython-feather_bluefruit_sense-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/en_US/adafruit-circuitpython-feather_bluefruit_sense-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/en_US/adafruit-circuitpython-feather_bluefruit_sense-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/en_x_pirate/adafruit-circuitpython-feather_bluefruit_sense-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/en_x_pirate/adafruit-circuitpython-feather_bluefruit_sense-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/es/adafruit-circuitpython-feather_bluefruit_sense-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/es/adafruit-circuitpython-feather_bluefruit_sense-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/fil/adafruit-circuitpython-feather_bluefruit_sense-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/fil/adafruit-circuitpython-feather_bluefruit_sense-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/fr/adafruit-circuitpython-feather_bluefruit_sense-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/fr/adafruit-circuitpython-feather_bluefruit_sense-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/it_IT/adafruit-circuitpython-feather_bluefruit_sense-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/it_IT/adafruit-circuitpython-feather_bluefruit_sense-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/ko/adafruit-circuitpython-feather_bluefruit_sense-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/ko/adafruit-circuitpython-feather_bluefruit_sense-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/nl/adafruit-circuitpython-feather_bluefruit_sense-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/pl/adafruit-circuitpython-feather_bluefruit_sense-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/pl/adafruit-circuitpython-feather_bluefruit_sense-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/pt_BR/adafruit-circuitpython-feather_bluefruit_sense-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/pt_BR/adafruit-circuitpython-feather_bluefruit_sense-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/sv/adafruit-circuitpython-feather_bluefruit_sense-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/sv/adafruit-circuitpython-feather_bluefruit_sense-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/zh_Latn_pinyin/adafruit-circuitpython-feather_bluefruit_sense-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_bluefruit_sense/zh_Latn_pinyin/adafruit-circuitpython-feather_bluefruit_sense-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 37,
+        "downloads": 0,
         "id": "feather_m0_adalogger",
         "versions": [
             {
@@ -3322,65 +3705,73 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/ID/adafruit-circuitpython-feather_m0_adalogger-ID-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/ID/adafruit-circuitpython-feather_m0_adalogger-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/ID/adafruit-circuitpython-feather_m0_adalogger-ID-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/ID/adafruit-circuitpython-feather_m0_adalogger-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/cs/adafruit-circuitpython-feather_m0_adalogger-cs-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/cs/adafruit-circuitpython-feather_m0_adalogger-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/de_DE/adafruit-circuitpython-feather_m0_adalogger-de_DE-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/de_DE/adafruit-circuitpython-feather_m0_adalogger-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/de_DE/adafruit-circuitpython-feather_m0_adalogger-de_DE-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/de_DE/adafruit-circuitpython-feather_m0_adalogger-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/en_US/adafruit-circuitpython-feather_m0_adalogger-en_US-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/en_US/adafruit-circuitpython-feather_m0_adalogger-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/en_US/adafruit-circuitpython-feather_m0_adalogger-en_US-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/en_US/adafruit-circuitpython-feather_m0_adalogger-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/en_x_pirate/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/en_x_pirate/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/en_x_pirate/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/en_x_pirate/adafruit-circuitpython-feather_m0_adalogger-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/es/adafruit-circuitpython-feather_m0_adalogger-es-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/es/adafruit-circuitpython-feather_m0_adalogger-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/es/adafruit-circuitpython-feather_m0_adalogger-es-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/es/adafruit-circuitpython-feather_m0_adalogger-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/fil/adafruit-circuitpython-feather_m0_adalogger-fil-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/fil/adafruit-circuitpython-feather_m0_adalogger-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/fil/adafruit-circuitpython-feather_m0_adalogger-fil-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/fil/adafruit-circuitpython-feather_m0_adalogger-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/fr/adafruit-circuitpython-feather_m0_adalogger-fr-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/fr/adafruit-circuitpython-feather_m0_adalogger-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/fr/adafruit-circuitpython-feather_m0_adalogger-fr-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/fr/adafruit-circuitpython-feather_m0_adalogger-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/it_IT/adafruit-circuitpython-feather_m0_adalogger-it_IT-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/it_IT/adafruit-circuitpython-feather_m0_adalogger-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/it_IT/adafruit-circuitpython-feather_m0_adalogger-it_IT-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/it_IT/adafruit-circuitpython-feather_m0_adalogger-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/ko/adafruit-circuitpython-feather_m0_adalogger-ko-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/ko/adafruit-circuitpython-feather_m0_adalogger-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/ko/adafruit-circuitpython-feather_m0_adalogger-ko-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/ko/adafruit-circuitpython-feather_m0_adalogger-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/nl/adafruit-circuitpython-feather_m0_adalogger-nl-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/nl/adafruit-circuitpython-feather_m0_adalogger-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/pl/adafruit-circuitpython-feather_m0_adalogger-pl-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/pl/adafruit-circuitpython-feather_m0_adalogger-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/pl/adafruit-circuitpython-feather_m0_adalogger-pl-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/pl/adafruit-circuitpython-feather_m0_adalogger-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/pt_BR/adafruit-circuitpython-feather_m0_adalogger-pt_BR-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/pt_BR/adafruit-circuitpython-feather_m0_adalogger-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/pt_BR/adafruit-circuitpython-feather_m0_adalogger-pt_BR-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/pt_BR/adafruit-circuitpython-feather_m0_adalogger-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/sv/adafruit-circuitpython-feather_m0_adalogger-sv-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/sv/adafruit-circuitpython-feather_m0_adalogger-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/sv/adafruit-circuitpython-feather_m0_adalogger-sv-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/sv/adafruit-circuitpython-feather_m0_adalogger-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_adalogger-zh_Latn_pinyin-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_adalogger-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_adalogger-zh_Latn_pinyin-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_adalogger/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_adalogger-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 32,
+        "downloads": 0,
         "id": "feather_m0_basic",
         "versions": [
             {
@@ -3440,65 +3831,73 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/ID/adafruit-circuitpython-feather_m0_basic-ID-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/ID/adafruit-circuitpython-feather_m0_basic-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/ID/adafruit-circuitpython-feather_m0_basic-ID-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/ID/adafruit-circuitpython-feather_m0_basic-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/cs/adafruit-circuitpython-feather_m0_basic-cs-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/cs/adafruit-circuitpython-feather_m0_basic-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/de_DE/adafruit-circuitpython-feather_m0_basic-de_DE-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/de_DE/adafruit-circuitpython-feather_m0_basic-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/de_DE/adafruit-circuitpython-feather_m0_basic-de_DE-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/de_DE/adafruit-circuitpython-feather_m0_basic-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/en_US/adafruit-circuitpython-feather_m0_basic-en_US-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/en_US/adafruit-circuitpython-feather_m0_basic-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/en_US/adafruit-circuitpython-feather_m0_basic-en_US-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/en_US/adafruit-circuitpython-feather_m0_basic-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/en_x_pirate/adafruit-circuitpython-feather_m0_basic-en_x_pirate-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/en_x_pirate/adafruit-circuitpython-feather_m0_basic-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/en_x_pirate/adafruit-circuitpython-feather_m0_basic-en_x_pirate-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/en_x_pirate/adafruit-circuitpython-feather_m0_basic-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/es/adafruit-circuitpython-feather_m0_basic-es-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/es/adafruit-circuitpython-feather_m0_basic-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/es/adafruit-circuitpython-feather_m0_basic-es-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/es/adafruit-circuitpython-feather_m0_basic-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/fil/adafruit-circuitpython-feather_m0_basic-fil-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/fil/adafruit-circuitpython-feather_m0_basic-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/fil/adafruit-circuitpython-feather_m0_basic-fil-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/fil/adafruit-circuitpython-feather_m0_basic-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/fr/adafruit-circuitpython-feather_m0_basic-fr-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/fr/adafruit-circuitpython-feather_m0_basic-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/fr/adafruit-circuitpython-feather_m0_basic-fr-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/fr/adafruit-circuitpython-feather_m0_basic-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/it_IT/adafruit-circuitpython-feather_m0_basic-it_IT-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/it_IT/adafruit-circuitpython-feather_m0_basic-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/it_IT/adafruit-circuitpython-feather_m0_basic-it_IT-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/it_IT/adafruit-circuitpython-feather_m0_basic-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/ko/adafruit-circuitpython-feather_m0_basic-ko-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/ko/adafruit-circuitpython-feather_m0_basic-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/ko/adafruit-circuitpython-feather_m0_basic-ko-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/ko/adafruit-circuitpython-feather_m0_basic-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/nl/adafruit-circuitpython-feather_m0_basic-nl-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/nl/adafruit-circuitpython-feather_m0_basic-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/pl/adafruit-circuitpython-feather_m0_basic-pl-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/pl/adafruit-circuitpython-feather_m0_basic-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/pl/adafruit-circuitpython-feather_m0_basic-pl-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/pl/adafruit-circuitpython-feather_m0_basic-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/pt_BR/adafruit-circuitpython-feather_m0_basic-pt_BR-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/pt_BR/adafruit-circuitpython-feather_m0_basic-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/pt_BR/adafruit-circuitpython-feather_m0_basic-pt_BR-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/pt_BR/adafruit-circuitpython-feather_m0_basic-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/sv/adafruit-circuitpython-feather_m0_basic-sv-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/sv/adafruit-circuitpython-feather_m0_basic-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/sv/adafruit-circuitpython-feather_m0_basic-sv-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/sv/adafruit-circuitpython-feather_m0_basic-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_basic-zh_Latn_pinyin-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_basic/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_basic-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_basic-zh_Latn_pinyin-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_basic/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_basic-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 97,
+        "downloads": 0,
         "id": "feather_m0_express",
         "versions": [
             {
@@ -3546,52 +3945,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/ID/adafruit-circuitpython-feather_m0_express-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/ID/adafruit-circuitpython-feather_m0_express-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/cs/adafruit-circuitpython-feather_m0_express-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/de_DE/adafruit-circuitpython-feather_m0_express-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/de_DE/adafruit-circuitpython-feather_m0_express-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/en_US/adafruit-circuitpython-feather_m0_express-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/en_US/adafruit-circuitpython-feather_m0_express-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/en_x_pirate/adafruit-circuitpython-feather_m0_express-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/en_x_pirate/adafruit-circuitpython-feather_m0_express-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/es/adafruit-circuitpython-feather_m0_express-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/es/adafruit-circuitpython-feather_m0_express-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/fil/adafruit-circuitpython-feather_m0_express-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/fil/adafruit-circuitpython-feather_m0_express-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/fr/adafruit-circuitpython-feather_m0_express-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/fr/adafruit-circuitpython-feather_m0_express-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/it_IT/adafruit-circuitpython-feather_m0_express-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/it_IT/adafruit-circuitpython-feather_m0_express-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/ko/adafruit-circuitpython-feather_m0_express-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/ko/adafruit-circuitpython-feather_m0_express-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/nl/adafruit-circuitpython-feather_m0_express-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/pl/adafruit-circuitpython-feather_m0_express-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/pl/adafruit-circuitpython-feather_m0_express-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/pt_BR/adafruit-circuitpython-feather_m0_express-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/pt_BR/adafruit-circuitpython-feather_m0_express-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/sv/adafruit-circuitpython-feather_m0_express-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/sv/adafruit-circuitpython-feather_m0_express-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_express/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_express-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 6,
+        "downloads": 0,
         "id": "feather_m0_express_crickit",
         "versions": [
             {
@@ -3639,52 +4044,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/ID/adafruit-circuitpython-feather_m0_express_crickit-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/ID/adafruit-circuitpython-feather_m0_express_crickit-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/cs/adafruit-circuitpython-feather_m0_express_crickit-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/de_DE/adafruit-circuitpython-feather_m0_express_crickit-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/de_DE/adafruit-circuitpython-feather_m0_express_crickit-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/en_US/adafruit-circuitpython-feather_m0_express_crickit-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/en_US/adafruit-circuitpython-feather_m0_express_crickit-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/en_x_pirate/adafruit-circuitpython-feather_m0_express_crickit-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/en_x_pirate/adafruit-circuitpython-feather_m0_express_crickit-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/es/adafruit-circuitpython-feather_m0_express_crickit-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/es/adafruit-circuitpython-feather_m0_express_crickit-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/fil/adafruit-circuitpython-feather_m0_express_crickit-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/fil/adafruit-circuitpython-feather_m0_express_crickit-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/fr/adafruit-circuitpython-feather_m0_express_crickit-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/fr/adafruit-circuitpython-feather_m0_express_crickit-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/it_IT/adafruit-circuitpython-feather_m0_express_crickit-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/it_IT/adafruit-circuitpython-feather_m0_express_crickit-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/ko/adafruit-circuitpython-feather_m0_express_crickit-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/ko/adafruit-circuitpython-feather_m0_express_crickit-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/nl/adafruit-circuitpython-feather_m0_express_crickit-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/pl/adafruit-circuitpython-feather_m0_express_crickit-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/pl/adafruit-circuitpython-feather_m0_express_crickit-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/pt_BR/adafruit-circuitpython-feather_m0_express_crickit-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/pt_BR/adafruit-circuitpython-feather_m0_express_crickit-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/sv/adafruit-circuitpython-feather_m0_express_crickit-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/sv/adafruit-circuitpython-feather_m0_express_crickit-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_express_crickit-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_express_crickit/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_express_crickit-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 20,
+        "downloads": 0,
         "id": "feather_m0_rfm69",
         "versions": [
             {
@@ -3744,65 +4155,73 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/ID/adafruit-circuitpython-feather_m0_rfm69-ID-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/ID/adafruit-circuitpython-feather_m0_rfm69-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/ID/adafruit-circuitpython-feather_m0_rfm69-ID-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/ID/adafruit-circuitpython-feather_m0_rfm69-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/cs/adafruit-circuitpython-feather_m0_rfm69-cs-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/cs/adafruit-circuitpython-feather_m0_rfm69-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/de_DE/adafruit-circuitpython-feather_m0_rfm69-de_DE-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/de_DE/adafruit-circuitpython-feather_m0_rfm69-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/de_DE/adafruit-circuitpython-feather_m0_rfm69-de_DE-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/de_DE/adafruit-circuitpython-feather_m0_rfm69-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/en_US/adafruit-circuitpython-feather_m0_rfm69-en_US-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/en_US/adafruit-circuitpython-feather_m0_rfm69-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/en_US/adafruit-circuitpython-feather_m0_rfm69-en_US-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/en_US/adafruit-circuitpython-feather_m0_rfm69-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/en_x_pirate/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/en_x_pirate/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/en_x_pirate/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/en_x_pirate/adafruit-circuitpython-feather_m0_rfm69-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/es/adafruit-circuitpython-feather_m0_rfm69-es-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/es/adafruit-circuitpython-feather_m0_rfm69-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/es/adafruit-circuitpython-feather_m0_rfm69-es-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/es/adafruit-circuitpython-feather_m0_rfm69-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/fil/adafruit-circuitpython-feather_m0_rfm69-fil-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/fil/adafruit-circuitpython-feather_m0_rfm69-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/fil/adafruit-circuitpython-feather_m0_rfm69-fil-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/fil/adafruit-circuitpython-feather_m0_rfm69-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/fr/adafruit-circuitpython-feather_m0_rfm69-fr-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/fr/adafruit-circuitpython-feather_m0_rfm69-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/fr/adafruit-circuitpython-feather_m0_rfm69-fr-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/fr/adafruit-circuitpython-feather_m0_rfm69-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/it_IT/adafruit-circuitpython-feather_m0_rfm69-it_IT-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/it_IT/adafruit-circuitpython-feather_m0_rfm69-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/it_IT/adafruit-circuitpython-feather_m0_rfm69-it_IT-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/it_IT/adafruit-circuitpython-feather_m0_rfm69-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/ko/adafruit-circuitpython-feather_m0_rfm69-ko-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/ko/adafruit-circuitpython-feather_m0_rfm69-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/ko/adafruit-circuitpython-feather_m0_rfm69-ko-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/ko/adafruit-circuitpython-feather_m0_rfm69-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/nl/adafruit-circuitpython-feather_m0_rfm69-nl-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/nl/adafruit-circuitpython-feather_m0_rfm69-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/pl/adafruit-circuitpython-feather_m0_rfm69-pl-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/pl/adafruit-circuitpython-feather_m0_rfm69-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/pl/adafruit-circuitpython-feather_m0_rfm69-pl-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/pl/adafruit-circuitpython-feather_m0_rfm69-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/pt_BR/adafruit-circuitpython-feather_m0_rfm69-pt_BR-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/pt_BR/adafruit-circuitpython-feather_m0_rfm69-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/pt_BR/adafruit-circuitpython-feather_m0_rfm69-pt_BR-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/pt_BR/adafruit-circuitpython-feather_m0_rfm69-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/sv/adafruit-circuitpython-feather_m0_rfm69-sv-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/sv/adafruit-circuitpython-feather_m0_rfm69-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/sv/adafruit-circuitpython-feather_m0_rfm69-sv-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/sv/adafruit-circuitpython-feather_m0_rfm69-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_rfm69-zh_Latn_pinyin-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_rfm69-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_rfm69-zh_Latn_pinyin-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm69/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_rfm69-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 19,
+        "downloads": 0,
         "id": "feather_m0_rfm9x",
         "versions": [
             {
@@ -3862,65 +4281,73 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/ID/adafruit-circuitpython-feather_m0_rfm9x-ID-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/ID/adafruit-circuitpython-feather_m0_rfm9x-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/ID/adafruit-circuitpython-feather_m0_rfm9x-ID-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/ID/adafruit-circuitpython-feather_m0_rfm9x-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/cs/adafruit-circuitpython-feather_m0_rfm9x-cs-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/cs/adafruit-circuitpython-feather_m0_rfm9x-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/de_DE/adafruit-circuitpython-feather_m0_rfm9x-de_DE-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/de_DE/adafruit-circuitpython-feather_m0_rfm9x-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/de_DE/adafruit-circuitpython-feather_m0_rfm9x-de_DE-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/de_DE/adafruit-circuitpython-feather_m0_rfm9x-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/en_US/adafruit-circuitpython-feather_m0_rfm9x-en_US-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/en_US/adafruit-circuitpython-feather_m0_rfm9x-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/en_US/adafruit-circuitpython-feather_m0_rfm9x-en_US-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/en_US/adafruit-circuitpython-feather_m0_rfm9x-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/en_x_pirate/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/en_x_pirate/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/en_x_pirate/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/en_x_pirate/adafruit-circuitpython-feather_m0_rfm9x-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/es/adafruit-circuitpython-feather_m0_rfm9x-es-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/es/adafruit-circuitpython-feather_m0_rfm9x-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/es/adafruit-circuitpython-feather_m0_rfm9x-es-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/es/adafruit-circuitpython-feather_m0_rfm9x-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/fil/adafruit-circuitpython-feather_m0_rfm9x-fil-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/fil/adafruit-circuitpython-feather_m0_rfm9x-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/fil/adafruit-circuitpython-feather_m0_rfm9x-fil-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/fil/adafruit-circuitpython-feather_m0_rfm9x-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/fr/adafruit-circuitpython-feather_m0_rfm9x-fr-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/fr/adafruit-circuitpython-feather_m0_rfm9x-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/fr/adafruit-circuitpython-feather_m0_rfm9x-fr-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/fr/adafruit-circuitpython-feather_m0_rfm9x-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/it_IT/adafruit-circuitpython-feather_m0_rfm9x-it_IT-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/it_IT/adafruit-circuitpython-feather_m0_rfm9x-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/it_IT/adafruit-circuitpython-feather_m0_rfm9x-it_IT-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/it_IT/adafruit-circuitpython-feather_m0_rfm9x-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/ko/adafruit-circuitpython-feather_m0_rfm9x-ko-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/ko/adafruit-circuitpython-feather_m0_rfm9x-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/ko/adafruit-circuitpython-feather_m0_rfm9x-ko-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/ko/adafruit-circuitpython-feather_m0_rfm9x-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/nl/adafruit-circuitpython-feather_m0_rfm9x-nl-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/nl/adafruit-circuitpython-feather_m0_rfm9x-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/pl/adafruit-circuitpython-feather_m0_rfm9x-pl-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/pl/adafruit-circuitpython-feather_m0_rfm9x-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/pl/adafruit-circuitpython-feather_m0_rfm9x-pl-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/pl/adafruit-circuitpython-feather_m0_rfm9x-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/pt_BR/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/pt_BR/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/pt_BR/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/pt_BR/adafruit-circuitpython-feather_m0_rfm9x-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/sv/adafruit-circuitpython-feather_m0_rfm9x-sv-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/sv/adafruit-circuitpython-feather_m0_rfm9x-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/sv/adafruit-circuitpython-feather_m0_rfm9x-sv-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/sv/adafruit-circuitpython-feather_m0_rfm9x-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_rfm9x-zh_Latn_pinyin-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_rfm9x-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_rfm9x-zh_Latn_pinyin-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/feather_m0_rfm9x/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_rfm9x-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 13,
+        "downloads": 0,
         "id": "feather_m0_supersized",
         "versions": [
             {
@@ -3968,52 +4395,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/ID/adafruit-circuitpython-feather_m0_supersized-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/ID/adafruit-circuitpython-feather_m0_supersized-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/cs/adafruit-circuitpython-feather_m0_supersized-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/de_DE/adafruit-circuitpython-feather_m0_supersized-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/de_DE/adafruit-circuitpython-feather_m0_supersized-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/en_US/adafruit-circuitpython-feather_m0_supersized-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/en_US/adafruit-circuitpython-feather_m0_supersized-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/en_x_pirate/adafruit-circuitpython-feather_m0_supersized-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/en_x_pirate/adafruit-circuitpython-feather_m0_supersized-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/es/adafruit-circuitpython-feather_m0_supersized-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/es/adafruit-circuitpython-feather_m0_supersized-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/fil/adafruit-circuitpython-feather_m0_supersized-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/fil/adafruit-circuitpython-feather_m0_supersized-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/fr/adafruit-circuitpython-feather_m0_supersized-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/fr/adafruit-circuitpython-feather_m0_supersized-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/it_IT/adafruit-circuitpython-feather_m0_supersized-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/it_IT/adafruit-circuitpython-feather_m0_supersized-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/ko/adafruit-circuitpython-feather_m0_supersized-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/ko/adafruit-circuitpython-feather_m0_supersized-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/nl/adafruit-circuitpython-feather_m0_supersized-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/pl/adafruit-circuitpython-feather_m0_supersized-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/pl/adafruit-circuitpython-feather_m0_supersized-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/pt_BR/adafruit-circuitpython-feather_m0_supersized-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/pt_BR/adafruit-circuitpython-feather_m0_supersized-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/sv/adafruit-circuitpython-feather_m0_supersized-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/sv/adafruit-circuitpython-feather_m0_supersized-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_supersized-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m0_supersized/zh_Latn_pinyin/adafruit-circuitpython-feather_m0_supersized-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 201,
+        "downloads": 0,
         "id": "feather_m4_express",
         "versions": [
             {
@@ -4061,52 +4494,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/ID/adafruit-circuitpython-feather_m4_express-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/ID/adafruit-circuitpython-feather_m4_express-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/cs/adafruit-circuitpython-feather_m4_express-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/de_DE/adafruit-circuitpython-feather_m4_express-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/de_DE/adafruit-circuitpython-feather_m4_express-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/en_US/adafruit-circuitpython-feather_m4_express-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/en_US/adafruit-circuitpython-feather_m4_express-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/en_x_pirate/adafruit-circuitpython-feather_m4_express-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/en_x_pirate/adafruit-circuitpython-feather_m4_express-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/es/adafruit-circuitpython-feather_m4_express-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/es/adafruit-circuitpython-feather_m4_express-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/fil/adafruit-circuitpython-feather_m4_express-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/fil/adafruit-circuitpython-feather_m4_express-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/fr/adafruit-circuitpython-feather_m4_express-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/fr/adafruit-circuitpython-feather_m4_express-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/it_IT/adafruit-circuitpython-feather_m4_express-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/it_IT/adafruit-circuitpython-feather_m4_express-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/ko/adafruit-circuitpython-feather_m4_express-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/ko/adafruit-circuitpython-feather_m4_express-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/nl/adafruit-circuitpython-feather_m4_express-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/pl/adafruit-circuitpython-feather_m4_express-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/pl/adafruit-circuitpython-feather_m4_express-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/pt_BR/adafruit-circuitpython-feather_m4_express-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/pt_BR/adafruit-circuitpython-feather_m4_express-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/sv/adafruit-circuitpython-feather_m4_express-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/sv/adafruit-circuitpython-feather_m4_express-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_m4_express/zh_Latn_pinyin/adafruit-circuitpython-feather_m4_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m4_express/zh_Latn_pinyin/adafruit-circuitpython-feather_m4_express-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 13,
+        "downloads": 0,
         "id": "feather_m7_1011",
         "versions": [
             {
@@ -4166,65 +4605,73 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/ID/adafruit-circuitpython-feather_m7_1011-ID-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/ID/adafruit-circuitpython-feather_m7_1011-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/ID/adafruit-circuitpython-feather_m7_1011-ID-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/ID/adafruit-circuitpython-feather_m7_1011-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/cs/adafruit-circuitpython-feather_m7_1011-cs-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/cs/adafruit-circuitpython-feather_m7_1011-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/de_DE/adafruit-circuitpython-feather_m7_1011-de_DE-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/de_DE/adafruit-circuitpython-feather_m7_1011-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/de_DE/adafruit-circuitpython-feather_m7_1011-de_DE-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/de_DE/adafruit-circuitpython-feather_m7_1011-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/en_US/adafruit-circuitpython-feather_m7_1011-en_US-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/en_US/adafruit-circuitpython-feather_m7_1011-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/en_US/adafruit-circuitpython-feather_m7_1011-en_US-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/en_US/adafruit-circuitpython-feather_m7_1011-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/en_x_pirate/adafruit-circuitpython-feather_m7_1011-en_x_pirate-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/en_x_pirate/adafruit-circuitpython-feather_m7_1011-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/en_x_pirate/adafruit-circuitpython-feather_m7_1011-en_x_pirate-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/en_x_pirate/adafruit-circuitpython-feather_m7_1011-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/es/adafruit-circuitpython-feather_m7_1011-es-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/es/adafruit-circuitpython-feather_m7_1011-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/es/adafruit-circuitpython-feather_m7_1011-es-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/es/adafruit-circuitpython-feather_m7_1011-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/fil/adafruit-circuitpython-feather_m7_1011-fil-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/fil/adafruit-circuitpython-feather_m7_1011-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/fil/adafruit-circuitpython-feather_m7_1011-fil-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/fil/adafruit-circuitpython-feather_m7_1011-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/fr/adafruit-circuitpython-feather_m7_1011-fr-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/fr/adafruit-circuitpython-feather_m7_1011-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/fr/adafruit-circuitpython-feather_m7_1011-fr-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/fr/adafruit-circuitpython-feather_m7_1011-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/it_IT/adafruit-circuitpython-feather_m7_1011-it_IT-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/it_IT/adafruit-circuitpython-feather_m7_1011-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/it_IT/adafruit-circuitpython-feather_m7_1011-it_IT-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/it_IT/adafruit-circuitpython-feather_m7_1011-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/ko/adafruit-circuitpython-feather_m7_1011-ko-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/ko/adafruit-circuitpython-feather_m7_1011-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/ko/adafruit-circuitpython-feather_m7_1011-ko-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/ko/adafruit-circuitpython-feather_m7_1011-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/nl/adafruit-circuitpython-feather_m7_1011-nl-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/nl/adafruit-circuitpython-feather_m7_1011-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/pl/adafruit-circuitpython-feather_m7_1011-pl-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/pl/adafruit-circuitpython-feather_m7_1011-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/pl/adafruit-circuitpython-feather_m7_1011-pl-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/pl/adafruit-circuitpython-feather_m7_1011-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/pt_BR/adafruit-circuitpython-feather_m7_1011-pt_BR-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/pt_BR/adafruit-circuitpython-feather_m7_1011-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/pt_BR/adafruit-circuitpython-feather_m7_1011-pt_BR-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/pt_BR/adafruit-circuitpython-feather_m7_1011-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/sv/adafruit-circuitpython-feather_m7_1011-sv-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/sv/adafruit-circuitpython-feather_m7_1011-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/sv/adafruit-circuitpython-feather_m7_1011-sv-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/sv/adafruit-circuitpython-feather_m7_1011-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/zh_Latn_pinyin/adafruit-circuitpython-feather_m7_1011-zh_Latn_pinyin-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_m7_1011/zh_Latn_pinyin/adafruit-circuitpython-feather_m7_1011-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/zh_Latn_pinyin/adafruit-circuitpython-feather_m7_1011-zh_Latn_pinyin-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_m7_1011/zh_Latn_pinyin/adafruit-circuitpython-feather_m7_1011-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 9,
+        "downloads": 0,
         "id": "feather_mimxrt1011",
         "versions": [
             {
@@ -4284,65 +4731,73 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/ID/adafruit-circuitpython-feather_mimxrt1011-ID-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/ID/adafruit-circuitpython-feather_mimxrt1011-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/ID/adafruit-circuitpython-feather_mimxrt1011-ID-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/ID/adafruit-circuitpython-feather_mimxrt1011-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/cs/adafruit-circuitpython-feather_mimxrt1011-cs-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/cs/adafruit-circuitpython-feather_mimxrt1011-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/de_DE/adafruit-circuitpython-feather_mimxrt1011-de_DE-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/de_DE/adafruit-circuitpython-feather_mimxrt1011-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/de_DE/adafruit-circuitpython-feather_mimxrt1011-de_DE-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/de_DE/adafruit-circuitpython-feather_mimxrt1011-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/en_US/adafruit-circuitpython-feather_mimxrt1011-en_US-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/en_US/adafruit-circuitpython-feather_mimxrt1011-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/en_US/adafruit-circuitpython-feather_mimxrt1011-en_US-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/en_US/adafruit-circuitpython-feather_mimxrt1011-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/en_x_pirate/adafruit-circuitpython-feather_mimxrt1011-en_x_pirate-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/en_x_pirate/adafruit-circuitpython-feather_mimxrt1011-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/en_x_pirate/adafruit-circuitpython-feather_mimxrt1011-en_x_pirate-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/en_x_pirate/adafruit-circuitpython-feather_mimxrt1011-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/es/adafruit-circuitpython-feather_mimxrt1011-es-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/es/adafruit-circuitpython-feather_mimxrt1011-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/es/adafruit-circuitpython-feather_mimxrt1011-es-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/es/adafruit-circuitpython-feather_mimxrt1011-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/fil/adafruit-circuitpython-feather_mimxrt1011-fil-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/fil/adafruit-circuitpython-feather_mimxrt1011-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/fil/adafruit-circuitpython-feather_mimxrt1011-fil-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/fil/adafruit-circuitpython-feather_mimxrt1011-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/fr/adafruit-circuitpython-feather_mimxrt1011-fr-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/fr/adafruit-circuitpython-feather_mimxrt1011-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/fr/adafruit-circuitpython-feather_mimxrt1011-fr-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/fr/adafruit-circuitpython-feather_mimxrt1011-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/it_IT/adafruit-circuitpython-feather_mimxrt1011-it_IT-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/it_IT/adafruit-circuitpython-feather_mimxrt1011-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/it_IT/adafruit-circuitpython-feather_mimxrt1011-it_IT-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/it_IT/adafruit-circuitpython-feather_mimxrt1011-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/ko/adafruit-circuitpython-feather_mimxrt1011-ko-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/ko/adafruit-circuitpython-feather_mimxrt1011-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/ko/adafruit-circuitpython-feather_mimxrt1011-ko-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/ko/adafruit-circuitpython-feather_mimxrt1011-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/nl/adafruit-circuitpython-feather_mimxrt1011-nl-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/nl/adafruit-circuitpython-feather_mimxrt1011-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/pl/adafruit-circuitpython-feather_mimxrt1011-pl-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/pl/adafruit-circuitpython-feather_mimxrt1011-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/pl/adafruit-circuitpython-feather_mimxrt1011-pl-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/pl/adafruit-circuitpython-feather_mimxrt1011-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/pt_BR/adafruit-circuitpython-feather_mimxrt1011-pt_BR-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/pt_BR/adafruit-circuitpython-feather_mimxrt1011-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/pt_BR/adafruit-circuitpython-feather_mimxrt1011-pt_BR-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/pt_BR/adafruit-circuitpython-feather_mimxrt1011-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/sv/adafruit-circuitpython-feather_mimxrt1011-sv-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/sv/adafruit-circuitpython-feather_mimxrt1011-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/sv/adafruit-circuitpython-feather_mimxrt1011-sv-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/sv/adafruit-circuitpython-feather_mimxrt1011-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/zh_Latn_pinyin/adafruit-circuitpython-feather_mimxrt1011-zh_Latn_pinyin-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/zh_Latn_pinyin/adafruit-circuitpython-feather_mimxrt1011-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/zh_Latn_pinyin/adafruit-circuitpython-feather_mimxrt1011-zh_Latn_pinyin-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1011/zh_Latn_pinyin/adafruit-circuitpython-feather_mimxrt1011-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 10,
+        "downloads": 0,
         "id": "feather_mimxrt1062",
         "versions": [
             {
@@ -4402,65 +4857,73 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/ID/adafruit-circuitpython-feather_mimxrt1062-ID-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/ID/adafruit-circuitpython-feather_mimxrt1062-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/ID/adafruit-circuitpython-feather_mimxrt1062-ID-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/ID/adafruit-circuitpython-feather_mimxrt1062-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/cs/adafruit-circuitpython-feather_mimxrt1062-cs-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/cs/adafruit-circuitpython-feather_mimxrt1062-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/de_DE/adafruit-circuitpython-feather_mimxrt1062-de_DE-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/de_DE/adafruit-circuitpython-feather_mimxrt1062-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/de_DE/adafruit-circuitpython-feather_mimxrt1062-de_DE-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/de_DE/adafruit-circuitpython-feather_mimxrt1062-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/en_US/adafruit-circuitpython-feather_mimxrt1062-en_US-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/en_US/adafruit-circuitpython-feather_mimxrt1062-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/en_US/adafruit-circuitpython-feather_mimxrt1062-en_US-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/en_US/adafruit-circuitpython-feather_mimxrt1062-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/en_x_pirate/adafruit-circuitpython-feather_mimxrt1062-en_x_pirate-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/en_x_pirate/adafruit-circuitpython-feather_mimxrt1062-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/en_x_pirate/adafruit-circuitpython-feather_mimxrt1062-en_x_pirate-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/en_x_pirate/adafruit-circuitpython-feather_mimxrt1062-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/es/adafruit-circuitpython-feather_mimxrt1062-es-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/es/adafruit-circuitpython-feather_mimxrt1062-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/es/adafruit-circuitpython-feather_mimxrt1062-es-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/es/adafruit-circuitpython-feather_mimxrt1062-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/fil/adafruit-circuitpython-feather_mimxrt1062-fil-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/fil/adafruit-circuitpython-feather_mimxrt1062-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/fil/adafruit-circuitpython-feather_mimxrt1062-fil-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/fil/adafruit-circuitpython-feather_mimxrt1062-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/fr/adafruit-circuitpython-feather_mimxrt1062-fr-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/fr/adafruit-circuitpython-feather_mimxrt1062-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/fr/adafruit-circuitpython-feather_mimxrt1062-fr-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/fr/adafruit-circuitpython-feather_mimxrt1062-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/it_IT/adafruit-circuitpython-feather_mimxrt1062-it_IT-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/it_IT/adafruit-circuitpython-feather_mimxrt1062-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/it_IT/adafruit-circuitpython-feather_mimxrt1062-it_IT-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/it_IT/adafruit-circuitpython-feather_mimxrt1062-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/ko/adafruit-circuitpython-feather_mimxrt1062-ko-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/ko/adafruit-circuitpython-feather_mimxrt1062-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/ko/adafruit-circuitpython-feather_mimxrt1062-ko-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/ko/adafruit-circuitpython-feather_mimxrt1062-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/nl/adafruit-circuitpython-feather_mimxrt1062-nl-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/nl/adafruit-circuitpython-feather_mimxrt1062-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/pl/adafruit-circuitpython-feather_mimxrt1062-pl-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/pl/adafruit-circuitpython-feather_mimxrt1062-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/pl/adafruit-circuitpython-feather_mimxrt1062-pl-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/pl/adafruit-circuitpython-feather_mimxrt1062-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/pt_BR/adafruit-circuitpython-feather_mimxrt1062-pt_BR-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/pt_BR/adafruit-circuitpython-feather_mimxrt1062-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/pt_BR/adafruit-circuitpython-feather_mimxrt1062-pt_BR-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/pt_BR/adafruit-circuitpython-feather_mimxrt1062-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/sv/adafruit-circuitpython-feather_mimxrt1062-sv-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/sv/adafruit-circuitpython-feather_mimxrt1062-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/sv/adafruit-circuitpython-feather_mimxrt1062-sv-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/sv/adafruit-circuitpython-feather_mimxrt1062-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/zh_Latn_pinyin/adafruit-circuitpython-feather_mimxrt1062-zh_Latn_pinyin-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/zh_Latn_pinyin/adafruit-circuitpython-feather_mimxrt1062-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/zh_Latn_pinyin/adafruit-circuitpython-feather_mimxrt1062-zh_Latn_pinyin-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/feather_mimxrt1062/zh_Latn_pinyin/adafruit-circuitpython-feather_mimxrt1062-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 86,
+        "downloads": 0,
         "id": "feather_nrf52840_express",
         "versions": [
             {
@@ -4508,52 +4971,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/ID/adafruit-circuitpython-feather_nrf52840_express-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/ID/adafruit-circuitpython-feather_nrf52840_express-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/cs/adafruit-circuitpython-feather_nrf52840_express-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/de_DE/adafruit-circuitpython-feather_nrf52840_express-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/de_DE/adafruit-circuitpython-feather_nrf52840_express-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/en_US/adafruit-circuitpython-feather_nrf52840_express-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/en_US/adafruit-circuitpython-feather_nrf52840_express-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/en_x_pirate/adafruit-circuitpython-feather_nrf52840_express-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/en_x_pirate/adafruit-circuitpython-feather_nrf52840_express-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/es/adafruit-circuitpython-feather_nrf52840_express-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/es/adafruit-circuitpython-feather_nrf52840_express-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/fil/adafruit-circuitpython-feather_nrf52840_express-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/fil/adafruit-circuitpython-feather_nrf52840_express-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/fr/adafruit-circuitpython-feather_nrf52840_express-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/fr/adafruit-circuitpython-feather_nrf52840_express-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/it_IT/adafruit-circuitpython-feather_nrf52840_express-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/it_IT/adafruit-circuitpython-feather_nrf52840_express-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/ko/adafruit-circuitpython-feather_nrf52840_express-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/ko/adafruit-circuitpython-feather_nrf52840_express-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/nl/adafruit-circuitpython-feather_nrf52840_express-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/pl/adafruit-circuitpython-feather_nrf52840_express-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/pl/adafruit-circuitpython-feather_nrf52840_express-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/pt_BR/adafruit-circuitpython-feather_nrf52840_express-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/pt_BR/adafruit-circuitpython-feather_nrf52840_express-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/sv/adafruit-circuitpython-feather_nrf52840_express-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/sv/adafruit-circuitpython-feather_nrf52840_express-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/zh_Latn_pinyin/adafruit-circuitpython-feather_nrf52840_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_nrf52840_express/zh_Latn_pinyin/adafruit-circuitpython-feather_nrf52840_express-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 27,
+        "downloads": 0,
         "id": "feather_radiofruit_zigbee",
         "versions": [
             {
@@ -4601,52 +5070,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/ID/adafruit-circuitpython-feather_radiofruit_zigbee-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/ID/adafruit-circuitpython-feather_radiofruit_zigbee-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/cs/adafruit-circuitpython-feather_radiofruit_zigbee-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/de_DE/adafruit-circuitpython-feather_radiofruit_zigbee-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/de_DE/adafruit-circuitpython-feather_radiofruit_zigbee-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/en_US/adafruit-circuitpython-feather_radiofruit_zigbee-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/en_US/adafruit-circuitpython-feather_radiofruit_zigbee-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/en_x_pirate/adafruit-circuitpython-feather_radiofruit_zigbee-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/en_x_pirate/adafruit-circuitpython-feather_radiofruit_zigbee-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/es/adafruit-circuitpython-feather_radiofruit_zigbee-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/es/adafruit-circuitpython-feather_radiofruit_zigbee-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/fil/adafruit-circuitpython-feather_radiofruit_zigbee-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/fil/adafruit-circuitpython-feather_radiofruit_zigbee-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/fr/adafruit-circuitpython-feather_radiofruit_zigbee-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/fr/adafruit-circuitpython-feather_radiofruit_zigbee-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/it_IT/adafruit-circuitpython-feather_radiofruit_zigbee-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/it_IT/adafruit-circuitpython-feather_radiofruit_zigbee-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/ko/adafruit-circuitpython-feather_radiofruit_zigbee-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/ko/adafruit-circuitpython-feather_radiofruit_zigbee-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/nl/adafruit-circuitpython-feather_radiofruit_zigbee-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/pl/adafruit-circuitpython-feather_radiofruit_zigbee-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/pl/adafruit-circuitpython-feather_radiofruit_zigbee-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/pt_BR/adafruit-circuitpython-feather_radiofruit_zigbee-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/pt_BR/adafruit-circuitpython-feather_radiofruit_zigbee-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/sv/adafruit-circuitpython-feather_radiofruit_zigbee-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/sv/adafruit-circuitpython-feather_radiofruit_zigbee-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/zh_Latn_pinyin/adafruit-circuitpython-feather_radiofruit_zigbee-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/feather_radiofruit_zigbee/zh_Latn_pinyin/adafruit-circuitpython-feather_radiofruit_zigbee-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 47,
+        "downloads": 0,
         "id": "feather_stm32f405_express",
         "versions": [
             {
@@ -4694,52 +5169,115 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/ID/adafruit-circuitpython-feather_stm32f405_express-ID-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/ID/adafruit-circuitpython-feather_stm32f405_express-ID-5.4.0-beta.1.bin"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/cs/adafruit-circuitpython-feather_stm32f405_express-cs-5.4.0-beta.1.bin"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/de_DE/adafruit-circuitpython-feather_stm32f405_express-de_DE-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/de_DE/adafruit-circuitpython-feather_stm32f405_express-de_DE-5.4.0-beta.1.bin"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/en_US/adafruit-circuitpython-feather_stm32f405_express-en_US-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/en_US/adafruit-circuitpython-feather_stm32f405_express-en_US-5.4.0-beta.1.bin"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/en_x_pirate/adafruit-circuitpython-feather_stm32f405_express-en_x_pirate-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/en_x_pirate/adafruit-circuitpython-feather_stm32f405_express-en_x_pirate-5.4.0-beta.1.bin"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/es/adafruit-circuitpython-feather_stm32f405_express-es-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/es/adafruit-circuitpython-feather_stm32f405_express-es-5.4.0-beta.1.bin"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/fil/adafruit-circuitpython-feather_stm32f405_express-fil-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/fil/adafruit-circuitpython-feather_stm32f405_express-fil-5.4.0-beta.1.bin"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/fr/adafruit-circuitpython-feather_stm32f405_express-fr-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/fr/adafruit-circuitpython-feather_stm32f405_express-fr-5.4.0-beta.1.bin"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/it_IT/adafruit-circuitpython-feather_stm32f405_express-it_IT-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/it_IT/adafruit-circuitpython-feather_stm32f405_express-it_IT-5.4.0-beta.1.bin"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/ko/adafruit-circuitpython-feather_stm32f405_express-ko-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/ko/adafruit-circuitpython-feather_stm32f405_express-ko-5.4.0-beta.1.bin"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/nl/adafruit-circuitpython-feather_stm32f405_express-nl-5.4.0-beta.1.bin"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/pl/adafruit-circuitpython-feather_stm32f405_express-pl-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/pl/adafruit-circuitpython-feather_stm32f405_express-pl-5.4.0-beta.1.bin"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/pt_BR/adafruit-circuitpython-feather_stm32f405_express-pt_BR-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/pt_BR/adafruit-circuitpython-feather_stm32f405_express-pt_BR-5.4.0-beta.1.bin"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/sv/adafruit-circuitpython-feather_stm32f405_express-sv-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/sv/adafruit-circuitpython-feather_stm32f405_express-sv-5.4.0-beta.1.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/zh_Latn_pinyin/adafruit-circuitpython-feather_stm32f405_express-zh_Latn_pinyin-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/feather_stm32f405_express/zh_Latn_pinyin/adafruit-circuitpython-feather_stm32f405_express-zh_Latn_pinyin-5.4.0-beta.1.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 39,
+        "downloads": 0,
+        "id": "fluff_m0",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/fluff_m0/ID/adafruit-circuitpython-fluff_m0-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/fluff_m0/cs/adafruit-circuitpython-fluff_m0-cs-5.4.0-beta.1.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/fluff_m0/de_DE/adafruit-circuitpython-fluff_m0-de_DE-5.4.0-beta.1.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/fluff_m0/en_US/adafruit-circuitpython-fluff_m0-en_US-5.4.0-beta.1.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/fluff_m0/en_x_pirate/adafruit-circuitpython-fluff_m0-en_x_pirate-5.4.0-beta.1.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/fluff_m0/es/adafruit-circuitpython-fluff_m0-es-5.4.0-beta.1.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/fluff_m0/fil/adafruit-circuitpython-fluff_m0-fil-5.4.0-beta.1.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/fluff_m0/fr/adafruit-circuitpython-fluff_m0-fr-5.4.0-beta.1.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/fluff_m0/it_IT/adafruit-circuitpython-fluff_m0-it_IT-5.4.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/fluff_m0/ko/adafruit-circuitpython-fluff_m0-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/fluff_m0/nl/adafruit-circuitpython-fluff_m0-nl-5.4.0-beta.1.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/fluff_m0/pl/adafruit-circuitpython-fluff_m0-pl-5.4.0-beta.1.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/fluff_m0/pt_BR/adafruit-circuitpython-fluff_m0-pt_BR-5.4.0-beta.1.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/fluff_m0/sv/adafruit-circuitpython-fluff_m0-sv-5.4.0-beta.1.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/fluff_m0/zh_Latn_pinyin/adafruit-circuitpython-fluff_m0-zh_Latn_pinyin-5.4.0-beta.1.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.1"
+            }
+        ]
+    },
+    {
+        "downloads": 0,
         "id": "fomu",
         "versions": [
             {
@@ -4787,47 +5325,53 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/fomu/ID/adafruit-circuitpython-fomu-ID-5.4.0-beta.0.dfu"
+                        "https://downloads.circuitpython.org/bin/fomu/ID/adafruit-circuitpython-fomu-ID-5.4.0-beta.1.dfu"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/fomu/cs/adafruit-circuitpython-fomu-cs-5.4.0-beta.1.dfu"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/fomu/de_DE/adafruit-circuitpython-fomu-de_DE-5.4.0-beta.0.dfu"
+                        "https://downloads.circuitpython.org/bin/fomu/de_DE/adafruit-circuitpython-fomu-de_DE-5.4.0-beta.1.dfu"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/fomu/en_US/adafruit-circuitpython-fomu-en_US-5.4.0-beta.0.dfu"
+                        "https://downloads.circuitpython.org/bin/fomu/en_US/adafruit-circuitpython-fomu-en_US-5.4.0-beta.1.dfu"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/fomu/en_x_pirate/adafruit-circuitpython-fomu-en_x_pirate-5.4.0-beta.0.dfu"
+                        "https://downloads.circuitpython.org/bin/fomu/en_x_pirate/adafruit-circuitpython-fomu-en_x_pirate-5.4.0-beta.1.dfu"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/fomu/es/adafruit-circuitpython-fomu-es-5.4.0-beta.0.dfu"
+                        "https://downloads.circuitpython.org/bin/fomu/es/adafruit-circuitpython-fomu-es-5.4.0-beta.1.dfu"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/fomu/fil/adafruit-circuitpython-fomu-fil-5.4.0-beta.0.dfu"
+                        "https://downloads.circuitpython.org/bin/fomu/fil/adafruit-circuitpython-fomu-fil-5.4.0-beta.1.dfu"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/fomu/fr/adafruit-circuitpython-fomu-fr-5.4.0-beta.0.dfu"
+                        "https://downloads.circuitpython.org/bin/fomu/fr/adafruit-circuitpython-fomu-fr-5.4.0-beta.1.dfu"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/fomu/it_IT/adafruit-circuitpython-fomu-it_IT-5.4.0-beta.0.dfu"
+                        "https://downloads.circuitpython.org/bin/fomu/it_IT/adafruit-circuitpython-fomu-it_IT-5.4.0-beta.1.dfu"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/fomu/ko/adafruit-circuitpython-fomu-ko-5.4.0-beta.0.dfu"
+                        "https://downloads.circuitpython.org/bin/fomu/ko/adafruit-circuitpython-fomu-ko-5.4.0-beta.1.dfu"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/fomu/nl/adafruit-circuitpython-fomu-nl-5.4.0-beta.1.dfu"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/fomu/pl/adafruit-circuitpython-fomu-pl-5.4.0-beta.0.dfu"
+                        "https://downloads.circuitpython.org/bin/fomu/pl/adafruit-circuitpython-fomu-pl-5.4.0-beta.1.dfu"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/fomu/pt_BR/adafruit-circuitpython-fomu-pt_BR-5.4.0-beta.0.dfu"
+                        "https://downloads.circuitpython.org/bin/fomu/pt_BR/adafruit-circuitpython-fomu-pt_BR-5.4.0-beta.1.dfu"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/fomu/sv/adafruit-circuitpython-fomu-sv-5.4.0-beta.0.dfu"
+                        "https://downloads.circuitpython.org/bin/fomu/sv/adafruit-circuitpython-fomu-sv-5.4.0-beta.1.dfu"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/fomu/zh_Latn_pinyin/adafruit-circuitpython-fomu-zh_Latn_pinyin-5.4.0-beta.0.dfu"
+                        "https://downloads.circuitpython.org/bin/fomu/zh_Latn_pinyin/adafruit-circuitpython-fomu-zh_Latn_pinyin-5.4.0-beta.1.dfu"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
@@ -4837,7 +5381,7 @@
         "versions": []
     },
     {
-        "downloads": 74,
+        "downloads": 0,
         "id": "gemma_m0",
         "versions": [
             {
@@ -4885,52 +5429,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/ID/adafruit-circuitpython-gemma_m0-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/gemma_m0/ID/adafruit-circuitpython-gemma_m0-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0/cs/adafruit-circuitpython-gemma_m0-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/de_DE/adafruit-circuitpython-gemma_m0-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/gemma_m0/de_DE/adafruit-circuitpython-gemma_m0-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/en_US/adafruit-circuitpython-gemma_m0-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/gemma_m0/en_US/adafruit-circuitpython-gemma_m0-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/en_x_pirate/adafruit-circuitpython-gemma_m0-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/gemma_m0/en_x_pirate/adafruit-circuitpython-gemma_m0-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/es/adafruit-circuitpython-gemma_m0-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/gemma_m0/es/adafruit-circuitpython-gemma_m0-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/fil/adafruit-circuitpython-gemma_m0-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/gemma_m0/fil/adafruit-circuitpython-gemma_m0-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/fr/adafruit-circuitpython-gemma_m0-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/gemma_m0/fr/adafruit-circuitpython-gemma_m0-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/it_IT/adafruit-circuitpython-gemma_m0-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/gemma_m0/it_IT/adafruit-circuitpython-gemma_m0-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/ko/adafruit-circuitpython-gemma_m0-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/gemma_m0/ko/adafruit-circuitpython-gemma_m0-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0/nl/adafruit-circuitpython-gemma_m0-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/pl/adafruit-circuitpython-gemma_m0-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/gemma_m0/pl/adafruit-circuitpython-gemma_m0-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/pt_BR/adafruit-circuitpython-gemma_m0-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/gemma_m0/pt_BR/adafruit-circuitpython-gemma_m0-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/sv/adafruit-circuitpython-gemma_m0-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/gemma_m0/sv/adafruit-circuitpython-gemma_m0-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0/zh_Latn_pinyin/adafruit-circuitpython-gemma_m0-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/gemma_m0/zh_Latn_pinyin/adafruit-circuitpython-gemma_m0-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 28,
+        "downloads": 0,
         "id": "gemma_m0_pycon2018",
         "versions": [
             {
@@ -4978,52 +5528,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/ID/adafruit-circuitpython-gemma_m0_pycon2018-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/ID/adafruit-circuitpython-gemma_m0_pycon2018-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/cs/adafruit-circuitpython-gemma_m0_pycon2018-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/de_DE/adafruit-circuitpython-gemma_m0_pycon2018-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/de_DE/adafruit-circuitpython-gemma_m0_pycon2018-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/en_US/adafruit-circuitpython-gemma_m0_pycon2018-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/en_US/adafruit-circuitpython-gemma_m0_pycon2018-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/en_x_pirate/adafruit-circuitpython-gemma_m0_pycon2018-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/en_x_pirate/adafruit-circuitpython-gemma_m0_pycon2018-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/es/adafruit-circuitpython-gemma_m0_pycon2018-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/es/adafruit-circuitpython-gemma_m0_pycon2018-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/fil/adafruit-circuitpython-gemma_m0_pycon2018-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/fil/adafruit-circuitpython-gemma_m0_pycon2018-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/fr/adafruit-circuitpython-gemma_m0_pycon2018-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/fr/adafruit-circuitpython-gemma_m0_pycon2018-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/it_IT/adafruit-circuitpython-gemma_m0_pycon2018-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/it_IT/adafruit-circuitpython-gemma_m0_pycon2018-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/ko/adafruit-circuitpython-gemma_m0_pycon2018-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/ko/adafruit-circuitpython-gemma_m0_pycon2018-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/nl/adafruit-circuitpython-gemma_m0_pycon2018-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/pl/adafruit-circuitpython-gemma_m0_pycon2018-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/pl/adafruit-circuitpython-gemma_m0_pycon2018-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/pt_BR/adafruit-circuitpython-gemma_m0_pycon2018-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/pt_BR/adafruit-circuitpython-gemma_m0_pycon2018-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/sv/adafruit-circuitpython-gemma_m0_pycon2018-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/sv/adafruit-circuitpython-gemma_m0_pycon2018-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/zh_Latn_pinyin/adafruit-circuitpython-gemma_m0_pycon2018-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/gemma_m0_pycon2018/zh_Latn_pinyin/adafruit-circuitpython-gemma_m0_pycon2018-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 61,
+        "downloads": 0,
         "id": "grandcentral_m4_express",
         "versions": [
             {
@@ -5071,52 +5627,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/ID/adafruit-circuitpython-grandcentral_m4_express-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/ID/adafruit-circuitpython-grandcentral_m4_express-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/cs/adafruit-circuitpython-grandcentral_m4_express-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/de_DE/adafruit-circuitpython-grandcentral_m4_express-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/de_DE/adafruit-circuitpython-grandcentral_m4_express-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/en_US/adafruit-circuitpython-grandcentral_m4_express-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/en_US/adafruit-circuitpython-grandcentral_m4_express-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/en_x_pirate/adafruit-circuitpython-grandcentral_m4_express-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/en_x_pirate/adafruit-circuitpython-grandcentral_m4_express-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/es/adafruit-circuitpython-grandcentral_m4_express-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/es/adafruit-circuitpython-grandcentral_m4_express-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/fil/adafruit-circuitpython-grandcentral_m4_express-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/fil/adafruit-circuitpython-grandcentral_m4_express-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/fr/adafruit-circuitpython-grandcentral_m4_express-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/fr/adafruit-circuitpython-grandcentral_m4_express-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/it_IT/adafruit-circuitpython-grandcentral_m4_express-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/it_IT/adafruit-circuitpython-grandcentral_m4_express-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/ko/adafruit-circuitpython-grandcentral_m4_express-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/ko/adafruit-circuitpython-grandcentral_m4_express-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/nl/adafruit-circuitpython-grandcentral_m4_express-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/pl/adafruit-circuitpython-grandcentral_m4_express-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/pl/adafruit-circuitpython-grandcentral_m4_express-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/pt_BR/adafruit-circuitpython-grandcentral_m4_express-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/pt_BR/adafruit-circuitpython-grandcentral_m4_express-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/sv/adafruit-circuitpython-grandcentral_m4_express-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/sv/adafruit-circuitpython-grandcentral_m4_express-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/zh_Latn_pinyin/adafruit-circuitpython-grandcentral_m4_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/grandcentral_m4_express/zh_Latn_pinyin/adafruit-circuitpython-grandcentral_m4_express-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 44,
+        "downloads": 0,
         "id": "hallowing_m0_express",
         "versions": [
             {
@@ -5164,52 +5726,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/ID/adafruit-circuitpython-hallowing_m0_express-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/ID/adafruit-circuitpython-hallowing_m0_express-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/cs/adafruit-circuitpython-hallowing_m0_express-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/de_DE/adafruit-circuitpython-hallowing_m0_express-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/de_DE/adafruit-circuitpython-hallowing_m0_express-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/en_US/adafruit-circuitpython-hallowing_m0_express-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/en_US/adafruit-circuitpython-hallowing_m0_express-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/en_x_pirate/adafruit-circuitpython-hallowing_m0_express-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/en_x_pirate/adafruit-circuitpython-hallowing_m0_express-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/es/adafruit-circuitpython-hallowing_m0_express-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/es/adafruit-circuitpython-hallowing_m0_express-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/fil/adafruit-circuitpython-hallowing_m0_express-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/fil/adafruit-circuitpython-hallowing_m0_express-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/fr/adafruit-circuitpython-hallowing_m0_express-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/fr/adafruit-circuitpython-hallowing_m0_express-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/it_IT/adafruit-circuitpython-hallowing_m0_express-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/it_IT/adafruit-circuitpython-hallowing_m0_express-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/ko/adafruit-circuitpython-hallowing_m0_express-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/ko/adafruit-circuitpython-hallowing_m0_express-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/nl/adafruit-circuitpython-hallowing_m0_express-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/pl/adafruit-circuitpython-hallowing_m0_express-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/pl/adafruit-circuitpython-hallowing_m0_express-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/pt_BR/adafruit-circuitpython-hallowing_m0_express-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/pt_BR/adafruit-circuitpython-hallowing_m0_express-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/sv/adafruit-circuitpython-hallowing_m0_express-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/sv/adafruit-circuitpython-hallowing_m0_express-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/zh_Latn_pinyin/adafruit-circuitpython-hallowing_m0_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/hallowing_m0_express/zh_Latn_pinyin/adafruit-circuitpython-hallowing_m0_express-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 38,
+        "downloads": 0,
         "id": "hallowing_m4_express",
         "versions": [
             {
@@ -5257,52 +5825,115 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/ID/adafruit-circuitpython-hallowing_m4_express-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/ID/adafruit-circuitpython-hallowing_m4_express-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/cs/adafruit-circuitpython-hallowing_m4_express-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/de_DE/adafruit-circuitpython-hallowing_m4_express-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/de_DE/adafruit-circuitpython-hallowing_m4_express-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/en_US/adafruit-circuitpython-hallowing_m4_express-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/en_US/adafruit-circuitpython-hallowing_m4_express-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/en_x_pirate/adafruit-circuitpython-hallowing_m4_express-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/en_x_pirate/adafruit-circuitpython-hallowing_m4_express-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/es/adafruit-circuitpython-hallowing_m4_express-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/es/adafruit-circuitpython-hallowing_m4_express-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/fil/adafruit-circuitpython-hallowing_m4_express-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/fil/adafruit-circuitpython-hallowing_m4_express-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/fr/adafruit-circuitpython-hallowing_m4_express-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/fr/adafruit-circuitpython-hallowing_m4_express-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/it_IT/adafruit-circuitpython-hallowing_m4_express-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/it_IT/adafruit-circuitpython-hallowing_m4_express-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/ko/adafruit-circuitpython-hallowing_m4_express-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/ko/adafruit-circuitpython-hallowing_m4_express-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/nl/adafruit-circuitpython-hallowing_m4_express-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/pl/adafruit-circuitpython-hallowing_m4_express-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/pl/adafruit-circuitpython-hallowing_m4_express-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/pt_BR/adafruit-circuitpython-hallowing_m4_express-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/pt_BR/adafruit-circuitpython-hallowing_m4_express-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/sv/adafruit-circuitpython-hallowing_m4_express-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/sv/adafruit-circuitpython-hallowing_m4_express-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/zh_Latn_pinyin/adafruit-circuitpython-hallowing_m4_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/hallowing_m4_express/zh_Latn_pinyin/adafruit-circuitpython-hallowing_m4_express-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 11,
+        "downloads": 0,
+        "id": "hiibot_bluefi",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/hiibot_bluefi/ID/adafruit-circuitpython-hiibot_bluefi-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/hiibot_bluefi/cs/adafruit-circuitpython-hiibot_bluefi-cs-5.4.0-beta.1.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/hiibot_bluefi/de_DE/adafruit-circuitpython-hiibot_bluefi-de_DE-5.4.0-beta.1.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/hiibot_bluefi/en_US/adafruit-circuitpython-hiibot_bluefi-en_US-5.4.0-beta.1.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/hiibot_bluefi/en_x_pirate/adafruit-circuitpython-hiibot_bluefi-en_x_pirate-5.4.0-beta.1.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/hiibot_bluefi/es/adafruit-circuitpython-hiibot_bluefi-es-5.4.0-beta.1.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/hiibot_bluefi/fil/adafruit-circuitpython-hiibot_bluefi-fil-5.4.0-beta.1.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/hiibot_bluefi/fr/adafruit-circuitpython-hiibot_bluefi-fr-5.4.0-beta.1.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/hiibot_bluefi/it_IT/adafruit-circuitpython-hiibot_bluefi-it_IT-5.4.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/hiibot_bluefi/ko/adafruit-circuitpython-hiibot_bluefi-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/hiibot_bluefi/nl/adafruit-circuitpython-hiibot_bluefi-nl-5.4.0-beta.1.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/hiibot_bluefi/pl/adafruit-circuitpython-hiibot_bluefi-pl-5.4.0-beta.1.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/hiibot_bluefi/pt_BR/adafruit-circuitpython-hiibot_bluefi-pt_BR-5.4.0-beta.1.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/hiibot_bluefi/sv/adafruit-circuitpython-hiibot_bluefi-sv-5.4.0-beta.1.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/hiibot_bluefi/zh_Latn_pinyin/adafruit-circuitpython-hiibot_bluefi-zh_Latn_pinyin-5.4.0-beta.1.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.1"
+            }
+        ]
+    },
+    {
+        "downloads": 0,
         "id": "imxrt1010_evk",
         "versions": [
             {
@@ -5362,65 +5993,73 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/ID/adafruit-circuitpython-imxrt1010_evk-ID-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/ID/adafruit-circuitpython-imxrt1010_evk-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/ID/adafruit-circuitpython-imxrt1010_evk-ID-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/ID/adafruit-circuitpython-imxrt1010_evk-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/cs/adafruit-circuitpython-imxrt1010_evk-cs-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/cs/adafruit-circuitpython-imxrt1010_evk-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/de_DE/adafruit-circuitpython-imxrt1010_evk-de_DE-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/de_DE/adafruit-circuitpython-imxrt1010_evk-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/de_DE/adafruit-circuitpython-imxrt1010_evk-de_DE-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/de_DE/adafruit-circuitpython-imxrt1010_evk-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/en_US/adafruit-circuitpython-imxrt1010_evk-en_US-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/en_US/adafruit-circuitpython-imxrt1010_evk-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/en_US/adafruit-circuitpython-imxrt1010_evk-en_US-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/en_US/adafruit-circuitpython-imxrt1010_evk-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/en_x_pirate/adafruit-circuitpython-imxrt1010_evk-en_x_pirate-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/en_x_pirate/adafruit-circuitpython-imxrt1010_evk-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/en_x_pirate/adafruit-circuitpython-imxrt1010_evk-en_x_pirate-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/en_x_pirate/adafruit-circuitpython-imxrt1010_evk-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/es/adafruit-circuitpython-imxrt1010_evk-es-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/es/adafruit-circuitpython-imxrt1010_evk-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/es/adafruit-circuitpython-imxrt1010_evk-es-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/es/adafruit-circuitpython-imxrt1010_evk-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/fil/adafruit-circuitpython-imxrt1010_evk-fil-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/fil/adafruit-circuitpython-imxrt1010_evk-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/fil/adafruit-circuitpython-imxrt1010_evk-fil-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/fil/adafruit-circuitpython-imxrt1010_evk-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/fr/adafruit-circuitpython-imxrt1010_evk-fr-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/fr/adafruit-circuitpython-imxrt1010_evk-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/fr/adafruit-circuitpython-imxrt1010_evk-fr-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/fr/adafruit-circuitpython-imxrt1010_evk-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/it_IT/adafruit-circuitpython-imxrt1010_evk-it_IT-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/it_IT/adafruit-circuitpython-imxrt1010_evk-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/it_IT/adafruit-circuitpython-imxrt1010_evk-it_IT-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/it_IT/adafruit-circuitpython-imxrt1010_evk-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/ko/adafruit-circuitpython-imxrt1010_evk-ko-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/ko/adafruit-circuitpython-imxrt1010_evk-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/ko/adafruit-circuitpython-imxrt1010_evk-ko-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/ko/adafruit-circuitpython-imxrt1010_evk-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/nl/adafruit-circuitpython-imxrt1010_evk-nl-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/nl/adafruit-circuitpython-imxrt1010_evk-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/pl/adafruit-circuitpython-imxrt1010_evk-pl-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/pl/adafruit-circuitpython-imxrt1010_evk-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/pl/adafruit-circuitpython-imxrt1010_evk-pl-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/pl/adafruit-circuitpython-imxrt1010_evk-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/pt_BR/adafruit-circuitpython-imxrt1010_evk-pt_BR-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/pt_BR/adafruit-circuitpython-imxrt1010_evk-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/pt_BR/adafruit-circuitpython-imxrt1010_evk-pt_BR-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/pt_BR/adafruit-circuitpython-imxrt1010_evk-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/sv/adafruit-circuitpython-imxrt1010_evk-sv-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/sv/adafruit-circuitpython-imxrt1010_evk-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/sv/adafruit-circuitpython-imxrt1010_evk-sv-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/sv/adafruit-circuitpython-imxrt1010_evk-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1010_evk-zh_Latn_pinyin-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1010_evk-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1010_evk-zh_Latn_pinyin-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1010_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1010_evk-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 4,
+        "downloads": 0,
         "id": "imxrt1020_evk",
         "versions": [
             {
@@ -5480,65 +6119,73 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/ID/adafruit-circuitpython-imxrt1020_evk-ID-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/ID/adafruit-circuitpython-imxrt1020_evk-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/ID/adafruit-circuitpython-imxrt1020_evk-ID-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/ID/adafruit-circuitpython-imxrt1020_evk-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/cs/adafruit-circuitpython-imxrt1020_evk-cs-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/cs/adafruit-circuitpython-imxrt1020_evk-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/de_DE/adafruit-circuitpython-imxrt1020_evk-de_DE-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/de_DE/adafruit-circuitpython-imxrt1020_evk-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/de_DE/adafruit-circuitpython-imxrt1020_evk-de_DE-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/de_DE/adafruit-circuitpython-imxrt1020_evk-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/en_US/adafruit-circuitpython-imxrt1020_evk-en_US-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/en_US/adafruit-circuitpython-imxrt1020_evk-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/en_US/adafruit-circuitpython-imxrt1020_evk-en_US-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/en_US/adafruit-circuitpython-imxrt1020_evk-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/en_x_pirate/adafruit-circuitpython-imxrt1020_evk-en_x_pirate-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/en_x_pirate/adafruit-circuitpython-imxrt1020_evk-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/en_x_pirate/adafruit-circuitpython-imxrt1020_evk-en_x_pirate-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/en_x_pirate/adafruit-circuitpython-imxrt1020_evk-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/es/adafruit-circuitpython-imxrt1020_evk-es-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/es/adafruit-circuitpython-imxrt1020_evk-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/es/adafruit-circuitpython-imxrt1020_evk-es-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/es/adafruit-circuitpython-imxrt1020_evk-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/fil/adafruit-circuitpython-imxrt1020_evk-fil-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/fil/adafruit-circuitpython-imxrt1020_evk-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/fil/adafruit-circuitpython-imxrt1020_evk-fil-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/fil/adafruit-circuitpython-imxrt1020_evk-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/fr/adafruit-circuitpython-imxrt1020_evk-fr-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/fr/adafruit-circuitpython-imxrt1020_evk-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/fr/adafruit-circuitpython-imxrt1020_evk-fr-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/fr/adafruit-circuitpython-imxrt1020_evk-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/it_IT/adafruit-circuitpython-imxrt1020_evk-it_IT-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/it_IT/adafruit-circuitpython-imxrt1020_evk-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/it_IT/adafruit-circuitpython-imxrt1020_evk-it_IT-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/it_IT/adafruit-circuitpython-imxrt1020_evk-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/ko/adafruit-circuitpython-imxrt1020_evk-ko-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/ko/adafruit-circuitpython-imxrt1020_evk-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/ko/adafruit-circuitpython-imxrt1020_evk-ko-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/ko/adafruit-circuitpython-imxrt1020_evk-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/nl/adafruit-circuitpython-imxrt1020_evk-nl-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/nl/adafruit-circuitpython-imxrt1020_evk-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/pl/adafruit-circuitpython-imxrt1020_evk-pl-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/pl/adafruit-circuitpython-imxrt1020_evk-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/pl/adafruit-circuitpython-imxrt1020_evk-pl-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/pl/adafruit-circuitpython-imxrt1020_evk-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/pt_BR/adafruit-circuitpython-imxrt1020_evk-pt_BR-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/pt_BR/adafruit-circuitpython-imxrt1020_evk-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/pt_BR/adafruit-circuitpython-imxrt1020_evk-pt_BR-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/pt_BR/adafruit-circuitpython-imxrt1020_evk-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/sv/adafruit-circuitpython-imxrt1020_evk-sv-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/sv/adafruit-circuitpython-imxrt1020_evk-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/sv/adafruit-circuitpython-imxrt1020_evk-sv-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/sv/adafruit-circuitpython-imxrt1020_evk-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1020_evk-zh_Latn_pinyin-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1020_evk-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1020_evk-zh_Latn_pinyin-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1020_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1020_evk-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 9,
+        "downloads": 0,
         "id": "imxrt1060_evk",
         "versions": [
             {
@@ -5598,65 +6245,73 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/ID/adafruit-circuitpython-imxrt1060_evk-ID-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/ID/adafruit-circuitpython-imxrt1060_evk-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/ID/adafruit-circuitpython-imxrt1060_evk-ID-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/ID/adafruit-circuitpython-imxrt1060_evk-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/cs/adafruit-circuitpython-imxrt1060_evk-cs-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/cs/adafruit-circuitpython-imxrt1060_evk-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/de_DE/adafruit-circuitpython-imxrt1060_evk-de_DE-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/de_DE/adafruit-circuitpython-imxrt1060_evk-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/de_DE/adafruit-circuitpython-imxrt1060_evk-de_DE-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/de_DE/adafruit-circuitpython-imxrt1060_evk-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/en_US/adafruit-circuitpython-imxrt1060_evk-en_US-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/en_US/adafruit-circuitpython-imxrt1060_evk-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/en_US/adafruit-circuitpython-imxrt1060_evk-en_US-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/en_US/adafruit-circuitpython-imxrt1060_evk-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/en_x_pirate/adafruit-circuitpython-imxrt1060_evk-en_x_pirate-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/en_x_pirate/adafruit-circuitpython-imxrt1060_evk-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/en_x_pirate/adafruit-circuitpython-imxrt1060_evk-en_x_pirate-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/en_x_pirate/adafruit-circuitpython-imxrt1060_evk-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/es/adafruit-circuitpython-imxrt1060_evk-es-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/es/adafruit-circuitpython-imxrt1060_evk-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/es/adafruit-circuitpython-imxrt1060_evk-es-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/es/adafruit-circuitpython-imxrt1060_evk-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/fil/adafruit-circuitpython-imxrt1060_evk-fil-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/fil/adafruit-circuitpython-imxrt1060_evk-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/fil/adafruit-circuitpython-imxrt1060_evk-fil-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/fil/adafruit-circuitpython-imxrt1060_evk-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/fr/adafruit-circuitpython-imxrt1060_evk-fr-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/fr/adafruit-circuitpython-imxrt1060_evk-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/fr/adafruit-circuitpython-imxrt1060_evk-fr-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/fr/adafruit-circuitpython-imxrt1060_evk-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/it_IT/adafruit-circuitpython-imxrt1060_evk-it_IT-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/it_IT/adafruit-circuitpython-imxrt1060_evk-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/it_IT/adafruit-circuitpython-imxrt1060_evk-it_IT-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/it_IT/adafruit-circuitpython-imxrt1060_evk-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/ko/adafruit-circuitpython-imxrt1060_evk-ko-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/ko/adafruit-circuitpython-imxrt1060_evk-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/ko/adafruit-circuitpython-imxrt1060_evk-ko-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/ko/adafruit-circuitpython-imxrt1060_evk-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/nl/adafruit-circuitpython-imxrt1060_evk-nl-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/nl/adafruit-circuitpython-imxrt1060_evk-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/pl/adafruit-circuitpython-imxrt1060_evk-pl-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/pl/adafruit-circuitpython-imxrt1060_evk-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/pl/adafruit-circuitpython-imxrt1060_evk-pl-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/pl/adafruit-circuitpython-imxrt1060_evk-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/pt_BR/adafruit-circuitpython-imxrt1060_evk-pt_BR-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/pt_BR/adafruit-circuitpython-imxrt1060_evk-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/pt_BR/adafruit-circuitpython-imxrt1060_evk-pt_BR-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/pt_BR/adafruit-circuitpython-imxrt1060_evk-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/sv/adafruit-circuitpython-imxrt1060_evk-sv-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/sv/adafruit-circuitpython-imxrt1060_evk-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/sv/adafruit-circuitpython-imxrt1060_evk-sv-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/sv/adafruit-circuitpython-imxrt1060_evk-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1060_evk-zh_Latn_pinyin-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1060_evk-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1060_evk-zh_Latn_pinyin-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/imxrt1060_evk/zh_Latn_pinyin/adafruit-circuitpython-imxrt1060_evk-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 57,
+        "downloads": 0,
         "id": "itsybitsy_m0_express",
         "versions": [
             {
@@ -5704,52 +6359,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/ID/adafruit-circuitpython-itsybitsy_m0_express-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/ID/adafruit-circuitpython-itsybitsy_m0_express-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/cs/adafruit-circuitpython-itsybitsy_m0_express-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/de_DE/adafruit-circuitpython-itsybitsy_m0_express-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/de_DE/adafruit-circuitpython-itsybitsy_m0_express-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/en_US/adafruit-circuitpython-itsybitsy_m0_express-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/en_US/adafruit-circuitpython-itsybitsy_m0_express-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/en_x_pirate/adafruit-circuitpython-itsybitsy_m0_express-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/en_x_pirate/adafruit-circuitpython-itsybitsy_m0_express-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/es/adafruit-circuitpython-itsybitsy_m0_express-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/es/adafruit-circuitpython-itsybitsy_m0_express-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/fil/adafruit-circuitpython-itsybitsy_m0_express-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/fil/adafruit-circuitpython-itsybitsy_m0_express-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/fr/adafruit-circuitpython-itsybitsy_m0_express-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/fr/adafruit-circuitpython-itsybitsy_m0_express-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/it_IT/adafruit-circuitpython-itsybitsy_m0_express-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/it_IT/adafruit-circuitpython-itsybitsy_m0_express-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/ko/adafruit-circuitpython-itsybitsy_m0_express-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/ko/adafruit-circuitpython-itsybitsy_m0_express-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/nl/adafruit-circuitpython-itsybitsy_m0_express-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/pl/adafruit-circuitpython-itsybitsy_m0_express-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/pl/adafruit-circuitpython-itsybitsy_m0_express-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/pt_BR/adafruit-circuitpython-itsybitsy_m0_express-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/pt_BR/adafruit-circuitpython-itsybitsy_m0_express-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/sv/adafruit-circuitpython-itsybitsy_m0_express-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/sv/adafruit-circuitpython-itsybitsy_m0_express-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/zh_Latn_pinyin/adafruit-circuitpython-itsybitsy_m0_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m0_express/zh_Latn_pinyin/adafruit-circuitpython-itsybitsy_m0_express-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 122,
+        "downloads": 0,
         "id": "itsybitsy_m4_express",
         "versions": [
             {
@@ -5797,52 +6458,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/ID/adafruit-circuitpython-itsybitsy_m4_express-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/ID/adafruit-circuitpython-itsybitsy_m4_express-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/cs/adafruit-circuitpython-itsybitsy_m4_express-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/de_DE/adafruit-circuitpython-itsybitsy_m4_express-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/de_DE/adafruit-circuitpython-itsybitsy_m4_express-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/en_US/adafruit-circuitpython-itsybitsy_m4_express-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/en_US/adafruit-circuitpython-itsybitsy_m4_express-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/en_x_pirate/adafruit-circuitpython-itsybitsy_m4_express-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/en_x_pirate/adafruit-circuitpython-itsybitsy_m4_express-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/es/adafruit-circuitpython-itsybitsy_m4_express-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/es/adafruit-circuitpython-itsybitsy_m4_express-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/fil/adafruit-circuitpython-itsybitsy_m4_express-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/fil/adafruit-circuitpython-itsybitsy_m4_express-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/fr/adafruit-circuitpython-itsybitsy_m4_express-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/fr/adafruit-circuitpython-itsybitsy_m4_express-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/it_IT/adafruit-circuitpython-itsybitsy_m4_express-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/it_IT/adafruit-circuitpython-itsybitsy_m4_express-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/ko/adafruit-circuitpython-itsybitsy_m4_express-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/ko/adafruit-circuitpython-itsybitsy_m4_express-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/nl/adafruit-circuitpython-itsybitsy_m4_express-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/pl/adafruit-circuitpython-itsybitsy_m4_express-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/pl/adafruit-circuitpython-itsybitsy_m4_express-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/pt_BR/adafruit-circuitpython-itsybitsy_m4_express-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/pt_BR/adafruit-circuitpython-itsybitsy_m4_express-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/sv/adafruit-circuitpython-itsybitsy_m4_express-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/sv/adafruit-circuitpython-itsybitsy_m4_express-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/zh_Latn_pinyin/adafruit-circuitpython-itsybitsy_m4_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_m4_express/zh_Latn_pinyin/adafruit-circuitpython-itsybitsy_m4_express-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 70,
+        "downloads": 0,
         "id": "itsybitsy_nrf52840_express",
         "versions": [
             {
@@ -5890,52 +6557,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/ID/adafruit-circuitpython-itsybitsy_nrf52840_express-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/ID/adafruit-circuitpython-itsybitsy_nrf52840_express-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/cs/adafruit-circuitpython-itsybitsy_nrf52840_express-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/de_DE/adafruit-circuitpython-itsybitsy_nrf52840_express-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/de_DE/adafruit-circuitpython-itsybitsy_nrf52840_express-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/en_US/adafruit-circuitpython-itsybitsy_nrf52840_express-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/en_US/adafruit-circuitpython-itsybitsy_nrf52840_express-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/en_x_pirate/adafruit-circuitpython-itsybitsy_nrf52840_express-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/en_x_pirate/adafruit-circuitpython-itsybitsy_nrf52840_express-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/es/adafruit-circuitpython-itsybitsy_nrf52840_express-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/es/adafruit-circuitpython-itsybitsy_nrf52840_express-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/fil/adafruit-circuitpython-itsybitsy_nrf52840_express-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/fil/adafruit-circuitpython-itsybitsy_nrf52840_express-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/fr/adafruit-circuitpython-itsybitsy_nrf52840_express-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/fr/adafruit-circuitpython-itsybitsy_nrf52840_express-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/it_IT/adafruit-circuitpython-itsybitsy_nrf52840_express-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/it_IT/adafruit-circuitpython-itsybitsy_nrf52840_express-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/ko/adafruit-circuitpython-itsybitsy_nrf52840_express-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/ko/adafruit-circuitpython-itsybitsy_nrf52840_express-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/nl/adafruit-circuitpython-itsybitsy_nrf52840_express-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/pl/adafruit-circuitpython-itsybitsy_nrf52840_express-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/pl/adafruit-circuitpython-itsybitsy_nrf52840_express-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/pt_BR/adafruit-circuitpython-itsybitsy_nrf52840_express-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/pt_BR/adafruit-circuitpython-itsybitsy_nrf52840_express-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/sv/adafruit-circuitpython-itsybitsy_nrf52840_express-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/sv/adafruit-circuitpython-itsybitsy_nrf52840_express-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/zh_Latn_pinyin/adafruit-circuitpython-itsybitsy_nrf52840_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/itsybitsy_nrf52840_express/zh_Latn_pinyin/adafruit-circuitpython-itsybitsy_nrf52840_express-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 49,
+        "downloads": 0,
         "id": "kicksat-sprite",
         "versions": [
             {
@@ -5983,52 +6656,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/ID/adafruit-circuitpython-kicksat-sprite-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/ID/adafruit-circuitpython-kicksat-sprite-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/cs/adafruit-circuitpython-kicksat-sprite-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/de_DE/adafruit-circuitpython-kicksat-sprite-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/de_DE/adafruit-circuitpython-kicksat-sprite-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/en_US/adafruit-circuitpython-kicksat-sprite-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/en_US/adafruit-circuitpython-kicksat-sprite-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/en_x_pirate/adafruit-circuitpython-kicksat-sprite-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/en_x_pirate/adafruit-circuitpython-kicksat-sprite-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/es/adafruit-circuitpython-kicksat-sprite-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/es/adafruit-circuitpython-kicksat-sprite-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/fil/adafruit-circuitpython-kicksat-sprite-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/fil/adafruit-circuitpython-kicksat-sprite-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/fr/adafruit-circuitpython-kicksat-sprite-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/fr/adafruit-circuitpython-kicksat-sprite-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/it_IT/adafruit-circuitpython-kicksat-sprite-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/it_IT/adafruit-circuitpython-kicksat-sprite-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/ko/adafruit-circuitpython-kicksat-sprite-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/ko/adafruit-circuitpython-kicksat-sprite-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/nl/adafruit-circuitpython-kicksat-sprite-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/pl/adafruit-circuitpython-kicksat-sprite-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/pl/adafruit-circuitpython-kicksat-sprite-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/pt_BR/adafruit-circuitpython-kicksat-sprite-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/pt_BR/adafruit-circuitpython-kicksat-sprite-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/sv/adafruit-circuitpython-kicksat-sprite-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/sv/adafruit-circuitpython-kicksat-sprite-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/kicksat-sprite/zh_Latn_pinyin/adafruit-circuitpython-kicksat-sprite-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/kicksat-sprite/zh_Latn_pinyin/adafruit-circuitpython-kicksat-sprite-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 26,
+        "downloads": 0,
         "id": "makerdiary_nrf52840_mdk",
         "versions": [
             {
@@ -6076,52 +6755,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/ID/adafruit-circuitpython-makerdiary_nrf52840_mdk-ID-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/ID/adafruit-circuitpython-makerdiary_nrf52840_mdk-ID-5.4.0-beta.1.hex"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/cs/adafruit-circuitpython-makerdiary_nrf52840_mdk-cs-5.4.0-beta.1.hex"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/de_DE/adafruit-circuitpython-makerdiary_nrf52840_mdk-de_DE-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/de_DE/adafruit-circuitpython-makerdiary_nrf52840_mdk-de_DE-5.4.0-beta.1.hex"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/en_US/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_US-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/en_US/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_US-5.4.0-beta.1.hex"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/en_x_pirate/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_x_pirate-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/en_x_pirate/adafruit-circuitpython-makerdiary_nrf52840_mdk-en_x_pirate-5.4.0-beta.1.hex"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/es/adafruit-circuitpython-makerdiary_nrf52840_mdk-es-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/es/adafruit-circuitpython-makerdiary_nrf52840_mdk-es-5.4.0-beta.1.hex"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/fil/adafruit-circuitpython-makerdiary_nrf52840_mdk-fil-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/fil/adafruit-circuitpython-makerdiary_nrf52840_mdk-fil-5.4.0-beta.1.hex"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/fr/adafruit-circuitpython-makerdiary_nrf52840_mdk-fr-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/fr/adafruit-circuitpython-makerdiary_nrf52840_mdk-fr-5.4.0-beta.1.hex"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/it_IT/adafruit-circuitpython-makerdiary_nrf52840_mdk-it_IT-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/it_IT/adafruit-circuitpython-makerdiary_nrf52840_mdk-it_IT-5.4.0-beta.1.hex"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/ko/adafruit-circuitpython-makerdiary_nrf52840_mdk-ko-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/ko/adafruit-circuitpython-makerdiary_nrf52840_mdk-ko-5.4.0-beta.1.hex"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/nl/adafruit-circuitpython-makerdiary_nrf52840_mdk-nl-5.4.0-beta.1.hex"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/pl/adafruit-circuitpython-makerdiary_nrf52840_mdk-pl-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/pl/adafruit-circuitpython-makerdiary_nrf52840_mdk-pl-5.4.0-beta.1.hex"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/pt_BR/adafruit-circuitpython-makerdiary_nrf52840_mdk-pt_BR-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/pt_BR/adafruit-circuitpython-makerdiary_nrf52840_mdk-pt_BR-5.4.0-beta.1.hex"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/sv/adafruit-circuitpython-makerdiary_nrf52840_mdk-sv-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/sv/adafruit-circuitpython-makerdiary_nrf52840_mdk-sv-5.4.0-beta.1.hex"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/zh_Latn_pinyin/adafruit-circuitpython-makerdiary_nrf52840_mdk-zh_Latn_pinyin-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk/zh_Latn_pinyin/adafruit-circuitpython-makerdiary_nrf52840_mdk-zh_Latn_pinyin-5.4.0-beta.1.hex"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 40,
+        "downloads": 0,
         "id": "makerdiary_nrf52840_mdk_usb_dongle",
         "versions": [
             {
@@ -6169,52 +6854,73 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/ID/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-ID-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/ID/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-ID-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/ID/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/cs/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-cs-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/cs/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/de_DE/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-de_DE-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/de_DE/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-de_DE-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/de_DE/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/en_US/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_US-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/en_US/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_US-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/en_US/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/en_x_pirate/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_x_pirate-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/en_x_pirate/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_x_pirate-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/en_x_pirate/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/es/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-es-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/es/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-es-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/es/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/fil/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fil-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/fil/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fil-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/fil/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/fr/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fr-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/fr/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fr-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/fr/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/it_IT/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-it_IT-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/it_IT/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-it_IT-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/it_IT/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/ko/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-ko-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/ko/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-ko-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/ko/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/nl/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-nl-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/nl/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/pl/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pl-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/pl/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pl-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/pl/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/pt_BR/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pt_BR-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/pt_BR/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pt_BR-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/pt_BR/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/sv/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-sv-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/sv/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-sv-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/sv/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/zh_Latn_pinyin/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-zh_Latn_pinyin-5.4.0-beta.0.hex"
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/zh_Latn_pinyin/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-zh_Latn_pinyin-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/makerdiary_nrf52840_mdk_usb_dongle/zh_Latn_pinyin/adafruit-circuitpython-makerdiary_nrf52840_mdk_usb_dongle-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 9,
+        "downloads": 0,
         "id": "meowbit_v121",
         "versions": [
             {
@@ -6262,52 +6968,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/ID/adafruit-circuitpython-meowbit_v121-ID-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/ID/adafruit-circuitpython-meowbit_v121-ID-5.4.0-beta.1.bin"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/cs/adafruit-circuitpython-meowbit_v121-cs-5.4.0-beta.1.bin"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/de_DE/adafruit-circuitpython-meowbit_v121-de_DE-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/de_DE/adafruit-circuitpython-meowbit_v121-de_DE-5.4.0-beta.1.bin"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/en_US/adafruit-circuitpython-meowbit_v121-en_US-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/en_US/adafruit-circuitpython-meowbit_v121-en_US-5.4.0-beta.1.bin"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/en_x_pirate/adafruit-circuitpython-meowbit_v121-en_x_pirate-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/en_x_pirate/adafruit-circuitpython-meowbit_v121-en_x_pirate-5.4.0-beta.1.bin"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/es/adafruit-circuitpython-meowbit_v121-es-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/es/adafruit-circuitpython-meowbit_v121-es-5.4.0-beta.1.bin"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/fil/adafruit-circuitpython-meowbit_v121-fil-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/fil/adafruit-circuitpython-meowbit_v121-fil-5.4.0-beta.1.bin"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/fr/adafruit-circuitpython-meowbit_v121-fr-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/fr/adafruit-circuitpython-meowbit_v121-fr-5.4.0-beta.1.bin"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/it_IT/adafruit-circuitpython-meowbit_v121-it_IT-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/it_IT/adafruit-circuitpython-meowbit_v121-it_IT-5.4.0-beta.1.bin"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/ko/adafruit-circuitpython-meowbit_v121-ko-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/ko/adafruit-circuitpython-meowbit_v121-ko-5.4.0-beta.1.bin"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/nl/adafruit-circuitpython-meowbit_v121-nl-5.4.0-beta.1.bin"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/pl/adafruit-circuitpython-meowbit_v121-pl-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/pl/adafruit-circuitpython-meowbit_v121-pl-5.4.0-beta.1.bin"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/pt_BR/adafruit-circuitpython-meowbit_v121-pt_BR-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/pt_BR/adafruit-circuitpython-meowbit_v121-pt_BR-5.4.0-beta.1.bin"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/sv/adafruit-circuitpython-meowbit_v121-sv-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/sv/adafruit-circuitpython-meowbit_v121-sv-5.4.0-beta.1.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/meowbit_v121/zh_Latn_pinyin/adafruit-circuitpython-meowbit_v121-zh_Latn_pinyin-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/meowbit_v121/zh_Latn_pinyin/adafruit-circuitpython-meowbit_v121-zh_Latn_pinyin-5.4.0-beta.1.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 27,
+        "downloads": 0,
         "id": "meowmeow",
         "versions": [
             {
@@ -6355,52 +7067,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/ID/adafruit-circuitpython-meowmeow-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/meowmeow/ID/adafruit-circuitpython-meowmeow-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/meowmeow/cs/adafruit-circuitpython-meowmeow-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/de_DE/adafruit-circuitpython-meowmeow-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/meowmeow/de_DE/adafruit-circuitpython-meowmeow-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/en_US/adafruit-circuitpython-meowmeow-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/meowmeow/en_US/adafruit-circuitpython-meowmeow-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/en_x_pirate/adafruit-circuitpython-meowmeow-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/meowmeow/en_x_pirate/adafruit-circuitpython-meowmeow-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/es/adafruit-circuitpython-meowmeow-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/meowmeow/es/adafruit-circuitpython-meowmeow-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/fil/adafruit-circuitpython-meowmeow-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/meowmeow/fil/adafruit-circuitpython-meowmeow-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/fr/adafruit-circuitpython-meowmeow-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/meowmeow/fr/adafruit-circuitpython-meowmeow-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/it_IT/adafruit-circuitpython-meowmeow-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/meowmeow/it_IT/adafruit-circuitpython-meowmeow-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/ko/adafruit-circuitpython-meowmeow-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/meowmeow/ko/adafruit-circuitpython-meowmeow-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/meowmeow/nl/adafruit-circuitpython-meowmeow-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/pl/adafruit-circuitpython-meowmeow-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/meowmeow/pl/adafruit-circuitpython-meowmeow-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/pt_BR/adafruit-circuitpython-meowmeow-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/meowmeow/pt_BR/adafruit-circuitpython-meowmeow-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/sv/adafruit-circuitpython-meowmeow-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/meowmeow/sv/adafruit-circuitpython-meowmeow-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/meowmeow/zh_Latn_pinyin/adafruit-circuitpython-meowmeow-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/meowmeow/zh_Latn_pinyin/adafruit-circuitpython-meowmeow-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 83,
+        "downloads": 0,
         "id": "metro_m0_express",
         "versions": [
             {
@@ -6448,52 +7166,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/ID/adafruit-circuitpython-metro_m0_express-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/ID/adafruit-circuitpython-metro_m0_express-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/cs/adafruit-circuitpython-metro_m0_express-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/de_DE/adafruit-circuitpython-metro_m0_express-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/de_DE/adafruit-circuitpython-metro_m0_express-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/en_US/adafruit-circuitpython-metro_m0_express-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/en_US/adafruit-circuitpython-metro_m0_express-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/en_x_pirate/adafruit-circuitpython-metro_m0_express-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/en_x_pirate/adafruit-circuitpython-metro_m0_express-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/es/adafruit-circuitpython-metro_m0_express-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/es/adafruit-circuitpython-metro_m0_express-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/fil/adafruit-circuitpython-metro_m0_express-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/fil/adafruit-circuitpython-metro_m0_express-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/fr/adafruit-circuitpython-metro_m0_express-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/fr/adafruit-circuitpython-metro_m0_express-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/it_IT/adafruit-circuitpython-metro_m0_express-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/it_IT/adafruit-circuitpython-metro_m0_express-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/ko/adafruit-circuitpython-metro_m0_express-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/ko/adafruit-circuitpython-metro_m0_express-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/nl/adafruit-circuitpython-metro_m0_express-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/pl/adafruit-circuitpython-metro_m0_express-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/pl/adafruit-circuitpython-metro_m0_express-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/pt_BR/adafruit-circuitpython-metro_m0_express-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/pt_BR/adafruit-circuitpython-metro_m0_express-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/sv/adafruit-circuitpython-metro_m0_express-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/sv/adafruit-circuitpython-metro_m0_express-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/metro_m0_express/zh_Latn_pinyin/adafruit-circuitpython-metro_m0_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m0_express/zh_Latn_pinyin/adafruit-circuitpython-metro_m0_express-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 46,
+        "downloads": 0,
         "id": "metro_m4_airlift_lite",
         "versions": [
             {
@@ -6541,52 +7265,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/ID/adafruit-circuitpython-metro_m4_airlift_lite-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/ID/adafruit-circuitpython-metro_m4_airlift_lite-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/cs/adafruit-circuitpython-metro_m4_airlift_lite-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/de_DE/adafruit-circuitpython-metro_m4_airlift_lite-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/de_DE/adafruit-circuitpython-metro_m4_airlift_lite-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/en_US/adafruit-circuitpython-metro_m4_airlift_lite-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/en_US/adafruit-circuitpython-metro_m4_airlift_lite-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/en_x_pirate/adafruit-circuitpython-metro_m4_airlift_lite-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/en_x_pirate/adafruit-circuitpython-metro_m4_airlift_lite-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/es/adafruit-circuitpython-metro_m4_airlift_lite-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/es/adafruit-circuitpython-metro_m4_airlift_lite-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/fil/adafruit-circuitpython-metro_m4_airlift_lite-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/fil/adafruit-circuitpython-metro_m4_airlift_lite-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/fr/adafruit-circuitpython-metro_m4_airlift_lite-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/fr/adafruit-circuitpython-metro_m4_airlift_lite-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/it_IT/adafruit-circuitpython-metro_m4_airlift_lite-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/it_IT/adafruit-circuitpython-metro_m4_airlift_lite-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/ko/adafruit-circuitpython-metro_m4_airlift_lite-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/ko/adafruit-circuitpython-metro_m4_airlift_lite-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/nl/adafruit-circuitpython-metro_m4_airlift_lite-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/pl/adafruit-circuitpython-metro_m4_airlift_lite-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/pl/adafruit-circuitpython-metro_m4_airlift_lite-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/pt_BR/adafruit-circuitpython-metro_m4_airlift_lite-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/pt_BR/adafruit-circuitpython-metro_m4_airlift_lite-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/sv/adafruit-circuitpython-metro_m4_airlift_lite-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/sv/adafruit-circuitpython-metro_m4_airlift_lite-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/zh_Latn_pinyin/adafruit-circuitpython-metro_m4_airlift_lite-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m4_airlift_lite/zh_Latn_pinyin/adafruit-circuitpython-metro_m4_airlift_lite-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 47,
+        "downloads": 0,
         "id": "metro_m4_express",
         "versions": [
             {
@@ -6634,52 +7364,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/ID/adafruit-circuitpython-metro_m4_express-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/ID/adafruit-circuitpython-metro_m4_express-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/cs/adafruit-circuitpython-metro_m4_express-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/de_DE/adafruit-circuitpython-metro_m4_express-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/de_DE/adafruit-circuitpython-metro_m4_express-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/en_US/adafruit-circuitpython-metro_m4_express-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/en_US/adafruit-circuitpython-metro_m4_express-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/en_x_pirate/adafruit-circuitpython-metro_m4_express-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/en_x_pirate/adafruit-circuitpython-metro_m4_express-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/es/adafruit-circuitpython-metro_m4_express-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/es/adafruit-circuitpython-metro_m4_express-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/fil/adafruit-circuitpython-metro_m4_express-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/fil/adafruit-circuitpython-metro_m4_express-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/fr/adafruit-circuitpython-metro_m4_express-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/fr/adafruit-circuitpython-metro_m4_express-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/it_IT/adafruit-circuitpython-metro_m4_express-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/it_IT/adafruit-circuitpython-metro_m4_express-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/ko/adafruit-circuitpython-metro_m4_express-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/ko/adafruit-circuitpython-metro_m4_express-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/nl/adafruit-circuitpython-metro_m4_express-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/pl/adafruit-circuitpython-metro_m4_express-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/pl/adafruit-circuitpython-metro_m4_express-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/pt_BR/adafruit-circuitpython-metro_m4_express-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/pt_BR/adafruit-circuitpython-metro_m4_express-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/sv/adafruit-circuitpython-metro_m4_express-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/sv/adafruit-circuitpython-metro_m4_express-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/metro_m4_express/zh_Latn_pinyin/adafruit-circuitpython-metro_m4_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_m4_express/zh_Latn_pinyin/adafruit-circuitpython-metro_m4_express-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 29,
+        "downloads": 0,
         "id": "metro_nrf52840_express",
         "versions": [
             {
@@ -6727,52 +7463,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/ID/adafruit-circuitpython-metro_nrf52840_express-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/ID/adafruit-circuitpython-metro_nrf52840_express-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/cs/adafruit-circuitpython-metro_nrf52840_express-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/de_DE/adafruit-circuitpython-metro_nrf52840_express-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/de_DE/adafruit-circuitpython-metro_nrf52840_express-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/en_US/adafruit-circuitpython-metro_nrf52840_express-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/en_US/adafruit-circuitpython-metro_nrf52840_express-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/en_x_pirate/adafruit-circuitpython-metro_nrf52840_express-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/en_x_pirate/adafruit-circuitpython-metro_nrf52840_express-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/es/adafruit-circuitpython-metro_nrf52840_express-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/es/adafruit-circuitpython-metro_nrf52840_express-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/fil/adafruit-circuitpython-metro_nrf52840_express-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/fil/adafruit-circuitpython-metro_nrf52840_express-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/fr/adafruit-circuitpython-metro_nrf52840_express-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/fr/adafruit-circuitpython-metro_nrf52840_express-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/it_IT/adafruit-circuitpython-metro_nrf52840_express-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/it_IT/adafruit-circuitpython-metro_nrf52840_express-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/ko/adafruit-circuitpython-metro_nrf52840_express-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/ko/adafruit-circuitpython-metro_nrf52840_express-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/nl/adafruit-circuitpython-metro_nrf52840_express-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/pl/adafruit-circuitpython-metro_nrf52840_express-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/pl/adafruit-circuitpython-metro_nrf52840_express-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/pt_BR/adafruit-circuitpython-metro_nrf52840_express-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/pt_BR/adafruit-circuitpython-metro_nrf52840_express-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/sv/adafruit-circuitpython-metro_nrf52840_express-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/sv/adafruit-circuitpython-metro_nrf52840_express-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/zh_Latn_pinyin/adafruit-circuitpython-metro_nrf52840_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/metro_nrf52840_express/zh_Latn_pinyin/adafruit-circuitpython-metro_nrf52840_express-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 25,
+        "downloads": 0,
         "id": "mini_sam_m4",
         "versions": [
             {
@@ -6820,52 +7562,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/ID/adafruit-circuitpython-mini_sam_m4-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/ID/adafruit-circuitpython-mini_sam_m4-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/cs/adafruit-circuitpython-mini_sam_m4-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/de_DE/adafruit-circuitpython-mini_sam_m4-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/de_DE/adafruit-circuitpython-mini_sam_m4-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/en_US/adafruit-circuitpython-mini_sam_m4-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/en_US/adafruit-circuitpython-mini_sam_m4-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/en_x_pirate/adafruit-circuitpython-mini_sam_m4-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/en_x_pirate/adafruit-circuitpython-mini_sam_m4-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/es/adafruit-circuitpython-mini_sam_m4-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/es/adafruit-circuitpython-mini_sam_m4-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/fil/adafruit-circuitpython-mini_sam_m4-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/fil/adafruit-circuitpython-mini_sam_m4-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/fr/adafruit-circuitpython-mini_sam_m4-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/fr/adafruit-circuitpython-mini_sam_m4-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/it_IT/adafruit-circuitpython-mini_sam_m4-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/it_IT/adafruit-circuitpython-mini_sam_m4-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/ko/adafruit-circuitpython-mini_sam_m4-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/ko/adafruit-circuitpython-mini_sam_m4-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/nl/adafruit-circuitpython-mini_sam_m4-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/pl/adafruit-circuitpython-mini_sam_m4-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/pl/adafruit-circuitpython-mini_sam_m4-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/pt_BR/adafruit-circuitpython-mini_sam_m4-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/pt_BR/adafruit-circuitpython-mini_sam_m4-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/sv/adafruit-circuitpython-mini_sam_m4-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/sv/adafruit-circuitpython-mini_sam_m4-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/mini_sam_m4/zh_Latn_pinyin/adafruit-circuitpython-mini_sam_m4-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/mini_sam_m4/zh_Latn_pinyin/adafruit-circuitpython-mini_sam_m4-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 56,
+        "downloads": 0,
         "id": "monster_m4sk",
         "versions": [
             {
@@ -6913,52 +7661,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/ID/adafruit-circuitpython-monster_m4sk-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/ID/adafruit-circuitpython-monster_m4sk-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/cs/adafruit-circuitpython-monster_m4sk-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/de_DE/adafruit-circuitpython-monster_m4sk-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/de_DE/adafruit-circuitpython-monster_m4sk-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/en_US/adafruit-circuitpython-monster_m4sk-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/en_US/adafruit-circuitpython-monster_m4sk-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/en_x_pirate/adafruit-circuitpython-monster_m4sk-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/en_x_pirate/adafruit-circuitpython-monster_m4sk-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/es/adafruit-circuitpython-monster_m4sk-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/es/adafruit-circuitpython-monster_m4sk-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/fil/adafruit-circuitpython-monster_m4sk-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/fil/adafruit-circuitpython-monster_m4sk-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/fr/adafruit-circuitpython-monster_m4sk-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/fr/adafruit-circuitpython-monster_m4sk-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/it_IT/adafruit-circuitpython-monster_m4sk-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/it_IT/adafruit-circuitpython-monster_m4sk-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/ko/adafruit-circuitpython-monster_m4sk-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/ko/adafruit-circuitpython-monster_m4sk-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/nl/adafruit-circuitpython-monster_m4sk-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/pl/adafruit-circuitpython-monster_m4sk-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/pl/adafruit-circuitpython-monster_m4sk-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/pt_BR/adafruit-circuitpython-monster_m4sk-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/pt_BR/adafruit-circuitpython-monster_m4sk-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/sv/adafruit-circuitpython-monster_m4sk-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/sv/adafruit-circuitpython-monster_m4sk-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/monster_m4sk/zh_Latn_pinyin/adafruit-circuitpython-monster_m4sk-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/monster_m4sk/zh_Latn_pinyin/adafruit-circuitpython-monster_m4sk-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 26,
+        "downloads": 0,
         "id": "ndgarage_ndbit6",
         "versions": [
             {
@@ -7006,52 +7760,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/ID/adafruit-circuitpython-ndgarage_ndbit6-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/ID/adafruit-circuitpython-ndgarage_ndbit6-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/cs/adafruit-circuitpython-ndgarage_ndbit6-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/de_DE/adafruit-circuitpython-ndgarage_ndbit6-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/de_DE/adafruit-circuitpython-ndgarage_ndbit6-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/en_US/adafruit-circuitpython-ndgarage_ndbit6-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/en_US/adafruit-circuitpython-ndgarage_ndbit6-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/en_x_pirate/adafruit-circuitpython-ndgarage_ndbit6-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/en_x_pirate/adafruit-circuitpython-ndgarage_ndbit6-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/es/adafruit-circuitpython-ndgarage_ndbit6-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/es/adafruit-circuitpython-ndgarage_ndbit6-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/fil/adafruit-circuitpython-ndgarage_ndbit6-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/fil/adafruit-circuitpython-ndgarage_ndbit6-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/fr/adafruit-circuitpython-ndgarage_ndbit6-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/fr/adafruit-circuitpython-ndgarage_ndbit6-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/it_IT/adafruit-circuitpython-ndgarage_ndbit6-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/it_IT/adafruit-circuitpython-ndgarage_ndbit6-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/ko/adafruit-circuitpython-ndgarage_ndbit6-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/ko/adafruit-circuitpython-ndgarage_ndbit6-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/nl/adafruit-circuitpython-ndgarage_ndbit6-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/pl/adafruit-circuitpython-ndgarage_ndbit6-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/pl/adafruit-circuitpython-ndgarage_ndbit6-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/pt_BR/adafruit-circuitpython-ndgarage_ndbit6-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/pt_BR/adafruit-circuitpython-ndgarage_ndbit6-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/sv/adafruit-circuitpython-ndgarage_ndbit6-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/sv/adafruit-circuitpython-ndgarage_ndbit6-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/zh_Latn_pinyin/adafruit-circuitpython-ndgarage_ndbit6-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ndgarage_ndbit6/zh_Latn_pinyin/adafruit-circuitpython-ndgarage_ndbit6-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 44,
+        "downloads": 0,
         "id": "nfc_copy_cat",
         "versions": [
             {
@@ -7099,47 +7859,110 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/ID/adafruit-circuitpython-nfc_copy_cat-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/ID/adafruit-circuitpython-nfc_copy_cat-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/cs/adafruit-circuitpython-nfc_copy_cat-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/de_DE/adafruit-circuitpython-nfc_copy_cat-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/de_DE/adafruit-circuitpython-nfc_copy_cat-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/en_US/adafruit-circuitpython-nfc_copy_cat-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/en_US/adafruit-circuitpython-nfc_copy_cat-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/en_x_pirate/adafruit-circuitpython-nfc_copy_cat-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/en_x_pirate/adafruit-circuitpython-nfc_copy_cat-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/es/adafruit-circuitpython-nfc_copy_cat-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/es/adafruit-circuitpython-nfc_copy_cat-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/fil/adafruit-circuitpython-nfc_copy_cat-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/fil/adafruit-circuitpython-nfc_copy_cat-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/fr/adafruit-circuitpython-nfc_copy_cat-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/fr/adafruit-circuitpython-nfc_copy_cat-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/it_IT/adafruit-circuitpython-nfc_copy_cat-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/it_IT/adafruit-circuitpython-nfc_copy_cat-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/ko/adafruit-circuitpython-nfc_copy_cat-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/ko/adafruit-circuitpython-nfc_copy_cat-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/nl/adafruit-circuitpython-nfc_copy_cat-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/pl/adafruit-circuitpython-nfc_copy_cat-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/pl/adafruit-circuitpython-nfc_copy_cat-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/pt_BR/adafruit-circuitpython-nfc_copy_cat-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/pt_BR/adafruit-circuitpython-nfc_copy_cat-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/sv/adafruit-circuitpython-nfc_copy_cat-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/sv/adafruit-circuitpython-nfc_copy_cat-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/zh_Latn_pinyin/adafruit-circuitpython-nfc_copy_cat-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/nfc_copy_cat/zh_Latn_pinyin/adafruit-circuitpython-nfc_copy_cat-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
+            }
+        ]
+    },
+    {
+        "downloads": 0,
+        "id": "nice_nano",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/nice_nano/ID/adafruit-circuitpython-nice_nano-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/nice_nano/cs/adafruit-circuitpython-nice_nano-cs-5.4.0-beta.1.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/nice_nano/de_DE/adafruit-circuitpython-nice_nano-de_DE-5.4.0-beta.1.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/nice_nano/en_US/adafruit-circuitpython-nice_nano-en_US-5.4.0-beta.1.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/nice_nano/en_x_pirate/adafruit-circuitpython-nice_nano-en_x_pirate-5.4.0-beta.1.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/nice_nano/es/adafruit-circuitpython-nice_nano-es-5.4.0-beta.1.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/nice_nano/fil/adafruit-circuitpython-nice_nano-fil-5.4.0-beta.1.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/nice_nano/fr/adafruit-circuitpython-nice_nano-fr-5.4.0-beta.1.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/nice_nano/it_IT/adafruit-circuitpython-nice_nano-it_IT-5.4.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/nice_nano/ko/adafruit-circuitpython-nice_nano-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/nice_nano/nl/adafruit-circuitpython-nice_nano-nl-5.4.0-beta.1.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/nice_nano/pl/adafruit-circuitpython-nice_nano-pl-5.4.0-beta.1.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/nice_nano/pt_BR/adafruit-circuitpython-nice_nano-pt_BR-5.4.0-beta.1.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/nice_nano/sv/adafruit-circuitpython-nice_nano-sv-5.4.0-beta.1.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/nice_nano/zh_Latn_pinyin/adafruit-circuitpython-nice_nano-zh_Latn_pinyin-5.4.0-beta.1.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.1"
             }
         ]
     },
@@ -7150,47 +7973,53 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/ID/adafruit-circuitpython-nucleo_f746zg-ID-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/ID/adafruit-circuitpython-nucleo_f746zg-ID-5.4.0-beta.1.bin"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/cs/adafruit-circuitpython-nucleo_f746zg-cs-5.4.0-beta.1.bin"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/de_DE/adafruit-circuitpython-nucleo_f746zg-de_DE-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/de_DE/adafruit-circuitpython-nucleo_f746zg-de_DE-5.4.0-beta.1.bin"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/en_US/adafruit-circuitpython-nucleo_f746zg-en_US-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/en_US/adafruit-circuitpython-nucleo_f746zg-en_US-5.4.0-beta.1.bin"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/en_x_pirate/adafruit-circuitpython-nucleo_f746zg-en_x_pirate-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/en_x_pirate/adafruit-circuitpython-nucleo_f746zg-en_x_pirate-5.4.0-beta.1.bin"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/es/adafruit-circuitpython-nucleo_f746zg-es-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/es/adafruit-circuitpython-nucleo_f746zg-es-5.4.0-beta.1.bin"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/fil/adafruit-circuitpython-nucleo_f746zg-fil-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/fil/adafruit-circuitpython-nucleo_f746zg-fil-5.4.0-beta.1.bin"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/fr/adafruit-circuitpython-nucleo_f746zg-fr-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/fr/adafruit-circuitpython-nucleo_f746zg-fr-5.4.0-beta.1.bin"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/it_IT/adafruit-circuitpython-nucleo_f746zg-it_IT-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/it_IT/adafruit-circuitpython-nucleo_f746zg-it_IT-5.4.0-beta.1.bin"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/ko/adafruit-circuitpython-nucleo_f746zg-ko-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/ko/adafruit-circuitpython-nucleo_f746zg-ko-5.4.0-beta.1.bin"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/nl/adafruit-circuitpython-nucleo_f746zg-nl-5.4.0-beta.1.bin"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/pl/adafruit-circuitpython-nucleo_f746zg-pl-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/pl/adafruit-circuitpython-nucleo_f746zg-pl-5.4.0-beta.1.bin"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/pt_BR/adafruit-circuitpython-nucleo_f746zg-pt_BR-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/pt_BR/adafruit-circuitpython-nucleo_f746zg-pt_BR-5.4.0-beta.1.bin"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/sv/adafruit-circuitpython-nucleo_f746zg-sv-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/sv/adafruit-circuitpython-nucleo_f746zg-sv-5.4.0-beta.1.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/zh_Latn_pinyin/adafruit-circuitpython-nucleo_f746zg-zh_Latn_pinyin-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_f746zg/zh_Latn_pinyin/adafruit-circuitpython-nucleo_f746zg-zh_Latn_pinyin-5.4.0-beta.1.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
@@ -7243,47 +8072,53 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/ID/adafruit-circuitpython-nucleo_f767zi-ID-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/ID/adafruit-circuitpython-nucleo_f767zi-ID-5.4.0-beta.1.bin"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/cs/adafruit-circuitpython-nucleo_f767zi-cs-5.4.0-beta.1.bin"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/de_DE/adafruit-circuitpython-nucleo_f767zi-de_DE-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/de_DE/adafruit-circuitpython-nucleo_f767zi-de_DE-5.4.0-beta.1.bin"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/en_US/adafruit-circuitpython-nucleo_f767zi-en_US-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/en_US/adafruit-circuitpython-nucleo_f767zi-en_US-5.4.0-beta.1.bin"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/en_x_pirate/adafruit-circuitpython-nucleo_f767zi-en_x_pirate-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/en_x_pirate/adafruit-circuitpython-nucleo_f767zi-en_x_pirate-5.4.0-beta.1.bin"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/es/adafruit-circuitpython-nucleo_f767zi-es-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/es/adafruit-circuitpython-nucleo_f767zi-es-5.4.0-beta.1.bin"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/fil/adafruit-circuitpython-nucleo_f767zi-fil-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/fil/adafruit-circuitpython-nucleo_f767zi-fil-5.4.0-beta.1.bin"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/fr/adafruit-circuitpython-nucleo_f767zi-fr-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/fr/adafruit-circuitpython-nucleo_f767zi-fr-5.4.0-beta.1.bin"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/it_IT/adafruit-circuitpython-nucleo_f767zi-it_IT-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/it_IT/adafruit-circuitpython-nucleo_f767zi-it_IT-5.4.0-beta.1.bin"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/ko/adafruit-circuitpython-nucleo_f767zi-ko-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/ko/adafruit-circuitpython-nucleo_f767zi-ko-5.4.0-beta.1.bin"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/nl/adafruit-circuitpython-nucleo_f767zi-nl-5.4.0-beta.1.bin"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/pl/adafruit-circuitpython-nucleo_f767zi-pl-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/pl/adafruit-circuitpython-nucleo_f767zi-pl-5.4.0-beta.1.bin"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/pt_BR/adafruit-circuitpython-nucleo_f767zi-pt_BR-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/pt_BR/adafruit-circuitpython-nucleo_f767zi-pt_BR-5.4.0-beta.1.bin"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/sv/adafruit-circuitpython-nucleo_f767zi-sv-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/sv/adafruit-circuitpython-nucleo_f767zi-sv-5.4.0-beta.1.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/zh_Latn_pinyin/adafruit-circuitpython-nucleo_f767zi-zh_Latn_pinyin-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_f767zi/zh_Latn_pinyin/adafruit-circuitpython-nucleo_f767zi-zh_Latn_pinyin-5.4.0-beta.1.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
@@ -7336,52 +8171,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/ID/adafruit-circuitpython-nucleo_h743zi_2-ID-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/ID/adafruit-circuitpython-nucleo_h743zi_2-ID-5.4.0-beta.1.bin"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/cs/adafruit-circuitpython-nucleo_h743zi_2-cs-5.4.0-beta.1.bin"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/de_DE/adafruit-circuitpython-nucleo_h743zi_2-de_DE-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/de_DE/adafruit-circuitpython-nucleo_h743zi_2-de_DE-5.4.0-beta.1.bin"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/en_US/adafruit-circuitpython-nucleo_h743zi_2-en_US-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/en_US/adafruit-circuitpython-nucleo_h743zi_2-en_US-5.4.0-beta.1.bin"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/en_x_pirate/adafruit-circuitpython-nucleo_h743zi_2-en_x_pirate-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/en_x_pirate/adafruit-circuitpython-nucleo_h743zi_2-en_x_pirate-5.4.0-beta.1.bin"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/es/adafruit-circuitpython-nucleo_h743zi_2-es-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/es/adafruit-circuitpython-nucleo_h743zi_2-es-5.4.0-beta.1.bin"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/fil/adafruit-circuitpython-nucleo_h743zi_2-fil-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/fil/adafruit-circuitpython-nucleo_h743zi_2-fil-5.4.0-beta.1.bin"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/fr/adafruit-circuitpython-nucleo_h743zi_2-fr-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/fr/adafruit-circuitpython-nucleo_h743zi_2-fr-5.4.0-beta.1.bin"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/it_IT/adafruit-circuitpython-nucleo_h743zi_2-it_IT-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/it_IT/adafruit-circuitpython-nucleo_h743zi_2-it_IT-5.4.0-beta.1.bin"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/ko/adafruit-circuitpython-nucleo_h743zi_2-ko-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/ko/adafruit-circuitpython-nucleo_h743zi_2-ko-5.4.0-beta.1.bin"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/nl/adafruit-circuitpython-nucleo_h743zi_2-nl-5.4.0-beta.1.bin"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/pl/adafruit-circuitpython-nucleo_h743zi_2-pl-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/pl/adafruit-circuitpython-nucleo_h743zi_2-pl-5.4.0-beta.1.bin"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/pt_BR/adafruit-circuitpython-nucleo_h743zi_2-pt_BR-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/pt_BR/adafruit-circuitpython-nucleo_h743zi_2-pt_BR-5.4.0-beta.1.bin"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/sv/adafruit-circuitpython-nucleo_h743zi_2-sv-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/sv/adafruit-circuitpython-nucleo_h743zi_2-sv-5.4.0-beta.1.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/zh_Latn_pinyin/adafruit-circuitpython-nucleo_h743zi_2-zh_Latn_pinyin-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/nucleo_h743zi_2/zh_Latn_pinyin/adafruit-circuitpython-nucleo_h743zi_2-zh_Latn_pinyin-5.4.0-beta.1.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 58,
+        "downloads": 0,
         "id": "ohs2020_badge",
         "versions": [
             {
@@ -7429,52 +8270,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/ID/adafruit-circuitpython-ohs2020_badge-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/ID/adafruit-circuitpython-ohs2020_badge-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/cs/adafruit-circuitpython-ohs2020_badge-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/de_DE/adafruit-circuitpython-ohs2020_badge-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/de_DE/adafruit-circuitpython-ohs2020_badge-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/en_US/adafruit-circuitpython-ohs2020_badge-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/en_US/adafruit-circuitpython-ohs2020_badge-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/en_x_pirate/adafruit-circuitpython-ohs2020_badge-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/en_x_pirate/adafruit-circuitpython-ohs2020_badge-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/es/adafruit-circuitpython-ohs2020_badge-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/es/adafruit-circuitpython-ohs2020_badge-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/fil/adafruit-circuitpython-ohs2020_badge-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/fil/adafruit-circuitpython-ohs2020_badge-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/fr/adafruit-circuitpython-ohs2020_badge-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/fr/adafruit-circuitpython-ohs2020_badge-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/it_IT/adafruit-circuitpython-ohs2020_badge-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/it_IT/adafruit-circuitpython-ohs2020_badge-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/ko/adafruit-circuitpython-ohs2020_badge-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/ko/adafruit-circuitpython-ohs2020_badge-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/nl/adafruit-circuitpython-ohs2020_badge-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/pl/adafruit-circuitpython-ohs2020_badge-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/pl/adafruit-circuitpython-ohs2020_badge-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/pt_BR/adafruit-circuitpython-ohs2020_badge-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/pt_BR/adafruit-circuitpython-ohs2020_badge-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/sv/adafruit-circuitpython-ohs2020_badge-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/sv/adafruit-circuitpython-ohs2020_badge-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/ohs2020_badge/zh_Latn_pinyin/adafruit-circuitpython-ohs2020_badge-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ohs2020_badge/zh_Latn_pinyin/adafruit-circuitpython-ohs2020_badge-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 31,
+        "downloads": 0,
         "id": "openbook_m4",
         "versions": [
             {
@@ -7522,47 +8369,53 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/ID/adafruit-circuitpython-openbook_m4-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/openbook_m4/ID/adafruit-circuitpython-openbook_m4-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/openbook_m4/cs/adafruit-circuitpython-openbook_m4-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/de_DE/adafruit-circuitpython-openbook_m4-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/openbook_m4/de_DE/adafruit-circuitpython-openbook_m4-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/en_US/adafruit-circuitpython-openbook_m4-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/openbook_m4/en_US/adafruit-circuitpython-openbook_m4-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/en_x_pirate/adafruit-circuitpython-openbook_m4-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/openbook_m4/en_x_pirate/adafruit-circuitpython-openbook_m4-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/es/adafruit-circuitpython-openbook_m4-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/openbook_m4/es/adafruit-circuitpython-openbook_m4-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/fil/adafruit-circuitpython-openbook_m4-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/openbook_m4/fil/adafruit-circuitpython-openbook_m4-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/fr/adafruit-circuitpython-openbook_m4-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/openbook_m4/fr/adafruit-circuitpython-openbook_m4-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/it_IT/adafruit-circuitpython-openbook_m4-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/openbook_m4/it_IT/adafruit-circuitpython-openbook_m4-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/ko/adafruit-circuitpython-openbook_m4-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/openbook_m4/ko/adafruit-circuitpython-openbook_m4-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/openbook_m4/nl/adafruit-circuitpython-openbook_m4-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/pl/adafruit-circuitpython-openbook_m4-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/openbook_m4/pl/adafruit-circuitpython-openbook_m4-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/pt_BR/adafruit-circuitpython-openbook_m4-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/openbook_m4/pt_BR/adafruit-circuitpython-openbook_m4-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/sv/adafruit-circuitpython-openbook_m4-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/openbook_m4/sv/adafruit-circuitpython-openbook_m4-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/openbook_m4/zh_Latn_pinyin/adafruit-circuitpython-openbook_m4-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/openbook_m4/zh_Latn_pinyin/adafruit-circuitpython-openbook_m4-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
@@ -7573,52 +8426,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/openmv_h7/ID/adafruit-circuitpython-openmv_h7-ID-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/openmv_h7/ID/adafruit-circuitpython-openmv_h7-ID-5.4.0-beta.1.bin"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/openmv_h7/cs/adafruit-circuitpython-openmv_h7-cs-5.4.0-beta.1.bin"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/openmv_h7/de_DE/adafruit-circuitpython-openmv_h7-de_DE-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/openmv_h7/de_DE/adafruit-circuitpython-openmv_h7-de_DE-5.4.0-beta.1.bin"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/openmv_h7/en_US/adafruit-circuitpython-openmv_h7-en_US-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/openmv_h7/en_US/adafruit-circuitpython-openmv_h7-en_US-5.4.0-beta.1.bin"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/openmv_h7/en_x_pirate/adafruit-circuitpython-openmv_h7-en_x_pirate-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/openmv_h7/en_x_pirate/adafruit-circuitpython-openmv_h7-en_x_pirate-5.4.0-beta.1.bin"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/openmv_h7/es/adafruit-circuitpython-openmv_h7-es-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/openmv_h7/es/adafruit-circuitpython-openmv_h7-es-5.4.0-beta.1.bin"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/openmv_h7/fil/adafruit-circuitpython-openmv_h7-fil-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/openmv_h7/fil/adafruit-circuitpython-openmv_h7-fil-5.4.0-beta.1.bin"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/openmv_h7/fr/adafruit-circuitpython-openmv_h7-fr-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/openmv_h7/fr/adafruit-circuitpython-openmv_h7-fr-5.4.0-beta.1.bin"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/openmv_h7/it_IT/adafruit-circuitpython-openmv_h7-it_IT-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/openmv_h7/it_IT/adafruit-circuitpython-openmv_h7-it_IT-5.4.0-beta.1.bin"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/openmv_h7/ko/adafruit-circuitpython-openmv_h7-ko-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/openmv_h7/ko/adafruit-circuitpython-openmv_h7-ko-5.4.0-beta.1.bin"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/openmv_h7/nl/adafruit-circuitpython-openmv_h7-nl-5.4.0-beta.1.bin"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/openmv_h7/pl/adafruit-circuitpython-openmv_h7-pl-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/openmv_h7/pl/adafruit-circuitpython-openmv_h7-pl-5.4.0-beta.1.bin"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/openmv_h7/pt_BR/adafruit-circuitpython-openmv_h7-pt_BR-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/openmv_h7/pt_BR/adafruit-circuitpython-openmv_h7-pt_BR-5.4.0-beta.1.bin"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/openmv_h7/sv/adafruit-circuitpython-openmv_h7-sv-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/openmv_h7/sv/adafruit-circuitpython-openmv_h7-sv-5.4.0-beta.1.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/openmv_h7/zh_Latn_pinyin/adafruit-circuitpython-openmv_h7-zh_Latn_pinyin-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/openmv_h7/zh_Latn_pinyin/adafruit-circuitpython-openmv_h7-zh_Latn_pinyin-5.4.0-beta.1.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 27,
+        "downloads": 0,
         "id": "particle_argon",
         "versions": [
             {
@@ -7666,47 +8525,53 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/ID/adafruit-circuitpython-particle_argon-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_argon/ID/adafruit-circuitpython-particle_argon-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/particle_argon/cs/adafruit-circuitpython-particle_argon-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/de_DE/adafruit-circuitpython-particle_argon-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_argon/de_DE/adafruit-circuitpython-particle_argon-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/en_US/adafruit-circuitpython-particle_argon-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_argon/en_US/adafruit-circuitpython-particle_argon-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/en_x_pirate/adafruit-circuitpython-particle_argon-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_argon/en_x_pirate/adafruit-circuitpython-particle_argon-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/es/adafruit-circuitpython-particle_argon-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_argon/es/adafruit-circuitpython-particle_argon-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/fil/adafruit-circuitpython-particle_argon-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_argon/fil/adafruit-circuitpython-particle_argon-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/fr/adafruit-circuitpython-particle_argon-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_argon/fr/adafruit-circuitpython-particle_argon-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/it_IT/adafruit-circuitpython-particle_argon-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_argon/it_IT/adafruit-circuitpython-particle_argon-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/ko/adafruit-circuitpython-particle_argon-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_argon/ko/adafruit-circuitpython-particle_argon-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/particle_argon/nl/adafruit-circuitpython-particle_argon-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/pl/adafruit-circuitpython-particle_argon-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_argon/pl/adafruit-circuitpython-particle_argon-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/pt_BR/adafruit-circuitpython-particle_argon-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_argon/pt_BR/adafruit-circuitpython-particle_argon-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/sv/adafruit-circuitpython-particle_argon-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_argon/sv/adafruit-circuitpython-particle_argon-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/particle_argon/zh_Latn_pinyin/adafruit-circuitpython-particle_argon-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_argon/zh_Latn_pinyin/adafruit-circuitpython-particle_argon-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
@@ -7759,52 +8624,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/ID/adafruit-circuitpython-particle_boron-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_boron/ID/adafruit-circuitpython-particle_boron-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/particle_boron/cs/adafruit-circuitpython-particle_boron-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/de_DE/adafruit-circuitpython-particle_boron-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_boron/de_DE/adafruit-circuitpython-particle_boron-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/en_US/adafruit-circuitpython-particle_boron-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_boron/en_US/adafruit-circuitpython-particle_boron-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/en_x_pirate/adafruit-circuitpython-particle_boron-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_boron/en_x_pirate/adafruit-circuitpython-particle_boron-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/es/adafruit-circuitpython-particle_boron-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_boron/es/adafruit-circuitpython-particle_boron-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/fil/adafruit-circuitpython-particle_boron-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_boron/fil/adafruit-circuitpython-particle_boron-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/fr/adafruit-circuitpython-particle_boron-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_boron/fr/adafruit-circuitpython-particle_boron-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/it_IT/adafruit-circuitpython-particle_boron-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_boron/it_IT/adafruit-circuitpython-particle_boron-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/ko/adafruit-circuitpython-particle_boron-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_boron/ko/adafruit-circuitpython-particle_boron-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/particle_boron/nl/adafruit-circuitpython-particle_boron-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/pl/adafruit-circuitpython-particle_boron-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_boron/pl/adafruit-circuitpython-particle_boron-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/pt_BR/adafruit-circuitpython-particle_boron-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_boron/pt_BR/adafruit-circuitpython-particle_boron-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/sv/adafruit-circuitpython-particle_boron-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_boron/sv/adafruit-circuitpython-particle_boron-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/particle_boron/zh_Latn_pinyin/adafruit-circuitpython-particle_boron-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_boron/zh_Latn_pinyin/adafruit-circuitpython-particle_boron-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 32,
+        "downloads": 0,
         "id": "particle_xenon",
         "versions": [
             {
@@ -7852,47 +8723,53 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/ID/adafruit-circuitpython-particle_xenon-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_xenon/ID/adafruit-circuitpython-particle_xenon-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/particle_xenon/cs/adafruit-circuitpython-particle_xenon-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/de_DE/adafruit-circuitpython-particle_xenon-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_xenon/de_DE/adafruit-circuitpython-particle_xenon-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/en_US/adafruit-circuitpython-particle_xenon-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_xenon/en_US/adafruit-circuitpython-particle_xenon-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/en_x_pirate/adafruit-circuitpython-particle_xenon-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_xenon/en_x_pirate/adafruit-circuitpython-particle_xenon-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/es/adafruit-circuitpython-particle_xenon-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_xenon/es/adafruit-circuitpython-particle_xenon-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/fil/adafruit-circuitpython-particle_xenon-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_xenon/fil/adafruit-circuitpython-particle_xenon-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/fr/adafruit-circuitpython-particle_xenon-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_xenon/fr/adafruit-circuitpython-particle_xenon-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/it_IT/adafruit-circuitpython-particle_xenon-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_xenon/it_IT/adafruit-circuitpython-particle_xenon-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/ko/adafruit-circuitpython-particle_xenon-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_xenon/ko/adafruit-circuitpython-particle_xenon-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/particle_xenon/nl/adafruit-circuitpython-particle_xenon-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/pl/adafruit-circuitpython-particle_xenon-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_xenon/pl/adafruit-circuitpython-particle_xenon-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/pt_BR/adafruit-circuitpython-particle_xenon-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_xenon/pt_BR/adafruit-circuitpython-particle_xenon-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/sv/adafruit-circuitpython-particle_xenon-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_xenon/sv/adafruit-circuitpython-particle_xenon-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/particle_xenon/zh_Latn_pinyin/adafruit-circuitpython-particle_xenon-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/particle_xenon/zh_Latn_pinyin/adafruit-circuitpython-particle_xenon-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
@@ -7902,7 +8779,7 @@
         "versions": []
     },
     {
-        "downloads": 9,
+        "downloads": 0,
         "id": "pca10056",
         "versions": [
             {
@@ -7962,65 +8839,73 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/pca10056/ID/adafruit-circuitpython-pca10056-ID-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/ID/adafruit-circuitpython-pca10056-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10056/ID/adafruit-circuitpython-pca10056-ID-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/ID/adafruit-circuitpython-pca10056-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/pca10056/cs/adafruit-circuitpython-pca10056-cs-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/cs/adafruit-circuitpython-pca10056-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pca10056/de_DE/adafruit-circuitpython-pca10056-de_DE-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/de_DE/adafruit-circuitpython-pca10056-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10056/de_DE/adafruit-circuitpython-pca10056-de_DE-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/de_DE/adafruit-circuitpython-pca10056-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/pca10056/en_US/adafruit-circuitpython-pca10056-en_US-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/en_US/adafruit-circuitpython-pca10056-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10056/en_US/adafruit-circuitpython-pca10056-en_US-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/en_US/adafruit-circuitpython-pca10056-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pca10056/en_x_pirate/adafruit-circuitpython-pca10056-en_x_pirate-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/en_x_pirate/adafruit-circuitpython-pca10056-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10056/en_x_pirate/adafruit-circuitpython-pca10056-en_x_pirate-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/en_x_pirate/adafruit-circuitpython-pca10056-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/pca10056/es/adafruit-circuitpython-pca10056-es-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/es/adafruit-circuitpython-pca10056-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10056/es/adafruit-circuitpython-pca10056-es-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/es/adafruit-circuitpython-pca10056-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/pca10056/fil/adafruit-circuitpython-pca10056-fil-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/fil/adafruit-circuitpython-pca10056-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10056/fil/adafruit-circuitpython-pca10056-fil-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/fil/adafruit-circuitpython-pca10056-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/pca10056/fr/adafruit-circuitpython-pca10056-fr-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/fr/adafruit-circuitpython-pca10056-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10056/fr/adafruit-circuitpython-pca10056-fr-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/fr/adafruit-circuitpython-pca10056-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pca10056/it_IT/adafruit-circuitpython-pca10056-it_IT-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/it_IT/adafruit-circuitpython-pca10056-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10056/it_IT/adafruit-circuitpython-pca10056-it_IT-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/it_IT/adafruit-circuitpython-pca10056-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/pca10056/ko/adafruit-circuitpython-pca10056-ko-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/ko/adafruit-circuitpython-pca10056-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10056/ko/adafruit-circuitpython-pca10056-ko-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/ko/adafruit-circuitpython-pca10056-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/pca10056/nl/adafruit-circuitpython-pca10056-nl-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/nl/adafruit-circuitpython-pca10056-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/pca10056/pl/adafruit-circuitpython-pca10056-pl-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/pl/adafruit-circuitpython-pca10056-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10056/pl/adafruit-circuitpython-pca10056-pl-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/pl/adafruit-circuitpython-pca10056-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pca10056/pt_BR/adafruit-circuitpython-pca10056-pt_BR-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/pt_BR/adafruit-circuitpython-pca10056-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10056/pt_BR/adafruit-circuitpython-pca10056-pt_BR-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/pt_BR/adafruit-circuitpython-pca10056-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/pca10056/sv/adafruit-circuitpython-pca10056-sv-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/sv/adafruit-circuitpython-pca10056-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10056/sv/adafruit-circuitpython-pca10056-sv-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/sv/adafruit-circuitpython-pca10056-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pca10056/zh_Latn_pinyin/adafruit-circuitpython-pca10056-zh_Latn_pinyin-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10056/zh_Latn_pinyin/adafruit-circuitpython-pca10056-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10056/zh_Latn_pinyin/adafruit-circuitpython-pca10056-zh_Latn_pinyin-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/pca10056/zh_Latn_pinyin/adafruit-circuitpython-pca10056-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 19,
+        "downloads": 0,
         "id": "pca10059",
         "versions": [
             {
@@ -8080,60 +8965,68 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/pca10059/ID/adafruit-circuitpython-pca10059-ID-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/ID/adafruit-circuitpython-pca10059-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10059/ID/adafruit-circuitpython-pca10059-ID-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/ID/adafruit-circuitpython-pca10059-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/pca10059/cs/adafruit-circuitpython-pca10059-cs-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/cs/adafruit-circuitpython-pca10059-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pca10059/de_DE/adafruit-circuitpython-pca10059-de_DE-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/de_DE/adafruit-circuitpython-pca10059-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10059/de_DE/adafruit-circuitpython-pca10059-de_DE-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/de_DE/adafruit-circuitpython-pca10059-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/pca10059/en_US/adafruit-circuitpython-pca10059-en_US-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/en_US/adafruit-circuitpython-pca10059-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10059/en_US/adafruit-circuitpython-pca10059-en_US-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/en_US/adafruit-circuitpython-pca10059-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pca10059/en_x_pirate/adafruit-circuitpython-pca10059-en_x_pirate-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/en_x_pirate/adafruit-circuitpython-pca10059-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10059/en_x_pirate/adafruit-circuitpython-pca10059-en_x_pirate-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/en_x_pirate/adafruit-circuitpython-pca10059-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/pca10059/es/adafruit-circuitpython-pca10059-es-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/es/adafruit-circuitpython-pca10059-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10059/es/adafruit-circuitpython-pca10059-es-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/es/adafruit-circuitpython-pca10059-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/pca10059/fil/adafruit-circuitpython-pca10059-fil-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/fil/adafruit-circuitpython-pca10059-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10059/fil/adafruit-circuitpython-pca10059-fil-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/fil/adafruit-circuitpython-pca10059-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/pca10059/fr/adafruit-circuitpython-pca10059-fr-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/fr/adafruit-circuitpython-pca10059-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10059/fr/adafruit-circuitpython-pca10059-fr-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/fr/adafruit-circuitpython-pca10059-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pca10059/it_IT/adafruit-circuitpython-pca10059-it_IT-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/it_IT/adafruit-circuitpython-pca10059-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10059/it_IT/adafruit-circuitpython-pca10059-it_IT-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/it_IT/adafruit-circuitpython-pca10059-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/pca10059/ko/adafruit-circuitpython-pca10059-ko-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/ko/adafruit-circuitpython-pca10059-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10059/ko/adafruit-circuitpython-pca10059-ko-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/ko/adafruit-circuitpython-pca10059-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/pca10059/nl/adafruit-circuitpython-pca10059-nl-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/nl/adafruit-circuitpython-pca10059-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/pca10059/pl/adafruit-circuitpython-pca10059-pl-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/pl/adafruit-circuitpython-pca10059-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10059/pl/adafruit-circuitpython-pca10059-pl-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/pl/adafruit-circuitpython-pca10059-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pca10059/pt_BR/adafruit-circuitpython-pca10059-pt_BR-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/pt_BR/adafruit-circuitpython-pca10059-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10059/pt_BR/adafruit-circuitpython-pca10059-pt_BR-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/pt_BR/adafruit-circuitpython-pca10059-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/pca10059/sv/adafruit-circuitpython-pca10059-sv-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/sv/adafruit-circuitpython-pca10059-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10059/sv/adafruit-circuitpython-pca10059-sv-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/sv/adafruit-circuitpython-pca10059-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pca10059/zh_Latn_pinyin/adafruit-circuitpython-pca10059-zh_Latn_pinyin-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/pca10059/zh_Latn_pinyin/adafruit-circuitpython-pca10059-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10059/zh_Latn_pinyin/adafruit-circuitpython-pca10059-zh_Latn_pinyin-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/pca10059/zh_Latn_pinyin/adafruit-circuitpython-pca10059-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
@@ -8144,52 +9037,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/pca10100/ID/adafruit-circuitpython-pca10100-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10100/ID/adafruit-circuitpython-pca10100-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/pca10100/cs/adafruit-circuitpython-pca10100-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pca10100/de_DE/adafruit-circuitpython-pca10100-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10100/de_DE/adafruit-circuitpython-pca10100-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/pca10100/en_US/adafruit-circuitpython-pca10100-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10100/en_US/adafruit-circuitpython-pca10100-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pca10100/en_x_pirate/adafruit-circuitpython-pca10100-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10100/en_x_pirate/adafruit-circuitpython-pca10100-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/pca10100/es/adafruit-circuitpython-pca10100-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10100/es/adafruit-circuitpython-pca10100-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/pca10100/fil/adafruit-circuitpython-pca10100-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10100/fil/adafruit-circuitpython-pca10100-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/pca10100/fr/adafruit-circuitpython-pca10100-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10100/fr/adafruit-circuitpython-pca10100-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pca10100/it_IT/adafruit-circuitpython-pca10100-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10100/it_IT/adafruit-circuitpython-pca10100-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/pca10100/ko/adafruit-circuitpython-pca10100-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10100/ko/adafruit-circuitpython-pca10100-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/pca10100/nl/adafruit-circuitpython-pca10100-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/pca10100/pl/adafruit-circuitpython-pca10100-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10100/pl/adafruit-circuitpython-pca10100-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pca10100/pt_BR/adafruit-circuitpython-pca10100-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10100/pt_BR/adafruit-circuitpython-pca10100-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/pca10100/sv/adafruit-circuitpython-pca10100-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10100/sv/adafruit-circuitpython-pca10100-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pca10100/zh_Latn_pinyin/adafruit-circuitpython-pca10100-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pca10100/zh_Latn_pinyin/adafruit-circuitpython-pca10100-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 29,
+        "downloads": 0,
         "id": "pewpew10",
         "versions": [
             {
@@ -8237,52 +9136,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/ID/adafruit-circuitpython-pewpew10-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew10/ID/adafruit-circuitpython-pewpew10-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/pewpew10/cs/adafruit-circuitpython-pewpew10-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/de_DE/adafruit-circuitpython-pewpew10-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew10/de_DE/adafruit-circuitpython-pewpew10-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/en_US/adafruit-circuitpython-pewpew10-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew10/en_US/adafruit-circuitpython-pewpew10-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/en_x_pirate/adafruit-circuitpython-pewpew10-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew10/en_x_pirate/adafruit-circuitpython-pewpew10-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/es/adafruit-circuitpython-pewpew10-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew10/es/adafruit-circuitpython-pewpew10-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/fil/adafruit-circuitpython-pewpew10-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew10/fil/adafruit-circuitpython-pewpew10-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/fr/adafruit-circuitpython-pewpew10-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew10/fr/adafruit-circuitpython-pewpew10-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/it_IT/adafruit-circuitpython-pewpew10-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew10/it_IT/adafruit-circuitpython-pewpew10-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/ko/adafruit-circuitpython-pewpew10-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew10/ko/adafruit-circuitpython-pewpew10-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/pewpew10/nl/adafruit-circuitpython-pewpew10-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/pl/adafruit-circuitpython-pewpew10-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew10/pl/adafruit-circuitpython-pewpew10-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/pt_BR/adafruit-circuitpython-pewpew10-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew10/pt_BR/adafruit-circuitpython-pewpew10-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/sv/adafruit-circuitpython-pewpew10-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew10/sv/adafruit-circuitpython-pewpew10-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pewpew10/zh_Latn_pinyin/adafruit-circuitpython-pewpew10-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew10/zh_Latn_pinyin/adafruit-circuitpython-pewpew10-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 16,
+        "downloads": 0,
         "id": "pewpew13",
         "versions": [
             {
@@ -8330,52 +9235,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/ID/adafruit-circuitpython-pewpew13-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew13/ID/adafruit-circuitpython-pewpew13-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/pewpew13/cs/adafruit-circuitpython-pewpew13-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/de_DE/adafruit-circuitpython-pewpew13-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew13/de_DE/adafruit-circuitpython-pewpew13-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/en_US/adafruit-circuitpython-pewpew13-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew13/en_US/adafruit-circuitpython-pewpew13-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/en_x_pirate/adafruit-circuitpython-pewpew13-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew13/en_x_pirate/adafruit-circuitpython-pewpew13-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/es/adafruit-circuitpython-pewpew13-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew13/es/adafruit-circuitpython-pewpew13-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/fil/adafruit-circuitpython-pewpew13-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew13/fil/adafruit-circuitpython-pewpew13-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/fr/adafruit-circuitpython-pewpew13-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew13/fr/adafruit-circuitpython-pewpew13-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/it_IT/adafruit-circuitpython-pewpew13-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew13/it_IT/adafruit-circuitpython-pewpew13-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/ko/adafruit-circuitpython-pewpew13-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew13/ko/adafruit-circuitpython-pewpew13-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/pewpew13/nl/adafruit-circuitpython-pewpew13-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/pl/adafruit-circuitpython-pewpew13-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew13/pl/adafruit-circuitpython-pewpew13-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/pt_BR/adafruit-circuitpython-pewpew13-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew13/pt_BR/adafruit-circuitpython-pewpew13-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/sv/adafruit-circuitpython-pewpew13-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew13/sv/adafruit-circuitpython-pewpew13-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pewpew13/zh_Latn_pinyin/adafruit-circuitpython-pewpew13-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew13/zh_Latn_pinyin/adafruit-circuitpython-pewpew13-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 26,
+        "downloads": 0,
         "id": "pewpew_m4",
         "versions": [
             {
@@ -8423,52 +9334,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/ID/adafruit-circuitpython-pewpew_m4-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/ID/adafruit-circuitpython-pewpew_m4-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/cs/adafruit-circuitpython-pewpew_m4-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/de_DE/adafruit-circuitpython-pewpew_m4-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/de_DE/adafruit-circuitpython-pewpew_m4-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/en_US/adafruit-circuitpython-pewpew_m4-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/en_US/adafruit-circuitpython-pewpew_m4-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/en_x_pirate/adafruit-circuitpython-pewpew_m4-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/en_x_pirate/adafruit-circuitpython-pewpew_m4-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/es/adafruit-circuitpython-pewpew_m4-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/es/adafruit-circuitpython-pewpew_m4-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/fil/adafruit-circuitpython-pewpew_m4-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/fil/adafruit-circuitpython-pewpew_m4-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/fr/adafruit-circuitpython-pewpew_m4-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/fr/adafruit-circuitpython-pewpew_m4-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/it_IT/adafruit-circuitpython-pewpew_m4-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/it_IT/adafruit-circuitpython-pewpew_m4-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/ko/adafruit-circuitpython-pewpew_m4-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/ko/adafruit-circuitpython-pewpew_m4-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/nl/adafruit-circuitpython-pewpew_m4-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/pl/adafruit-circuitpython-pewpew_m4-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/pl/adafruit-circuitpython-pewpew_m4-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/pt_BR/adafruit-circuitpython-pewpew_m4-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/pt_BR/adafruit-circuitpython-pewpew_m4-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/sv/adafruit-circuitpython-pewpew_m4-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/sv/adafruit-circuitpython-pewpew_m4-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pewpew_m4/zh_Latn_pinyin/adafruit-circuitpython-pewpew_m4-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pewpew_m4/zh_Latn_pinyin/adafruit-circuitpython-pewpew_m4-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 27,
+        "downloads": 0,
         "id": "pirkey_m0",
         "versions": [
             {
@@ -8516,47 +9433,53 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/ID/adafruit-circuitpython-pirkey_m0-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/ID/adafruit-circuitpython-pirkey_m0-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/cs/adafruit-circuitpython-pirkey_m0-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/de_DE/adafruit-circuitpython-pirkey_m0-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/de_DE/adafruit-circuitpython-pirkey_m0-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/en_US/adafruit-circuitpython-pirkey_m0-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/en_US/adafruit-circuitpython-pirkey_m0-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/en_x_pirate/adafruit-circuitpython-pirkey_m0-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/en_x_pirate/adafruit-circuitpython-pirkey_m0-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/es/adafruit-circuitpython-pirkey_m0-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/es/adafruit-circuitpython-pirkey_m0-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/fil/adafruit-circuitpython-pirkey_m0-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/fil/adafruit-circuitpython-pirkey_m0-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/fr/adafruit-circuitpython-pirkey_m0-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/fr/adafruit-circuitpython-pirkey_m0-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/it_IT/adafruit-circuitpython-pirkey_m0-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/it_IT/adafruit-circuitpython-pirkey_m0-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/ko/adafruit-circuitpython-pirkey_m0-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/ko/adafruit-circuitpython-pirkey_m0-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/nl/adafruit-circuitpython-pirkey_m0-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/pl/adafruit-circuitpython-pirkey_m0-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/pl/adafruit-circuitpython-pirkey_m0-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/pt_BR/adafruit-circuitpython-pirkey_m0-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/pt_BR/adafruit-circuitpython-pirkey_m0-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/sv/adafruit-circuitpython-pirkey_m0-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/sv/adafruit-circuitpython-pirkey_m0-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pirkey_m0/zh_Latn_pinyin/adafruit-circuitpython-pirkey_m0-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pirkey_m0/zh_Latn_pinyin/adafruit-circuitpython-pirkey_m0-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
@@ -8567,52 +9490,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/pitaya_go/ID/adafruit-circuitpython-pitaya_go-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pitaya_go/ID/adafruit-circuitpython-pitaya_go-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/pitaya_go/cs/adafruit-circuitpython-pitaya_go-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pitaya_go/de_DE/adafruit-circuitpython-pitaya_go-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pitaya_go/de_DE/adafruit-circuitpython-pitaya_go-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/pitaya_go/en_US/adafruit-circuitpython-pitaya_go-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pitaya_go/en_US/adafruit-circuitpython-pitaya_go-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pitaya_go/en_x_pirate/adafruit-circuitpython-pitaya_go-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pitaya_go/en_x_pirate/adafruit-circuitpython-pitaya_go-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/pitaya_go/es/adafruit-circuitpython-pitaya_go-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pitaya_go/es/adafruit-circuitpython-pitaya_go-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/pitaya_go/fil/adafruit-circuitpython-pitaya_go-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pitaya_go/fil/adafruit-circuitpython-pitaya_go-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/pitaya_go/fr/adafruit-circuitpython-pitaya_go-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pitaya_go/fr/adafruit-circuitpython-pitaya_go-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pitaya_go/it_IT/adafruit-circuitpython-pitaya_go-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pitaya_go/it_IT/adafruit-circuitpython-pitaya_go-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/pitaya_go/ko/adafruit-circuitpython-pitaya_go-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pitaya_go/ko/adafruit-circuitpython-pitaya_go-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/pitaya_go/nl/adafruit-circuitpython-pitaya_go-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/pitaya_go/pl/adafruit-circuitpython-pitaya_go-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pitaya_go/pl/adafruit-circuitpython-pitaya_go-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pitaya_go/pt_BR/adafruit-circuitpython-pitaya_go-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pitaya_go/pt_BR/adafruit-circuitpython-pitaya_go-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/pitaya_go/sv/adafruit-circuitpython-pitaya_go-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pitaya_go/sv/adafruit-circuitpython-pitaya_go-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pitaya_go/zh_Latn_pinyin/adafruit-circuitpython-pitaya_go-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pitaya_go/zh_Latn_pinyin/adafruit-circuitpython-pitaya_go-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 3,
+        "downloads": 0,
         "id": "pyb_nano_v2",
         "versions": [
             {
@@ -8660,52 +9589,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/ID/adafruit-circuitpython-pyb_nano_v2-ID-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/ID/adafruit-circuitpython-pyb_nano_v2-ID-5.4.0-beta.1.bin"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/cs/adafruit-circuitpython-pyb_nano_v2-cs-5.4.0-beta.1.bin"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/de_DE/adafruit-circuitpython-pyb_nano_v2-de_DE-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/de_DE/adafruit-circuitpython-pyb_nano_v2-de_DE-5.4.0-beta.1.bin"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/en_US/adafruit-circuitpython-pyb_nano_v2-en_US-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/en_US/adafruit-circuitpython-pyb_nano_v2-en_US-5.4.0-beta.1.bin"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/en_x_pirate/adafruit-circuitpython-pyb_nano_v2-en_x_pirate-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/en_x_pirate/adafruit-circuitpython-pyb_nano_v2-en_x_pirate-5.4.0-beta.1.bin"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/es/adafruit-circuitpython-pyb_nano_v2-es-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/es/adafruit-circuitpython-pyb_nano_v2-es-5.4.0-beta.1.bin"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/fil/adafruit-circuitpython-pyb_nano_v2-fil-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/fil/adafruit-circuitpython-pyb_nano_v2-fil-5.4.0-beta.1.bin"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/fr/adafruit-circuitpython-pyb_nano_v2-fr-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/fr/adafruit-circuitpython-pyb_nano_v2-fr-5.4.0-beta.1.bin"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/it_IT/adafruit-circuitpython-pyb_nano_v2-it_IT-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/it_IT/adafruit-circuitpython-pyb_nano_v2-it_IT-5.4.0-beta.1.bin"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/ko/adafruit-circuitpython-pyb_nano_v2-ko-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/ko/adafruit-circuitpython-pyb_nano_v2-ko-5.4.0-beta.1.bin"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/nl/adafruit-circuitpython-pyb_nano_v2-nl-5.4.0-beta.1.bin"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/pl/adafruit-circuitpython-pyb_nano_v2-pl-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/pl/adafruit-circuitpython-pyb_nano_v2-pl-5.4.0-beta.1.bin"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/pt_BR/adafruit-circuitpython-pyb_nano_v2-pt_BR-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/pt_BR/adafruit-circuitpython-pyb_nano_v2-pt_BR-5.4.0-beta.1.bin"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/sv/adafruit-circuitpython-pyb_nano_v2-sv-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/sv/adafruit-circuitpython-pyb_nano_v2-sv-5.4.0-beta.1.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/zh_Latn_pinyin/adafruit-circuitpython-pyb_nano_v2-zh_Latn_pinyin-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/pyb_nano_v2/zh_Latn_pinyin/adafruit-circuitpython-pyb_nano_v2-zh_Latn_pinyin-5.4.0-beta.1.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 52,
+        "downloads": 0,
         "id": "pybadge",
         "versions": [
             {
@@ -8753,52 +9688,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/pybadge/ID/adafruit-circuitpython-pybadge-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pybadge/ID/adafruit-circuitpython-pybadge-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/pybadge/cs/adafruit-circuitpython-pybadge-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pybadge/de_DE/adafruit-circuitpython-pybadge-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pybadge/de_DE/adafruit-circuitpython-pybadge-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/pybadge/en_US/adafruit-circuitpython-pybadge-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pybadge/en_US/adafruit-circuitpython-pybadge-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pybadge/en_x_pirate/adafruit-circuitpython-pybadge-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pybadge/en_x_pirate/adafruit-circuitpython-pybadge-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/pybadge/es/adafruit-circuitpython-pybadge-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pybadge/es/adafruit-circuitpython-pybadge-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/pybadge/fil/adafruit-circuitpython-pybadge-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pybadge/fil/adafruit-circuitpython-pybadge-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/pybadge/fr/adafruit-circuitpython-pybadge-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pybadge/fr/adafruit-circuitpython-pybadge-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pybadge/it_IT/adafruit-circuitpython-pybadge-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pybadge/it_IT/adafruit-circuitpython-pybadge-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/pybadge/ko/adafruit-circuitpython-pybadge-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pybadge/ko/adafruit-circuitpython-pybadge-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/pybadge/nl/adafruit-circuitpython-pybadge-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/pybadge/pl/adafruit-circuitpython-pybadge-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pybadge/pl/adafruit-circuitpython-pybadge-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pybadge/pt_BR/adafruit-circuitpython-pybadge-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pybadge/pt_BR/adafruit-circuitpython-pybadge-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/pybadge/sv/adafruit-circuitpython-pybadge-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pybadge/sv/adafruit-circuitpython-pybadge-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pybadge/zh_Latn_pinyin/adafruit-circuitpython-pybadge-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pybadge/zh_Latn_pinyin/adafruit-circuitpython-pybadge-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 16,
+        "downloads": 0,
         "id": "pybadge_airlift",
         "versions": [
             {
@@ -8846,52 +9787,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/ID/adafruit-circuitpython-pybadge_airlift-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/ID/adafruit-circuitpython-pybadge_airlift-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/cs/adafruit-circuitpython-pybadge_airlift-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/de_DE/adafruit-circuitpython-pybadge_airlift-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/de_DE/adafruit-circuitpython-pybadge_airlift-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/en_US/adafruit-circuitpython-pybadge_airlift-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/en_US/adafruit-circuitpython-pybadge_airlift-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/en_x_pirate/adafruit-circuitpython-pybadge_airlift-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/en_x_pirate/adafruit-circuitpython-pybadge_airlift-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/es/adafruit-circuitpython-pybadge_airlift-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/es/adafruit-circuitpython-pybadge_airlift-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/fil/adafruit-circuitpython-pybadge_airlift-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/fil/adafruit-circuitpython-pybadge_airlift-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/fr/adafruit-circuitpython-pybadge_airlift-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/fr/adafruit-circuitpython-pybadge_airlift-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/it_IT/adafruit-circuitpython-pybadge_airlift-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/it_IT/adafruit-circuitpython-pybadge_airlift-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/ko/adafruit-circuitpython-pybadge_airlift-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/ko/adafruit-circuitpython-pybadge_airlift-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/nl/adafruit-circuitpython-pybadge_airlift-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/pl/adafruit-circuitpython-pybadge_airlift-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/pl/adafruit-circuitpython-pybadge_airlift-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/pt_BR/adafruit-circuitpython-pybadge_airlift-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/pt_BR/adafruit-circuitpython-pybadge_airlift-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/sv/adafruit-circuitpython-pybadge_airlift-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/sv/adafruit-circuitpython-pybadge_airlift-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pybadge_airlift/zh_Latn_pinyin/adafruit-circuitpython-pybadge_airlift-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pybadge_airlift/zh_Latn_pinyin/adafruit-circuitpython-pybadge_airlift-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 34,
+        "downloads": 0,
         "id": "pyboard_v11",
         "versions": [
             {
@@ -8939,52 +9886,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/ID/adafruit-circuitpython-pyboard_v11-ID-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/ID/adafruit-circuitpython-pyboard_v11-ID-5.4.0-beta.1.bin"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/cs/adafruit-circuitpython-pyboard_v11-cs-5.4.0-beta.1.bin"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/de_DE/adafruit-circuitpython-pyboard_v11-de_DE-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/de_DE/adafruit-circuitpython-pyboard_v11-de_DE-5.4.0-beta.1.bin"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/en_US/adafruit-circuitpython-pyboard_v11-en_US-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/en_US/adafruit-circuitpython-pyboard_v11-en_US-5.4.0-beta.1.bin"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/en_x_pirate/adafruit-circuitpython-pyboard_v11-en_x_pirate-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/en_x_pirate/adafruit-circuitpython-pyboard_v11-en_x_pirate-5.4.0-beta.1.bin"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/es/adafruit-circuitpython-pyboard_v11-es-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/es/adafruit-circuitpython-pyboard_v11-es-5.4.0-beta.1.bin"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/fil/adafruit-circuitpython-pyboard_v11-fil-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/fil/adafruit-circuitpython-pyboard_v11-fil-5.4.0-beta.1.bin"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/fr/adafruit-circuitpython-pyboard_v11-fr-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/fr/adafruit-circuitpython-pyboard_v11-fr-5.4.0-beta.1.bin"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/it_IT/adafruit-circuitpython-pyboard_v11-it_IT-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/it_IT/adafruit-circuitpython-pyboard_v11-it_IT-5.4.0-beta.1.bin"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/ko/adafruit-circuitpython-pyboard_v11-ko-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/ko/adafruit-circuitpython-pyboard_v11-ko-5.4.0-beta.1.bin"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/nl/adafruit-circuitpython-pyboard_v11-nl-5.4.0-beta.1.bin"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/pl/adafruit-circuitpython-pyboard_v11-pl-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/pl/adafruit-circuitpython-pyboard_v11-pl-5.4.0-beta.1.bin"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/pt_BR/adafruit-circuitpython-pyboard_v11-pt_BR-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/pt_BR/adafruit-circuitpython-pyboard_v11-pt_BR-5.4.0-beta.1.bin"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/sv/adafruit-circuitpython-pyboard_v11-sv-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/sv/adafruit-circuitpython-pyboard_v11-sv-5.4.0-beta.1.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pyboard_v11/zh_Latn_pinyin/adafruit-circuitpython-pyboard_v11-zh_Latn_pinyin-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/pyboard_v11/zh_Latn_pinyin/adafruit-circuitpython-pyboard_v11-zh_Latn_pinyin-5.4.0-beta.1.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 35,
+        "downloads": 0,
         "id": "pycubed",
         "versions": [
             {
@@ -9032,52 +9985,115 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/pycubed/ID/adafruit-circuitpython-pycubed-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pycubed/ID/adafruit-circuitpython-pycubed-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/pycubed/cs/adafruit-circuitpython-pycubed-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pycubed/de_DE/adafruit-circuitpython-pycubed-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pycubed/de_DE/adafruit-circuitpython-pycubed-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/pycubed/en_US/adafruit-circuitpython-pycubed-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pycubed/en_US/adafruit-circuitpython-pycubed-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pycubed/en_x_pirate/adafruit-circuitpython-pycubed-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pycubed/en_x_pirate/adafruit-circuitpython-pycubed-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/pycubed/es/adafruit-circuitpython-pycubed-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pycubed/es/adafruit-circuitpython-pycubed-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/pycubed/fil/adafruit-circuitpython-pycubed-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pycubed/fil/adafruit-circuitpython-pycubed-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/pycubed/fr/adafruit-circuitpython-pycubed-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pycubed/fr/adafruit-circuitpython-pycubed-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pycubed/it_IT/adafruit-circuitpython-pycubed-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pycubed/it_IT/adafruit-circuitpython-pycubed-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/pycubed/ko/adafruit-circuitpython-pycubed-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pycubed/ko/adafruit-circuitpython-pycubed-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/pycubed/nl/adafruit-circuitpython-pycubed-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/pycubed/pl/adafruit-circuitpython-pycubed-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pycubed/pl/adafruit-circuitpython-pycubed-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pycubed/pt_BR/adafruit-circuitpython-pycubed-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pycubed/pt_BR/adafruit-circuitpython-pycubed-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/pycubed/sv/adafruit-circuitpython-pycubed-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pycubed/sv/adafruit-circuitpython-pycubed-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pycubed/zh_Latn_pinyin/adafruit-circuitpython-pycubed-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pycubed/zh_Latn_pinyin/adafruit-circuitpython-pycubed-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 67,
+        "downloads": 0,
+        "id": "pycubed_mram",
+        "versions": [
+            {
+                "files": {
+                    "ID": [
+                        "https://downloads.circuitpython.org/bin/pycubed_mram/ID/adafruit-circuitpython-pycubed_mram-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/pycubed_mram/cs/adafruit-circuitpython-pycubed_mram-cs-5.4.0-beta.1.uf2"
+                    ],
+                    "de_DE": [
+                        "https://downloads.circuitpython.org/bin/pycubed_mram/de_DE/adafruit-circuitpython-pycubed_mram-de_DE-5.4.0-beta.1.uf2"
+                    ],
+                    "en_US": [
+                        "https://downloads.circuitpython.org/bin/pycubed_mram/en_US/adafruit-circuitpython-pycubed_mram-en_US-5.4.0-beta.1.uf2"
+                    ],
+                    "en_x_pirate": [
+                        "https://downloads.circuitpython.org/bin/pycubed_mram/en_x_pirate/adafruit-circuitpython-pycubed_mram-en_x_pirate-5.4.0-beta.1.uf2"
+                    ],
+                    "es": [
+                        "https://downloads.circuitpython.org/bin/pycubed_mram/es/adafruit-circuitpython-pycubed_mram-es-5.4.0-beta.1.uf2"
+                    ],
+                    "fil": [
+                        "https://downloads.circuitpython.org/bin/pycubed_mram/fil/adafruit-circuitpython-pycubed_mram-fil-5.4.0-beta.1.uf2"
+                    ],
+                    "fr": [
+                        "https://downloads.circuitpython.org/bin/pycubed_mram/fr/adafruit-circuitpython-pycubed_mram-fr-5.4.0-beta.1.uf2"
+                    ],
+                    "it_IT": [
+                        "https://downloads.circuitpython.org/bin/pycubed_mram/it_IT/adafruit-circuitpython-pycubed_mram-it_IT-5.4.0-beta.1.uf2"
+                    ],
+                    "ko": [
+                        "https://downloads.circuitpython.org/bin/pycubed_mram/ko/adafruit-circuitpython-pycubed_mram-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/pycubed_mram/nl/adafruit-circuitpython-pycubed_mram-nl-5.4.0-beta.1.uf2"
+                    ],
+                    "pl": [
+                        "https://downloads.circuitpython.org/bin/pycubed_mram/pl/adafruit-circuitpython-pycubed_mram-pl-5.4.0-beta.1.uf2"
+                    ],
+                    "pt_BR": [
+                        "https://downloads.circuitpython.org/bin/pycubed_mram/pt_BR/adafruit-circuitpython-pycubed_mram-pt_BR-5.4.0-beta.1.uf2"
+                    ],
+                    "sv": [
+                        "https://downloads.circuitpython.org/bin/pycubed_mram/sv/adafruit-circuitpython-pycubed_mram-sv-5.4.0-beta.1.uf2"
+                    ],
+                    "zh_Latn_pinyin": [
+                        "https://downloads.circuitpython.org/bin/pycubed_mram/zh_Latn_pinyin/adafruit-circuitpython-pycubed_mram-zh_Latn_pinyin-5.4.0-beta.1.uf2"
+                    ]
+                },
+                "stable": false,
+                "version": "5.4.0-beta.1"
+            }
+        ]
+    },
+    {
+        "downloads": 0,
         "id": "pygamer",
         "versions": [
             {
@@ -9125,52 +10141,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/pygamer/ID/adafruit-circuitpython-pygamer-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pygamer/ID/adafruit-circuitpython-pygamer-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/pygamer/cs/adafruit-circuitpython-pygamer-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pygamer/de_DE/adafruit-circuitpython-pygamer-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pygamer/de_DE/adafruit-circuitpython-pygamer-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/pygamer/en_US/adafruit-circuitpython-pygamer-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pygamer/en_US/adafruit-circuitpython-pygamer-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pygamer/en_x_pirate/adafruit-circuitpython-pygamer-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pygamer/en_x_pirate/adafruit-circuitpython-pygamer-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/pygamer/es/adafruit-circuitpython-pygamer-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pygamer/es/adafruit-circuitpython-pygamer-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/pygamer/fil/adafruit-circuitpython-pygamer-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pygamer/fil/adafruit-circuitpython-pygamer-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/pygamer/fr/adafruit-circuitpython-pygamer-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pygamer/fr/adafruit-circuitpython-pygamer-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pygamer/it_IT/adafruit-circuitpython-pygamer-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pygamer/it_IT/adafruit-circuitpython-pygamer-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/pygamer/ko/adafruit-circuitpython-pygamer-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pygamer/ko/adafruit-circuitpython-pygamer-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/pygamer/nl/adafruit-circuitpython-pygamer-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/pygamer/pl/adafruit-circuitpython-pygamer-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pygamer/pl/adafruit-circuitpython-pygamer-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pygamer/pt_BR/adafruit-circuitpython-pygamer-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pygamer/pt_BR/adafruit-circuitpython-pygamer-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/pygamer/sv/adafruit-circuitpython-pygamer-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pygamer/sv/adafruit-circuitpython-pygamer-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pygamer/zh_Latn_pinyin/adafruit-circuitpython-pygamer-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pygamer/zh_Latn_pinyin/adafruit-circuitpython-pygamer-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 28,
+        "downloads": 0,
         "id": "pygamer_advance",
         "versions": [
             {
@@ -9218,52 +10240,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/ID/adafruit-circuitpython-pygamer_advance-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/ID/adafruit-circuitpython-pygamer_advance-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/cs/adafruit-circuitpython-pygamer_advance-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/de_DE/adafruit-circuitpython-pygamer_advance-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/de_DE/adafruit-circuitpython-pygamer_advance-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/en_US/adafruit-circuitpython-pygamer_advance-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/en_US/adafruit-circuitpython-pygamer_advance-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/en_x_pirate/adafruit-circuitpython-pygamer_advance-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/en_x_pirate/adafruit-circuitpython-pygamer_advance-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/es/adafruit-circuitpython-pygamer_advance-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/es/adafruit-circuitpython-pygamer_advance-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/fil/adafruit-circuitpython-pygamer_advance-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/fil/adafruit-circuitpython-pygamer_advance-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/fr/adafruit-circuitpython-pygamer_advance-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/fr/adafruit-circuitpython-pygamer_advance-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/it_IT/adafruit-circuitpython-pygamer_advance-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/it_IT/adafruit-circuitpython-pygamer_advance-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/ko/adafruit-circuitpython-pygamer_advance-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/ko/adafruit-circuitpython-pygamer_advance-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/nl/adafruit-circuitpython-pygamer_advance-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/pl/adafruit-circuitpython-pygamer_advance-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/pl/adafruit-circuitpython-pygamer_advance-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/pt_BR/adafruit-circuitpython-pygamer_advance-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/pt_BR/adafruit-circuitpython-pygamer_advance-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/sv/adafruit-circuitpython-pygamer_advance-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/sv/adafruit-circuitpython-pygamer_advance-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pygamer_advance/zh_Latn_pinyin/adafruit-circuitpython-pygamer_advance-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pygamer_advance/zh_Latn_pinyin/adafruit-circuitpython-pygamer_advance-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 183,
+        "downloads": 0,
         "id": "pyportal",
         "versions": [
             {
@@ -9311,52 +10339,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/pyportal/ID/adafruit-circuitpython-pyportal-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal/ID/adafruit-circuitpython-pyportal-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/pyportal/cs/adafruit-circuitpython-pyportal-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pyportal/de_DE/adafruit-circuitpython-pyportal-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal/de_DE/adafruit-circuitpython-pyportal-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/pyportal/en_US/adafruit-circuitpython-pyportal-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal/en_US/adafruit-circuitpython-pyportal-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pyportal/en_x_pirate/adafruit-circuitpython-pyportal-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal/en_x_pirate/adafruit-circuitpython-pyportal-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/pyportal/es/adafruit-circuitpython-pyportal-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal/es/adafruit-circuitpython-pyportal-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/pyportal/fil/adafruit-circuitpython-pyportal-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal/fil/adafruit-circuitpython-pyportal-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/pyportal/fr/adafruit-circuitpython-pyportal-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal/fr/adafruit-circuitpython-pyportal-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pyportal/it_IT/adafruit-circuitpython-pyportal-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal/it_IT/adafruit-circuitpython-pyportal-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/pyportal/ko/adafruit-circuitpython-pyportal-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal/ko/adafruit-circuitpython-pyportal-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/pyportal/nl/adafruit-circuitpython-pyportal-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/pyportal/pl/adafruit-circuitpython-pyportal-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal/pl/adafruit-circuitpython-pyportal-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pyportal/pt_BR/adafruit-circuitpython-pyportal-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal/pt_BR/adafruit-circuitpython-pyportal-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/pyportal/sv/adafruit-circuitpython-pyportal-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal/sv/adafruit-circuitpython-pyportal-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pyportal/zh_Latn_pinyin/adafruit-circuitpython-pyportal-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal/zh_Latn_pinyin/adafruit-circuitpython-pyportal-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 14,
+        "downloads": 0,
         "id": "pyportal_pynt",
         "versions": [
             {
@@ -9404,52 +10438,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/ID/adafruit-circuitpython-pyportal_pynt-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/ID/adafruit-circuitpython-pyportal_pynt-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/cs/adafruit-circuitpython-pyportal_pynt-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/de_DE/adafruit-circuitpython-pyportal_pynt-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/de_DE/adafruit-circuitpython-pyportal_pynt-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/en_US/adafruit-circuitpython-pyportal_pynt-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/en_US/adafruit-circuitpython-pyportal_pynt-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/en_x_pirate/adafruit-circuitpython-pyportal_pynt-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/en_x_pirate/adafruit-circuitpython-pyportal_pynt-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/es/adafruit-circuitpython-pyportal_pynt-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/es/adafruit-circuitpython-pyportal_pynt-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/fil/adafruit-circuitpython-pyportal_pynt-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/fil/adafruit-circuitpython-pyportal_pynt-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/fr/adafruit-circuitpython-pyportal_pynt-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/fr/adafruit-circuitpython-pyportal_pynt-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/it_IT/adafruit-circuitpython-pyportal_pynt-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/it_IT/adafruit-circuitpython-pyportal_pynt-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/ko/adafruit-circuitpython-pyportal_pynt-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/ko/adafruit-circuitpython-pyportal_pynt-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/nl/adafruit-circuitpython-pyportal_pynt-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/pl/adafruit-circuitpython-pyportal_pynt-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/pl/adafruit-circuitpython-pyportal_pynt-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/pt_BR/adafruit-circuitpython-pyportal_pynt-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/pt_BR/adafruit-circuitpython-pyportal_pynt-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/sv/adafruit-circuitpython-pyportal_pynt-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/sv/adafruit-circuitpython-pyportal_pynt-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pyportal_pynt/zh_Latn_pinyin/adafruit-circuitpython-pyportal_pynt-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal_pynt/zh_Latn_pinyin/adafruit-circuitpython-pyportal_pynt-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 41,
+        "downloads": 0,
         "id": "pyportal_titano",
         "versions": [
             {
@@ -9497,52 +10537,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/ID/adafruit-circuitpython-pyportal_titano-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/ID/adafruit-circuitpython-pyportal_titano-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/cs/adafruit-circuitpython-pyportal_titano-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/de_DE/adafruit-circuitpython-pyportal_titano-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/de_DE/adafruit-circuitpython-pyportal_titano-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/en_US/adafruit-circuitpython-pyportal_titano-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/en_US/adafruit-circuitpython-pyportal_titano-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/en_x_pirate/adafruit-circuitpython-pyportal_titano-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/en_x_pirate/adafruit-circuitpython-pyportal_titano-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/es/adafruit-circuitpython-pyportal_titano-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/es/adafruit-circuitpython-pyportal_titano-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/fil/adafruit-circuitpython-pyportal_titano-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/fil/adafruit-circuitpython-pyportal_titano-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/fr/adafruit-circuitpython-pyportal_titano-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/fr/adafruit-circuitpython-pyportal_titano-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/it_IT/adafruit-circuitpython-pyportal_titano-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/it_IT/adafruit-circuitpython-pyportal_titano-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/ko/adafruit-circuitpython-pyportal_titano-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/ko/adafruit-circuitpython-pyportal_titano-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/nl/adafruit-circuitpython-pyportal_titano-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/pl/adafruit-circuitpython-pyportal_titano-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/pl/adafruit-circuitpython-pyportal_titano-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/pt_BR/adafruit-circuitpython-pyportal_titano-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/pt_BR/adafruit-circuitpython-pyportal_titano-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/sv/adafruit-circuitpython-pyportal_titano-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/sv/adafruit-circuitpython-pyportal_titano-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pyportal_titano/zh_Latn_pinyin/adafruit-circuitpython-pyportal_titano-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyportal_titano/zh_Latn_pinyin/adafruit-circuitpython-pyportal_titano-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 41,
+        "downloads": 0,
         "id": "pyruler",
         "versions": [
             {
@@ -9590,52 +10636,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/pyruler/ID/adafruit-circuitpython-pyruler-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyruler/ID/adafruit-circuitpython-pyruler-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/pyruler/cs/adafruit-circuitpython-pyruler-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/pyruler/de_DE/adafruit-circuitpython-pyruler-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyruler/de_DE/adafruit-circuitpython-pyruler-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/pyruler/en_US/adafruit-circuitpython-pyruler-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyruler/en_US/adafruit-circuitpython-pyruler-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/pyruler/en_x_pirate/adafruit-circuitpython-pyruler-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyruler/en_x_pirate/adafruit-circuitpython-pyruler-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/pyruler/es/adafruit-circuitpython-pyruler-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyruler/es/adafruit-circuitpython-pyruler-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/pyruler/fil/adafruit-circuitpython-pyruler-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyruler/fil/adafruit-circuitpython-pyruler-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/pyruler/fr/adafruit-circuitpython-pyruler-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyruler/fr/adafruit-circuitpython-pyruler-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/pyruler/it_IT/adafruit-circuitpython-pyruler-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyruler/it_IT/adafruit-circuitpython-pyruler-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/pyruler/ko/adafruit-circuitpython-pyruler-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyruler/ko/adafruit-circuitpython-pyruler-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/pyruler/nl/adafruit-circuitpython-pyruler-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/pyruler/pl/adafruit-circuitpython-pyruler-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyruler/pl/adafruit-circuitpython-pyruler-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/pyruler/pt_BR/adafruit-circuitpython-pyruler-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyruler/pt_BR/adafruit-circuitpython-pyruler-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/pyruler/sv/adafruit-circuitpython-pyruler-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyruler/sv/adafruit-circuitpython-pyruler-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/pyruler/zh_Latn_pinyin/adafruit-circuitpython-pyruler-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/pyruler/zh_Latn_pinyin/adafruit-circuitpython-pyruler-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 34,
+        "downloads": 0,
         "id": "robohatmm1_m4",
         "versions": [
             {
@@ -9683,52 +10735,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/ID/adafruit-circuitpython-robohatmm1_m4-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/ID/adafruit-circuitpython-robohatmm1_m4-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/cs/adafruit-circuitpython-robohatmm1_m4-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/de_DE/adafruit-circuitpython-robohatmm1_m4-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/de_DE/adafruit-circuitpython-robohatmm1_m4-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/en_US/adafruit-circuitpython-robohatmm1_m4-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/en_US/adafruit-circuitpython-robohatmm1_m4-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/en_x_pirate/adafruit-circuitpython-robohatmm1_m4-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/en_x_pirate/adafruit-circuitpython-robohatmm1_m4-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/es/adafruit-circuitpython-robohatmm1_m4-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/es/adafruit-circuitpython-robohatmm1_m4-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/fil/adafruit-circuitpython-robohatmm1_m4-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/fil/adafruit-circuitpython-robohatmm1_m4-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/fr/adafruit-circuitpython-robohatmm1_m4-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/fr/adafruit-circuitpython-robohatmm1_m4-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/it_IT/adafruit-circuitpython-robohatmm1_m4-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/it_IT/adafruit-circuitpython-robohatmm1_m4-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/ko/adafruit-circuitpython-robohatmm1_m4-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/ko/adafruit-circuitpython-robohatmm1_m4-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/nl/adafruit-circuitpython-robohatmm1_m4-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/pl/adafruit-circuitpython-robohatmm1_m4-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/pl/adafruit-circuitpython-robohatmm1_m4-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/pt_BR/adafruit-circuitpython-robohatmm1_m4-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/pt_BR/adafruit-circuitpython-robohatmm1_m4-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/sv/adafruit-circuitpython-robohatmm1_m4-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/sv/adafruit-circuitpython-robohatmm1_m4-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/zh_Latn_pinyin/adafruit-circuitpython-robohatmm1_m4-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/robohatmm1_m4/zh_Latn_pinyin/adafruit-circuitpython-robohatmm1_m4-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 28,
+        "downloads": 0,
         "id": "sam32",
         "versions": [
             {
@@ -9776,52 +10834,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/sam32/ID/adafruit-circuitpython-sam32-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sam32/ID/adafruit-circuitpython-sam32-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/sam32/cs/adafruit-circuitpython-sam32-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/sam32/de_DE/adafruit-circuitpython-sam32-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sam32/de_DE/adafruit-circuitpython-sam32-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/sam32/en_US/adafruit-circuitpython-sam32-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sam32/en_US/adafruit-circuitpython-sam32-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/sam32/en_x_pirate/adafruit-circuitpython-sam32-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sam32/en_x_pirate/adafruit-circuitpython-sam32-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/sam32/es/adafruit-circuitpython-sam32-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sam32/es/adafruit-circuitpython-sam32-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/sam32/fil/adafruit-circuitpython-sam32-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sam32/fil/adafruit-circuitpython-sam32-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/sam32/fr/adafruit-circuitpython-sam32-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sam32/fr/adafruit-circuitpython-sam32-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/sam32/it_IT/adafruit-circuitpython-sam32-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sam32/it_IT/adafruit-circuitpython-sam32-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/sam32/ko/adafruit-circuitpython-sam32-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sam32/ko/adafruit-circuitpython-sam32-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/sam32/nl/adafruit-circuitpython-sam32-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/sam32/pl/adafruit-circuitpython-sam32-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sam32/pl/adafruit-circuitpython-sam32-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/sam32/pt_BR/adafruit-circuitpython-sam32-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sam32/pt_BR/adafruit-circuitpython-sam32-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/sam32/sv/adafruit-circuitpython-sam32-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sam32/sv/adafruit-circuitpython-sam32-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/sam32/zh_Latn_pinyin/adafruit-circuitpython-sam32-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sam32/zh_Latn_pinyin/adafruit-circuitpython-sam32-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 49,
+        "downloads": 0,
         "id": "seeeduino_xiao",
         "versions": [
             {
@@ -9869,52 +10933,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/ID/adafruit-circuitpython-seeeduino_xiao-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/ID/adafruit-circuitpython-seeeduino_xiao-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/cs/adafruit-circuitpython-seeeduino_xiao-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/de_DE/adafruit-circuitpython-seeeduino_xiao-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/de_DE/adafruit-circuitpython-seeeduino_xiao-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/en_US/adafruit-circuitpython-seeeduino_xiao-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/en_US/adafruit-circuitpython-seeeduino_xiao-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/en_x_pirate/adafruit-circuitpython-seeeduino_xiao-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/en_x_pirate/adafruit-circuitpython-seeeduino_xiao-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/es/adafruit-circuitpython-seeeduino_xiao-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/es/adafruit-circuitpython-seeeduino_xiao-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/fil/adafruit-circuitpython-seeeduino_xiao-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/fil/adafruit-circuitpython-seeeduino_xiao-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/fr/adafruit-circuitpython-seeeduino_xiao-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/fr/adafruit-circuitpython-seeeduino_xiao-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/it_IT/adafruit-circuitpython-seeeduino_xiao-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/it_IT/adafruit-circuitpython-seeeduino_xiao-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/ko/adafruit-circuitpython-seeeduino_xiao-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/ko/adafruit-circuitpython-seeeduino_xiao-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/nl/adafruit-circuitpython-seeeduino_xiao-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/pl/adafruit-circuitpython-seeeduino_xiao-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/pl/adafruit-circuitpython-seeeduino_xiao-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/pt_BR/adafruit-circuitpython-seeeduino_xiao-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/pt_BR/adafruit-circuitpython-seeeduino_xiao-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/sv/adafruit-circuitpython-seeeduino_xiao-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/sv/adafruit-circuitpython-seeeduino_xiao-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/zh_Latn_pinyin/adafruit-circuitpython-seeeduino_xiao-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/seeeduino_xiao/zh_Latn_pinyin/adafruit-circuitpython-seeeduino_xiao-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 55,
+        "downloads": 0,
         "id": "serpente",
         "versions": [
             {
@@ -9962,52 +11032,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/serpente/ID/adafruit-circuitpython-serpente-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/serpente/ID/adafruit-circuitpython-serpente-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/serpente/cs/adafruit-circuitpython-serpente-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/serpente/de_DE/adafruit-circuitpython-serpente-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/serpente/de_DE/adafruit-circuitpython-serpente-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/serpente/en_US/adafruit-circuitpython-serpente-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/serpente/en_US/adafruit-circuitpython-serpente-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/serpente/en_x_pirate/adafruit-circuitpython-serpente-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/serpente/en_x_pirate/adafruit-circuitpython-serpente-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/serpente/es/adafruit-circuitpython-serpente-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/serpente/es/adafruit-circuitpython-serpente-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/serpente/fil/adafruit-circuitpython-serpente-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/serpente/fil/adafruit-circuitpython-serpente-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/serpente/fr/adafruit-circuitpython-serpente-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/serpente/fr/adafruit-circuitpython-serpente-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/serpente/it_IT/adafruit-circuitpython-serpente-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/serpente/it_IT/adafruit-circuitpython-serpente-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/serpente/ko/adafruit-circuitpython-serpente-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/serpente/ko/adafruit-circuitpython-serpente-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/serpente/nl/adafruit-circuitpython-serpente-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/serpente/pl/adafruit-circuitpython-serpente-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/serpente/pl/adafruit-circuitpython-serpente-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/serpente/pt_BR/adafruit-circuitpython-serpente-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/serpente/pt_BR/adafruit-circuitpython-serpente-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/serpente/sv/adafruit-circuitpython-serpente-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/serpente/sv/adafruit-circuitpython-serpente-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/serpente/zh_Latn_pinyin/adafruit-circuitpython-serpente-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/serpente/zh_Latn_pinyin/adafruit-circuitpython-serpente-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 4,
+        "downloads": 0,
         "id": "shirtty",
         "versions": [
             {
@@ -10055,47 +11131,53 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/shirtty/ID/adafruit-circuitpython-shirtty-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/shirtty/ID/adafruit-circuitpython-shirtty-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/shirtty/cs/adafruit-circuitpython-shirtty-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/shirtty/de_DE/adafruit-circuitpython-shirtty-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/shirtty/de_DE/adafruit-circuitpython-shirtty-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/shirtty/en_US/adafruit-circuitpython-shirtty-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/shirtty/en_US/adafruit-circuitpython-shirtty-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/shirtty/en_x_pirate/adafruit-circuitpython-shirtty-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/shirtty/en_x_pirate/adafruit-circuitpython-shirtty-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/shirtty/es/adafruit-circuitpython-shirtty-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/shirtty/es/adafruit-circuitpython-shirtty-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/shirtty/fil/adafruit-circuitpython-shirtty-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/shirtty/fil/adafruit-circuitpython-shirtty-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/shirtty/fr/adafruit-circuitpython-shirtty-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/shirtty/fr/adafruit-circuitpython-shirtty-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/shirtty/it_IT/adafruit-circuitpython-shirtty-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/shirtty/it_IT/adafruit-circuitpython-shirtty-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/shirtty/ko/adafruit-circuitpython-shirtty-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/shirtty/ko/adafruit-circuitpython-shirtty-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/shirtty/nl/adafruit-circuitpython-shirtty-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/shirtty/pl/adafruit-circuitpython-shirtty-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/shirtty/pl/adafruit-circuitpython-shirtty-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/shirtty/pt_BR/adafruit-circuitpython-shirtty-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/shirtty/pt_BR/adafruit-circuitpython-shirtty-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/shirtty/sv/adafruit-circuitpython-shirtty-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/shirtty/sv/adafruit-circuitpython-shirtty-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/shirtty/zh_Latn_pinyin/adafruit-circuitpython-shirtty-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/shirtty/zh_Latn_pinyin/adafruit-circuitpython-shirtty-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
@@ -10106,52 +11188,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/simmel/ID/adafruit-circuitpython-simmel-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/simmel/ID/adafruit-circuitpython-simmel-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/simmel/cs/adafruit-circuitpython-simmel-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/simmel/de_DE/adafruit-circuitpython-simmel-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/simmel/de_DE/adafruit-circuitpython-simmel-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/simmel/en_US/adafruit-circuitpython-simmel-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/simmel/en_US/adafruit-circuitpython-simmel-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/simmel/en_x_pirate/adafruit-circuitpython-simmel-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/simmel/en_x_pirate/adafruit-circuitpython-simmel-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/simmel/es/adafruit-circuitpython-simmel-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/simmel/es/adafruit-circuitpython-simmel-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/simmel/fil/adafruit-circuitpython-simmel-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/simmel/fil/adafruit-circuitpython-simmel-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/simmel/fr/adafruit-circuitpython-simmel-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/simmel/fr/adafruit-circuitpython-simmel-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/simmel/it_IT/adafruit-circuitpython-simmel-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/simmel/it_IT/adafruit-circuitpython-simmel-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/simmel/ko/adafruit-circuitpython-simmel-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/simmel/ko/adafruit-circuitpython-simmel-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/simmel/nl/adafruit-circuitpython-simmel-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/simmel/pl/adafruit-circuitpython-simmel-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/simmel/pl/adafruit-circuitpython-simmel-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/simmel/pt_BR/adafruit-circuitpython-simmel-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/simmel/pt_BR/adafruit-circuitpython-simmel-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/simmel/sv/adafruit-circuitpython-simmel-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/simmel/sv/adafruit-circuitpython-simmel-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/simmel/zh_Latn_pinyin/adafruit-circuitpython-simmel-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/simmel/zh_Latn_pinyin/adafruit-circuitpython-simmel-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 29,
+        "downloads": 0,
         "id": "snekboard",
         "versions": [
             {
@@ -10199,52 +11287,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/snekboard/ID/adafruit-circuitpython-snekboard-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/snekboard/ID/adafruit-circuitpython-snekboard-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/snekboard/cs/adafruit-circuitpython-snekboard-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/snekboard/de_DE/adafruit-circuitpython-snekboard-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/snekboard/de_DE/adafruit-circuitpython-snekboard-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/snekboard/en_US/adafruit-circuitpython-snekboard-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/snekboard/en_US/adafruit-circuitpython-snekboard-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/snekboard/en_x_pirate/adafruit-circuitpython-snekboard-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/snekboard/en_x_pirate/adafruit-circuitpython-snekboard-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/snekboard/es/adafruit-circuitpython-snekboard-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/snekboard/es/adafruit-circuitpython-snekboard-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/snekboard/fil/adafruit-circuitpython-snekboard-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/snekboard/fil/adafruit-circuitpython-snekboard-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/snekboard/fr/adafruit-circuitpython-snekboard-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/snekboard/fr/adafruit-circuitpython-snekboard-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/snekboard/it_IT/adafruit-circuitpython-snekboard-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/snekboard/it_IT/adafruit-circuitpython-snekboard-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/snekboard/ko/adafruit-circuitpython-snekboard-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/snekboard/ko/adafruit-circuitpython-snekboard-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/snekboard/nl/adafruit-circuitpython-snekboard-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/snekboard/pl/adafruit-circuitpython-snekboard-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/snekboard/pl/adafruit-circuitpython-snekboard-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/snekboard/pt_BR/adafruit-circuitpython-snekboard-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/snekboard/pt_BR/adafruit-circuitpython-snekboard-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/snekboard/sv/adafruit-circuitpython-snekboard-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/snekboard/sv/adafruit-circuitpython-snekboard-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/snekboard/zh_Latn_pinyin/adafruit-circuitpython-snekboard-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/snekboard/zh_Latn_pinyin/adafruit-circuitpython-snekboard-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 28,
+        "downloads": 0,
         "id": "sparkfun_lumidrive",
         "versions": [
             {
@@ -10292,52 +11386,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/ID/adafruit-circuitpython-sparkfun_lumidrive-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/ID/adafruit-circuitpython-sparkfun_lumidrive-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/cs/adafruit-circuitpython-sparkfun_lumidrive-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/de_DE/adafruit-circuitpython-sparkfun_lumidrive-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/de_DE/adafruit-circuitpython-sparkfun_lumidrive-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/en_US/adafruit-circuitpython-sparkfun_lumidrive-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/en_US/adafruit-circuitpython-sparkfun_lumidrive-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/en_x_pirate/adafruit-circuitpython-sparkfun_lumidrive-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/en_x_pirate/adafruit-circuitpython-sparkfun_lumidrive-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/es/adafruit-circuitpython-sparkfun_lumidrive-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/es/adafruit-circuitpython-sparkfun_lumidrive-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/fil/adafruit-circuitpython-sparkfun_lumidrive-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/fil/adafruit-circuitpython-sparkfun_lumidrive-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/fr/adafruit-circuitpython-sparkfun_lumidrive-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/fr/adafruit-circuitpython-sparkfun_lumidrive-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/it_IT/adafruit-circuitpython-sparkfun_lumidrive-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/it_IT/adafruit-circuitpython-sparkfun_lumidrive-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/ko/adafruit-circuitpython-sparkfun_lumidrive-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/ko/adafruit-circuitpython-sparkfun_lumidrive-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/nl/adafruit-circuitpython-sparkfun_lumidrive-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/pl/adafruit-circuitpython-sparkfun_lumidrive-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/pl/adafruit-circuitpython-sparkfun_lumidrive-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/pt_BR/adafruit-circuitpython-sparkfun_lumidrive-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/pt_BR/adafruit-circuitpython-sparkfun_lumidrive-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/sv/adafruit-circuitpython-sparkfun_lumidrive-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/sv/adafruit-circuitpython-sparkfun_lumidrive-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_lumidrive-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_lumidrive/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_lumidrive-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 31,
+        "downloads": 0,
         "id": "sparkfun_nrf52840_mini",
         "versions": [
             {
@@ -10385,52 +11485,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/ID/adafruit-circuitpython-sparkfun_nrf52840_mini-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/ID/adafruit-circuitpython-sparkfun_nrf52840_mini-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/cs/adafruit-circuitpython-sparkfun_nrf52840_mini-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/de_DE/adafruit-circuitpython-sparkfun_nrf52840_mini-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/de_DE/adafruit-circuitpython-sparkfun_nrf52840_mini-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/en_US/adafruit-circuitpython-sparkfun_nrf52840_mini-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/en_US/adafruit-circuitpython-sparkfun_nrf52840_mini-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/en_x_pirate/adafruit-circuitpython-sparkfun_nrf52840_mini-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/en_x_pirate/adafruit-circuitpython-sparkfun_nrf52840_mini-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/es/adafruit-circuitpython-sparkfun_nrf52840_mini-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/es/adafruit-circuitpython-sparkfun_nrf52840_mini-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/fil/adafruit-circuitpython-sparkfun_nrf52840_mini-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/fil/adafruit-circuitpython-sparkfun_nrf52840_mini-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/fr/adafruit-circuitpython-sparkfun_nrf52840_mini-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/fr/adafruit-circuitpython-sparkfun_nrf52840_mini-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/it_IT/adafruit-circuitpython-sparkfun_nrf52840_mini-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/it_IT/adafruit-circuitpython-sparkfun_nrf52840_mini-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/ko/adafruit-circuitpython-sparkfun_nrf52840_mini-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/ko/adafruit-circuitpython-sparkfun_nrf52840_mini-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/nl/adafruit-circuitpython-sparkfun_nrf52840_mini-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/pl/adafruit-circuitpython-sparkfun_nrf52840_mini-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/pl/adafruit-circuitpython-sparkfun_nrf52840_mini-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/pt_BR/adafruit-circuitpython-sparkfun_nrf52840_mini-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/pt_BR/adafruit-circuitpython-sparkfun_nrf52840_mini-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/sv/adafruit-circuitpython-sparkfun_nrf52840_mini-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/sv/adafruit-circuitpython-sparkfun_nrf52840_mini-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_nrf52840_mini-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_nrf52840_mini/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_nrf52840_mini-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 38,
+        "downloads": 0,
         "id": "sparkfun_qwiic_micro_no_flash",
         "versions": [
             {
@@ -10478,52 +11584,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/ID/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/ID/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/cs/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/de_DE/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/de_DE/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/en_US/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/en_US/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/en_x_pirate/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/en_x_pirate/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/es/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/es/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/fil/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/fil/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/fr/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/fr/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/it_IT/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/it_IT/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/ko/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/ko/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/nl/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/pl/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/pl/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/pt_BR/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/pt_BR/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/sv/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/sv/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_no_flash/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_qwiic_micro_no_flash-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 3,
+        "downloads": 0,
         "id": "sparkfun_qwiic_micro_with_flash",
         "versions": [
             {
@@ -10571,52 +11683,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/ID/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/ID/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/cs/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/de_DE/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/de_DE/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/en_US/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/en_US/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/en_x_pirate/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/en_x_pirate/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/es/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/es/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/fil/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/fil/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/fr/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/fr/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/it_IT/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/it_IT/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/ko/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/ko/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/nl/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/pl/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/pl/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/pt_BR/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/pt_BR/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/sv/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/sv/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_qwiic_micro_with_flash/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_qwiic_micro_with_flash-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 29,
+        "downloads": 0,
         "id": "sparkfun_redboard_turbo",
         "versions": [
             {
@@ -10664,52 +11782,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/ID/adafruit-circuitpython-sparkfun_redboard_turbo-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/ID/adafruit-circuitpython-sparkfun_redboard_turbo-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/cs/adafruit-circuitpython-sparkfun_redboard_turbo-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/de_DE/adafruit-circuitpython-sparkfun_redboard_turbo-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/de_DE/adafruit-circuitpython-sparkfun_redboard_turbo-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/en_US/adafruit-circuitpython-sparkfun_redboard_turbo-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/en_US/adafruit-circuitpython-sparkfun_redboard_turbo-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/en_x_pirate/adafruit-circuitpython-sparkfun_redboard_turbo-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/en_x_pirate/adafruit-circuitpython-sparkfun_redboard_turbo-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/es/adafruit-circuitpython-sparkfun_redboard_turbo-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/es/adafruit-circuitpython-sparkfun_redboard_turbo-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/fil/adafruit-circuitpython-sparkfun_redboard_turbo-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/fil/adafruit-circuitpython-sparkfun_redboard_turbo-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/fr/adafruit-circuitpython-sparkfun_redboard_turbo-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/fr/adafruit-circuitpython-sparkfun_redboard_turbo-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/it_IT/adafruit-circuitpython-sparkfun_redboard_turbo-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/it_IT/adafruit-circuitpython-sparkfun_redboard_turbo-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/ko/adafruit-circuitpython-sparkfun_redboard_turbo-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/ko/adafruit-circuitpython-sparkfun_redboard_turbo-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/nl/adafruit-circuitpython-sparkfun_redboard_turbo-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/pl/adafruit-circuitpython-sparkfun_redboard_turbo-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/pl/adafruit-circuitpython-sparkfun_redboard_turbo-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/pt_BR/adafruit-circuitpython-sparkfun_redboard_turbo-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/pt_BR/adafruit-circuitpython-sparkfun_redboard_turbo-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/sv/adafruit-circuitpython-sparkfun_redboard_turbo-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/sv/adafruit-circuitpython-sparkfun_redboard_turbo-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_redboard_turbo-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_redboard_turbo/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_redboard_turbo-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 7,
+        "downloads": 0,
         "id": "sparkfun_samd21_dev",
         "versions": [
             {
@@ -10757,52 +11881,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/ID/adafruit-circuitpython-sparkfun_samd21_dev-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/ID/adafruit-circuitpython-sparkfun_samd21_dev-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/cs/adafruit-circuitpython-sparkfun_samd21_dev-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/de_DE/adafruit-circuitpython-sparkfun_samd21_dev-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/de_DE/adafruit-circuitpython-sparkfun_samd21_dev-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/en_US/adafruit-circuitpython-sparkfun_samd21_dev-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/en_US/adafruit-circuitpython-sparkfun_samd21_dev-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/en_x_pirate/adafruit-circuitpython-sparkfun_samd21_dev-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/en_x_pirate/adafruit-circuitpython-sparkfun_samd21_dev-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/es/adafruit-circuitpython-sparkfun_samd21_dev-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/es/adafruit-circuitpython-sparkfun_samd21_dev-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/fil/adafruit-circuitpython-sparkfun_samd21_dev-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/fil/adafruit-circuitpython-sparkfun_samd21_dev-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/fr/adafruit-circuitpython-sparkfun_samd21_dev-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/fr/adafruit-circuitpython-sparkfun_samd21_dev-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/it_IT/adafruit-circuitpython-sparkfun_samd21_dev-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/it_IT/adafruit-circuitpython-sparkfun_samd21_dev-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/ko/adafruit-circuitpython-sparkfun_samd21_dev-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/ko/adafruit-circuitpython-sparkfun_samd21_dev-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/nl/adafruit-circuitpython-sparkfun_samd21_dev-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/pl/adafruit-circuitpython-sparkfun_samd21_dev-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/pl/adafruit-circuitpython-sparkfun_samd21_dev-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/pt_BR/adafruit-circuitpython-sparkfun_samd21_dev-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/pt_BR/adafruit-circuitpython-sparkfun_samd21_dev-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/sv/adafruit-circuitpython-sparkfun_samd21_dev-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/sv/adafruit-circuitpython-sparkfun_samd21_dev-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_samd21_dev-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_dev/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_samd21_dev-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 31,
+        "downloads": 0,
         "id": "sparkfun_samd21_mini",
         "versions": [
             {
@@ -10850,52 +11980,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/ID/adafruit-circuitpython-sparkfun_samd21_mini-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/ID/adafruit-circuitpython-sparkfun_samd21_mini-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/cs/adafruit-circuitpython-sparkfun_samd21_mini-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/de_DE/adafruit-circuitpython-sparkfun_samd21_mini-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/de_DE/adafruit-circuitpython-sparkfun_samd21_mini-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/en_US/adafruit-circuitpython-sparkfun_samd21_mini-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/en_US/adafruit-circuitpython-sparkfun_samd21_mini-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/en_x_pirate/adafruit-circuitpython-sparkfun_samd21_mini-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/en_x_pirate/adafruit-circuitpython-sparkfun_samd21_mini-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/es/adafruit-circuitpython-sparkfun_samd21_mini-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/es/adafruit-circuitpython-sparkfun_samd21_mini-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/fil/adafruit-circuitpython-sparkfun_samd21_mini-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/fil/adafruit-circuitpython-sparkfun_samd21_mini-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/fr/adafruit-circuitpython-sparkfun_samd21_mini-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/fr/adafruit-circuitpython-sparkfun_samd21_mini-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/it_IT/adafruit-circuitpython-sparkfun_samd21_mini-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/it_IT/adafruit-circuitpython-sparkfun_samd21_mini-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/ko/adafruit-circuitpython-sparkfun_samd21_mini-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/ko/adafruit-circuitpython-sparkfun_samd21_mini-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/nl/adafruit-circuitpython-sparkfun_samd21_mini-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/pl/adafruit-circuitpython-sparkfun_samd21_mini-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/pl/adafruit-circuitpython-sparkfun_samd21_mini-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/pt_BR/adafruit-circuitpython-sparkfun_samd21_mini-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/pt_BR/adafruit-circuitpython-sparkfun_samd21_mini-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/sv/adafruit-circuitpython-sparkfun_samd21_mini-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/sv/adafruit-circuitpython-sparkfun_samd21_mini-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_samd21_mini-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd21_mini/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_samd21_mini-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 42,
+        "downloads": 0,
         "id": "sparkfun_samd51_thing_plus",
         "versions": [
             {
@@ -10943,52 +12079,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/ID/adafruit-circuitpython-sparkfun_samd51_thing_plus-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/ID/adafruit-circuitpython-sparkfun_samd51_thing_plus-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/cs/adafruit-circuitpython-sparkfun_samd51_thing_plus-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/de_DE/adafruit-circuitpython-sparkfun_samd51_thing_plus-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/de_DE/adafruit-circuitpython-sparkfun_samd51_thing_plus-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/en_US/adafruit-circuitpython-sparkfun_samd51_thing_plus-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/en_US/adafruit-circuitpython-sparkfun_samd51_thing_plus-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/en_x_pirate/adafruit-circuitpython-sparkfun_samd51_thing_plus-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/en_x_pirate/adafruit-circuitpython-sparkfun_samd51_thing_plus-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/es/adafruit-circuitpython-sparkfun_samd51_thing_plus-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/es/adafruit-circuitpython-sparkfun_samd51_thing_plus-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/fil/adafruit-circuitpython-sparkfun_samd51_thing_plus-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/fil/adafruit-circuitpython-sparkfun_samd51_thing_plus-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/fr/adafruit-circuitpython-sparkfun_samd51_thing_plus-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/fr/adafruit-circuitpython-sparkfun_samd51_thing_plus-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/it_IT/adafruit-circuitpython-sparkfun_samd51_thing_plus-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/it_IT/adafruit-circuitpython-sparkfun_samd51_thing_plus-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/ko/adafruit-circuitpython-sparkfun_samd51_thing_plus-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/ko/adafruit-circuitpython-sparkfun_samd51_thing_plus-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/nl/adafruit-circuitpython-sparkfun_samd51_thing_plus-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/pl/adafruit-circuitpython-sparkfun_samd51_thing_plus-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/pl/adafruit-circuitpython-sparkfun_samd51_thing_plus-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/pt_BR/adafruit-circuitpython-sparkfun_samd51_thing_plus-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/pt_BR/adafruit-circuitpython-sparkfun_samd51_thing_plus-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/sv/adafruit-circuitpython-sparkfun_samd51_thing_plus-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/sv/adafruit-circuitpython-sparkfun_samd51_thing_plus-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_samd51_thing_plus-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/sparkfun_samd51_thing_plus/zh_Latn_pinyin/adafruit-circuitpython-sparkfun_samd51_thing_plus-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 54,
+        "downloads": 0,
         "id": "spresense",
         "versions": [
             {
@@ -11036,52 +12178,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/spresense/ID/adafruit-circuitpython-spresense-ID-5.4.0-beta.0.spk"
+                        "https://downloads.circuitpython.org/bin/spresense/ID/adafruit-circuitpython-spresense-ID-5.4.0-beta.1.spk"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/spresense/cs/adafruit-circuitpython-spresense-cs-5.4.0-beta.1.spk"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/spresense/de_DE/adafruit-circuitpython-spresense-de_DE-5.4.0-beta.0.spk"
+                        "https://downloads.circuitpython.org/bin/spresense/de_DE/adafruit-circuitpython-spresense-de_DE-5.4.0-beta.1.spk"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/spresense/en_US/adafruit-circuitpython-spresense-en_US-5.4.0-beta.0.spk"
+                        "https://downloads.circuitpython.org/bin/spresense/en_US/adafruit-circuitpython-spresense-en_US-5.4.0-beta.1.spk"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/spresense/en_x_pirate/adafruit-circuitpython-spresense-en_x_pirate-5.4.0-beta.0.spk"
+                        "https://downloads.circuitpython.org/bin/spresense/en_x_pirate/adafruit-circuitpython-spresense-en_x_pirate-5.4.0-beta.1.spk"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/spresense/es/adafruit-circuitpython-spresense-es-5.4.0-beta.0.spk"
+                        "https://downloads.circuitpython.org/bin/spresense/es/adafruit-circuitpython-spresense-es-5.4.0-beta.1.spk"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/spresense/fil/adafruit-circuitpython-spresense-fil-5.4.0-beta.0.spk"
+                        "https://downloads.circuitpython.org/bin/spresense/fil/adafruit-circuitpython-spresense-fil-5.4.0-beta.1.spk"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/spresense/fr/adafruit-circuitpython-spresense-fr-5.4.0-beta.0.spk"
+                        "https://downloads.circuitpython.org/bin/spresense/fr/adafruit-circuitpython-spresense-fr-5.4.0-beta.1.spk"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/spresense/it_IT/adafruit-circuitpython-spresense-it_IT-5.4.0-beta.0.spk"
+                        "https://downloads.circuitpython.org/bin/spresense/it_IT/adafruit-circuitpython-spresense-it_IT-5.4.0-beta.1.spk"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/spresense/ko/adafruit-circuitpython-spresense-ko-5.4.0-beta.0.spk"
+                        "https://downloads.circuitpython.org/bin/spresense/ko/adafruit-circuitpython-spresense-ko-5.4.0-beta.1.spk"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/spresense/nl/adafruit-circuitpython-spresense-nl-5.4.0-beta.1.spk"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/spresense/pl/adafruit-circuitpython-spresense-pl-5.4.0-beta.0.spk"
+                        "https://downloads.circuitpython.org/bin/spresense/pl/adafruit-circuitpython-spresense-pl-5.4.0-beta.1.spk"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/spresense/pt_BR/adafruit-circuitpython-spresense-pt_BR-5.4.0-beta.0.spk"
+                        "https://downloads.circuitpython.org/bin/spresense/pt_BR/adafruit-circuitpython-spresense-pt_BR-5.4.0-beta.1.spk"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/spresense/sv/adafruit-circuitpython-spresense-sv-5.4.0-beta.0.spk"
+                        "https://downloads.circuitpython.org/bin/spresense/sv/adafruit-circuitpython-spresense-sv-5.4.0-beta.1.spk"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/spresense/zh_Latn_pinyin/adafruit-circuitpython-spresense-zh_Latn_pinyin-5.4.0-beta.0.spk"
+                        "https://downloads.circuitpython.org/bin/spresense/zh_Latn_pinyin/adafruit-circuitpython-spresense-zh_Latn_pinyin-5.4.0-beta.1.spk"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 34,
+        "downloads": 0,
         "id": "stm32f411ce_blackpill",
         "versions": [
             {
@@ -11129,52 +12277,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/ID/adafruit-circuitpython-stm32f411ce_blackpill-ID-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/ID/adafruit-circuitpython-stm32f411ce_blackpill-ID-5.4.0-beta.1.bin"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/cs/adafruit-circuitpython-stm32f411ce_blackpill-cs-5.4.0-beta.1.bin"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/de_DE/adafruit-circuitpython-stm32f411ce_blackpill-de_DE-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/de_DE/adafruit-circuitpython-stm32f411ce_blackpill-de_DE-5.4.0-beta.1.bin"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/en_US/adafruit-circuitpython-stm32f411ce_blackpill-en_US-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/en_US/adafruit-circuitpython-stm32f411ce_blackpill-en_US-5.4.0-beta.1.bin"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/en_x_pirate/adafruit-circuitpython-stm32f411ce_blackpill-en_x_pirate-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/en_x_pirate/adafruit-circuitpython-stm32f411ce_blackpill-en_x_pirate-5.4.0-beta.1.bin"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/es/adafruit-circuitpython-stm32f411ce_blackpill-es-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/es/adafruit-circuitpython-stm32f411ce_blackpill-es-5.4.0-beta.1.bin"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/fil/adafruit-circuitpython-stm32f411ce_blackpill-fil-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/fil/adafruit-circuitpython-stm32f411ce_blackpill-fil-5.4.0-beta.1.bin"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/fr/adafruit-circuitpython-stm32f411ce_blackpill-fr-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/fr/adafruit-circuitpython-stm32f411ce_blackpill-fr-5.4.0-beta.1.bin"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/it_IT/adafruit-circuitpython-stm32f411ce_blackpill-it_IT-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/it_IT/adafruit-circuitpython-stm32f411ce_blackpill-it_IT-5.4.0-beta.1.bin"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/ko/adafruit-circuitpython-stm32f411ce_blackpill-ko-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/ko/adafruit-circuitpython-stm32f411ce_blackpill-ko-5.4.0-beta.1.bin"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/nl/adafruit-circuitpython-stm32f411ce_blackpill-nl-5.4.0-beta.1.bin"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/pl/adafruit-circuitpython-stm32f411ce_blackpill-pl-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/pl/adafruit-circuitpython-stm32f411ce_blackpill-pl-5.4.0-beta.1.bin"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/pt_BR/adafruit-circuitpython-stm32f411ce_blackpill-pt_BR-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/pt_BR/adafruit-circuitpython-stm32f411ce_blackpill-pt_BR-5.4.0-beta.1.bin"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/sv/adafruit-circuitpython-stm32f411ce_blackpill-sv-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/sv/adafruit-circuitpython-stm32f411ce_blackpill-sv-5.4.0-beta.1.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/zh_Latn_pinyin/adafruit-circuitpython-stm32f411ce_blackpill-zh_Latn_pinyin-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f411ce_blackpill/zh_Latn_pinyin/adafruit-circuitpython-stm32f411ce_blackpill-zh_Latn_pinyin-5.4.0-beta.1.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 23,
+        "downloads": 0,
         "id": "stm32f411ve_discovery",
         "versions": [
             {
@@ -11222,52 +12376,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/ID/adafruit-circuitpython-stm32f411ve_discovery-ID-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/ID/adafruit-circuitpython-stm32f411ve_discovery-ID-5.4.0-beta.1.bin"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/cs/adafruit-circuitpython-stm32f411ve_discovery-cs-5.4.0-beta.1.bin"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/de_DE/adafruit-circuitpython-stm32f411ve_discovery-de_DE-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/de_DE/adafruit-circuitpython-stm32f411ve_discovery-de_DE-5.4.0-beta.1.bin"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/en_US/adafruit-circuitpython-stm32f411ve_discovery-en_US-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/en_US/adafruit-circuitpython-stm32f411ve_discovery-en_US-5.4.0-beta.1.bin"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/en_x_pirate/adafruit-circuitpython-stm32f411ve_discovery-en_x_pirate-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/en_x_pirate/adafruit-circuitpython-stm32f411ve_discovery-en_x_pirate-5.4.0-beta.1.bin"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/es/adafruit-circuitpython-stm32f411ve_discovery-es-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/es/adafruit-circuitpython-stm32f411ve_discovery-es-5.4.0-beta.1.bin"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/fil/adafruit-circuitpython-stm32f411ve_discovery-fil-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/fil/adafruit-circuitpython-stm32f411ve_discovery-fil-5.4.0-beta.1.bin"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/fr/adafruit-circuitpython-stm32f411ve_discovery-fr-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/fr/adafruit-circuitpython-stm32f411ve_discovery-fr-5.4.0-beta.1.bin"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/it_IT/adafruit-circuitpython-stm32f411ve_discovery-it_IT-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/it_IT/adafruit-circuitpython-stm32f411ve_discovery-it_IT-5.4.0-beta.1.bin"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/ko/adafruit-circuitpython-stm32f411ve_discovery-ko-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/ko/adafruit-circuitpython-stm32f411ve_discovery-ko-5.4.0-beta.1.bin"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/nl/adafruit-circuitpython-stm32f411ve_discovery-nl-5.4.0-beta.1.bin"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/pl/adafruit-circuitpython-stm32f411ve_discovery-pl-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/pl/adafruit-circuitpython-stm32f411ve_discovery-pl-5.4.0-beta.1.bin"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/pt_BR/adafruit-circuitpython-stm32f411ve_discovery-pt_BR-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/pt_BR/adafruit-circuitpython-stm32f411ve_discovery-pt_BR-5.4.0-beta.1.bin"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/sv/adafruit-circuitpython-stm32f411ve_discovery-sv-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/sv/adafruit-circuitpython-stm32f411ve_discovery-sv-5.4.0-beta.1.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/zh_Latn_pinyin/adafruit-circuitpython-stm32f411ve_discovery-zh_Latn_pinyin-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f411ve_discovery/zh_Latn_pinyin/adafruit-circuitpython-stm32f411ve_discovery-zh_Latn_pinyin-5.4.0-beta.1.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 20,
+        "downloads": 0,
         "id": "stm32f412zg_discovery",
         "versions": [
             {
@@ -11315,52 +12475,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/ID/adafruit-circuitpython-stm32f412zg_discovery-ID-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/ID/adafruit-circuitpython-stm32f412zg_discovery-ID-5.4.0-beta.1.bin"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/cs/adafruit-circuitpython-stm32f412zg_discovery-cs-5.4.0-beta.1.bin"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/de_DE/adafruit-circuitpython-stm32f412zg_discovery-de_DE-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/de_DE/adafruit-circuitpython-stm32f412zg_discovery-de_DE-5.4.0-beta.1.bin"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/en_US/adafruit-circuitpython-stm32f412zg_discovery-en_US-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/en_US/adafruit-circuitpython-stm32f412zg_discovery-en_US-5.4.0-beta.1.bin"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/en_x_pirate/adafruit-circuitpython-stm32f412zg_discovery-en_x_pirate-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/en_x_pirate/adafruit-circuitpython-stm32f412zg_discovery-en_x_pirate-5.4.0-beta.1.bin"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/es/adafruit-circuitpython-stm32f412zg_discovery-es-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/es/adafruit-circuitpython-stm32f412zg_discovery-es-5.4.0-beta.1.bin"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/fil/adafruit-circuitpython-stm32f412zg_discovery-fil-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/fil/adafruit-circuitpython-stm32f412zg_discovery-fil-5.4.0-beta.1.bin"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/fr/adafruit-circuitpython-stm32f412zg_discovery-fr-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/fr/adafruit-circuitpython-stm32f412zg_discovery-fr-5.4.0-beta.1.bin"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/it_IT/adafruit-circuitpython-stm32f412zg_discovery-it_IT-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/it_IT/adafruit-circuitpython-stm32f412zg_discovery-it_IT-5.4.0-beta.1.bin"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/ko/adafruit-circuitpython-stm32f412zg_discovery-ko-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/ko/adafruit-circuitpython-stm32f412zg_discovery-ko-5.4.0-beta.1.bin"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/nl/adafruit-circuitpython-stm32f412zg_discovery-nl-5.4.0-beta.1.bin"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/pl/adafruit-circuitpython-stm32f412zg_discovery-pl-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/pl/adafruit-circuitpython-stm32f412zg_discovery-pl-5.4.0-beta.1.bin"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/pt_BR/adafruit-circuitpython-stm32f412zg_discovery-pt_BR-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/pt_BR/adafruit-circuitpython-stm32f412zg_discovery-pt_BR-5.4.0-beta.1.bin"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/sv/adafruit-circuitpython-stm32f412zg_discovery-sv-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/sv/adafruit-circuitpython-stm32f412zg_discovery-sv-5.4.0-beta.1.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/zh_Latn_pinyin/adafruit-circuitpython-stm32f412zg_discovery-zh_Latn_pinyin-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f412zg_discovery/zh_Latn_pinyin/adafruit-circuitpython-stm32f412zg_discovery-zh_Latn_pinyin-5.4.0-beta.1.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 26,
+        "downloads": 0,
         "id": "stm32f4_discovery",
         "versions": [
             {
@@ -11408,47 +12574,53 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/ID/adafruit-circuitpython-stm32f4_discovery-ID-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/ID/adafruit-circuitpython-stm32f4_discovery-ID-5.4.0-beta.1.bin"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/cs/adafruit-circuitpython-stm32f4_discovery-cs-5.4.0-beta.1.bin"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/de_DE/adafruit-circuitpython-stm32f4_discovery-de_DE-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/de_DE/adafruit-circuitpython-stm32f4_discovery-de_DE-5.4.0-beta.1.bin"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/en_US/adafruit-circuitpython-stm32f4_discovery-en_US-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/en_US/adafruit-circuitpython-stm32f4_discovery-en_US-5.4.0-beta.1.bin"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/en_x_pirate/adafruit-circuitpython-stm32f4_discovery-en_x_pirate-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/en_x_pirate/adafruit-circuitpython-stm32f4_discovery-en_x_pirate-5.4.0-beta.1.bin"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/es/adafruit-circuitpython-stm32f4_discovery-es-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/es/adafruit-circuitpython-stm32f4_discovery-es-5.4.0-beta.1.bin"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/fil/adafruit-circuitpython-stm32f4_discovery-fil-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/fil/adafruit-circuitpython-stm32f4_discovery-fil-5.4.0-beta.1.bin"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/fr/adafruit-circuitpython-stm32f4_discovery-fr-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/fr/adafruit-circuitpython-stm32f4_discovery-fr-5.4.0-beta.1.bin"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/it_IT/adafruit-circuitpython-stm32f4_discovery-it_IT-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/it_IT/adafruit-circuitpython-stm32f4_discovery-it_IT-5.4.0-beta.1.bin"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/ko/adafruit-circuitpython-stm32f4_discovery-ko-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/ko/adafruit-circuitpython-stm32f4_discovery-ko-5.4.0-beta.1.bin"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/nl/adafruit-circuitpython-stm32f4_discovery-nl-5.4.0-beta.1.bin"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/pl/adafruit-circuitpython-stm32f4_discovery-pl-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/pl/adafruit-circuitpython-stm32f4_discovery-pl-5.4.0-beta.1.bin"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/pt_BR/adafruit-circuitpython-stm32f4_discovery-pt_BR-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/pt_BR/adafruit-circuitpython-stm32f4_discovery-pt_BR-5.4.0-beta.1.bin"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/sv/adafruit-circuitpython-stm32f4_discovery-sv-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/sv/adafruit-circuitpython-stm32f4_discovery-sv-5.4.0-beta.1.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/zh_Latn_pinyin/adafruit-circuitpython-stm32f4_discovery-zh_Latn_pinyin-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f4_discovery/zh_Latn_pinyin/adafruit-circuitpython-stm32f4_discovery-zh_Latn_pinyin-5.4.0-beta.1.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
@@ -11459,52 +12631,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/ID/adafruit-circuitpython-stm32f746g_discovery-ID-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/ID/adafruit-circuitpython-stm32f746g_discovery-ID-5.4.0-beta.1.bin"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/cs/adafruit-circuitpython-stm32f746g_discovery-cs-5.4.0-beta.1.bin"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/de_DE/adafruit-circuitpython-stm32f746g_discovery-de_DE-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/de_DE/adafruit-circuitpython-stm32f746g_discovery-de_DE-5.4.0-beta.1.bin"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/en_US/adafruit-circuitpython-stm32f746g_discovery-en_US-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/en_US/adafruit-circuitpython-stm32f746g_discovery-en_US-5.4.0-beta.1.bin"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/en_x_pirate/adafruit-circuitpython-stm32f746g_discovery-en_x_pirate-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/en_x_pirate/adafruit-circuitpython-stm32f746g_discovery-en_x_pirate-5.4.0-beta.1.bin"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/es/adafruit-circuitpython-stm32f746g_discovery-es-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/es/adafruit-circuitpython-stm32f746g_discovery-es-5.4.0-beta.1.bin"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/fil/adafruit-circuitpython-stm32f746g_discovery-fil-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/fil/adafruit-circuitpython-stm32f746g_discovery-fil-5.4.0-beta.1.bin"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/fr/adafruit-circuitpython-stm32f746g_discovery-fr-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/fr/adafruit-circuitpython-stm32f746g_discovery-fr-5.4.0-beta.1.bin"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/it_IT/adafruit-circuitpython-stm32f746g_discovery-it_IT-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/it_IT/adafruit-circuitpython-stm32f746g_discovery-it_IT-5.4.0-beta.1.bin"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/ko/adafruit-circuitpython-stm32f746g_discovery-ko-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/ko/adafruit-circuitpython-stm32f746g_discovery-ko-5.4.0-beta.1.bin"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/nl/adafruit-circuitpython-stm32f746g_discovery-nl-5.4.0-beta.1.bin"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/pl/adafruit-circuitpython-stm32f746g_discovery-pl-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/pl/adafruit-circuitpython-stm32f746g_discovery-pl-5.4.0-beta.1.bin"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/pt_BR/adafruit-circuitpython-stm32f746g_discovery-pt_BR-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/pt_BR/adafruit-circuitpython-stm32f746g_discovery-pt_BR-5.4.0-beta.1.bin"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/sv/adafruit-circuitpython-stm32f746g_discovery-sv-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/sv/adafruit-circuitpython-stm32f746g_discovery-sv-5.4.0-beta.1.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/zh_Latn_pinyin/adafruit-circuitpython-stm32f746g_discovery-zh_Latn_pinyin-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/stm32f746g_discovery/zh_Latn_pinyin/adafruit-circuitpython-stm32f746g_discovery-zh_Latn_pinyin-5.4.0-beta.1.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 31,
+        "downloads": 0,
         "id": "stringcar_m0_express",
         "versions": [
             {
@@ -11552,52 +12730,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/ID/adafruit-circuitpython-stringcar_m0_express-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/ID/adafruit-circuitpython-stringcar_m0_express-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/cs/adafruit-circuitpython-stringcar_m0_express-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/de_DE/adafruit-circuitpython-stringcar_m0_express-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/de_DE/adafruit-circuitpython-stringcar_m0_express-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/en_US/adafruit-circuitpython-stringcar_m0_express-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/en_US/adafruit-circuitpython-stringcar_m0_express-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/en_x_pirate/adafruit-circuitpython-stringcar_m0_express-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/en_x_pirate/adafruit-circuitpython-stringcar_m0_express-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/es/adafruit-circuitpython-stringcar_m0_express-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/es/adafruit-circuitpython-stringcar_m0_express-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/fil/adafruit-circuitpython-stringcar_m0_express-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/fil/adafruit-circuitpython-stringcar_m0_express-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/fr/adafruit-circuitpython-stringcar_m0_express-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/fr/adafruit-circuitpython-stringcar_m0_express-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/it_IT/adafruit-circuitpython-stringcar_m0_express-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/it_IT/adafruit-circuitpython-stringcar_m0_express-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/ko/adafruit-circuitpython-stringcar_m0_express-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/ko/adafruit-circuitpython-stringcar_m0_express-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/nl/adafruit-circuitpython-stringcar_m0_express-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/pl/adafruit-circuitpython-stringcar_m0_express-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/pl/adafruit-circuitpython-stringcar_m0_express-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/pt_BR/adafruit-circuitpython-stringcar_m0_express-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/pt_BR/adafruit-circuitpython-stringcar_m0_express-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/sv/adafruit-circuitpython-stringcar_m0_express-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/sv/adafruit-circuitpython-stringcar_m0_express-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/zh_Latn_pinyin/adafruit-circuitpython-stringcar_m0_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/stringcar_m0_express/zh_Latn_pinyin/adafruit-circuitpython-stringcar_m0_express-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 55,
+        "downloads": 0,
         "id": "teensy40",
         "versions": [
             {
@@ -11657,60 +12841,68 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/teensy40/ID/adafruit-circuitpython-teensy40-ID-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/ID/adafruit-circuitpython-teensy40-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy40/ID/adafruit-circuitpython-teensy40-ID-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/ID/adafruit-circuitpython-teensy40-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/teensy40/cs/adafruit-circuitpython-teensy40-cs-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/cs/adafruit-circuitpython-teensy40-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/teensy40/de_DE/adafruit-circuitpython-teensy40-de_DE-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/de_DE/adafruit-circuitpython-teensy40-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy40/de_DE/adafruit-circuitpython-teensy40-de_DE-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/de_DE/adafruit-circuitpython-teensy40-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/teensy40/en_US/adafruit-circuitpython-teensy40-en_US-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/en_US/adafruit-circuitpython-teensy40-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy40/en_US/adafruit-circuitpython-teensy40-en_US-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/en_US/adafruit-circuitpython-teensy40-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/teensy40/en_x_pirate/adafruit-circuitpython-teensy40-en_x_pirate-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/en_x_pirate/adafruit-circuitpython-teensy40-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy40/en_x_pirate/adafruit-circuitpython-teensy40-en_x_pirate-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/en_x_pirate/adafruit-circuitpython-teensy40-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/teensy40/es/adafruit-circuitpython-teensy40-es-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/es/adafruit-circuitpython-teensy40-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy40/es/adafruit-circuitpython-teensy40-es-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/es/adafruit-circuitpython-teensy40-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/teensy40/fil/adafruit-circuitpython-teensy40-fil-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/fil/adafruit-circuitpython-teensy40-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy40/fil/adafruit-circuitpython-teensy40-fil-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/fil/adafruit-circuitpython-teensy40-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/teensy40/fr/adafruit-circuitpython-teensy40-fr-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/fr/adafruit-circuitpython-teensy40-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy40/fr/adafruit-circuitpython-teensy40-fr-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/fr/adafruit-circuitpython-teensy40-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/teensy40/it_IT/adafruit-circuitpython-teensy40-it_IT-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/it_IT/adafruit-circuitpython-teensy40-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy40/it_IT/adafruit-circuitpython-teensy40-it_IT-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/it_IT/adafruit-circuitpython-teensy40-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/teensy40/ko/adafruit-circuitpython-teensy40-ko-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/ko/adafruit-circuitpython-teensy40-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy40/ko/adafruit-circuitpython-teensy40-ko-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/ko/adafruit-circuitpython-teensy40-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/teensy40/nl/adafruit-circuitpython-teensy40-nl-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/nl/adafruit-circuitpython-teensy40-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/teensy40/pl/adafruit-circuitpython-teensy40-pl-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/pl/adafruit-circuitpython-teensy40-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy40/pl/adafruit-circuitpython-teensy40-pl-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/pl/adafruit-circuitpython-teensy40-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/teensy40/pt_BR/adafruit-circuitpython-teensy40-pt_BR-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/pt_BR/adafruit-circuitpython-teensy40-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy40/pt_BR/adafruit-circuitpython-teensy40-pt_BR-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/pt_BR/adafruit-circuitpython-teensy40-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/teensy40/sv/adafruit-circuitpython-teensy40-sv-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/sv/adafruit-circuitpython-teensy40-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy40/sv/adafruit-circuitpython-teensy40-sv-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/sv/adafruit-circuitpython-teensy40-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/teensy40/zh_Latn_pinyin/adafruit-circuitpython-teensy40-zh_Latn_pinyin-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy40/zh_Latn_pinyin/adafruit-circuitpython-teensy40-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy40/zh_Latn_pinyin/adafruit-circuitpython-teensy40-zh_Latn_pinyin-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/teensy40/zh_Latn_pinyin/adafruit-circuitpython-teensy40-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
@@ -11721,65 +12913,73 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/teensy41/ID/adafruit-circuitpython-teensy41-ID-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy41/ID/adafruit-circuitpython-teensy41-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy41/ID/adafruit-circuitpython-teensy41-ID-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/teensy41/ID/adafruit-circuitpython-teensy41-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/teensy41/cs/adafruit-circuitpython-teensy41-cs-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/teensy41/cs/adafruit-circuitpython-teensy41-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/teensy41/de_DE/adafruit-circuitpython-teensy41-de_DE-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy41/de_DE/adafruit-circuitpython-teensy41-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy41/de_DE/adafruit-circuitpython-teensy41-de_DE-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/teensy41/de_DE/adafruit-circuitpython-teensy41-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/teensy41/en_US/adafruit-circuitpython-teensy41-en_US-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy41/en_US/adafruit-circuitpython-teensy41-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy41/en_US/adafruit-circuitpython-teensy41-en_US-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/teensy41/en_US/adafruit-circuitpython-teensy41-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/teensy41/en_x_pirate/adafruit-circuitpython-teensy41-en_x_pirate-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy41/en_x_pirate/adafruit-circuitpython-teensy41-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy41/en_x_pirate/adafruit-circuitpython-teensy41-en_x_pirate-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/teensy41/en_x_pirate/adafruit-circuitpython-teensy41-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/teensy41/es/adafruit-circuitpython-teensy41-es-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy41/es/adafruit-circuitpython-teensy41-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy41/es/adafruit-circuitpython-teensy41-es-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/teensy41/es/adafruit-circuitpython-teensy41-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/teensy41/fil/adafruit-circuitpython-teensy41-fil-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy41/fil/adafruit-circuitpython-teensy41-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy41/fil/adafruit-circuitpython-teensy41-fil-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/teensy41/fil/adafruit-circuitpython-teensy41-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/teensy41/fr/adafruit-circuitpython-teensy41-fr-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy41/fr/adafruit-circuitpython-teensy41-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy41/fr/adafruit-circuitpython-teensy41-fr-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/teensy41/fr/adafruit-circuitpython-teensy41-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/teensy41/it_IT/adafruit-circuitpython-teensy41-it_IT-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy41/it_IT/adafruit-circuitpython-teensy41-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy41/it_IT/adafruit-circuitpython-teensy41-it_IT-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/teensy41/it_IT/adafruit-circuitpython-teensy41-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/teensy41/ko/adafruit-circuitpython-teensy41-ko-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy41/ko/adafruit-circuitpython-teensy41-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy41/ko/adafruit-circuitpython-teensy41-ko-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/teensy41/ko/adafruit-circuitpython-teensy41-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/teensy41/nl/adafruit-circuitpython-teensy41-nl-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/teensy41/nl/adafruit-circuitpython-teensy41-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/teensy41/pl/adafruit-circuitpython-teensy41-pl-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy41/pl/adafruit-circuitpython-teensy41-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy41/pl/adafruit-circuitpython-teensy41-pl-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/teensy41/pl/adafruit-circuitpython-teensy41-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/teensy41/pt_BR/adafruit-circuitpython-teensy41-pt_BR-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy41/pt_BR/adafruit-circuitpython-teensy41-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy41/pt_BR/adafruit-circuitpython-teensy41-pt_BR-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/teensy41/pt_BR/adafruit-circuitpython-teensy41-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/teensy41/sv/adafruit-circuitpython-teensy41-sv-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy41/sv/adafruit-circuitpython-teensy41-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy41/sv/adafruit-circuitpython-teensy41-sv-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/teensy41/sv/adafruit-circuitpython-teensy41-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/teensy41/zh_Latn_pinyin/adafruit-circuitpython-teensy41-zh_Latn_pinyin-5.4.0-beta.0.hex",
-                        "https://downloads.circuitpython.org/bin/teensy41/zh_Latn_pinyin/adafruit-circuitpython-teensy41-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teensy41/zh_Latn_pinyin/adafruit-circuitpython-teensy41-zh_Latn_pinyin-5.4.0-beta.1.hex",
+                        "https://downloads.circuitpython.org/bin/teensy41/zh_Latn_pinyin/adafruit-circuitpython-teensy41-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 27,
+        "downloads": 0,
         "id": "teknikio_bluebird",
         "versions": [
             {
@@ -11827,52 +13027,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/ID/adafruit-circuitpython-teknikio_bluebird-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/ID/adafruit-circuitpython-teknikio_bluebird-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/cs/adafruit-circuitpython-teknikio_bluebird-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/de_DE/adafruit-circuitpython-teknikio_bluebird-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/de_DE/adafruit-circuitpython-teknikio_bluebird-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/en_US/adafruit-circuitpython-teknikio_bluebird-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/en_US/adafruit-circuitpython-teknikio_bluebird-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/en_x_pirate/adafruit-circuitpython-teknikio_bluebird-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/en_x_pirate/adafruit-circuitpython-teknikio_bluebird-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/es/adafruit-circuitpython-teknikio_bluebird-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/es/adafruit-circuitpython-teknikio_bluebird-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/fil/adafruit-circuitpython-teknikio_bluebird-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/fil/adafruit-circuitpython-teknikio_bluebird-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/fr/adafruit-circuitpython-teknikio_bluebird-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/fr/adafruit-circuitpython-teknikio_bluebird-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/it_IT/adafruit-circuitpython-teknikio_bluebird-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/it_IT/adafruit-circuitpython-teknikio_bluebird-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/ko/adafruit-circuitpython-teknikio_bluebird-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/ko/adafruit-circuitpython-teknikio_bluebird-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/nl/adafruit-circuitpython-teknikio_bluebird-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/pl/adafruit-circuitpython-teknikio_bluebird-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/pl/adafruit-circuitpython-teknikio_bluebird-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/pt_BR/adafruit-circuitpython-teknikio_bluebird-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/pt_BR/adafruit-circuitpython-teknikio_bluebird-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/sv/adafruit-circuitpython-teknikio_bluebird-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/sv/adafruit-circuitpython-teknikio_bluebird-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/zh_Latn_pinyin/adafruit-circuitpython-teknikio_bluebird-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/teknikio_bluebird/zh_Latn_pinyin/adafruit-circuitpython-teknikio_bluebird-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 15,
+        "downloads": 0,
         "id": "thunderpack",
         "versions": [
             {
@@ -11920,52 +13126,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/thunderpack/ID/adafruit-circuitpython-thunderpack-ID-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/thunderpack/ID/adafruit-circuitpython-thunderpack-ID-5.4.0-beta.1.bin"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/thunderpack/cs/adafruit-circuitpython-thunderpack-cs-5.4.0-beta.1.bin"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/thunderpack/de_DE/adafruit-circuitpython-thunderpack-de_DE-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/thunderpack/de_DE/adafruit-circuitpython-thunderpack-de_DE-5.4.0-beta.1.bin"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/thunderpack/en_US/adafruit-circuitpython-thunderpack-en_US-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/thunderpack/en_US/adafruit-circuitpython-thunderpack-en_US-5.4.0-beta.1.bin"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/thunderpack/en_x_pirate/adafruit-circuitpython-thunderpack-en_x_pirate-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/thunderpack/en_x_pirate/adafruit-circuitpython-thunderpack-en_x_pirate-5.4.0-beta.1.bin"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/thunderpack/es/adafruit-circuitpython-thunderpack-es-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/thunderpack/es/adafruit-circuitpython-thunderpack-es-5.4.0-beta.1.bin"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/thunderpack/fil/adafruit-circuitpython-thunderpack-fil-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/thunderpack/fil/adafruit-circuitpython-thunderpack-fil-5.4.0-beta.1.bin"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/thunderpack/fr/adafruit-circuitpython-thunderpack-fr-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/thunderpack/fr/adafruit-circuitpython-thunderpack-fr-5.4.0-beta.1.bin"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/thunderpack/it_IT/adafruit-circuitpython-thunderpack-it_IT-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/thunderpack/it_IT/adafruit-circuitpython-thunderpack-it_IT-5.4.0-beta.1.bin"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/thunderpack/ko/adafruit-circuitpython-thunderpack-ko-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/thunderpack/ko/adafruit-circuitpython-thunderpack-ko-5.4.0-beta.1.bin"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/thunderpack/nl/adafruit-circuitpython-thunderpack-nl-5.4.0-beta.1.bin"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/thunderpack/pl/adafruit-circuitpython-thunderpack-pl-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/thunderpack/pl/adafruit-circuitpython-thunderpack-pl-5.4.0-beta.1.bin"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/thunderpack/pt_BR/adafruit-circuitpython-thunderpack-pt_BR-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/thunderpack/pt_BR/adafruit-circuitpython-thunderpack-pt_BR-5.4.0-beta.1.bin"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/thunderpack/sv/adafruit-circuitpython-thunderpack-sv-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/thunderpack/sv/adafruit-circuitpython-thunderpack-sv-5.4.0-beta.1.bin"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/thunderpack/zh_Latn_pinyin/adafruit-circuitpython-thunderpack-zh_Latn_pinyin-5.4.0-beta.0.bin"
+                        "https://downloads.circuitpython.org/bin/thunderpack/zh_Latn_pinyin/adafruit-circuitpython-thunderpack-zh_Latn_pinyin-5.4.0-beta.1.bin"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 94,
+        "downloads": 0,
         "id": "trellis_m4_express",
         "versions": [
             {
@@ -12013,52 +13225,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/ID/adafruit-circuitpython-trellis_m4_express-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/ID/adafruit-circuitpython-trellis_m4_express-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/cs/adafruit-circuitpython-trellis_m4_express-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/de_DE/adafruit-circuitpython-trellis_m4_express-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/de_DE/adafruit-circuitpython-trellis_m4_express-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/en_US/adafruit-circuitpython-trellis_m4_express-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/en_US/adafruit-circuitpython-trellis_m4_express-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/en_x_pirate/adafruit-circuitpython-trellis_m4_express-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/en_x_pirate/adafruit-circuitpython-trellis_m4_express-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/es/adafruit-circuitpython-trellis_m4_express-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/es/adafruit-circuitpython-trellis_m4_express-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/fil/adafruit-circuitpython-trellis_m4_express-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/fil/adafruit-circuitpython-trellis_m4_express-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/fr/adafruit-circuitpython-trellis_m4_express-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/fr/adafruit-circuitpython-trellis_m4_express-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/it_IT/adafruit-circuitpython-trellis_m4_express-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/it_IT/adafruit-circuitpython-trellis_m4_express-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/ko/adafruit-circuitpython-trellis_m4_express-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/ko/adafruit-circuitpython-trellis_m4_express-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/nl/adafruit-circuitpython-trellis_m4_express-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/pl/adafruit-circuitpython-trellis_m4_express-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/pl/adafruit-circuitpython-trellis_m4_express-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/pt_BR/adafruit-circuitpython-trellis_m4_express-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/pt_BR/adafruit-circuitpython-trellis_m4_express-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/sv/adafruit-circuitpython-trellis_m4_express-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/sv/adafruit-circuitpython-trellis_m4_express-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/trellis_m4_express/zh_Latn_pinyin/adafruit-circuitpython-trellis_m4_express-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trellis_m4_express/zh_Latn_pinyin/adafruit-circuitpython-trellis_m4_express-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 150,
+        "downloads": 0,
         "id": "trinket_m0",
         "versions": [
             {
@@ -12106,52 +13324,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/ID/adafruit-circuitpython-trinket_m0-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trinket_m0/ID/adafruit-circuitpython-trinket_m0-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0/cs/adafruit-circuitpython-trinket_m0-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/de_DE/adafruit-circuitpython-trinket_m0-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trinket_m0/de_DE/adafruit-circuitpython-trinket_m0-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/en_US/adafruit-circuitpython-trinket_m0-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trinket_m0/en_US/adafruit-circuitpython-trinket_m0-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/en_x_pirate/adafruit-circuitpython-trinket_m0-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trinket_m0/en_x_pirate/adafruit-circuitpython-trinket_m0-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/es/adafruit-circuitpython-trinket_m0-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trinket_m0/es/adafruit-circuitpython-trinket_m0-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/fil/adafruit-circuitpython-trinket_m0-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trinket_m0/fil/adafruit-circuitpython-trinket_m0-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/fr/adafruit-circuitpython-trinket_m0-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trinket_m0/fr/adafruit-circuitpython-trinket_m0-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/it_IT/adafruit-circuitpython-trinket_m0-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trinket_m0/it_IT/adafruit-circuitpython-trinket_m0-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/ko/adafruit-circuitpython-trinket_m0-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trinket_m0/ko/adafruit-circuitpython-trinket_m0-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0/nl/adafruit-circuitpython-trinket_m0-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/pl/adafruit-circuitpython-trinket_m0-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trinket_m0/pl/adafruit-circuitpython-trinket_m0-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/pt_BR/adafruit-circuitpython-trinket_m0-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trinket_m0/pt_BR/adafruit-circuitpython-trinket_m0-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/sv/adafruit-circuitpython-trinket_m0-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trinket_m0/sv/adafruit-circuitpython-trinket_m0-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0/zh_Latn_pinyin/adafruit-circuitpython-trinket_m0-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trinket_m0/zh_Latn_pinyin/adafruit-circuitpython-trinket_m0-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 1,
+        "downloads": 0,
         "id": "trinket_m0_haxpress",
         "versions": [
             {
@@ -12199,47 +13423,53 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/ID/adafruit-circuitpython-trinket_m0_haxpress-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/ID/adafruit-circuitpython-trinket_m0_haxpress-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/cs/adafruit-circuitpython-trinket_m0_haxpress-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/de_DE/adafruit-circuitpython-trinket_m0_haxpress-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/de_DE/adafruit-circuitpython-trinket_m0_haxpress-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/en_US/adafruit-circuitpython-trinket_m0_haxpress-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/en_US/adafruit-circuitpython-trinket_m0_haxpress-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/en_x_pirate/adafruit-circuitpython-trinket_m0_haxpress-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/en_x_pirate/adafruit-circuitpython-trinket_m0_haxpress-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/es/adafruit-circuitpython-trinket_m0_haxpress-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/es/adafruit-circuitpython-trinket_m0_haxpress-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/fil/adafruit-circuitpython-trinket_m0_haxpress-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/fil/adafruit-circuitpython-trinket_m0_haxpress-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/fr/adafruit-circuitpython-trinket_m0_haxpress-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/fr/adafruit-circuitpython-trinket_m0_haxpress-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/it_IT/adafruit-circuitpython-trinket_m0_haxpress-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/it_IT/adafruit-circuitpython-trinket_m0_haxpress-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/ko/adafruit-circuitpython-trinket_m0_haxpress-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/ko/adafruit-circuitpython-trinket_m0_haxpress-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/nl/adafruit-circuitpython-trinket_m0_haxpress-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/pl/adafruit-circuitpython-trinket_m0_haxpress-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/pl/adafruit-circuitpython-trinket_m0_haxpress-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/pt_BR/adafruit-circuitpython-trinket_m0_haxpress-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/pt_BR/adafruit-circuitpython-trinket_m0_haxpress-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/sv/adafruit-circuitpython-trinket_m0_haxpress-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/sv/adafruit-circuitpython-trinket_m0_haxpress-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/zh_Latn_pinyin/adafruit-circuitpython-trinket_m0_haxpress-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/trinket_m0_haxpress/zh_Latn_pinyin/adafruit-circuitpython-trinket_m0_haxpress-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
@@ -12292,52 +13522,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/uartlogger2/ID/adafruit-circuitpython-uartlogger2-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/uartlogger2/ID/adafruit-circuitpython-uartlogger2-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/uartlogger2/cs/adafruit-circuitpython-uartlogger2-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/uartlogger2/de_DE/adafruit-circuitpython-uartlogger2-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/uartlogger2/de_DE/adafruit-circuitpython-uartlogger2-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/uartlogger2/en_US/adafruit-circuitpython-uartlogger2-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/uartlogger2/en_US/adafruit-circuitpython-uartlogger2-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/uartlogger2/en_x_pirate/adafruit-circuitpython-uartlogger2-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/uartlogger2/en_x_pirate/adafruit-circuitpython-uartlogger2-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/uartlogger2/es/adafruit-circuitpython-uartlogger2-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/uartlogger2/es/adafruit-circuitpython-uartlogger2-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/uartlogger2/fil/adafruit-circuitpython-uartlogger2-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/uartlogger2/fil/adafruit-circuitpython-uartlogger2-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/uartlogger2/fr/adafruit-circuitpython-uartlogger2-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/uartlogger2/fr/adafruit-circuitpython-uartlogger2-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/uartlogger2/it_IT/adafruit-circuitpython-uartlogger2-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/uartlogger2/it_IT/adafruit-circuitpython-uartlogger2-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/uartlogger2/ko/adafruit-circuitpython-uartlogger2-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/uartlogger2/ko/adafruit-circuitpython-uartlogger2-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/uartlogger2/nl/adafruit-circuitpython-uartlogger2-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/uartlogger2/pl/adafruit-circuitpython-uartlogger2-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/uartlogger2/pl/adafruit-circuitpython-uartlogger2-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/uartlogger2/pt_BR/adafruit-circuitpython-uartlogger2-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/uartlogger2/pt_BR/adafruit-circuitpython-uartlogger2-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/uartlogger2/sv/adafruit-circuitpython-uartlogger2-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/uartlogger2/sv/adafruit-circuitpython-uartlogger2-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/uartlogger2/zh_Latn_pinyin/adafruit-circuitpython-uartlogger2-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/uartlogger2/zh_Latn_pinyin/adafruit-circuitpython-uartlogger2-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 29,
+        "downloads": 0,
         "id": "uchip",
         "versions": [
             {
@@ -12385,65 +13621,73 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/uchip/ID/adafruit-circuitpython-uchip-ID-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/uchip/ID/adafruit-circuitpython-uchip-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/uchip/ID/adafruit-circuitpython-uchip-ID-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/uchip/ID/adafruit-circuitpython-uchip-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/uchip/cs/adafruit-circuitpython-uchip-cs-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/uchip/cs/adafruit-circuitpython-uchip-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/uchip/de_DE/adafruit-circuitpython-uchip-de_DE-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/uchip/de_DE/adafruit-circuitpython-uchip-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/uchip/de_DE/adafruit-circuitpython-uchip-de_DE-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/uchip/de_DE/adafruit-circuitpython-uchip-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/uchip/en_US/adafruit-circuitpython-uchip-en_US-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/uchip/en_US/adafruit-circuitpython-uchip-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/uchip/en_US/adafruit-circuitpython-uchip-en_US-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/uchip/en_US/adafruit-circuitpython-uchip-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/uchip/en_x_pirate/adafruit-circuitpython-uchip-en_x_pirate-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/uchip/en_x_pirate/adafruit-circuitpython-uchip-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/uchip/en_x_pirate/adafruit-circuitpython-uchip-en_x_pirate-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/uchip/en_x_pirate/adafruit-circuitpython-uchip-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/uchip/es/adafruit-circuitpython-uchip-es-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/uchip/es/adafruit-circuitpython-uchip-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/uchip/es/adafruit-circuitpython-uchip-es-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/uchip/es/adafruit-circuitpython-uchip-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/uchip/fil/adafruit-circuitpython-uchip-fil-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/uchip/fil/adafruit-circuitpython-uchip-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/uchip/fil/adafruit-circuitpython-uchip-fil-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/uchip/fil/adafruit-circuitpython-uchip-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/uchip/fr/adafruit-circuitpython-uchip-fr-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/uchip/fr/adafruit-circuitpython-uchip-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/uchip/fr/adafruit-circuitpython-uchip-fr-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/uchip/fr/adafruit-circuitpython-uchip-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/uchip/it_IT/adafruit-circuitpython-uchip-it_IT-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/uchip/it_IT/adafruit-circuitpython-uchip-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/uchip/it_IT/adafruit-circuitpython-uchip-it_IT-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/uchip/it_IT/adafruit-circuitpython-uchip-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/uchip/ko/adafruit-circuitpython-uchip-ko-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/uchip/ko/adafruit-circuitpython-uchip-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/uchip/ko/adafruit-circuitpython-uchip-ko-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/uchip/ko/adafruit-circuitpython-uchip-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/uchip/nl/adafruit-circuitpython-uchip-nl-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/uchip/nl/adafruit-circuitpython-uchip-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/uchip/pl/adafruit-circuitpython-uchip-pl-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/uchip/pl/adafruit-circuitpython-uchip-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/uchip/pl/adafruit-circuitpython-uchip-pl-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/uchip/pl/adafruit-circuitpython-uchip-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/uchip/pt_BR/adafruit-circuitpython-uchip-pt_BR-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/uchip/pt_BR/adafruit-circuitpython-uchip-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/uchip/pt_BR/adafruit-circuitpython-uchip-pt_BR-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/uchip/pt_BR/adafruit-circuitpython-uchip-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/uchip/sv/adafruit-circuitpython-uchip-sv-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/uchip/sv/adafruit-circuitpython-uchip-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/uchip/sv/adafruit-circuitpython-uchip-sv-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/uchip/sv/adafruit-circuitpython-uchip-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/uchip/zh_Latn_pinyin/adafruit-circuitpython-uchip-zh_Latn_pinyin-5.4.0-beta.0.bin",
-                        "https://downloads.circuitpython.org/bin/uchip/zh_Latn_pinyin/adafruit-circuitpython-uchip-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/uchip/zh_Latn_pinyin/adafruit-circuitpython-uchip-zh_Latn_pinyin-5.4.0-beta.1.bin",
+                        "https://downloads.circuitpython.org/bin/uchip/zh_Latn_pinyin/adafruit-circuitpython-uchip-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 24,
+        "downloads": 0,
         "id": "ugame10",
         "versions": [
             {
@@ -12491,52 +13735,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/ugame10/ID/adafruit-circuitpython-ugame10-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ugame10/ID/adafruit-circuitpython-ugame10-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/ugame10/cs/adafruit-circuitpython-ugame10-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/ugame10/de_DE/adafruit-circuitpython-ugame10-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ugame10/de_DE/adafruit-circuitpython-ugame10-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/ugame10/en_US/adafruit-circuitpython-ugame10-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ugame10/en_US/adafruit-circuitpython-ugame10-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/ugame10/en_x_pirate/adafruit-circuitpython-ugame10-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ugame10/en_x_pirate/adafruit-circuitpython-ugame10-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/ugame10/es/adafruit-circuitpython-ugame10-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ugame10/es/adafruit-circuitpython-ugame10-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/ugame10/fil/adafruit-circuitpython-ugame10-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ugame10/fil/adafruit-circuitpython-ugame10-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/ugame10/fr/adafruit-circuitpython-ugame10-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ugame10/fr/adafruit-circuitpython-ugame10-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/ugame10/it_IT/adafruit-circuitpython-ugame10-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ugame10/it_IT/adafruit-circuitpython-ugame10-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/ugame10/ko/adafruit-circuitpython-ugame10-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ugame10/ko/adafruit-circuitpython-ugame10-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/ugame10/nl/adafruit-circuitpython-ugame10-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/ugame10/pl/adafruit-circuitpython-ugame10-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ugame10/pl/adafruit-circuitpython-ugame10-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/ugame10/pt_BR/adafruit-circuitpython-ugame10-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ugame10/pt_BR/adafruit-circuitpython-ugame10-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/ugame10/sv/adafruit-circuitpython-ugame10-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ugame10/sv/adafruit-circuitpython-ugame10-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/ugame10/zh_Latn_pinyin/adafruit-circuitpython-ugame10-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/ugame10/zh_Latn_pinyin/adafruit-circuitpython-ugame10-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 39,
+        "downloads": 0,
         "id": "winterbloom_big_honking_button",
         "versions": [
             {
@@ -12584,52 +13834,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/ID/adafruit-circuitpython-winterbloom_big_honking_button-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/ID/adafruit-circuitpython-winterbloom_big_honking_button-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/cs/adafruit-circuitpython-winterbloom_big_honking_button-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/de_DE/adafruit-circuitpython-winterbloom_big_honking_button-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/de_DE/adafruit-circuitpython-winterbloom_big_honking_button-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/en_US/adafruit-circuitpython-winterbloom_big_honking_button-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/en_US/adafruit-circuitpython-winterbloom_big_honking_button-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/en_x_pirate/adafruit-circuitpython-winterbloom_big_honking_button-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/en_x_pirate/adafruit-circuitpython-winterbloom_big_honking_button-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/es/adafruit-circuitpython-winterbloom_big_honking_button-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/es/adafruit-circuitpython-winterbloom_big_honking_button-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/fil/adafruit-circuitpython-winterbloom_big_honking_button-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/fil/adafruit-circuitpython-winterbloom_big_honking_button-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/fr/adafruit-circuitpython-winterbloom_big_honking_button-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/fr/adafruit-circuitpython-winterbloom_big_honking_button-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/it_IT/adafruit-circuitpython-winterbloom_big_honking_button-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/it_IT/adafruit-circuitpython-winterbloom_big_honking_button-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/ko/adafruit-circuitpython-winterbloom_big_honking_button-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/ko/adafruit-circuitpython-winterbloom_big_honking_button-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/nl/adafruit-circuitpython-winterbloom_big_honking_button-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/pl/adafruit-circuitpython-winterbloom_big_honking_button-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/pl/adafruit-circuitpython-winterbloom_big_honking_button-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/pt_BR/adafruit-circuitpython-winterbloom_big_honking_button-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/pt_BR/adafruit-circuitpython-winterbloom_big_honking_button-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/sv/adafruit-circuitpython-winterbloom_big_honking_button-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/sv/adafruit-circuitpython-winterbloom_big_honking_button-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/zh_Latn_pinyin/adafruit-circuitpython-winterbloom_big_honking_button-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/winterbloom_big_honking_button/zh_Latn_pinyin/adafruit-circuitpython-winterbloom_big_honking_button-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 45,
+        "downloads": 0,
         "id": "winterbloom_sol",
         "versions": [
             {
@@ -12677,52 +13933,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/ID/adafruit-circuitpython-winterbloom_sol-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/ID/adafruit-circuitpython-winterbloom_sol-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/cs/adafruit-circuitpython-winterbloom_sol-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/de_DE/adafruit-circuitpython-winterbloom_sol-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/de_DE/adafruit-circuitpython-winterbloom_sol-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/en_US/adafruit-circuitpython-winterbloom_sol-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/en_US/adafruit-circuitpython-winterbloom_sol-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/en_x_pirate/adafruit-circuitpython-winterbloom_sol-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/en_x_pirate/adafruit-circuitpython-winterbloom_sol-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/es/adafruit-circuitpython-winterbloom_sol-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/es/adafruit-circuitpython-winterbloom_sol-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/fil/adafruit-circuitpython-winterbloom_sol-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/fil/adafruit-circuitpython-winterbloom_sol-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/fr/adafruit-circuitpython-winterbloom_sol-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/fr/adafruit-circuitpython-winterbloom_sol-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/it_IT/adafruit-circuitpython-winterbloom_sol-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/it_IT/adafruit-circuitpython-winterbloom_sol-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/ko/adafruit-circuitpython-winterbloom_sol-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/ko/adafruit-circuitpython-winterbloom_sol-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/nl/adafruit-circuitpython-winterbloom_sol-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/pl/adafruit-circuitpython-winterbloom_sol-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/pl/adafruit-circuitpython-winterbloom_sol-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/pt_BR/adafruit-circuitpython-winterbloom_sol-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/pt_BR/adafruit-circuitpython-winterbloom_sol-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/sv/adafruit-circuitpython-winterbloom_sol-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/sv/adafruit-circuitpython-winterbloom_sol-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/winterbloom_sol/zh_Latn_pinyin/adafruit-circuitpython-winterbloom_sol-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/winterbloom_sol/zh_Latn_pinyin/adafruit-circuitpython-winterbloom_sol-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 1,
+        "downloads": 0,
         "id": "xinabox_cc03",
         "versions": [
             {
@@ -12770,52 +14032,58 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/ID/adafruit-circuitpython-xinabox_cc03-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/ID/adafruit-circuitpython-xinabox_cc03-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/cs/adafruit-circuitpython-xinabox_cc03-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/de_DE/adafruit-circuitpython-xinabox_cc03-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/de_DE/adafruit-circuitpython-xinabox_cc03-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/en_US/adafruit-circuitpython-xinabox_cc03-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/en_US/adafruit-circuitpython-xinabox_cc03-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/en_x_pirate/adafruit-circuitpython-xinabox_cc03-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/en_x_pirate/adafruit-circuitpython-xinabox_cc03-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/es/adafruit-circuitpython-xinabox_cc03-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/es/adafruit-circuitpython-xinabox_cc03-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/fil/adafruit-circuitpython-xinabox_cc03-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/fil/adafruit-circuitpython-xinabox_cc03-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/fr/adafruit-circuitpython-xinabox_cc03-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/fr/adafruit-circuitpython-xinabox_cc03-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/it_IT/adafruit-circuitpython-xinabox_cc03-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/it_IT/adafruit-circuitpython-xinabox_cc03-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/ko/adafruit-circuitpython-xinabox_cc03-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/ko/adafruit-circuitpython-xinabox_cc03-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/nl/adafruit-circuitpython-xinabox_cc03-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/pl/adafruit-circuitpython-xinabox_cc03-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/pl/adafruit-circuitpython-xinabox_cc03-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/pt_BR/adafruit-circuitpython-xinabox_cc03-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/pt_BR/adafruit-circuitpython-xinabox_cc03-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/sv/adafruit-circuitpython-xinabox_cc03-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/sv/adafruit-circuitpython-xinabox_cc03-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cc03/zh_Latn_pinyin/adafruit-circuitpython-xinabox_cc03-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/xinabox_cc03/zh_Latn_pinyin/adafruit-circuitpython-xinabox_cc03-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     },
     {
-        "downloads": 38,
+        "downloads": 0,
         "id": "xinabox_cs11",
         "versions": [
             {
@@ -12863,47 +14131,53 @@
             {
                 "files": {
                     "ID": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/ID/adafruit-circuitpython-xinabox_cs11-ID-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/ID/adafruit-circuitpython-xinabox_cs11-ID-5.4.0-beta.1.uf2"
+                    ],
+                    "cs": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/cs/adafruit-circuitpython-xinabox_cs11-cs-5.4.0-beta.1.uf2"
                     ],
                     "de_DE": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/de_DE/adafruit-circuitpython-xinabox_cs11-de_DE-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/de_DE/adafruit-circuitpython-xinabox_cs11-de_DE-5.4.0-beta.1.uf2"
                     ],
                     "en_US": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/en_US/adafruit-circuitpython-xinabox_cs11-en_US-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/en_US/adafruit-circuitpython-xinabox_cs11-en_US-5.4.0-beta.1.uf2"
                     ],
                     "en_x_pirate": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/en_x_pirate/adafruit-circuitpython-xinabox_cs11-en_x_pirate-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/en_x_pirate/adafruit-circuitpython-xinabox_cs11-en_x_pirate-5.4.0-beta.1.uf2"
                     ],
                     "es": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/es/adafruit-circuitpython-xinabox_cs11-es-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/es/adafruit-circuitpython-xinabox_cs11-es-5.4.0-beta.1.uf2"
                     ],
                     "fil": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/fil/adafruit-circuitpython-xinabox_cs11-fil-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/fil/adafruit-circuitpython-xinabox_cs11-fil-5.4.0-beta.1.uf2"
                     ],
                     "fr": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/fr/adafruit-circuitpython-xinabox_cs11-fr-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/fr/adafruit-circuitpython-xinabox_cs11-fr-5.4.0-beta.1.uf2"
                     ],
                     "it_IT": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/it_IT/adafruit-circuitpython-xinabox_cs11-it_IT-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/it_IT/adafruit-circuitpython-xinabox_cs11-it_IT-5.4.0-beta.1.uf2"
                     ],
                     "ko": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/ko/adafruit-circuitpython-xinabox_cs11-ko-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/ko/adafruit-circuitpython-xinabox_cs11-ko-5.4.0-beta.1.uf2"
+                    ],
+                    "nl": [
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/nl/adafruit-circuitpython-xinabox_cs11-nl-5.4.0-beta.1.uf2"
                     ],
                     "pl": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/pl/adafruit-circuitpython-xinabox_cs11-pl-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/pl/adafruit-circuitpython-xinabox_cs11-pl-5.4.0-beta.1.uf2"
                     ],
                     "pt_BR": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/pt_BR/adafruit-circuitpython-xinabox_cs11-pt_BR-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/pt_BR/adafruit-circuitpython-xinabox_cs11-pt_BR-5.4.0-beta.1.uf2"
                     ],
                     "sv": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/sv/adafruit-circuitpython-xinabox_cs11-sv-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/sv/adafruit-circuitpython-xinabox_cs11-sv-5.4.0-beta.1.uf2"
                     ],
                     "zh_Latn_pinyin": [
-                        "https://downloads.circuitpython.org/bin/xinabox_cs11/zh_Latn_pinyin/adafruit-circuitpython-xinabox_cs11-zh_Latn_pinyin-5.4.0-beta.0.uf2"
+                        "https://downloads.circuitpython.org/bin/xinabox_cs11/zh_Latn_pinyin/adafruit-circuitpython-xinabox_cs11-zh_Latn_pinyin-5.4.0-beta.1.uf2"
                     ]
                 },
                 "stable": false,
-                "version": "5.4.0-beta.0"
+                "version": "5.4.0-beta.1"
             }
         ]
     }

--- a/_includes/download/board.html
+++ b/_includes/download/board.html
@@ -26,28 +26,36 @@
           {% for file in version.files %}
           <option value="{{ file[1] | join: ',' }}" data-files={{ file[1] | join: ',' }} data-locale={{ file[0] | replace: '_', '-' }} {% if file[0] == "en_US" %}selected{% endif %}>
             {% case file[0] %}
+              {% when 'cs' %}
+                CZECH
+              {% when 'de_DE' %}
+                GERMAN
               {% when 'en_US' %}
                 ENGLISH
               {% when 'en_x_pirate' %}
                 PIRATE (ENGLISH)
-              {% when 'zh_Latn_pinyin' %}
-                CHINESE (PINYIN)
-              {% when 'de_DE' %}
-                GERMAN
+              {% when 'es' %}
+                SPANISH
               {% when 'fil' %}
                 FILIPINO
               {% when 'fr' %}
                 FRENCH
-              {% when 'es' %}
-                SPANISH
+              {% when 'ID' %}
+                INDONESIAN
               {% when 'it_IT' %}
                 ITALIAN
+              {% when 'ko' %}
+                KOREAN
+              {% when 'nl' %}
+                DUTCH
               {% when 'pl' %}
                 POLISH
               {% when 'pt_BR' %}
                 PORTUGUESE (BRAZILIAN)
-              {% when 'ID' %}
-                INDONESIAN
+              {% when 'sv' %}
+                SWEDISH
+              {% when 'zh_Latn_pinyin' %}
+                CHINESE (PINYIN)
               {% else %}
                 {{ file[0] | upcase }}
             {% endcase %}


### PR DESCRIPTION
Automated website update for release 5.4.0-beta.1 by Blinka.

New boards:
* fluff_m0
* aloriumtech_evo_m51
* pycubed_mram
* espressif_saola_1_wrover
* espressif_saola_1_wroom
* hiibot_bluefi
* nice_nano

New languages:
* cs
* nl
