### PR TITLE
Added message for chrome users that displays info about blocked UF2s

### DIFF
--- a/_includes/download/board.html
+++ b/_includes/download/board.html
@@ -1,3 +1,12 @@
+<div class="section alert" id="chrome-alert">
+  <i class="fa fa-exclamation-circle"></i>
+  <p>
+    Google chrome recently blocked downloading UF2 files if safe browsing
+    is enabled. If you are experiencing problems, you can either <a href="https://support.google.com/chrome/answer/9890866">disable
+    safe browsing in settings</a> or go to your downloads page and manually
+    permit it.
+  </p>
+</div>
 {% assign board = site.data.files | where: "id", page.board_id %}
 {% if board[0] %}
 {% assign stable = board[0].versions | where: "stable", true | sort: "version" %}

--- a/assets/javascript/download.js
+++ b/assets/javascript/download.js
@@ -7,6 +7,10 @@ document.addEventListener('DOMContentLoaded',function() {
   var script = document.createElement('script');
   script.setAttribute('src', '//accounts.adafruit.com/users/locale?callback=setLocale');
   document.body.appendChild(script);
+
+  if (navigator.userAgent.indexOf("Chrome") !== -1) {
+      document.getElementById("chrome-alert").style.display = "flex";
+  }
 },false);
 
 function languageSelectHandler(event) {

--- a/assets/sass/pages/_download.scss
+++ b/assets/sass/pages/_download.scss
@@ -22,6 +22,10 @@
     margin: 0 0 10px 0;
   }
 
+  #chrome-alert {
+      display: none;
+  }
+
   .download-section {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
@@ -141,6 +145,16 @@
         a.download-button, a.download-button-unrecommended {
           background-color: $gray;
         }
+      }
+
+      .alert {
+          background-color: #fabfbe;
+          display: flex;
+          align-items: center;
+          i {
+              padding-right: 15px;
+              font-size: 33px;
+          }
       }
 
       .download-buttons {


### PR DESCRIPTION
Alert message will only show for chrome and includes a link to disabling protection in safe browsing.