### PR TITLE
RFC: Add Automated Tests For The Built Site

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Test Jekyll Site
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: true
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.x'
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install Ruby Dependencies
+        run: |
+          gem install bundler:1.17.3
+          bundle install
+      - name: Install Python Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r tests/requirements.txt
+      - name: Build & Serve site with jekyll
+        run: |
+          bundle exec jekyll serve --port 4000 --detach
+      - name: Run tests
+        run: |
+          pytest tests

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ _site
 _drafts/
 .bundle
 vendor
+
+.venv
+__pycache__
+.pytest_cache

--- a/_config.yml
+++ b/_config.yml
@@ -61,3 +61,4 @@ exclude:
   - icon.png
   - template.md
   - Rakefile
+  - tests

--- a/contributing/library_infrastructure.html
+++ b/contributing/library_infrastructure.html
@@ -25,7 +25,7 @@ permalink: /contributing/library-infrastructure-issues
 <div class="libraries">
     <ul>
     {% for repo_issue in site.data.libraries.repo_infrastructure_errors %}
-      <li>
+      <li class="library-libinfra-li">
         {{repo_issue[0]}}
         <ul>
         {% for issue in repo_issue[1] %}

--- a/contributing/open_issues.html
+++ b/contributing/open_issues.html
@@ -28,7 +28,7 @@ permalink: /contributing/open-issues
   <h3>Open Issues</h3>
   <ul>
     {% for library in site.data.libraries.open_issues %}
-      <li>
+      <li class="library-open-issue-li">
         {{library[0]}}
         <ul class="issues-list">
         {% for issue in library[1] %}

--- a/contributing/pull_requests.html
+++ b/contributing/pull_requests.html
@@ -11,7 +11,7 @@ permalink: /contributing
   <h3>Open Pull Requests</h3>
   <ul>
     {% for library in site.data.libraries.pull_requests %}
-      <li>
+      <li class="library-pr-li">
         {{library[0]}}
         <ul>
         {% for issue in library[1] %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+import json
+from pathlib import Path
+import pytest
+import requests
+import yaml
+
+@pytest.fixture(scope="session")
+def contrib_data_json():
+    contrib_data = None
+
+    conf_yaml_dir = Path(__file__).resolve().parents[1]
+    conf_yaml_file = conf_yaml_dir / "_config.yml"
+
+    yaml_data = {}
+    with open(conf_yaml_file) as file:
+        yaml_data = yaml.safe_load(file.read())
+
+    if yaml_data:
+        json_url = yaml_data.get("jekyll_get_json", [{}])[0].get("json")
+        result = requests.get(json_url)
+        if result.ok:
+            contrib_data = json.loads(result.text)
+
+    return contrib_data

--- a/tests/contributing/test_contributing_pages.py
+++ b/tests/contributing/test_contributing_pages.py
@@ -46,12 +46,18 @@ def test_library_data(contrib_data_json, page_data):
     source = BeautifulSoup(result.content, "html.parser")
     assert source.title.string == page_data["page_title"]
 
-    open_prs = BeautifulSoup(
+    # Get the specific content that is generated from libraries.v2.json
+    # on the S3 bucket.
+    page_content = BeautifulSoup(
         str(source),
         "html.parser",
         parse_only=SoupStrainer("div", class_=page_data["div_class_name"])
     )
-    assert open_prs
+    assert page_content
 
-    pr_list = open_prs.find_all("li", class_=page_data["list_item_class_name"])
-    assert len(pr_list) == len(contrib_data_json[page_data["json_data_key"]])
+    # Get the list items so that we can compare those to the source.
+    content_li = page_content.find_all(
+        "li",
+        class_=page_data["list_item_class_name"]
+    )
+    assert len(content_li) == len(contrib_data_json[page_data["json_data_key"]])

--- a/tests/contributing/test_contributing_pages.py
+++ b/tests/contributing/test_contributing_pages.py
@@ -1,0 +1,57 @@
+import pytest
+import requests
+from bs4 import BeautifulSoup, SoupStrainer
+
+contributing_pages = [
+    {
+        "test_id": "pull requests",
+        "url_path": "/",
+        "page_title": "Contributing - Pull Requests",
+        "div_class_name": "libraries open-pull-requests",
+        "list_item_class_name": "library-pr-li",
+        "json_data_key": "pull_requests"
+    },
+    {
+        "test_id": "open issues",
+        "url_path": "/open-issues",
+        "page_title": "Contributing - Open Issues",
+        "div_class_name": "libraries open-issues",
+        "list_item_class_name": "library-open-issue-li",
+        "json_data_key": "open_issues"
+    },
+    {
+        "test_id": "infrastructure issues",
+        "url_path": "/library-infrastructure-issues",
+        "page_title": "Contributing - Library Infrastructure Issues",
+        "div_class_name": "libraries",
+        "list_item_class_name": "library-libinfra-li",
+        "json_data_key": "repo_infrastructure_errors"
+    }
+]
+
+param_ids = [id["test_id"] for id in contributing_pages]
+
+@pytest.mark.parametrize('page_data', contributing_pages, ids=param_ids)
+def test_library_data(contrib_data_json, page_data):
+    try:
+        result = requests.get(
+            "http://localhost:4000/contributing" + page_data["url_path"],
+            allow_redirects=False,
+        )
+    except requests.exceptions.ConnectionError:
+        pytest.skip("local server not running.")
+
+    assert result.ok
+
+    source = BeautifulSoup(result.content, "html.parser")
+    assert source.title.string == page_data["page_title"]
+
+    open_prs = BeautifulSoup(
+        str(source),
+        "html.parser",
+        parse_only=SoupStrainer("div", class_=page_data["div_class_name"])
+    )
+    assert open_prs
+
+    pr_list = open_prs.find_all("li", class_=page_data["list_item_class_name"])
+    assert len(pr_list) == len(contrib_data_json[page_data["json_data_key"]])

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -vrs --tb=short

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,4 @@
+beautifulsoup4
+pytest
+pyyaml
+requests


### PR DESCRIPTION
After this past weekend's inadvertent errors on the `contributing` page, I wondered if we could add some testing to the CI.

This is a very limited prototype, that only tests 3 of the 4 sections in `contributing`. It builds and serves a local site via Jekyll, and tests the site with a `pytest` function. It compares the resulting site build against the actual source data from the S3 bucket.

This should be easily expandable to include more parts of the site, but I understand there are likely some preferences with regards to the tools used. Just wanted to get some wider input before getting too far with this.

EDIT: I keep forgetting that PRs will run new Actions workflows, if workflows are already present... See the `Test Jekyll Site` check.