### PR TITLE
manual release of 6.0.1

### DIFF
--- a/_data/files.json
+++ b/_data/files.json
@@ -1,6 +1,6 @@
 [
  {
-  "downloads": 74,
+  "downloads": 144,
   "id": "8086_commander",
   "versions": [
    {
@@ -51,7 +51,7 @@
      "usb_hid"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -181,7 +181,7 @@
   ]
  },
  {
-  "downloads": 57,
+  "downloads": 42,
   "id": "TG-Watch02A",
   "versions": [
    {
@@ -251,7 +251,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -402,7 +402,7 @@
   ]
  },
  {
-  "downloads": 99,
+  "downloads": 81,
   "id": "adafruit_metro_esp32s2",
   "versions": [
    {
@@ -466,7 +466,7 @@
      "wifi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -542,7 +542,7 @@
   ]
  },
  {
-  "downloads": 67,
+  "downloads": 229,
   "id": "aloriumtech_evo_m51",
   "versions": [
    {
@@ -614,7 +614,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -690,7 +690,7 @@
   ]
  },
  {
-  "downloads": 121,
+  "downloads": 102,
   "id": "aramcon_badge_2019",
   "versions": [
    {
@@ -760,7 +760,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -834,7 +834,7 @@
   ]
  },
  {
-  "downloads": 32,
+  "downloads": 24,
   "id": "arduino_mkr1300",
   "versions": [
    {
@@ -886,7 +886,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -942,7 +942,7 @@
   ]
  },
  {
-  "downloads": 42,
+  "downloads": 27,
   "id": "arduino_mkrzero",
   "versions": [
    {
@@ -994,7 +994,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -1050,7 +1050,7 @@
   ]
  },
  {
-  "downloads": 148,
+  "downloads": 301,
   "id": "arduino_nano_33_ble",
   "versions": [
    {
@@ -1120,7 +1120,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -1194,7 +1194,7 @@
   ]
  },
  {
-  "downloads": 47,
+  "downloads": 45,
   "id": "arduino_nano_33_iot",
   "versions": [
    {
@@ -1246,7 +1246,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -1302,7 +1302,7 @@
   ]
  },
  {
-  "downloads": 85,
+  "downloads": 67,
   "id": "arduino_zero",
   "versions": [
    {
@@ -1354,7 +1354,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -1410,7 +1410,7 @@
   ]
  },
  {
-  "downloads": 13,
+  "downloads": 32,
   "id": "bast_pro_mini_m0",
   "versions": [
    {
@@ -1461,7 +1461,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -1516,7 +1516,7 @@
   ]
  },
  {
-  "downloads": 77,
+  "downloads": 189,
   "id": "bdmicro_vina_d21",
   "versions": [
    {
@@ -1574,7 +1574,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -1636,7 +1636,7 @@
   ]
  },
  {
-  "downloads": 95,
+  "downloads": 266,
   "id": "bdmicro_vina_d51",
   "versions": [
    {
@@ -1708,7 +1708,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -1789,7 +1789,7 @@
   "versions": []
  },
  {
-  "downloads": 56,
+  "downloads": 159,
   "id": "bless_dev_board_multi_sensor",
   "versions": [
    {
@@ -1859,7 +1859,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -1933,7 +1933,7 @@
   ]
  },
  {
-  "downloads": 49,
+  "downloads": 46,
   "id": "blm_badge",
   "versions": [
    {
@@ -1982,7 +1982,7 @@
      "usb_hid"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -2035,7 +2035,7 @@
   ]
  },
  {
-  "downloads": 139,
+  "downloads": 145,
   "id": "capablerobot_usbhub",
   "versions": [
    {
@@ -2106,7 +2106,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -2181,7 +2181,7 @@
   ]
  },
  {
-  "downloads": 54,
+  "downloads": 74,
   "id": "catwan_usbstick",
   "versions": [
    {
@@ -2231,7 +2231,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -2285,7 +2285,7 @@
   ]
  },
  {
-  "downloads": 20,
+  "downloads": 129,
   "id": "circuitbrains_basic_m0",
   "versions": [
    {
@@ -2343,7 +2343,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -2405,7 +2405,7 @@
   ]
  },
  {
-  "downloads": 120,
+  "downloads": 316,
   "id": "circuitbrains_deluxe_m4",
   "versions": [
    {
@@ -2477,7 +2477,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -2553,7 +2553,7 @@
   ]
  },
  {
-  "downloads": 366,
+  "downloads": 483,
   "id": "circuitplayground_bluefruit",
   "versions": [
    {
@@ -2623,7 +2623,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -2697,7 +2697,7 @@
   ]
  },
  {
-  "downloads": 461,
+  "downloads": 546,
   "id": "circuitplayground_express",
   "versions": [
    {
@@ -2755,7 +2755,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -2817,7 +2817,7 @@
   ]
  },
  {
-  "downloads": 45,
+  "downloads": 180,
   "id": "circuitplayground_express_4h",
   "versions": [
    {
@@ -2846,7 +2846,7 @@
     ],
     "modules": "[]",
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -2879,7 +2879,7 @@
   ]
  },
  {
-  "downloads": 132,
+  "downloads": 381,
   "id": "circuitplayground_express_crickit",
   "versions": [
    {
@@ -2934,7 +2934,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -2993,7 +2993,7 @@
   ]
  },
  {
-  "downloads": 37,
+  "downloads": 34,
   "id": "circuitplayground_express_digikey_pycon2019",
   "versions": [
    {
@@ -3022,7 +3022,7 @@
     ],
     "modules": "[]",
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -3055,7 +3055,7 @@
   ]
  },
  {
-  "downloads": 223,
+  "downloads": 313,
   "id": "circuitplayground_express_displayio",
   "versions": [
    {
@@ -3110,7 +3110,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -3169,7 +3169,7 @@
   ]
  },
  {
-  "downloads": 254,
+  "downloads": 399,
   "id": "clue_nrf52840_express",
   "versions": [
    {
@@ -3239,7 +3239,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -3313,7 +3313,7 @@
   ]
  },
  {
-  "downloads": 27,
+  "downloads": 82,
   "id": "cp32-m4",
   "versions": [
    {
@@ -3384,7 +3384,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -3576,7 +3576,7 @@
   ]
  },
  {
-  "downloads": 23,
+  "downloads": 29,
   "id": "datalore_ip_m4",
   "versions": [
    {
@@ -3648,7 +3648,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -3724,7 +3724,7 @@
   ]
  },
  {
-  "downloads": 81,
+  "downloads": 206,
   "id": "datum_distance",
   "versions": [
    {
@@ -3775,7 +3775,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -3830,7 +3830,7 @@
   ]
  },
  {
-  "downloads": 42,
+  "downloads": 78,
   "id": "datum_imu",
   "versions": [
    {
@@ -3881,7 +3881,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -3936,7 +3936,7 @@
   ]
  },
  {
-  "downloads": 73,
+  "downloads": 260,
   "id": "datum_light",
   "versions": [
    {
@@ -3987,7 +3987,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -4042,7 +4042,7 @@
   ]
  },
  {
-  "downloads": 73,
+  "downloads": 237,
   "id": "datum_weather",
   "versions": [
    {
@@ -4093,7 +4093,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -4148,7 +4148,7 @@
   ]
  },
  {
-  "downloads": 41,
+  "downloads": 245,
   "id": "dynossat_edu_eps",
   "versions": [
    {
@@ -4206,7 +4206,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -4265,7 +4265,7 @@
   ]
  },
  {
-  "downloads": 49,
+  "downloads": 217,
   "id": "dynossat_edu_obc",
   "versions": [
    {
@@ -4337,7 +4337,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -4413,7 +4413,7 @@
   ]
  },
  {
-  "downloads": 70,
+  "downloads": 109,
   "id": "edgebadge",
   "versions": [
    {
@@ -4442,7 +4442,7 @@
     ],
     "modules": "[]",
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -4475,7 +4475,7 @@
   ]
  },
  {
-  "downloads": 25,
+  "downloads": 22,
   "id": "electroniccats_bastwifi",
   "versions": [
    {
@@ -4538,7 +4538,7 @@
      "wifi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -4613,7 +4613,7 @@
   ]
  },
  {
-  "downloads": 80,
+  "downloads": 291,
   "id": "electronut_labs_blip",
   "versions": [
    {
@@ -4684,7 +4684,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -4759,7 +4759,7 @@
   ]
  },
  {
-  "downloads": 45,
+  "downloads": 212,
   "id": "electronut_labs_papyr",
   "versions": [
    {
@@ -4829,7 +4829,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -4903,7 +4903,7 @@
   ]
  },
  {
-  "downloads": 21,
+  "downloads": 44,
   "id": "escornabot_makech",
   "versions": [
    {
@@ -4953,7 +4953,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -5007,7 +5007,7 @@
   ]
  },
  {
-  "downloads": 50,
+  "downloads": 53,
   "id": "espressif_kaluga_1",
   "versions": [
    {
@@ -5071,7 +5071,7 @@
      "wifi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -5147,7 +5147,7 @@
   ]
  },
  {
-  "downloads": 106,
+  "downloads": 97,
   "id": "espressif_saola_1_wroom",
   "versions": [
    {
@@ -5211,7 +5211,7 @@
      "wifi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -5287,7 +5287,7 @@
   ]
  },
  {
-  "downloads": 90,
+  "downloads": 96,
   "id": "espressif_saola_1_wrover",
   "versions": [
    {
@@ -5351,7 +5351,7 @@
      "wifi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -5427,7 +5427,7 @@
   ]
  },
  {
-  "downloads": 24,
+  "downloads": 39,
   "id": "espruino_pico",
   "versions": [
    {
@@ -5483,7 +5483,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -5543,7 +5543,7 @@
   ]
  },
  {
-  "downloads": 22,
+  "downloads": 27,
   "id": "espruino_wifi",
   "versions": [
    {
@@ -5600,7 +5600,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -5661,7 +5661,7 @@
   ]
  },
  {
-  "downloads": 161,
+  "downloads": 387,
   "id": "feather_bluefruit_sense",
   "versions": [
    {
@@ -5731,7 +5731,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -5805,7 +5805,7 @@
   ]
  },
  {
-  "downloads": 99,
+  "downloads": 65,
   "id": "feather_m0_adalogger",
   "versions": [
    {
@@ -5857,7 +5857,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -5913,7 +5913,7 @@
   ]
  },
  {
-  "downloads": 86,
+  "downloads": 61,
   "id": "feather_m0_basic",
   "versions": [
    {
@@ -5965,7 +5965,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -6021,7 +6021,7 @@
   ]
  },
  {
-  "downloads": 201,
+  "downloads": 394,
   "id": "feather_m0_express",
   "versions": [
    {
@@ -6079,7 +6079,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -6141,7 +6141,7 @@
   ]
  },
  {
-  "downloads": 81,
+  "downloads": 155,
   "id": "feather_m0_express_crickit",
   "versions": [
    {
@@ -6197,7 +6197,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -6257,7 +6257,7 @@
   ]
  },
  {
-  "downloads": 37,
+  "downloads": 41,
   "id": "feather_m0_rfm69",
   "versions": [
    {
@@ -6302,7 +6302,7 @@
      "time"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -6351,7 +6351,7 @@
   ]
  },
  {
-  "downloads": 94,
+  "downloads": 54,
   "id": "feather_m0_rfm9x",
   "versions": [
    {
@@ -6396,7 +6396,7 @@
      "time"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -6445,7 +6445,7 @@
   ]
  },
  {
-  "downloads": 16,
+  "downloads": 101,
   "id": "feather_m0_supersized",
   "versions": [
    {
@@ -6503,7 +6503,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -6565,7 +6565,7 @@
   ]
  },
  {
-  "downloads": 41,
+  "downloads": 168,
   "id": "feather_m4_can",
   "versions": [
    {
@@ -6636,7 +6636,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -6711,7 +6711,7 @@
   ]
  },
  {
-  "downloads": 316,
+  "downloads": 465,
   "id": "feather_m4_express",
   "versions": [
    {
@@ -6783,7 +6783,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -6859,7 +6859,7 @@
   ]
  },
  {
-  "downloads": 34,
+  "downloads": 38,
   "id": "feather_m7_1011",
   "versions": [
    {
@@ -6919,7 +6919,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -6983,7 +6983,7 @@
   ]
  },
  {
-  "downloads": 34,
+  "downloads": 30,
   "id": "feather_mimxrt1011",
   "versions": [
    {
@@ -7043,7 +7043,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -7107,7 +7107,7 @@
   ]
  },
  {
-  "downloads": 42,
+  "downloads": 37,
   "id": "feather_mimxrt1062",
   "versions": [
    {
@@ -7167,7 +7167,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -7231,7 +7231,7 @@
   ]
  },
  {
-  "downloads": 217,
+  "downloads": 347,
   "id": "feather_nrf52840_express",
   "versions": [
    {
@@ -7301,7 +7301,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -7375,7 +7375,7 @@
   ]
  },
  {
-  "downloads": 7,
+  "downloads": 2,
   "id": "feather_radiofruit_zigbee",
   "versions": [
    {
@@ -7430,7 +7430,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -7489,7 +7489,7 @@
   ]
  },
  {
-  "downloads": 85,
+  "downloads": 76,
   "id": "feather_stm32f405_express",
   "versions": [
    {
@@ -7549,7 +7549,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -7613,7 +7613,7 @@
   ]
  },
  {
-  "downloads": 81,
+  "downloads": 243,
   "id": "fluff_m0",
   "versions": [
    {
@@ -7664,7 +7664,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -7719,7 +7719,7 @@
   ]
  },
  {
-  "downloads": 86,
+  "downloads": 143,
   "id": "fomu",
   "versions": [
    {
@@ -7765,7 +7765,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -7820,7 +7820,7 @@
   "versions": []
  },
  {
-  "downloads": 149,
+  "downloads": 174,
   "id": "gemma_m0",
   "versions": [
    {
@@ -7871,7 +7871,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -7926,7 +7926,7 @@
   ]
  },
  {
-  "downloads": 24,
+  "downloads": 45,
   "id": "gemma_m0_pycon2018",
   "versions": [
    {
@@ -7955,7 +7955,7 @@
     ],
     "modules": "[]",
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -7988,7 +7988,7 @@
   ]
  },
  {
-  "downloads": 170,
+  "downloads": 386,
   "id": "grandcentral_m4_express",
   "versions": [
    {
@@ -8061,7 +8061,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -8138,7 +8138,7 @@
   ]
  },
  {
-  "downloads": 100,
+  "downloads": 254,
   "id": "hallowing_m0_express",
   "versions": [
    {
@@ -8192,7 +8192,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -8250,7 +8250,7 @@
   ]
  },
  {
-  "downloads": 117,
+  "downloads": 247,
   "id": "hallowing_m4_express",
   "versions": [
    {
@@ -8322,7 +8322,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -8398,7 +8398,7 @@
   ]
  },
  {
-  "downloads": 66,
+  "downloads": 148,
   "id": "hiibot_bluefi",
   "versions": [
    {
@@ -8468,7 +8468,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -8542,7 +8542,7 @@
   ]
  },
  {
-  "downloads": 30,
+  "downloads": 50,
   "id": "ikigaisense_vita",
   "versions": [
    {
@@ -8612,7 +8612,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -8686,7 +8686,7 @@
   ]
  },
  {
-  "downloads": 43,
+  "downloads": 40,
   "id": "imxrt1010_evk",
   "versions": [
    {
@@ -8746,7 +8746,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -8810,7 +8810,7 @@
   ]
  },
  {
-  "downloads": 36,
+  "downloads": 42,
   "id": "imxrt1020_evk",
   "versions": [
    {
@@ -8870,7 +8870,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -8934,7 +8934,7 @@
   ]
  },
  {
-  "downloads": 35,
+  "downloads": 41,
   "id": "imxrt1060_evk",
   "versions": [
    {
@@ -8994,7 +8994,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -9058,7 +9058,7 @@
   ]
  },
  {
-  "downloads": 170,
+  "downloads": 341,
   "id": "itsybitsy_m0_express",
   "versions": [
    {
@@ -9113,7 +9113,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -9172,7 +9172,7 @@
   ]
  },
  {
-  "downloads": 199,
+  "downloads": 278,
   "id": "itsybitsy_m4_express",
   "versions": [
    {
@@ -9243,7 +9243,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -9318,7 +9318,7 @@
   ]
  },
  {
-  "downloads": 197,
+  "downloads": 277,
   "id": "itsybitsy_nrf52840_express",
   "versions": [
    {
@@ -9388,7 +9388,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -9462,7 +9462,7 @@
   ]
  },
  {
-  "downloads": 60,
+  "downloads": 45,
   "id": "kicksat-sprite",
   "versions": [
    {
@@ -9523,7 +9523,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -9588,7 +9588,7 @@
   ]
  },
  {
-  "downloads": 32,
+  "downloads": 151,
   "id": "loc_ber_m4_base_board",
   "versions": [
    {
@@ -9640,7 +9640,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -9696,7 +9696,7 @@
   ]
  },
  {
-  "downloads": 105,
+  "downloads": 297,
   "id": "makerdiary_m60_keyboard",
   "versions": [
    {
@@ -9766,7 +9766,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -9840,7 +9840,7 @@
   ]
  },
  {
-  "downloads": 36,
+  "downloads": 87,
   "id": "makerdiary_nrf52840_m2_devkit",
   "versions": [
    {
@@ -9910,7 +9910,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -9984,7 +9984,7 @@
   ]
  },
  {
-  "downloads": 91,
+  "downloads": 283,
   "id": "makerdiary_nrf52840_mdk",
   "versions": [
    {
@@ -10054,7 +10054,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -10128,7 +10128,7 @@
   ]
  },
  {
-  "downloads": 88,
+  "downloads": 66,
   "id": "makerdiary_nrf52840_mdk_usb_dongle",
   "versions": [
    {
@@ -10199,7 +10199,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -10274,7 +10274,7 @@
   ]
  },
  {
-  "downloads": 416,
+  "downloads": 477,
   "id": "matrixportal_m4",
   "versions": [
    {
@@ -10346,7 +10346,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -10422,7 +10422,7 @@
   ]
  },
  {
-  "downloads": 120,
+  "downloads": 149,
   "id": "meowbit_v121",
   "versions": [
    {
@@ -10479,7 +10479,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -10539,7 +10539,7 @@
   ]
  },
  {
-  "downloads": 88,
+  "downloads": 255,
   "id": "meowmeow",
   "versions": [
    {
@@ -10588,7 +10588,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -10641,7 +10641,7 @@
   ]
  },
  {
-  "downloads": 152,
+  "downloads": 328,
   "id": "metro_m0_express",
   "versions": [
    {
@@ -10699,7 +10699,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -10761,7 +10761,7 @@
   ]
  },
  {
-  "downloads": 139,
+  "downloads": 296,
   "id": "metro_m4_airlift_lite",
   "versions": [
    {
@@ -10833,7 +10833,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -10909,7 +10909,7 @@
   ]
  },
  {
-  "downloads": 171,
+  "downloads": 265,
   "id": "metro_m4_express",
   "versions": [
    {
@@ -10981,7 +10981,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -11057,7 +11057,7 @@
   ]
  },
  {
-  "downloads": 29,
+  "downloads": 37,
   "id": "metro_m7_1011",
   "versions": [
    {
@@ -11117,7 +11117,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -11181,7 +11181,7 @@
   ]
  },
  {
-  "downloads": 70,
+  "downloads": 192,
   "id": "metro_nrf52840_express",
   "versions": [
    {
@@ -11251,7 +11251,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -11325,7 +11325,7 @@
   ]
  },
  {
-  "downloads": 29,
+  "downloads": 34,
   "id": "microdev_micro_s2",
   "versions": [
    {
@@ -11389,7 +11389,7 @@
      "wifi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -11465,7 +11465,7 @@
   ]
  },
  {
-  "downloads": 128,
+  "downloads": 254,
   "id": "mini_sam_m4",
   "versions": [
    {
@@ -11536,7 +11536,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -11611,7 +11611,7 @@
   ]
  },
  {
-  "downloads": 99,
+  "downloads": 287,
   "id": "monster_m4sk",
   "versions": [
    {
@@ -11683,7 +11683,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -11759,7 +11759,7 @@
   ]
  },
  {
-  "downloads": 83,
+  "downloads": 62,
   "id": "muselab_nanoesp32_s2",
   "versions": [
    {
@@ -11823,7 +11823,7 @@
      "wifi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -11899,7 +11899,7 @@
   ]
  },
  {
-  "downloads": 65,
+  "downloads": 195,
   "id": "ndgarage_ndbit6",
   "versions": [
    {
@@ -11950,7 +11950,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -12005,7 +12005,7 @@
   ]
  },
  {
-  "downloads": 4,
+  "downloads": 1,
   "id": "ndgarage_ndbit6_v2",
   "versions": [
    {
@@ -12056,7 +12056,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -12111,7 +12111,7 @@
   ]
  },
  {
-  "downloads": 127,
+  "downloads": 226,
   "id": "nfc_copy_cat",
   "versions": [
    {
@@ -12162,7 +12162,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -12217,7 +12217,7 @@
   ]
  },
  {
-  "downloads": 78,
+  "downloads": 319,
   "id": "nice_nano",
   "versions": [
    {
@@ -12287,7 +12287,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -12361,7 +12361,7 @@
   ]
  },
  {
-  "downloads": 20,
+  "downloads": 26,
   "id": "nucleo_f746zg",
   "versions": [
    {
@@ -12416,7 +12416,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -12475,7 +12475,7 @@
   ]
  },
  {
-  "downloads": 28,
+  "downloads": 30,
   "id": "nucleo_f767zi",
   "versions": [
    {
@@ -12530,7 +12530,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -12589,7 +12589,7 @@
   ]
  },
  {
-  "downloads": 53,
+  "downloads": 30,
   "id": "nucleo_h743zi_2",
   "versions": [
    {
@@ -12642,7 +12642,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -12699,7 +12699,7 @@
   ]
  },
  {
-  "downloads": 50,
+  "downloads": 52,
   "id": "ohs2020_badge",
   "versions": [
    {
@@ -12769,7 +12769,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -12843,7 +12843,7 @@
   ]
  },
  {
-  "downloads": 124,
+  "downloads": 243,
   "id": "openbook_m4",
   "versions": [
    {
@@ -12916,7 +12916,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -12993,7 +12993,7 @@
   ]
  },
  {
-  "downloads": 18,
+  "downloads": 24,
   "id": "openmv_h7",
   "versions": [
    {
@@ -13046,7 +13046,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -13103,7 +13103,7 @@
   ]
  },
  {
-  "downloads": 62,
+  "downloads": 100,
   "id": "particle_argon",
   "versions": [
    {
@@ -13173,7 +13173,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -13247,7 +13247,7 @@
   ]
  },
  {
-  "downloads": 41,
+  "downloads": 181,
   "id": "particle_boron",
   "versions": [
    {
@@ -13317,7 +13317,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -13391,7 +13391,7 @@
   ]
  },
  {
-  "downloads": 136,
+  "downloads": 259,
   "id": "particle_xenon",
   "versions": [
    {
@@ -13461,7 +13461,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -13540,7 +13540,7 @@
   "versions": []
  },
  {
-  "downloads": 51,
+  "downloads": 45,
   "id": "pca10056",
   "versions": [
    {
@@ -13611,7 +13611,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -13686,7 +13686,7 @@
   ]
  },
  {
-  "downloads": 92,
+  "downloads": 67,
   "id": "pca10059",
   "versions": [
    {
@@ -13757,7 +13757,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -13832,7 +13832,7 @@
   ]
  },
  {
-  "downloads": 117,
+  "downloads": 200,
   "id": "pca10100",
   "versions": [
    {
@@ -13886,7 +13886,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -13944,7 +13944,7 @@
   ]
  },
  {
-  "downloads": 81,
+  "downloads": 101,
   "id": "pewpew10",
   "versions": [
    {
@@ -13993,7 +13993,7 @@
      "usb_hid"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -14046,7 +14046,7 @@
   ]
  },
  {
-  "downloads": 64,
+  "downloads": 5,
   "id": "pewpew13",
   "versions": [
    {
@@ -14075,7 +14075,7 @@
     ],
     "modules": "[]",
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -14108,7 +14108,7 @@
   ]
  },
  {
-  "downloads": 51,
+  "downloads": 95,
   "id": "pewpew_m4",
   "versions": [
    {
@@ -14160,7 +14160,7 @@
      "time"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -14216,7 +14216,7 @@
   ]
  },
  {
-  "downloads": 45,
+  "downloads": 106,
   "id": "picoplanet",
   "versions": [
    {
@@ -14267,7 +14267,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -14322,7 +14322,7 @@
   ]
  },
  {
-  "downloads": 102,
+  "downloads": 219,
   "id": "pirkey_m0",
   "versions": [
    {
@@ -14367,7 +14367,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -14416,7 +14416,7 @@
   ]
  },
  {
-  "downloads": 78,
+  "downloads": 127,
   "id": "pitaya_go",
   "versions": [
    {
@@ -14486,7 +14486,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -14560,7 +14560,7 @@
   ]
  },
  {
-  "downloads": 18,
+  "downloads": 26,
   "id": "pyb_nano_v2",
   "versions": [
    {
@@ -14617,7 +14617,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -14678,7 +14678,7 @@
   ]
  },
  {
-  "downloads": 199,
+  "downloads": 341,
   "id": "pybadge",
   "versions": [
    {
@@ -14752,7 +14752,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -14830,7 +14830,7 @@
   ]
  },
  {
-  "downloads": 70,
+  "downloads": 107,
   "id": "pybadge_airlift",
   "versions": [
    {
@@ -14904,7 +14904,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -14982,7 +14982,7 @@
   ]
  },
  {
-  "downloads": 77,
+  "downloads": 44,
   "id": "pyboard_v11",
   "versions": [
    {
@@ -15042,7 +15042,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -15106,7 +15106,7 @@
   ]
  },
  {
-  "downloads": 128,
+  "downloads": 239,
   "id": "pycubed",
   "versions": [
    {
@@ -15169,7 +15169,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -15236,7 +15236,7 @@
   ]
  },
  {
-  "downloads": 60,
+  "downloads": 76,
   "id": "pycubed_mram",
   "versions": [
    {
@@ -15299,7 +15299,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -15366,7 +15366,7 @@
   ]
  },
  {
-  "downloads": 217,
+  "downloads": 342,
   "id": "pygamer",
   "versions": [
    {
@@ -15440,7 +15440,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -15518,7 +15518,7 @@
   ]
  },
  {
-  "downloads": 87,
+  "downloads": 205,
   "id": "pygamer_advance",
   "versions": [
    {
@@ -15592,7 +15592,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -15670,7 +15670,7 @@
   ]
  },
  {
-  "downloads": 264,
+  "downloads": 409,
   "id": "pyportal",
   "versions": [
    {
@@ -15742,7 +15742,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -15818,7 +15818,7 @@
   ]
  },
  {
-  "downloads": 77,
+  "downloads": 88,
   "id": "pyportal_pynt",
   "versions": [
    {
@@ -15847,7 +15847,7 @@
     ],
     "modules": "[]",
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -15880,7 +15880,7 @@
   ]
  },
  {
-  "downloads": 161,
+  "downloads": 276,
   "id": "pyportal_titano",
   "versions": [
    {
@@ -15952,7 +15952,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -16028,7 +16028,7 @@
   ]
  },
  {
-  "downloads": 186,
+  "downloads": 306,
   "id": "pyruler",
   "versions": [
    {
@@ -16078,7 +16078,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -16132,7 +16132,7 @@
   ]
  },
  {
-  "downloads": 162,
+  "downloads": 332,
   "id": "qtpy_m0",
   "versions": [
    {
@@ -16183,7 +16183,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -16238,7 +16238,7 @@
   ]
  },
  {
-  "downloads": 118,
+  "downloads": 203,
   "id": "qtpy_m0_haxpress",
   "versions": [
    {
@@ -16296,7 +16296,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -16358,7 +16358,7 @@
   ]
  },
  {
-  "downloads": 97,
+  "downloads": 278,
   "id": "raytac_mdbt50q-db-40",
   "versions": [
    {
@@ -16428,7 +16428,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -16502,7 +16502,7 @@
   ]
  },
  {
-  "downloads": 109,
+  "downloads": 268,
   "id": "robohatmm1_m4",
   "versions": [
    {
@@ -16566,7 +16566,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -16634,7 +16634,7 @@
   ]
  },
  {
-  "downloads": 143,
+  "downloads": 111,
   "id": "sam32",
   "versions": [
    {
@@ -16706,7 +16706,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -16782,7 +16782,7 @@
   ]
  },
  {
-  "downloads": 71,
+  "downloads": 203,
   "id": "same54_xplained",
   "versions": [
    {
@@ -16854,7 +16854,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -16930,7 +16930,7 @@
   ]
  },
  {
-  "downloads": 203,
+  "downloads": 347,
   "id": "seeeduino_wio_terminal",
   "versions": [
    {
@@ -17002,7 +17002,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -17078,7 +17078,7 @@
   ]
  },
  {
-  "downloads": 263,
+  "downloads": 519,
   "id": "seeeduino_xiao",
   "versions": [
    {
@@ -17129,7 +17129,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -17184,7 +17184,7 @@
   ]
  },
  {
-  "downloads": 173,
+  "downloads": 312,
   "id": "serpente",
   "versions": [
    {
@@ -17244,7 +17244,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -17308,7 +17308,7 @@
   ]
  },
  {
-  "downloads": 24,
+  "downloads": 188,
   "id": "shirtty",
   "versions": [
    {
@@ -17359,7 +17359,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -17414,7 +17414,7 @@
   ]
  },
  {
-  "downloads": 81,
+  "downloads": 164,
   "id": "simmel",
   "versions": [
    {
@@ -17471,7 +17471,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -17532,7 +17532,7 @@
   ]
  },
  {
-  "downloads": 140,
+  "downloads": 291,
   "id": "snekboard",
   "versions": [
    {
@@ -17590,7 +17590,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -17652,7 +17652,7 @@
   ]
  },
  {
-  "downloads": 20,
+  "downloads": 123,
   "id": "sparkfun_lumidrive",
   "versions": [
    {
@@ -17710,7 +17710,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -17772,7 +17772,7 @@
   ]
  },
  {
-  "downloads": 76,
+  "downloads": 167,
   "id": "sparkfun_nrf52840_mini",
   "versions": [
    {
@@ -17842,7 +17842,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -17916,7 +17916,7 @@
   ]
  },
  {
-  "downloads": 42,
+  "downloads": 49,
   "id": "sparkfun_qwiic_micro_no_flash",
   "versions": [
    {
@@ -17967,7 +17967,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -18022,7 +18022,7 @@
   ]
  },
  {
-  "downloads": 71,
+  "downloads": 141,
   "id": "sparkfun_qwiic_micro_with_flash",
   "versions": [
    {
@@ -18073,7 +18073,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -18128,7 +18128,7 @@
   ]
  },
  {
-  "downloads": 64,
+  "downloads": 112,
   "id": "sparkfun_redboard_turbo",
   "versions": [
    {
@@ -18185,7 +18185,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -18246,7 +18246,7 @@
   ]
  },
  {
-  "downloads": 53,
+  "downloads": 69,
   "id": "sparkfun_samd21_dev",
   "versions": [
    {
@@ -18297,7 +18297,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -18352,7 +18352,7 @@
   ]
  },
  {
-  "downloads": 45,
+  "downloads": 82,
   "id": "sparkfun_samd21_mini",
   "versions": [
    {
@@ -18403,7 +18403,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -18458,7 +18458,7 @@
   ]
  },
  {
-  "downloads": 101,
+  "downloads": 90,
   "id": "sparkfun_samd51_thing_plus",
   "versions": [
    {
@@ -18530,7 +18530,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -18606,7 +18606,7 @@
   ]
  },
  {
-  "downloads": 45,
+  "downloads": 119,
   "id": "spresense",
   "versions": [
    {
@@ -18635,7 +18635,7 @@
     ],
     "modules": "[]",
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -18668,7 +18668,7 @@
   ]
  },
  {
-  "downloads": 79,
+  "downloads": 52,
   "id": "stm32f411ce_blackpill",
   "versions": [
    {
@@ -18725,7 +18725,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -18786,7 +18786,7 @@
   ]
  },
  {
-  "downloads": 27,
+  "downloads": 29,
   "id": "stm32f411ve_discovery",
   "versions": [
    {
@@ -18843,7 +18843,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -18904,7 +18904,7 @@
   ]
  },
  {
-  "downloads": 17,
+  "downloads": 32,
   "id": "stm32f412zg_discovery",
   "versions": [
    {
@@ -18962,7 +18962,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -19024,7 +19024,7 @@
   ]
  },
  {
-  "downloads": 25,
+  "downloads": 38,
   "id": "stm32f4_discovery",
   "versions": [
    {
@@ -19081,7 +19081,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -19142,7 +19142,7 @@
   ]
  },
  {
-  "downloads": 18,
+  "downloads": 30,
   "id": "stm32f746g_discovery",
   "versions": [
    {
@@ -19197,7 +19197,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -19256,7 +19256,7 @@
   ]
  },
  {
-  "downloads": 76,
+  "downloads": 237,
   "id": "stringcar_m0_express",
   "versions": [
    {
@@ -19312,7 +19312,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -19526,7 +19526,7 @@
   ]
  },
  {
-  "downloads": 143,
+  "downloads": 95,
   "id": "teensy40",
   "versions": [
    {
@@ -19586,7 +19586,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -19650,7 +19650,7 @@
   ]
  },
  {
-  "downloads": 94,
+  "downloads": 102,
   "id": "teensy41",
   "versions": [
    {
@@ -19710,7 +19710,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -19774,7 +19774,7 @@
   ]
  },
  {
-  "downloads": 41,
+  "downloads": 44,
   "id": "teknikio_bluebird",
   "versions": [
    {
@@ -19844,7 +19844,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -19918,7 +19918,7 @@
   ]
  },
  {
-  "downloads": 25,
+  "downloads": 28,
   "id": "thunderpack",
   "versions": [
    {
@@ -19975,7 +19975,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    }
   ]
  },
@@ -20103,7 +20103,7 @@
   ]
  },
  {
-  "downloads": 44,
+  "downloads": 71,
   "id": "tinkeringtech_scoutmakes_azul",
   "versions": [
    {
@@ -20173,7 +20173,7 @@
      "watchdog"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -20247,7 +20247,7 @@
   ]
  },
  {
-  "downloads": 160,
+  "downloads": 248,
   "id": "trellis_m4_express",
   "versions": [
    {
@@ -20318,7 +20318,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -20393,7 +20393,7 @@
   ]
  },
  {
-  "downloads": 336,
+  "downloads": 447,
   "id": "trinket_m0",
   "versions": [
    {
@@ -20444,7 +20444,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -20499,7 +20499,7 @@
   ]
  },
  {
-  "downloads": 131,
+  "downloads": 296,
   "id": "trinket_m0_haxpress",
   "versions": [
    {
@@ -20556,7 +20556,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -20617,7 +20617,7 @@
   ]
  },
  {
-  "downloads": 75,
+  "downloads": 7,
   "id": "uartlogger2",
   "versions": [
    {
@@ -20689,7 +20689,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -20765,7 +20765,7 @@
   ]
  },
  {
-  "downloads": 55,
+  "downloads": 43,
   "id": "uchip",
   "versions": [
    {
@@ -20817,7 +20817,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -20873,7 +20873,7 @@
   ]
  },
  {
-  "downloads": 103,
+  "downloads": 300,
   "id": "ugame10",
   "versions": [
    {
@@ -20927,7 +20927,7 @@
      "vectorio"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -20985,7 +20985,7 @@
   ]
  },
  {
-  "downloads": 104,
+  "downloads": 81,
   "id": "unexpectedmaker_feathers2",
   "versions": [
    {
@@ -21049,7 +21049,7 @@
      "wifi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -21125,7 +21125,7 @@
   ]
  },
  {
-  "downloads": 16,
+  "downloads": 31,
   "id": "unexpectedmaker_feathers2_prerelease",
   "versions": [
    {
@@ -21189,7 +21189,7 @@
      "wifi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -21265,7 +21265,7 @@
   ]
  },
  {
-  "downloads": 87,
+  "downloads": 218,
   "id": "winterbloom_big_honking_button",
   "versions": [
    {
@@ -21316,7 +21316,7 @@
      "time"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -21371,7 +21371,7 @@
   ]
  },
  {
-  "downloads": 122,
+  "downloads": 256,
   "id": "winterbloom_sol",
   "versions": [
    {
@@ -21426,7 +21426,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -21530,7 +21530,7 @@
      "usb_midi"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [
@@ -21579,7 +21579,7 @@
   ]
  },
  {
-  "downloads": 18,
+  "downloads": 58,
   "id": "xinabox_cs11",
   "versions": [
    {
@@ -21622,7 +21622,7 @@
      "usb_hid"
     ],
     "stable": true,
-    "version": "6.0.0"
+    "version": "6.0.1"
    },
    {
     "extensions": [


### PR DESCRIPTION
Had to update version manually, due to change in `build_board_info.py` and structure of `_data/files.json`. Tried running new version in old tree, but ran into credential problems.
Also updated download counts, using December 2020 data.