### PR TITLE
Fixed sorting and hid unknown boards

### DIFF
--- a/_board/ADM_B_NRF52840_1.md
+++ b/_board/ADM_B_NRF52840_1.md
@@ -1,0 +1,12 @@
+---
+layout: download
+board_id: "unknown"
+title: "Unknown Board Download"
+name: "Unknown Board"
+manufacturer: "Unknown"
+board_url: ""
+board_image: "unknown.jpg"
+downloads_display: false
+---
+
+Oops! Looks like we don't know anything about this board. This means it's likely very new.

--- a/_board/blm_badge.md
+++ b/_board/blm_badge.md
@@ -6,6 +6,7 @@ name: "BLM Badge"
 manufacturer: "Adafruit"
 board_url: "https://github.com/adafruit/BLM-Badge-PCB"
 board_image: "blmbadge.jpg"
+date_added: 2020-9-1
 features:
   - STEMMA QT/QWIIC
 ---

--- a/_board/targett_module_clip_wroom.md
+++ b/_board/targett_module_clip_wroom.md
@@ -1,0 +1,12 @@
+---
+layout: download
+board_id: "unknown"
+title: "Unknown Board Download"
+name: "Unknown Board"
+manufacturer: "Unknown"
+board_url: ""
+board_image: "unknown.jpg"
+downloads_display: false
+---
+
+Oops! Looks like we don't know anything about this board. This means it's likely very new.

--- a/_board/targett_module_clip_wrover.md
+++ b/_board/targett_module_clip_wrover.md
@@ -1,0 +1,12 @@
+---
+layout: download
+board_id: "unknown"
+title: "Unknown Board Download"
+name: "Unknown Board"
+manufacturer: "Unknown"
+board_url: ""
+board_image: "unknown.jpg"
+downloads_display: false
+---
+
+Oops! Looks like we don't know anything about this board. This means it's likely very new.

--- a/assets/javascript/downloads.js
+++ b/assets/javascript/downloads.js
@@ -286,7 +286,7 @@ function handleSortResults(event) {
         case 'date-desc':
           dateA = new Date(a.dataset.date)
           dateB = new Date(b.dataset.date)
-          return dateA.getTime() > dateB.getTime() ? -1 : 1;
+          return dateA.getTime() < dateB.getTime() ? 1 : -1;
         default:
           // sort by download count is the default
           return parseInt(a.dataset.downloads, 10) < parseInt(b.dataset.downloads, 10) ? 1 : -1;


### PR DESCRIPTION
Fixes #601. This also hides some unknown boards until we can get them added and adds a missing date_added date to the BLM badge.