### PR TITLE
Per email communication from Seeed, there are no plans to support the…

### DIFF
--- a/_board/seeeduino_wio_terminal.md
+++ b/_board/seeeduino_wio_terminal.md
@@ -11,7 +11,7 @@ date_added: 2020-7-3
 
 The Seeed 's Wio Terminal is an ATSAMD51-based microcontroller with wireless connectivity supported by Realtek RTL8720DN. Its CPU speed runs at 120MHz (Boost up to 200MHz). Realtek RTL8720DN chip supports both Bluetooth and Wi-Fi providing the backbone for IoT projects. The Wio Terminal itself is equipped with a 2.4” LCD Screen, onboard IMU(LIS3DHTR), microphone, buzzer, microSD card slot, light sensor, and infrared emitter(IR 940nm).
 
-**NOTE:** The RTL8720DN isn't currently supported from CircuitPython. Therefore, Wifi and Bluetooth will not work.
+**NOTE:** The RTL8720DN isn't supported from CircuitPython. Therefore, Wifi and Bluetooth will not work.
 
 ## Purchase
 * [Seeed's Wio Terminal](https://www.seeedstudio.com/Wio-Terminal-p-4509.html)


### PR DESCRIPTION
… Wio Terminal's RTL8720DN in CircuitPython.

---

Wrote to Seeed about WiFi/BLE support in the Wio Terminal, received the following message:

 Hi
Thank you for like our wio terminal product.
We have a wiki to introduce the Circuitpython.   
But we have no plan to add Wifi and BLE on the RTL8720DN chip supported in
CircuitPython.  

Thanks for your time and patience.
Regards



