### PR TITLE
Remember language selection and fix autoselection

### DIFF
--- a/assets/javascript/download.js
+++ b/assets/javascript/download.js
@@ -4,9 +4,20 @@ document.addEventListener('DOMContentLoaded',function() {
     select.onchange = languageSelectHandler;
   });
 
-  var script = document.createElement('script');
-  script.setAttribute('src', '//accounts.adafruit.com/users/locale?callback=setLocale');
-  document.body.appendChild(script);
+  var languages = null;
+  if (window.localStorage) {
+    var storedLanguage = localStorage.getItem("language");
+    if (storedLanguage != null && storedLanguage != "") {
+      languages = { languages: storedLanguage };
+    }
+  }
+  if (languages != null) {
+    setLocale(languages);
+  } else {
+    var script = document.createElement('script');
+    script.setAttribute('src', '//accounts.adafruit.com/users/locale?callback=setLocale');
+    document.body.appendChild(script);
+  }
 },false);
 
 function languageSelectHandler(event) {
@@ -14,11 +25,16 @@ function languageSelectHandler(event) {
   // event may either be an event from selection, or passed from setLocale
   // as a select element.
   if (event.target) {
-    var selectedOption = event.target;
+    var selectedOption = event.target.selectedOptions[0];
     var parentNode = event.target.parentNode.parentNode;
   } else {
     var selectedOption = event.selectedOptions[0];
     var parentNode = event.parentNode.parentNode;
+  }
+  
+  if (window.localStorage) {
+    var selectedLanguage = selectedOption.dataset.locale;
+    localStorage.setItem("language",selectedLanguage);
   }
 
   var files = selectedOption.value.split(',');


### PR DESCRIPTION
When a user selects a language in a download menu:
- the language selected is memorized in the browser
- all language menus on the page are synchronized (if possible)

When a page is loaded
- the saved language is recovered and used to set the download menus
- if no language was saved it pulls the favorite languages from the browser as before

It's implemented with localStorage which seems more fitting to me for a static site, but could use cookies.

This also includes a fix to the selection of the menus' language. It now iterates on user languages in their order of preference to pick the best match.
Also, when the browser gives "`<language>-<region>`",  it first tries a full match, then tries to match `<language>` to the locales available on the site. And I tossed a couple of toLowerCase() in there for the string comparison.
- the browser's "fr-FR" will match the site's "fr"
- the browser's "id" will match the site's "ID" (Indonesian)

What it doesn't do is reduce the site's locale string to it's `<language>` for comparison, because I didn't want "en-UK" to accidentally match "en-x-pirate". Making that work would require to make sure that the default variant is first in the language lists, or otherwise identified.
- the browser's "en-UK" will not match the site's "en-US"
- the browser's "de-AT" will not match the site's "de-DE"

