### PR TITLE
downloads search: Enable text search on id, manufacturer, and features

### DIFF
--- a/assets/javascript/downloads.js
+++ b/assets/javascript/downloads.js
@@ -326,9 +326,9 @@ function shouldDisplayDownload(download, displayedManufacturers, displayedFeatur
 
   if (downloadsSearch.searchTerm && downloadsSearch.searchTerm.length > 0 && shouldDisplay) {
     var regex = new RegExp(downloadsSearch.searchTerm, "gi");
-    var name = download.dataset.name;
+    var haystack = download.dataset.name + " " + download.dataset.id + " " + download.dataset.manufacturer + " " + download.dataset.features;
 
-    shouldDisplay = name.match(regex);
+    shouldDisplay = haystack.match(regex);
   }
 
   return shouldDisplay;


### PR DESCRIPTION
I have repeatedly been tripped up by wanting to enter a manufacturer name in the text search area.  While it is possible to open the filter panel and select manufacturers, it is more convenient and intuitive to simply enter this in the single text search box.

By concatenating several fields from the dataset (name, id, manufacturer, and features), and then searching that it becomes possible to text-search e.g., for "alligator" (board feature), "diary" (manufacturer) or "metro_m4" (board id).

![image](https://user-images.githubusercontent.com/1517291/87855553-c9abdd00-c8de-11ea-8c99-e2d87a584512.png)
