### PR TITLE
Automated website update for release 6.1.0-beta.3

### DIFF
--- a/_data/files.json
+++ b/_data/files.json
@@ -1,6 +1,6 @@
 [
  {
-  "downloads": 144,
+  "downloads": 0,
   "id": "8086_commander",
   "versions": [
    {
@@ -58,24 +58,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -101,7 +101,7 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
@@ -114,24 +114,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -176,12 +176,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 42,
+  "downloads": 0,
   "id": "TG-Watch02A",
   "versions": [
    {
@@ -258,24 +258,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -320,7 +320,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
@@ -334,24 +334,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -365,6 +365,7 @@
      "countio",
      "digitalio",
      "displayio",
+     "dualbank",
      "framebufferio",
      "frequencyio",
      "gamepad",
@@ -397,12 +398,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 81,
+  "downloads": 0,
   "id": "adafruit_metro_esp32s2",
   "versions": [
    {
@@ -474,24 +475,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -505,6 +506,7 @@
      "countio",
      "digitalio",
      "displayio",
+     "dualbank",
      "framebufferio",
      "frequencyio",
      "gamepad",
@@ -537,12 +539,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 229,
+  "downloads": 0,
   "id": "aloriumtech_evo_m51",
   "versions": [
    {
@@ -621,24 +623,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -685,12 +687,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 102,
+  "downloads": 0,
   "id": "aramcon_badge_2019",
   "versions": [
    {
@@ -767,24 +769,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -829,12 +831,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 24,
+  "downloads": 0,
   "id": "arduino_mkr1300",
   "versions": [
    {
@@ -894,24 +896,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -937,12 +939,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 27,
+  "downloads": 0,
   "id": "arduino_mkrzero",
   "versions": [
    {
@@ -1002,24 +1004,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -1045,12 +1047,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 301,
+  "downloads": 0,
   "id": "arduino_nano_33_ble",
   "versions": [
    {
@@ -1127,24 +1129,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -1189,12 +1191,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 45,
+  "downloads": 0,
   "id": "arduino_nano_33_iot",
   "versions": [
    {
@@ -1254,24 +1256,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -1297,12 +1299,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 67,
+  "downloads": 0,
   "id": "arduino_zero",
   "versions": [
    {
@@ -1362,24 +1364,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -1405,12 +1407,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 32,
+  "downloads": 0,
   "id": "bast_pro_mini_m0",
   "versions": [
    {
@@ -1468,24 +1470,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -1511,12 +1513,87 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 189,
+  "downloads": 0,
+  "id": "bastble",
+  "versions": [
+   {
+    "extensions": [
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": [
+     "_bleio",
+     "_pixelbuf",
+     "aesio",
+     "analogio",
+     "audiobusio",
+     "audiocore",
+     "audiomixer",
+     "audiomp3",
+     "audiopwmio",
+     "bitbangio",
+     "board",
+     "busio",
+     "digitalio",
+     "displayio",
+     "framebufferio",
+     "gamepad",
+     "math",
+     "microcontroller",
+     "neopixel_write",
+     "nvm",
+     "os",
+     "pulseio",
+     "pwmio",
+     "random",
+     "rgbmatrix",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "touchio",
+     "ulab",
+     "usb_hid",
+     "usb_midi",
+     "vectorio",
+     "watchdog"
+    ],
+    "stable": false,
+    "version": "6.1.0-beta.3"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
   "id": "bdmicro_vina_d21",
   "versions": [
    {
@@ -1581,24 +1658,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -1631,12 +1708,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 266,
+  "downloads": 0,
   "id": "bdmicro_vina_d51",
   "versions": [
    {
@@ -1715,24 +1792,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -1779,7 +1856,7 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
@@ -1789,7 +1866,7 @@
   "versions": []
  },
  {
-  "downloads": 159,
+  "downloads": 0,
   "id": "bless_dev_board_multi_sensor",
   "versions": [
    {
@@ -1866,24 +1943,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -1928,12 +2005,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 46,
+  "downloads": 0,
   "id": "blm_badge",
   "versions": [
    {
@@ -1989,24 +2066,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -2030,12 +2107,12 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 145,
+  "downloads": 0,
   "id": "capablerobot_usbhub",
   "versions": [
    {
@@ -2113,24 +2190,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -2176,12 +2253,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 74,
+  "downloads": 0,
   "id": "catwan_usbstick",
   "versions": [
    {
@@ -2238,24 +2315,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -2280,12 +2357,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 129,
+  "downloads": 0,
   "id": "circuitbrains_basic_m0",
   "versions": [
    {
@@ -2350,24 +2427,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -2400,12 +2477,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 316,
+  "downloads": 0,
   "id": "circuitbrains_deluxe_m4",
   "versions": [
    {
@@ -2484,24 +2561,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -2548,12 +2625,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 483,
+  "downloads": 0,
   "id": "circuitplayground_bluefruit",
   "versions": [
    {
@@ -2630,24 +2707,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -2692,12 +2769,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 546,
+  "downloads": 0,
   "id": "circuitplayground_express",
   "versions": [
    {
@@ -2762,24 +2839,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -2812,12 +2889,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 180,
+  "downloads": 0,
   "id": "circuitplayground_express_4h",
   "versions": [
    {
@@ -2853,33 +2930,33 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": "[]",
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 381,
+  "downloads": 0,
   "id": "circuitplayground_express_crickit",
   "versions": [
    {
@@ -2941,24 +3018,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -2988,12 +3065,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 34,
+  "downloads": 0,
   "id": "circuitplayground_express_digikey_pycon2019",
   "versions": [
    {
@@ -3029,33 +3106,33 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": "[]",
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 313,
+  "downloads": 0,
   "id": "circuitplayground_express_displayio",
   "versions": [
    {
@@ -3117,24 +3194,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -3164,12 +3241,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 399,
+  "downloads": 0,
   "id": "clue_nrf52840_express",
   "versions": [
    {
@@ -3246,24 +3323,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -3308,12 +3385,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 82,
+  "downloads": 0,
   "id": "cp32-m4",
   "versions": [
    {
@@ -3391,24 +3468,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -3454,7 +3531,7 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
@@ -3467,24 +3544,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -3510,7 +3587,7 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
@@ -3523,24 +3600,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -3571,12 +3648,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 29,
+  "downloads": 0,
   "id": "datalore_ip_m4",
   "versions": [
    {
@@ -3655,24 +3732,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -3719,12 +3796,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 206,
+  "downloads": 0,
   "id": "datum_distance",
   "versions": [
    {
@@ -3782,24 +3859,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -3825,12 +3902,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 78,
+  "downloads": 0,
   "id": "datum_imu",
   "versions": [
    {
@@ -3888,24 +3965,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -3931,12 +4008,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 260,
+  "downloads": 0,
   "id": "datum_light",
   "versions": [
    {
@@ -3994,24 +4071,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -4037,12 +4114,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 237,
+  "downloads": 0,
   "id": "datum_weather",
   "versions": [
    {
@@ -4100,24 +4177,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -4143,12 +4220,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 245,
+  "downloads": 0,
   "id": "dynossat_edu_eps",
   "versions": [
    {
@@ -4213,24 +4290,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -4260,12 +4337,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 217,
+  "downloads": 0,
   "id": "dynossat_edu_obc",
   "versions": [
    {
@@ -4344,24 +4421,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -4408,12 +4485,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 109,
+  "downloads": 0,
   "id": "edgebadge",
   "versions": [
    {
@@ -4449,33 +4526,33 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": "[]",
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 22,
+  "downloads": 0,
   "id": "electroniccats_bastwifi",
   "versions": [
    {
@@ -4546,24 +4623,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -4577,6 +4654,7 @@
      "countio",
      "digitalio",
      "displayio",
+     "dualbank",
      "framebufferio",
      "frequencyio",
      "gamepad",
@@ -4608,12 +4686,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 291,
+  "downloads": 0,
   "id": "electronut_labs_blip",
   "versions": [
    {
@@ -4691,24 +4769,24 @@
      "hex"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -4754,12 +4832,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 212,
+  "downloads": 0,
   "id": "electronut_labs_papyr",
   "versions": [
    {
@@ -4836,24 +4914,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -4898,12 +4976,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 44,
+  "downloads": 0,
   "id": "escornabot_makech",
   "versions": [
    {
@@ -4960,24 +5038,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -5002,12 +5080,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 53,
+  "downloads": 0,
   "id": "espressif_kaluga_1",
   "versions": [
    {
@@ -5079,24 +5157,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -5110,6 +5188,7 @@
      "countio",
      "digitalio",
      "displayio",
+     "dualbank",
      "framebufferio",
      "frequencyio",
      "gamepad",
@@ -5142,12 +5221,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 97,
+  "downloads": 0,
   "id": "espressif_saola_1_wroom",
   "versions": [
    {
@@ -5219,24 +5298,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -5250,6 +5329,7 @@
      "countio",
      "digitalio",
      "displayio",
+     "dualbank",
      "framebufferio",
      "frequencyio",
      "gamepad",
@@ -5282,12 +5362,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 96,
+  "downloads": 0,
   "id": "espressif_saola_1_wrover",
   "versions": [
    {
@@ -5359,24 +5439,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -5390,6 +5470,7 @@
      "countio",
      "digitalio",
      "displayio",
+     "dualbank",
      "framebufferio",
      "frequencyio",
      "gamepad",
@@ -5422,12 +5503,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 39,
+  "downloads": 0,
   "id": "espruino_pico",
   "versions": [
    {
@@ -5490,24 +5571,24 @@
      "bin"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -5538,12 +5619,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 27,
+  "downloads": 0,
   "id": "espruino_wifi",
   "versions": [
    {
@@ -5607,24 +5688,24 @@
      "bin"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -5656,12 +5737,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 387,
+  "downloads": 0,
   "id": "feather_bluefruit_sense",
   "versions": [
    {
@@ -5738,24 +5819,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -5800,12 +5881,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 65,
+  "downloads": 0,
   "id": "feather_m0_adalogger",
   "versions": [
    {
@@ -5865,24 +5946,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -5908,12 +5989,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 61,
+  "downloads": 0,
   "id": "feather_m0_basic",
   "versions": [
    {
@@ -5973,24 +6054,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -6016,12 +6097,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 394,
+  "downloads": 0,
   "id": "feather_m0_express",
   "versions": [
    {
@@ -6086,24 +6167,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -6136,12 +6217,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 155,
+  "downloads": 0,
   "id": "feather_m0_express_crickit",
   "versions": [
    {
@@ -6204,24 +6285,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -6252,12 +6333,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 41,
+  "downloads": 0,
   "id": "feather_m0_rfm69",
   "versions": [
    {
@@ -6310,24 +6391,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -6346,12 +6427,12 @@
      "time"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 54,
+  "downloads": 0,
   "id": "feather_m0_rfm9x",
   "versions": [
    {
@@ -6404,24 +6485,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -6440,12 +6521,12 @@
      "time"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 101,
+  "downloads": 0,
   "id": "feather_m0_supersized",
   "versions": [
    {
@@ -6510,24 +6591,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -6560,12 +6641,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 168,
+  "downloads": 0,
   "id": "feather_m4_can",
   "versions": [
    {
@@ -6643,24 +6724,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -6706,12 +6787,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 465,
+  "downloads": 0,
   "id": "feather_m4_express",
   "versions": [
    {
@@ -6790,24 +6871,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -6854,12 +6935,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 38,
+  "downloads": 0,
   "id": "feather_m7_1011",
   "versions": [
    {
@@ -6927,24 +7008,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -6978,12 +7059,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 30,
+  "downloads": 0,
   "id": "feather_mimxrt1011",
   "versions": [
    {
@@ -7051,24 +7132,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -7102,12 +7183,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 37,
+  "downloads": 0,
   "id": "feather_mimxrt1062",
   "versions": [
    {
@@ -7175,24 +7256,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -7226,12 +7307,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 347,
+  "downloads": 0,
   "id": "feather_nrf52840_express",
   "versions": [
    {
@@ -7308,24 +7389,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -7370,12 +7451,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 2,
+  "downloads": 0,
   "id": "feather_radiofruit_zigbee",
   "versions": [
    {
@@ -7437,24 +7518,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -7484,12 +7565,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 76,
+  "downloads": 0,
   "id": "feather_stm32f405_express",
   "versions": [
    {
@@ -7556,24 +7637,24 @@
      "bin"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -7608,12 +7689,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 243,
+  "downloads": 0,
   "id": "fluff_m0",
   "versions": [
    {
@@ -7671,24 +7752,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -7714,12 +7795,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 143,
+  "downloads": 0,
   "id": "fomu",
   "versions": [
    {
@@ -7772,24 +7853,24 @@
      "dfu"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -7810,7 +7891,7 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
@@ -7820,7 +7901,7 @@
   "versions": []
  },
  {
-  "downloads": 174,
+  "downloads": 0,
   "id": "gemma_m0",
   "versions": [
    {
@@ -7878,24 +7959,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -7921,12 +8002,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 45,
+  "downloads": 0,
   "id": "gemma_m0_pycon2018",
   "versions": [
    {
@@ -7962,33 +8043,33 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": "[]",
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 386,
+  "downloads": 0,
   "id": "grandcentral_m4_express",
   "versions": [
    {
@@ -8068,24 +8149,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -8133,12 +8214,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 254,
+  "downloads": 0,
   "id": "hallowing_m0_express",
   "versions": [
    {
@@ -8199,24 +8280,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -8245,12 +8326,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 247,
+  "downloads": 0,
   "id": "hallowing_m4_express",
   "versions": [
    {
@@ -8329,24 +8410,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -8393,12 +8474,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 148,
+  "downloads": 0,
   "id": "hiibot_bluefi",
   "versions": [
    {
@@ -8475,24 +8556,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -8537,12 +8618,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 50,
+  "downloads": 0,
   "id": "ikigaisense_vita",
   "versions": [
    {
@@ -8619,24 +8700,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -8681,12 +8762,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 40,
+  "downloads": 0,
   "id": "imxrt1010_evk",
   "versions": [
    {
@@ -8754,24 +8835,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -8805,12 +8886,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 42,
+  "downloads": 0,
   "id": "imxrt1020_evk",
   "versions": [
    {
@@ -8878,24 +8959,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -8929,12 +9010,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 41,
+  "downloads": 0,
   "id": "imxrt1060_evk",
   "versions": [
    {
@@ -9002,24 +9083,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -9053,12 +9134,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 341,
+  "downloads": 0,
   "id": "itsybitsy_m0_express",
   "versions": [
    {
@@ -9120,24 +9201,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -9167,12 +9248,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 278,
+  "downloads": 0,
   "id": "itsybitsy_m4_express",
   "versions": [
    {
@@ -9250,24 +9331,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -9313,12 +9394,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 277,
+  "downloads": 0,
   "id": "itsybitsy_nrf52840_express",
   "versions": [
    {
@@ -9395,24 +9476,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -9457,12 +9538,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 45,
+  "downloads": 0,
   "id": "kicksat-sprite",
   "versions": [
    {
@@ -9530,24 +9611,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -9583,12 +9664,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 151,
+  "downloads": 0,
   "id": "loc_ber_m4_base_board",
   "versions": [
    {
@@ -9647,24 +9728,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -9691,12 +9772,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 297,
+  "downloads": 0,
   "id": "makerdiary_m60_keyboard",
   "versions": [
    {
@@ -9773,24 +9854,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -9835,12 +9916,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 87,
+  "downloads": 0,
   "id": "makerdiary_nrf52840_m2_devkit",
   "versions": [
    {
@@ -9917,24 +9998,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -9979,12 +10060,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 283,
+  "downloads": 0,
   "id": "makerdiary_nrf52840_mdk",
   "versions": [
    {
@@ -10061,24 +10142,24 @@
      "hex"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -10123,12 +10204,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 66,
+  "downloads": 0,
   "id": "makerdiary_nrf52840_mdk_usb_dongle",
   "versions": [
    {
@@ -10207,24 +10288,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -10269,12 +10350,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 477,
+  "downloads": 0,
   "id": "matrixportal_m4",
   "versions": [
    {
@@ -10353,24 +10434,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -10417,12 +10498,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 149,
+  "downloads": 0,
   "id": "meowbit_v121",
   "versions": [
    {
@@ -10486,24 +10567,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -10534,12 +10615,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 255,
+  "downloads": 0,
   "id": "meowmeow",
   "versions": [
    {
@@ -10595,24 +10676,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -10636,12 +10717,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 328,
+  "downloads": 0,
   "id": "metro_m0_express",
   "versions": [
    {
@@ -10706,24 +10787,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -10756,12 +10837,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 296,
+  "downloads": 0,
   "id": "metro_m4_airlift_lite",
   "versions": [
    {
@@ -10840,24 +10921,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -10904,12 +10985,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 265,
+  "downloads": 0,
   "id": "metro_m4_express",
   "versions": [
    {
@@ -10988,24 +11069,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -11052,12 +11133,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 37,
+  "downloads": 0,
   "id": "metro_m7_1011",
   "versions": [
    {
@@ -11125,24 +11206,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -11176,12 +11257,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 192,
+  "downloads": 0,
   "id": "metro_nrf52840_express",
   "versions": [
    {
@@ -11258,24 +11339,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -11320,12 +11401,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 34,
+  "downloads": 0,
   "id": "microdev_micro_s2",
   "versions": [
    {
@@ -11397,24 +11478,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -11428,6 +11509,7 @@
      "countio",
      "digitalio",
      "displayio",
+     "dualbank",
      "framebufferio",
      "frequencyio",
      "gamepad",
@@ -11460,12 +11542,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 254,
+  "downloads": 0,
   "id": "mini_sam_m4",
   "versions": [
    {
@@ -11543,24 +11625,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -11606,12 +11688,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 287,
+  "downloads": 0,
   "id": "monster_m4sk",
   "versions": [
    {
@@ -11690,24 +11772,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -11754,12 +11836,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 62,
+  "downloads": 0,
   "id": "muselab_nanoesp32_s2",
   "versions": [
    {
@@ -11831,24 +11913,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -11862,6 +11944,7 @@
      "countio",
      "digitalio",
      "displayio",
+     "dualbank",
      "framebufferio",
      "frequencyio",
      "gamepad",
@@ -11894,12 +11977,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 195,
+  "downloads": 0,
   "id": "ndgarage_ndbit6",
   "versions": [
    {
@@ -11957,24 +12040,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -12000,12 +12083,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 1,
+  "downloads": 0,
   "id": "ndgarage_ndbit6_v2",
   "versions": [
    {
@@ -12063,24 +12146,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -12106,12 +12189,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 226,
+  "downloads": 0,
   "id": "nfc_copy_cat",
   "versions": [
    {
@@ -12169,24 +12252,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -12212,12 +12295,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 319,
+  "downloads": 0,
   "id": "nice_nano",
   "versions": [
    {
@@ -12294,24 +12377,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -12356,12 +12439,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 26,
+  "downloads": 0,
   "id": "nucleo_f746zg",
   "versions": [
    {
@@ -12423,24 +12506,24 @@
      "bin"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -12470,12 +12553,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 30,
+  "downloads": 0,
   "id": "nucleo_f767zi",
   "versions": [
    {
@@ -12537,24 +12620,24 @@
      "bin"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -12584,12 +12667,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 30,
+  "downloads": 0,
   "id": "nucleo_h743zi_2",
   "versions": [
    {
@@ -12649,24 +12732,24 @@
      "bin"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -12694,12 +12777,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 52,
+  "downloads": 0,
   "id": "ohs2020_badge",
   "versions": [
    {
@@ -12776,24 +12859,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -12838,12 +12921,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 243,
+  "downloads": 0,
   "id": "openbook_m4",
   "versions": [
    {
@@ -12923,24 +13006,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -12988,12 +13071,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 24,
+  "downloads": 0,
   "id": "openmv_h7",
   "versions": [
    {
@@ -13053,24 +13136,24 @@
      "bin"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -13098,12 +13181,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 100,
+  "downloads": 0,
   "id": "particle_argon",
   "versions": [
    {
@@ -13180,24 +13263,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -13242,12 +13325,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 181,
+  "downloads": 0,
   "id": "particle_boron",
   "versions": [
    {
@@ -13324,24 +13407,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -13386,12 +13469,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 259,
+  "downloads": 0,
   "id": "particle_xenon",
   "versions": [
    {
@@ -13468,24 +13551,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -13530,7 +13613,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
@@ -13540,7 +13623,7 @@
   "versions": []
  },
  {
-  "downloads": 45,
+  "downloads": 0,
   "id": "pca10056",
   "versions": [
    {
@@ -13619,24 +13702,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -13681,12 +13764,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 67,
+  "downloads": 0,
   "id": "pca10059",
   "versions": [
    {
@@ -13765,24 +13848,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -13827,12 +13910,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 200,
+  "downloads": 0,
   "id": "pca10100",
   "versions": [
    {
@@ -13893,24 +13976,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -13939,12 +14022,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 101,
+  "downloads": 0,
   "id": "pewpew10",
   "versions": [
    {
@@ -14000,24 +14083,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pew",
@@ -14041,12 +14124,12 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 5,
+  "downloads": 0,
   "id": "pewpew13",
   "versions": [
    {
@@ -14082,33 +14165,33 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": "[]",
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 95,
+  "downloads": 0,
   "id": "pewpew_m4",
   "versions": [
    {
@@ -14167,24 +14250,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_stage",
@@ -14211,12 +14294,12 @@
      "time"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 106,
+  "downloads": 0,
   "id": "picoplanet",
   "versions": [
    {
@@ -14274,24 +14357,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -14317,12 +14400,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 219,
+  "downloads": 0,
   "id": "pirkey_m0",
   "versions": [
    {
@@ -14374,24 +14457,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "board",
@@ -14411,12 +14494,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 127,
+  "downloads": 0,
   "id": "pitaya_go",
   "versions": [
    {
@@ -14493,24 +14576,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -14555,12 +14638,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 26,
+  "downloads": 0,
   "id": "pyb_nano_v2",
   "versions": [
    {
@@ -14624,24 +14707,24 @@
      "bin"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -14673,12 +14756,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 341,
+  "downloads": 0,
   "id": "pybadge",
   "versions": [
    {
@@ -14759,24 +14842,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -14825,12 +14908,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 107,
+  "downloads": 0,
   "id": "pybadge_airlift",
   "versions": [
    {
@@ -14911,24 +14994,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -14977,12 +15060,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 44,
+  "downloads": 0,
   "id": "pyboard_v11",
   "versions": [
    {
@@ -15049,24 +15132,24 @@
      "bin"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -15101,12 +15184,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 239,
+  "downloads": 0,
   "id": "pycubed",
   "versions": [
    {
@@ -15176,24 +15259,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -15231,12 +15314,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 76,
+  "downloads": 0,
   "id": "pycubed_mram",
   "versions": [
    {
@@ -15306,24 +15389,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -15361,12 +15444,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 342,
+  "downloads": 0,
   "id": "pygamer",
   "versions": [
    {
@@ -15447,24 +15530,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -15513,12 +15596,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 205,
+  "downloads": 0,
   "id": "pygamer_advance",
   "versions": [
    {
@@ -15599,24 +15682,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -15665,12 +15748,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 409,
+  "downloads": 0,
   "id": "pyportal",
   "versions": [
    {
@@ -15749,24 +15832,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -15813,12 +15896,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 88,
+  "downloads": 0,
   "id": "pyportal_pynt",
   "versions": [
    {
@@ -15854,33 +15937,33 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": "[]",
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 276,
+  "downloads": 0,
   "id": "pyportal_titano",
   "versions": [
    {
@@ -15959,24 +16042,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -16023,12 +16106,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 306,
+  "downloads": 0,
   "id": "pyruler",
   "versions": [
    {
@@ -16085,24 +16168,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -16127,12 +16210,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 332,
+  "downloads": 0,
   "id": "qtpy_m0",
   "versions": [
    {
@@ -16190,24 +16273,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -16233,12 +16316,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 203,
+  "downloads": 0,
   "id": "qtpy_m0_haxpress",
   "versions": [
    {
@@ -16303,24 +16386,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -16353,12 +16436,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 278,
+  "downloads": 0,
   "id": "raytac_mdbt50q-db-40",
   "versions": [
    {
@@ -16435,24 +16518,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -16497,12 +16580,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 268,
+  "downloads": 0,
   "id": "robohatmm1_m4",
   "versions": [
    {
@@ -16573,24 +16656,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -16629,12 +16712,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 111,
+  "downloads": 0,
   "id": "sam32",
   "versions": [
    {
@@ -16713,24 +16796,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -16777,12 +16860,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 203,
+  "downloads": 0,
   "id": "same54_xplained",
   "versions": [
    {
@@ -16861,24 +16944,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -16925,12 +17008,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 347,
+  "downloads": 0,
   "id": "seeeduino_wio_terminal",
   "versions": [
    {
@@ -17009,24 +17092,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -17073,12 +17156,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 519,
+  "downloads": 0,
   "id": "seeeduino_xiao",
   "versions": [
    {
@@ -17136,24 +17219,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -17179,12 +17262,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 312,
+  "downloads": 0,
   "id": "serpente",
   "versions": [
    {
@@ -17251,24 +17334,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -17303,12 +17386,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 188,
+  "downloads": 0,
   "id": "shirtty",
   "versions": [
    {
@@ -17366,24 +17449,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -17409,12 +17492,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 164,
+  "downloads": 0,
   "id": "simmel",
   "versions": [
    {
@@ -17478,24 +17561,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -17509,7 +17592,6 @@
      "board",
      "busio",
      "digitalio",
-     "gamepad",
      "math",
      "microcontroller",
      "os",
@@ -17517,7 +17599,6 @@
      "pwmio",
      "random",
      "rtc",
-     "sdcardio",
      "storage",
      "struct",
      "supervisor",
@@ -17527,12 +17608,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 291,
+  "downloads": 0,
   "id": "snekboard",
   "versions": [
    {
@@ -17597,24 +17678,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -17647,12 +17728,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 123,
+  "downloads": 0,
   "id": "sparkfun_lumidrive",
   "versions": [
    {
@@ -17717,24 +17798,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -17767,12 +17848,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 167,
+  "downloads": 0,
   "id": "sparkfun_nrf52840_mini",
   "versions": [
    {
@@ -17849,24 +17930,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -17911,12 +17992,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 49,
+  "downloads": 0,
   "id": "sparkfun_qwiic_micro_no_flash",
   "versions": [
    {
@@ -17974,24 +18055,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -18017,12 +18098,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 141,
+  "downloads": 0,
   "id": "sparkfun_qwiic_micro_with_flash",
   "versions": [
    {
@@ -18080,24 +18161,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -18123,12 +18204,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 112,
+  "downloads": 0,
   "id": "sparkfun_redboard_turbo",
   "versions": [
    {
@@ -18192,24 +18273,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -18241,12 +18322,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 69,
+  "downloads": 0,
   "id": "sparkfun_samd21_dev",
   "versions": [
    {
@@ -18304,24 +18385,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -18347,12 +18428,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 82,
+  "downloads": 0,
   "id": "sparkfun_samd21_mini",
   "versions": [
    {
@@ -18410,24 +18491,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -18453,12 +18534,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 90,
+  "downloads": 0,
   "id": "sparkfun_samd51_thing_plus",
   "versions": [
    {
@@ -18537,24 +18618,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -18601,12 +18682,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 119,
+  "downloads": 0,
   "id": "spresense",
   "versions": [
    {
@@ -18642,33 +18723,96 @@
      "spk"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": "[]",
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 52,
+  "downloads": 0,
+  "id": "stackrduino_m0_pro",
+  "versions": [
+   {
+    "extensions": [
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": [
+     "_pixelbuf",
+     "analogio",
+     "audiobusio",
+     "audiocore",
+     "audioio",
+     "board",
+     "busio",
+     "digitalio",
+     "displayio",
+     "gamepad",
+     "math",
+     "microcontroller",
+     "neopixel_write",
+     "nvm",
+     "os",
+     "pulseio",
+     "pwmio",
+     "random",
+     "rotaryio",
+     "rtc",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "touchio",
+     "usb_hid",
+     "usb_midi"
+    ],
+    "stable": false,
+    "version": "6.1.0-beta.3"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
   "id": "stm32f411ce_blackpill",
   "versions": [
    {
@@ -18732,24 +18876,24 @@
      "bin"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -18781,12 +18925,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 29,
+  "downloads": 0,
   "id": "stm32f411ve_discovery",
   "versions": [
    {
@@ -18850,24 +18994,24 @@
      "bin"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -18899,12 +19043,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 32,
+  "downloads": 0,
   "id": "stm32f412zg_discovery",
   "versions": [
    {
@@ -18969,24 +19113,24 @@
      "bin"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -19019,12 +19163,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 38,
+  "downloads": 0,
   "id": "stm32f4_discovery",
   "versions": [
    {
@@ -19088,24 +19232,24 @@
      "bin"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -19137,12 +19281,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 30,
+  "downloads": 0,
   "id": "stm32f746g_discovery",
   "versions": [
    {
@@ -19204,24 +19348,24 @@
      "bin"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -19251,12 +19395,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 237,
+  "downloads": 0,
   "id": "stringcar_m0_express",
   "versions": [
    {
@@ -19319,24 +19463,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -19367,7 +19511,7 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
@@ -19381,24 +19525,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -19412,6 +19556,7 @@
      "countio",
      "digitalio",
      "displayio",
+     "dualbank",
      "framebufferio",
      "frequencyio",
      "gamepad",
@@ -19444,7 +19589,7 @@
      "wifi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
@@ -19458,24 +19603,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -19489,6 +19634,7 @@
      "countio",
      "digitalio",
      "displayio",
+     "dualbank",
      "framebufferio",
      "frequencyio",
      "gamepad",
@@ -19521,12 +19667,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 95,
+  "downloads": 0,
   "id": "teensy40",
   "versions": [
    {
@@ -19594,24 +19740,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -19645,12 +19791,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 102,
+  "downloads": 0,
   "id": "teensy41",
   "versions": [
    {
@@ -19718,24 +19864,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -19769,12 +19915,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 44,
+  "downloads": 0,
   "id": "teknikio_bluebird",
   "versions": [
    {
@@ -19851,24 +19997,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -19913,7 +20059,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
@@ -19988,24 +20134,24 @@
      "bin"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -20036,7 +20182,7 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
@@ -20049,24 +20195,24 @@
      "bin"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -20098,12 +20244,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 71,
+  "downloads": 0,
   "id": "tinkeringtech_scoutmakes_azul",
   "versions": [
    {
@@ -20180,24 +20326,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -20242,12 +20388,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 248,
+  "downloads": 0,
   "id": "trellis_m4_express",
   "versions": [
    {
@@ -20325,24 +20471,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -20388,12 +20534,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 447,
+  "downloads": 0,
   "id": "trinket_m0",
   "versions": [
    {
@@ -20451,24 +20597,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -20494,12 +20640,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 296,
+  "downloads": 0,
   "id": "trinket_m0_haxpress",
   "versions": [
    {
@@ -20563,24 +20709,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -20612,12 +20758,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 7,
+  "downloads": 0,
   "id": "uartlogger2",
   "versions": [
    {
@@ -20696,24 +20842,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -20760,12 +20906,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 43,
+  "downloads": 0,
   "id": "uchip",
   "versions": [
    {
@@ -20825,24 +20971,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -20868,12 +21014,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 300,
+  "downloads": 0,
   "id": "ugame10",
   "versions": [
    {
@@ -20934,24 +21080,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_stage",
@@ -20980,12 +21126,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 81,
+  "downloads": 0,
   "id": "unexpectedmaker_feathers2",
   "versions": [
    {
@@ -21057,24 +21203,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -21088,6 +21234,7 @@
      "countio",
      "digitalio",
      "displayio",
+     "dualbank",
      "framebufferio",
      "frequencyio",
      "gamepad",
@@ -21120,12 +21267,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 31,
+  "downloads": 0,
   "id": "unexpectedmaker_feathers2_prerelease",
   "versions": [
    {
@@ -21197,24 +21344,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -21228,6 +21375,7 @@
      "countio",
      "digitalio",
      "displayio",
+     "dualbank",
      "framebufferio",
      "frequencyio",
      "gamepad",
@@ -21260,12 +21408,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 218,
+  "downloads": 0,
   "id": "winterbloom_big_honking_button",
   "versions": [
    {
@@ -21323,24 +21471,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -21366,12 +21514,12 @@
      "time"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 256,
+  "downloads": 0,
   "id": "winterbloom_sol",
   "versions": [
    {
@@ -21433,24 +21581,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -21480,12 +21628,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 41,
+  "downloads": 0,
   "id": "xinabox_cc03",
   "versions": [
    {
@@ -21537,24 +21685,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "board",
@@ -21574,12 +21722,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  },
  {
-  "downloads": 58,
+  "downloads": 0,
   "id": "xinabox_cs11",
   "versions": [
    {
@@ -21629,24 +21777,24 @@
      "uf2"
     ],
     "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
      "hi",
      "ko",
      "fr",
-     "fil",
-     "ID",
-     "sv",
      "zh_Latn_pinyin",
-     "cs",
-     "en_US",
-     "el",
-     "pl",
      "ja",
-     "de_DE",
-     "en_x_pirate",
-     "it_IT",
+     "pt_BR",
+     "en_US",
      "es",
-     "nl",
-     "pt_BR"
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "board",
@@ -21664,7 +21812,7 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "6.1.0-beta.2"
+    "version": "6.1.0-beta.3"
    }
   ]
  }

--- a/_data/files.json
+++ b/_data/files.json
@@ -1,6 +1,6 @@
 [
  {
-  "downloads": 0,
+  "downloads": 144,
   "id": "8086_commander",
   "versions": [
    {
@@ -181,7 +181,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 42,
   "id": "TG-Watch02A",
   "versions": [
    {
@@ -403,7 +403,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 81,
   "id": "adafruit_metro_esp32s2",
   "versions": [
    {
@@ -544,7 +544,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 229,
   "id": "aloriumtech_evo_m51",
   "versions": [
    {
@@ -692,7 +692,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 102,
   "id": "aramcon_badge_2019",
   "versions": [
    {
@@ -836,7 +836,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 24,
   "id": "arduino_mkr1300",
   "versions": [
    {
@@ -944,7 +944,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 27,
   "id": "arduino_mkrzero",
   "versions": [
    {
@@ -1052,7 +1052,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 301,
   "id": "arduino_nano_33_ble",
   "versions": [
    {
@@ -1196,7 +1196,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 45,
   "id": "arduino_nano_33_iot",
   "versions": [
    {
@@ -1304,7 +1304,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 67,
   "id": "arduino_zero",
   "versions": [
    {
@@ -1412,7 +1412,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 32,
   "id": "bast_pro_mini_m0",
   "versions": [
    {
@@ -1593,7 +1593,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 189,
   "id": "bdmicro_vina_d21",
   "versions": [
    {
@@ -1713,7 +1713,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 266,
   "id": "bdmicro_vina_d51",
   "versions": [
    {
@@ -1866,7 +1866,7 @@
   "versions": []
  },
  {
-  "downloads": 0,
+  "downloads": 159,
   "id": "bless_dev_board_multi_sensor",
   "versions": [
    {
@@ -2010,7 +2010,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 46,
   "id": "blm_badge",
   "versions": [
    {
@@ -2112,7 +2112,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 145,
   "id": "capablerobot_usbhub",
   "versions": [
    {
@@ -2258,7 +2258,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 74,
   "id": "catwan_usbstick",
   "versions": [
    {
@@ -2362,7 +2362,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 129,
   "id": "circuitbrains_basic_m0",
   "versions": [
    {
@@ -2482,7 +2482,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 316,
   "id": "circuitbrains_deluxe_m4",
   "versions": [
    {
@@ -2630,7 +2630,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 483,
   "id": "circuitplayground_bluefruit",
   "versions": [
    {
@@ -2774,7 +2774,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 546,
   "id": "circuitplayground_express",
   "versions": [
    {
@@ -2894,7 +2894,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 180,
   "id": "circuitplayground_express_4h",
   "versions": [
    {
@@ -2956,7 +2956,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 381,
   "id": "circuitplayground_express_crickit",
   "versions": [
    {
@@ -3070,7 +3070,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 34,
   "id": "circuitplayground_express_digikey_pycon2019",
   "versions": [
    {
@@ -3132,7 +3132,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 313,
   "id": "circuitplayground_express_displayio",
   "versions": [
    {
@@ -3246,7 +3246,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 399,
   "id": "clue_nrf52840_express",
   "versions": [
    {
@@ -3390,7 +3390,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 82,
   "id": "cp32-m4",
   "versions": [
    {
@@ -3653,7 +3653,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 29,
   "id": "datalore_ip_m4",
   "versions": [
    {
@@ -3801,7 +3801,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 206,
   "id": "datum_distance",
   "versions": [
    {
@@ -3907,7 +3907,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 78,
   "id": "datum_imu",
   "versions": [
    {
@@ -4013,7 +4013,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 260,
   "id": "datum_light",
   "versions": [
    {
@@ -4119,7 +4119,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 237,
   "id": "datum_weather",
   "versions": [
    {
@@ -4225,7 +4225,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 245,
   "id": "dynossat_edu_eps",
   "versions": [
    {
@@ -4342,7 +4342,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 217,
   "id": "dynossat_edu_obc",
   "versions": [
    {
@@ -4490,7 +4490,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 109,
   "id": "edgebadge",
   "versions": [
    {
@@ -4552,7 +4552,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 22,
   "id": "electroniccats_bastwifi",
   "versions": [
    {
@@ -4691,7 +4691,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 291,
   "id": "electronut_labs_blip",
   "versions": [
    {
@@ -4837,7 +4837,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 212,
   "id": "electronut_labs_papyr",
   "versions": [
    {
@@ -4981,7 +4981,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 44,
   "id": "escornabot_makech",
   "versions": [
    {
@@ -5085,7 +5085,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 53,
   "id": "espressif_kaluga_1",
   "versions": [
    {
@@ -5226,7 +5226,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 97,
   "id": "espressif_saola_1_wroom",
   "versions": [
    {
@@ -5367,7 +5367,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 96,
   "id": "espressif_saola_1_wrover",
   "versions": [
    {
@@ -5508,7 +5508,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 39,
   "id": "espruino_pico",
   "versions": [
    {
@@ -5624,7 +5624,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 27,
   "id": "espruino_wifi",
   "versions": [
    {
@@ -5742,7 +5742,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 387,
   "id": "feather_bluefruit_sense",
   "versions": [
    {
@@ -5886,7 +5886,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 65,
   "id": "feather_m0_adalogger",
   "versions": [
    {
@@ -5994,7 +5994,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 61,
   "id": "feather_m0_basic",
   "versions": [
    {
@@ -6102,7 +6102,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 394,
   "id": "feather_m0_express",
   "versions": [
    {
@@ -6222,7 +6222,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 155,
   "id": "feather_m0_express_crickit",
   "versions": [
    {
@@ -6338,7 +6338,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 41,
   "id": "feather_m0_rfm69",
   "versions": [
    {
@@ -6432,7 +6432,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 54,
   "id": "feather_m0_rfm9x",
   "versions": [
    {
@@ -6526,7 +6526,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 101,
   "id": "feather_m0_supersized",
   "versions": [
    {
@@ -6646,7 +6646,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 168,
   "id": "feather_m4_can",
   "versions": [
    {
@@ -6792,7 +6792,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 465,
   "id": "feather_m4_express",
   "versions": [
    {
@@ -6940,7 +6940,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 38,
   "id": "feather_m7_1011",
   "versions": [
    {
@@ -7064,7 +7064,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 30,
   "id": "feather_mimxrt1011",
   "versions": [
    {
@@ -7188,7 +7188,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 37,
   "id": "feather_mimxrt1062",
   "versions": [
    {
@@ -7312,7 +7312,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 347,
   "id": "feather_nrf52840_express",
   "versions": [
    {
@@ -7456,7 +7456,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 2,
   "id": "feather_radiofruit_zigbee",
   "versions": [
    {
@@ -7570,7 +7570,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 76,
   "id": "feather_stm32f405_express",
   "versions": [
    {
@@ -7694,7 +7694,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 243,
   "id": "fluff_m0",
   "versions": [
    {
@@ -7800,7 +7800,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 143,
   "id": "fomu",
   "versions": [
    {
@@ -7901,7 +7901,7 @@
   "versions": []
  },
  {
-  "downloads": 0,
+  "downloads": 174,
   "id": "gemma_m0",
   "versions": [
    {
@@ -8007,7 +8007,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 45,
   "id": "gemma_m0_pycon2018",
   "versions": [
    {
@@ -8069,7 +8069,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 386,
   "id": "grandcentral_m4_express",
   "versions": [
    {
@@ -8219,7 +8219,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 254,
   "id": "hallowing_m0_express",
   "versions": [
    {
@@ -8331,7 +8331,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 247,
   "id": "hallowing_m4_express",
   "versions": [
    {
@@ -8479,7 +8479,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 148,
   "id": "hiibot_bluefi",
   "versions": [
    {
@@ -8623,7 +8623,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 50,
   "id": "ikigaisense_vita",
   "versions": [
    {
@@ -8767,7 +8767,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 40,
   "id": "imxrt1010_evk",
   "versions": [
    {
@@ -8891,7 +8891,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 42,
   "id": "imxrt1020_evk",
   "versions": [
    {
@@ -9015,7 +9015,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 41,
   "id": "imxrt1060_evk",
   "versions": [
    {
@@ -9139,7 +9139,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 341,
   "id": "itsybitsy_m0_express",
   "versions": [
    {
@@ -9253,7 +9253,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 278,
   "id": "itsybitsy_m4_express",
   "versions": [
    {
@@ -9399,7 +9399,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 277,
   "id": "itsybitsy_nrf52840_express",
   "versions": [
    {
@@ -9543,7 +9543,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 45,
   "id": "kicksat-sprite",
   "versions": [
    {
@@ -9669,7 +9669,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 151,
   "id": "loc_ber_m4_base_board",
   "versions": [
    {
@@ -9777,7 +9777,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 297,
   "id": "makerdiary_m60_keyboard",
   "versions": [
    {
@@ -9921,7 +9921,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 87,
   "id": "makerdiary_nrf52840_m2_devkit",
   "versions": [
    {
@@ -10065,7 +10065,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 283,
   "id": "makerdiary_nrf52840_mdk",
   "versions": [
    {
@@ -10209,7 +10209,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 66,
   "id": "makerdiary_nrf52840_mdk_usb_dongle",
   "versions": [
    {
@@ -10355,7 +10355,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 477,
   "id": "matrixportal_m4",
   "versions": [
    {
@@ -10503,7 +10503,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 149,
   "id": "meowbit_v121",
   "versions": [
    {
@@ -10620,7 +10620,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 255,
   "id": "meowmeow",
   "versions": [
    {
@@ -10722,7 +10722,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 328,
   "id": "metro_m0_express",
   "versions": [
    {
@@ -10842,7 +10842,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 296,
   "id": "metro_m4_airlift_lite",
   "versions": [
    {
@@ -10990,7 +10990,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 265,
   "id": "metro_m4_express",
   "versions": [
    {
@@ -11138,7 +11138,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 37,
   "id": "metro_m7_1011",
   "versions": [
    {
@@ -11262,7 +11262,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 192,
   "id": "metro_nrf52840_express",
   "versions": [
    {
@@ -11406,7 +11406,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 34,
   "id": "microdev_micro_s2",
   "versions": [
    {
@@ -11547,7 +11547,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 254,
   "id": "mini_sam_m4",
   "versions": [
    {
@@ -11693,7 +11693,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 287,
   "id": "monster_m4sk",
   "versions": [
    {
@@ -11841,7 +11841,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 62,
   "id": "muselab_nanoesp32_s2",
   "versions": [
    {
@@ -11982,7 +11982,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 195,
   "id": "ndgarage_ndbit6",
   "versions": [
    {
@@ -12088,7 +12088,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 1,
   "id": "ndgarage_ndbit6_v2",
   "versions": [
    {
@@ -12194,7 +12194,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 226,
   "id": "nfc_copy_cat",
   "versions": [
    {
@@ -12300,7 +12300,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 319,
   "id": "nice_nano",
   "versions": [
    {
@@ -12444,7 +12444,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 26,
   "id": "nucleo_f746zg",
   "versions": [
    {
@@ -12558,7 +12558,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 30,
   "id": "nucleo_f767zi",
   "versions": [
    {
@@ -12672,7 +12672,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 30,
   "id": "nucleo_h743zi_2",
   "versions": [
    {
@@ -12782,7 +12782,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 52,
   "id": "ohs2020_badge",
   "versions": [
    {
@@ -12926,7 +12926,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 243,
   "id": "openbook_m4",
   "versions": [
    {
@@ -13076,7 +13076,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 24,
   "id": "openmv_h7",
   "versions": [
    {
@@ -13186,7 +13186,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 100,
   "id": "particle_argon",
   "versions": [
    {
@@ -13330,7 +13330,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 181,
   "id": "particle_boron",
   "versions": [
    {
@@ -13474,7 +13474,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 259,
   "id": "particle_xenon",
   "versions": [
    {
@@ -13623,7 +13623,7 @@
   "versions": []
  },
  {
-  "downloads": 0,
+  "downloads": 45,
   "id": "pca10056",
   "versions": [
    {
@@ -13769,7 +13769,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 67,
   "id": "pca10059",
   "versions": [
    {
@@ -13915,7 +13915,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 200,
   "id": "pca10100",
   "versions": [
    {
@@ -14027,7 +14027,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 101,
   "id": "pewpew10",
   "versions": [
    {
@@ -14129,7 +14129,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 5,
   "id": "pewpew13",
   "versions": [
    {
@@ -14191,7 +14191,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 95,
   "id": "pewpew_m4",
   "versions": [
    {
@@ -14299,7 +14299,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 106,
   "id": "picoplanet",
   "versions": [
    {
@@ -14405,7 +14405,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 219,
   "id": "pirkey_m0",
   "versions": [
    {
@@ -14499,7 +14499,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 127,
   "id": "pitaya_go",
   "versions": [
    {
@@ -14643,7 +14643,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 26,
   "id": "pyb_nano_v2",
   "versions": [
    {
@@ -14761,7 +14761,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 341,
   "id": "pybadge",
   "versions": [
    {
@@ -14913,7 +14913,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 107,
   "id": "pybadge_airlift",
   "versions": [
    {
@@ -15065,7 +15065,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 44,
   "id": "pyboard_v11",
   "versions": [
    {
@@ -15189,7 +15189,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 239,
   "id": "pycubed",
   "versions": [
    {
@@ -15319,7 +15319,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 76,
   "id": "pycubed_mram",
   "versions": [
    {
@@ -15449,7 +15449,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 342,
   "id": "pygamer",
   "versions": [
    {
@@ -15601,7 +15601,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 205,
   "id": "pygamer_advance",
   "versions": [
    {
@@ -15753,7 +15753,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 409,
   "id": "pyportal",
   "versions": [
    {
@@ -15901,7 +15901,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 88,
   "id": "pyportal_pynt",
   "versions": [
    {
@@ -15963,7 +15963,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 276,
   "id": "pyportal_titano",
   "versions": [
    {
@@ -16111,7 +16111,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 306,
   "id": "pyruler",
   "versions": [
    {
@@ -16215,7 +16215,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 332,
   "id": "qtpy_m0",
   "versions": [
    {
@@ -16321,7 +16321,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 203,
   "id": "qtpy_m0_haxpress",
   "versions": [
    {
@@ -16441,7 +16441,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 278,
   "id": "raytac_mdbt50q-db-40",
   "versions": [
    {
@@ -16585,7 +16585,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 268,
   "id": "robohatmm1_m4",
   "versions": [
    {
@@ -16717,7 +16717,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 111,
   "id": "sam32",
   "versions": [
    {
@@ -16865,7 +16865,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 203,
   "id": "same54_xplained",
   "versions": [
    {
@@ -17013,7 +17013,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 347,
   "id": "seeeduino_wio_terminal",
   "versions": [
    {
@@ -17161,7 +17161,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 519,
   "id": "seeeduino_xiao",
   "versions": [
    {
@@ -17267,7 +17267,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 312,
   "id": "serpente",
   "versions": [
    {
@@ -17391,7 +17391,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 188,
   "id": "shirtty",
   "versions": [
    {
@@ -17497,7 +17497,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 164,
   "id": "simmel",
   "versions": [
    {
@@ -17613,7 +17613,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 291,
   "id": "snekboard",
   "versions": [
    {
@@ -17733,7 +17733,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 123,
   "id": "sparkfun_lumidrive",
   "versions": [
    {
@@ -17853,7 +17853,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 167,
   "id": "sparkfun_nrf52840_mini",
   "versions": [
    {
@@ -17997,7 +17997,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 49,
   "id": "sparkfun_qwiic_micro_no_flash",
   "versions": [
    {
@@ -18103,7 +18103,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 141,
   "id": "sparkfun_qwiic_micro_with_flash",
   "versions": [
    {
@@ -18209,7 +18209,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 112,
   "id": "sparkfun_redboard_turbo",
   "versions": [
    {
@@ -18327,7 +18327,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 69,
   "id": "sparkfun_samd21_dev",
   "versions": [
    {
@@ -18433,7 +18433,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 82,
   "id": "sparkfun_samd21_mini",
   "versions": [
    {
@@ -18539,7 +18539,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 90,
   "id": "sparkfun_samd51_thing_plus",
   "versions": [
    {
@@ -18687,7 +18687,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 119,
   "id": "spresense",
   "versions": [
    {
@@ -18812,7 +18812,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 52,
   "id": "stm32f411ce_blackpill",
   "versions": [
    {
@@ -18930,7 +18930,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 29,
   "id": "stm32f411ve_discovery",
   "versions": [
    {
@@ -19048,7 +19048,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 32,
   "id": "stm32f412zg_discovery",
   "versions": [
    {
@@ -19168,7 +19168,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 38,
   "id": "stm32f4_discovery",
   "versions": [
    {
@@ -19286,7 +19286,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 30,
   "id": "stm32f746g_discovery",
   "versions": [
    {
@@ -19400,7 +19400,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 237,
   "id": "stringcar_m0_express",
   "versions": [
    {
@@ -19672,7 +19672,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 95,
   "id": "teensy40",
   "versions": [
    {
@@ -19796,7 +19796,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 102,
   "id": "teensy41",
   "versions": [
    {
@@ -19920,7 +19920,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 44,
   "id": "teknikio_bluebird",
   "versions": [
    {
@@ -20249,7 +20249,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 71,
   "id": "tinkeringtech_scoutmakes_azul",
   "versions": [
    {
@@ -20393,7 +20393,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 248,
   "id": "trellis_m4_express",
   "versions": [
    {
@@ -20539,7 +20539,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 447,
   "id": "trinket_m0",
   "versions": [
    {
@@ -20645,7 +20645,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 296,
   "id": "trinket_m0_haxpress",
   "versions": [
    {
@@ -20763,7 +20763,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 7,
   "id": "uartlogger2",
   "versions": [
    {
@@ -20911,7 +20911,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 43,
   "id": "uchip",
   "versions": [
    {
@@ -21019,7 +21019,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 300,
   "id": "ugame10",
   "versions": [
    {
@@ -21131,7 +21131,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 81,
   "id": "unexpectedmaker_feathers2",
   "versions": [
    {
@@ -21272,7 +21272,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 31,
   "id": "unexpectedmaker_feathers2_prerelease",
   "versions": [
    {
@@ -21413,7 +21413,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 218,
   "id": "winterbloom_big_honking_button",
   "versions": [
    {
@@ -21519,7 +21519,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 256,
   "id": "winterbloom_sol",
   "versions": [
    {
@@ -21633,7 +21633,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 41,
   "id": "xinabox_cc03",
   "versions": [
    {
@@ -21727,7 +21727,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 58,
   "id": "xinabox_cs11",
   "versions": [
    {


### PR DESCRIPTION
Automated website update for release 6.1.0-beta.3 by Blinka.

New boards:
* stackrduino_m0_pro
* bastble

New languages:
* ja
* en_US
* zh_Latn_pinyin
* el
* fil
* nl
* pl
* it_IT
* hi
* en_x_pirate
* fr
* ID
* ko
* pt_BR
* de_DE
* es
* cs
* sv
