### PR TITLE
Automated website update for release 6.2.0-beta.0

### DIFF
--- a/_data/files.json
+++ b/_data/files.json
@@ -1,6 +1,6 @@
 [
  {
-  "downloads": 0,
+  "downloads": 123,
   "id": "8086_commander",
   "versions": [
    {
@@ -744,7 +744,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 419,
   "id": "adafruit_magtag_2.9_grayscale",
   "versions": [
    {
@@ -900,7 +900,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 184,
   "id": "adafruit_metro_esp32s2",
   "versions": [
    {
@@ -1056,7 +1056,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 105,
   "id": "aloriumtech_evo_m51",
   "versions": [
    {
@@ -1206,7 +1206,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 99,
   "id": "aramcon_badge_2019",
   "versions": [
    {
@@ -1352,7 +1352,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 34,
   "id": "arduino_mkr1300",
   "versions": [
    {
@@ -1460,7 +1460,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 73,
   "id": "arduino_mkrzero",
   "versions": [
    {
@@ -1568,7 +1568,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 125,
   "id": "arduino_nano_33_ble",
   "versions": [
    {
@@ -1714,7 +1714,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 64,
   "id": "arduino_nano_33_iot",
   "versions": [
    {
@@ -1822,7 +1822,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 75,
   "id": "arduino_zero",
   "versions": [
    {
@@ -1930,7 +1930,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 150,
   "id": "bast_pro_mini_m0",
   "versions": [
    {
@@ -2036,7 +2036,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 33,
   "id": "bastble",
   "versions": [
    {
@@ -2182,7 +2182,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 167,
   "id": "bdmicro_vina_d21",
   "versions": [
    {
@@ -2302,7 +2302,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 65,
   "id": "bdmicro_vina_d51",
   "versions": [
    {
@@ -2457,7 +2457,7 @@
   "versions": []
  },
  {
-  "downloads": 0,
+  "downloads": 221,
   "id": "bless_dev_board_multi_sensor",
   "versions": [
    {
@@ -2603,7 +2603,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 90,
   "id": "blm_badge",
   "versions": [
    {
@@ -2705,7 +2705,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 120,
   "id": "capablerobot_usbhub",
   "versions": [
    {
@@ -2853,7 +2853,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 89,
   "id": "catwan_usbstick",
   "versions": [
    {
@@ -2957,7 +2957,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 71,
   "id": "circuitbrains_basic_m0",
   "versions": [
    {
@@ -3079,7 +3079,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 103,
   "id": "circuitbrains_deluxe_m4",
   "versions": [
    {
@@ -3229,7 +3229,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 292,
   "id": "circuitplayground_bluefruit",
   "versions": [
    {
@@ -3375,7 +3375,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 404,
   "id": "circuitplayground_express",
   "versions": [
    {
@@ -3495,7 +3495,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 193,
   "id": "circuitplayground_express_4h",
   "versions": [
    {
@@ -3557,7 +3557,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 147,
   "id": "circuitplayground_express_crickit",
   "versions": [
    {
@@ -3671,7 +3671,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 26,
   "id": "circuitplayground_express_digikey_pycon2019",
   "versions": [
    {
@@ -3733,7 +3733,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 168,
   "id": "circuitplayground_express_displayio",
   "versions": [
    {
@@ -3847,7 +3847,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 210,
   "id": "clue_nrf52840_express",
   "versions": [
    {
@@ -3993,7 +3993,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 108,
   "id": "cp32-m4",
   "versions": [
    {
@@ -4141,7 +4141,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 74,
   "id": "cp_sapling_m0",
   "versions": [
    {
@@ -4515,7 +4515,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 56,
   "id": "datum_distance",
   "versions": [
    {
@@ -4621,7 +4621,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 98,
   "id": "datum_imu",
   "versions": [
    {
@@ -4727,7 +4727,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 47,
   "id": "datum_light",
   "versions": [
    {
@@ -4833,7 +4833,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 50,
   "id": "datum_weather",
   "versions": [
    {
@@ -4939,7 +4939,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 69,
   "id": "dynossat_edu_eps",
   "versions": [
    {
@@ -5055,7 +5055,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 89,
   "id": "dynossat_edu_obc",
   "versions": [
    {
@@ -5205,7 +5205,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 132,
   "id": "edgebadge",
   "versions": [
    {
@@ -5267,7 +5267,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 35,
   "id": "electroniccats_bastwifi",
   "versions": [
    {
@@ -5421,7 +5421,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 116,
   "id": "electronut_labs_blip",
   "versions": [
    {
@@ -5569,7 +5569,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 146,
   "id": "electronut_labs_papyr",
   "versions": [
    {
@@ -5715,7 +5715,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 113,
   "id": "escornabot_makech",
   "versions": [
    {
@@ -5819,7 +5819,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 63,
   "id": "espressif_kaluga_1",
   "versions": [
    {
@@ -5975,7 +5975,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 127,
   "id": "espressif_saola_1_wroom",
   "versions": [
    {
@@ -6131,7 +6131,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 115,
   "id": "espressif_saola_1_wrover",
   "versions": [
    {
@@ -6287,7 +6287,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 45,
   "id": "espruino_pico",
   "versions": [
    {
@@ -6405,7 +6405,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 11,
   "id": "espruino_wifi",
   "versions": [
    {
@@ -6525,7 +6525,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 258,
   "id": "feather_bluefruit_sense",
   "versions": [
    {
@@ -6671,7 +6671,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 81,
   "id": "feather_m0_adalogger",
   "versions": [
    {
@@ -6779,7 +6779,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 93,
   "id": "feather_m0_basic",
   "versions": [
    {
@@ -6887,7 +6887,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 237,
   "id": "feather_m0_express",
   "versions": [
    {
@@ -7007,7 +7007,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 71,
   "id": "feather_m0_express_crickit",
   "versions": [
    {
@@ -7123,7 +7123,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 58,
   "id": "feather_m0_rfm69",
   "versions": [
    {
@@ -7217,7 +7217,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 86,
   "id": "feather_m0_rfm9x",
   "versions": [
    {
@@ -7311,7 +7311,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 97,
   "id": "feather_m0_supersized",
   "versions": [
    {
@@ -7431,7 +7431,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 128,
   "id": "feather_m4_can",
   "versions": [
    {
@@ -7579,7 +7579,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 330,
   "id": "feather_m4_express",
   "versions": [
    {
@@ -7729,7 +7729,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 42,
   "id": "feather_m7_1011",
   "versions": [
    {
@@ -7855,7 +7855,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 39,
   "id": "feather_mimxrt1011",
   "versions": [
    {
@@ -7981,7 +7981,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 57,
   "id": "feather_mimxrt1062",
   "versions": [
    {
@@ -8107,7 +8107,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 226,
   "id": "feather_nrf52840_express",
   "versions": [
    {
@@ -8253,7 +8253,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 92,
   "id": "feather_radiofruit_zigbee",
   "versions": [
    {
@@ -8369,7 +8369,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 88,
   "id": "feather_stm32f405_express",
   "versions": [
    {
@@ -8495,7 +8495,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 96,
   "id": "fluff_m0",
   "versions": [
    {
@@ -8601,7 +8601,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 80,
   "id": "fomu",
   "versions": [
    {
@@ -8704,7 +8704,7 @@
   "versions": []
  },
  {
-  "downloads": 0,
+  "downloads": 159,
   "id": "gemma_m0",
   "versions": [
    {
@@ -8810,7 +8810,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 74,
   "id": "gemma_m0_pycon2018",
   "versions": [
    {
@@ -8872,7 +8872,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 145,
   "id": "grandcentral_m4_express",
   "versions": [
    {
@@ -9024,7 +9024,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 153,
   "id": "hallowing_m0_express",
   "versions": [
    {
@@ -9138,7 +9138,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 112,
   "id": "hallowing_m4_express",
   "versions": [
    {
@@ -9288,7 +9288,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 121,
   "id": "hiibot_bluefi",
   "versions": [
    {
@@ -9434,7 +9434,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 71,
   "id": "ikigaisense_vita",
   "versions": [
    {
@@ -9580,7 +9580,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 45,
   "id": "imxrt1010_evk",
   "versions": [
    {
@@ -9706,7 +9706,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 43,
   "id": "imxrt1020_evk",
   "versions": [
    {
@@ -9832,7 +9832,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 46,
   "id": "imxrt1060_evk",
   "versions": [
    {
@@ -9958,7 +9958,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 164,
   "id": "itsybitsy_m0_express",
   "versions": [
    {
@@ -10074,7 +10074,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 183,
   "id": "itsybitsy_m4_express",
   "versions": [
    {
@@ -10222,7 +10222,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 248,
   "id": "itsybitsy_nrf52840_express",
   "versions": [
    {
@@ -10368,7 +10368,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 87,
   "id": "kicksat-sprite",
   "versions": [
    {
@@ -10496,7 +10496,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 55,
   "id": "loc_ber_m4_base_board",
   "versions": [
    {
@@ -10604,7 +10604,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 166,
   "id": "makerdiary_m60_keyboard",
   "versions": [
    {
@@ -10750,7 +10750,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 204,
   "id": "makerdiary_nrf52840_m2_devkit",
   "versions": [
    {
@@ -10896,7 +10896,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 84,
   "id": "makerdiary_nrf52840_mdk",
   "versions": [
    {
@@ -11042,7 +11042,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 98,
   "id": "makerdiary_nrf52840_mdk_usb_dongle",
   "versions": [
    {
@@ -11190,7 +11190,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 337,
   "id": "matrixportal_m4",
   "versions": [
    {
@@ -11340,7 +11340,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 162,
   "id": "meowbit_v121",
   "versions": [
    {
@@ -11458,7 +11458,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 116,
   "id": "meowmeow",
   "versions": [
    {
@@ -11560,7 +11560,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 177,
   "id": "metro_m0_express",
   "versions": [
    {
@@ -11680,7 +11680,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 223,
   "id": "metro_m4_airlift_lite",
   "versions": [
    {
@@ -11830,7 +11830,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 154,
   "id": "metro_m4_express",
   "versions": [
    {
@@ -11980,7 +11980,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 50,
   "id": "metro_m7_1011",
   "versions": [
    {
@@ -12106,7 +12106,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 117,
   "id": "metro_nrf52840_express",
   "versions": [
    {
@@ -12252,7 +12252,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 63,
   "id": "microdev_micro_s2",
   "versions": [
    {
@@ -12408,7 +12408,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 146,
   "id": "mini_sam_m4",
   "versions": [
    {
@@ -12556,7 +12556,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 101,
   "id": "monster_m4sk",
   "versions": [
    {
@@ -12706,7 +12706,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 111,
   "id": "muselab_nanoesp32_s2",
   "versions": [
    {
@@ -12862,7 +12862,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 47,
   "id": "ndgarage_ndbit6",
   "versions": [
    {
@@ -12968,7 +12968,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 2,
   "id": "ndgarage_ndbit6_v2",
   "versions": [
    {
@@ -13168,7 +13168,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 128,
   "id": "nfc_copy_cat",
   "versions": [
    {
@@ -13274,7 +13274,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 87,
   "id": "nice_nano",
   "versions": [
    {
@@ -13420,7 +13420,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 18,
   "id": "nucleo_f746zg",
   "versions": [
    {
@@ -13536,7 +13536,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 32,
   "id": "nucleo_f767zi",
   "versions": [
    {
@@ -13652,7 +13652,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 22,
   "id": "nucleo_h743zi_2",
   "versions": [
    {
@@ -13764,7 +13764,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 114,
   "id": "ohs2020_badge",
   "versions": [
    {
@@ -13910,7 +13910,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 153,
   "id": "openbook_m4",
   "versions": [
    {
@@ -14062,7 +14062,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 19,
   "id": "openmv_h7",
   "versions": [
    {
@@ -14174,7 +14174,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 132,
   "id": "particle_argon",
   "versions": [
    {
@@ -14320,7 +14320,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 99,
   "id": "particle_boron",
   "versions": [
    {
@@ -14466,7 +14466,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 128,
   "id": "particle_xenon",
   "versions": [
    {
@@ -14617,7 +14617,7 @@
   "versions": []
  },
  {
-  "downloads": 0,
+  "downloads": 70,
   "id": "pca10056",
   "versions": [
    {
@@ -14765,7 +14765,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 98,
   "id": "pca10059",
   "versions": [
    {
@@ -14913,7 +14913,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 136,
   "id": "pca10100",
   "versions": [
    {
@@ -15025,7 +15025,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 100,
   "id": "pewpew10",
   "versions": [
    {
@@ -15127,7 +15127,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 50,
   "id": "pewpew13",
   "versions": [
    {
@@ -15189,7 +15189,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 146,
   "id": "pewpew_m4",
   "versions": [
    {
@@ -15297,7 +15297,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 118,
   "id": "picoplanet",
   "versions": [
    {
@@ -15403,7 +15403,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 79,
   "id": "pirkey_m0",
   "versions": [
    {
@@ -15497,7 +15497,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 108,
   "id": "pitaya_go",
   "versions": [
    {
@@ -15643,7 +15643,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 16,
   "id": "pyb_nano_v2",
   "versions": [
    {
@@ -15763,7 +15763,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 143,
   "id": "pybadge",
   "versions": [
    {
@@ -15917,7 +15917,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 95,
   "id": "pybadge_airlift",
   "versions": [
    {
@@ -16071,7 +16071,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 39,
   "id": "pyboard_v11",
   "versions": [
    {
@@ -16197,7 +16197,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 104,
   "id": "pycubed",
   "versions": [
    {
@@ -16329,7 +16329,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 67,
   "id": "pycubed_mram",
   "versions": [
    {
@@ -16461,7 +16461,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 109,
   "id": "pygamer",
   "versions": [
    {
@@ -16615,7 +16615,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 124,
   "id": "pygamer_advance",
   "versions": [
    {
@@ -16769,7 +16769,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 261,
   "id": "pyportal",
   "versions": [
    {
@@ -16919,7 +16919,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 132,
   "id": "pyportal_pynt",
   "versions": [
    {
@@ -16981,7 +16981,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 165,
   "id": "pyportal_titano",
   "versions": [
    {
@@ -17131,7 +17131,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 118,
   "id": "pyruler",
   "versions": [
    {
@@ -17235,7 +17235,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 280,
   "id": "qtpy_m0",
   "versions": [
    {
@@ -17341,7 +17341,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 194,
   "id": "qtpy_m0_haxpress",
   "versions": [
    {
@@ -17495,7 +17495,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 152,
   "id": "raytac_mdbt50q-db-40",
   "versions": [
    {
@@ -17641,7 +17641,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 83,
   "id": "robohatmm1_m4",
   "versions": [
    {
@@ -17775,7 +17775,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 74,
   "id": "sam32",
   "versions": [
    {
@@ -17925,7 +17925,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 48,
   "id": "same54_xplained",
   "versions": [
    {
@@ -18075,7 +18075,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 250,
   "id": "seeeduino_wio_terminal",
   "versions": [
    {
@@ -18225,7 +18225,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 426,
   "id": "seeeduino_xiao",
   "versions": [
    {
@@ -18331,7 +18331,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 158,
   "id": "serpente",
   "versions": [
    {
@@ -18457,7 +18457,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 26,
   "id": "shirtty",
   "versions": [
    {
@@ -18563,7 +18563,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 63,
   "id": "simmel",
   "versions": [
    {
@@ -18677,7 +18677,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 116,
   "id": "snekboard",
   "versions": [
    {
@@ -18797,7 +18797,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 112,
   "id": "sparkfun_lumidrive",
   "versions": [
    {
@@ -18919,7 +18919,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 232,
   "id": "sparkfun_nrf52840_mini",
   "versions": [
    {
@@ -19065,7 +19065,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 50,
   "id": "sparkfun_qwiic_micro_no_flash",
   "versions": [
    {
@@ -19171,7 +19171,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 209,
   "id": "sparkfun_qwiic_micro_with_flash",
   "versions": [
    {
@@ -19277,7 +19277,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 168,
   "id": "sparkfun_redboard_turbo",
   "versions": [
    {
@@ -19395,7 +19395,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 150,
   "id": "sparkfun_samd21_dev",
   "versions": [
    {
@@ -19501,7 +19501,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 156,
   "id": "sparkfun_samd21_mini",
   "versions": [
    {
@@ -19607,7 +19607,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 102,
   "id": "sparkfun_samd51_thing_plus",
   "versions": [
    {
@@ -19757,7 +19757,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 155,
   "id": "spresense",
   "versions": [
    {
@@ -19939,7 +19939,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 70,
   "id": "stm32f411ce_blackpill",
   "versions": [
    {
@@ -20122,7 +20122,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 26,
   "id": "stm32f411ve_discovery",
   "versions": [
    {
@@ -20242,7 +20242,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 14,
   "id": "stm32f412zg_discovery",
   "versions": [
    {
@@ -20364,7 +20364,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 31,
   "id": "stm32f4_discovery",
   "versions": [
    {
@@ -20484,7 +20484,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 23,
   "id": "stm32f746g_discovery",
   "versions": [
    {
@@ -20600,7 +20600,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 105,
   "id": "stringcar_m0_express",
   "versions": [
    {
@@ -20718,7 +20718,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 46,
   "id": "targett_module_clip_wroom",
   "versions": [
    {
@@ -20874,7 +20874,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 37,
   "id": "targett_module_clip_wrover",
   "versions": [
    {
@@ -21030,7 +21030,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 177,
   "id": "teensy40",
   "versions": [
    {
@@ -21156,7 +21156,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 161,
   "id": "teensy41",
   "versions": [
    {
@@ -21282,7 +21282,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 23,
   "id": "teknikio_bluebird",
   "versions": [
    {
@@ -21428,7 +21428,7 @@
   ]
  },
  {
-  "downloads": 5,
+  "downloads": 7,
   "id": "thunderpack",
   "versions": []
  },
@@ -21671,7 +21671,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 87,
   "id": "tinkeringtech_scoutmakes_azul",
   "versions": [
    {
@@ -21817,7 +21817,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 202,
   "id": "trellis_m4_express",
   "versions": [
    {
@@ -21965,7 +21965,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 393,
   "id": "trinket_m0",
   "versions": [
    {
@@ -22071,7 +22071,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 145,
   "id": "trinket_m0_haxpress",
   "versions": [
    {
@@ -22191,7 +22191,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 146,
   "id": "uartlogger2",
   "versions": [
    {
@@ -22341,7 +22341,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 28,
   "id": "uchip",
   "versions": [
    {
@@ -22449,7 +22449,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 90,
   "id": "ugame10",
   "versions": [
    {
@@ -22563,7 +22563,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 263,
   "id": "unexpectedmaker_feathers2",
   "versions": [
    {
@@ -22719,7 +22719,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 35,
   "id": "unexpectedmaker_feathers2_prerelease",
   "versions": [
    {
@@ -22875,7 +22875,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 127,
   "id": "winterbloom_big_honking_button",
   "versions": [
    {
@@ -22983,7 +22983,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 110,
   "id": "winterbloom_sol",
   "versions": [
    {
@@ -23099,7 +23099,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 39,
   "id": "xinabox_cc03",
   "versions": [
    {
@@ -23193,7 +23193,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 20,
   "id": "xinabox_cs11",
   "versions": [
    {

--- a/_data/files.json
+++ b/_data/files.json
@@ -1,58 +1,8 @@
 [
  {
-  "downloads": 103,
+  "downloads": 0,
   "id": "8086_commander",
   "versions": [
-   {
-    "extensions": [
-     "uf2"
-    ],
-    "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
-     "cs",
-     "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
-     "it_IT",
-     "de_DE"
-    ],
-    "modules": [
-     "analogio",
-     "board",
-     "busio",
-     "digitalio",
-     "gamepad",
-     "math",
-     "microcontroller",
-     "neopixel_write",
-     "nvm",
-     "os",
-     "pulseio",
-     "pwmio",
-     "random",
-     "rotaryio",
-     "rtc",
-     "storage",
-     "struct",
-     "supervisor",
-     "time",
-     "touchio",
-     "usb_hid"
-    ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
-   },
    {
     "extensions": [
      "uf2"
@@ -102,6 +52,56 @@
     ],
     "stable": true,
     "version": "6.1.0"
+   },
+   {
+    "extensions": [
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": [
+     "analogio",
+     "board",
+     "busio",
+     "digitalio",
+     "gamepad",
+     "math",
+     "microcontroller",
+     "neopixel_write",
+     "nvm",
+     "os",
+     "pulseio",
+     "pwmio",
+     "random",
+     "rotaryio",
+     "rtc",
+     "storage",
+     "struct",
+     "supervisor",
+     "time",
+     "touchio",
+     "usb_hid"
+    ],
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
@@ -178,6 +178,76 @@
     ],
     "stable": true,
     "version": "6.1.0"
+   },
+   {
+    "extensions": [
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": [
+     "_bleio",
+     "_pixelbuf",
+     "aesio",
+     "analogio",
+     "audiobusio",
+     "audiocore",
+     "audiomixer",
+     "audiomp3",
+     "audiopwmio",
+     "bitbangio",
+     "board",
+     "busio",
+     "digitalio",
+     "displayio",
+     "framebufferio",
+     "gamepad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "os",
+     "pulseio",
+     "pwmio",
+     "random",
+     "rgbmatrix",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "touchio",
+     "ulab",
+     "usb_hid",
+     "usb_midi",
+     "vectorio",
+     "watchdog"
+    ],
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
@@ -254,6 +324,76 @@
     ],
     "stable": true,
     "version": "6.1.0"
+   },
+   {
+    "extensions": [
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": [
+     "_bleio",
+     "_pixelbuf",
+     "aesio",
+     "analogio",
+     "audiobusio",
+     "audiocore",
+     "audiomixer",
+     "audiomp3",
+     "audiopwmio",
+     "bitbangio",
+     "board",
+     "busio",
+     "digitalio",
+     "displayio",
+     "framebufferio",
+     "gamepad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "os",
+     "pulseio",
+     "pwmio",
+     "random",
+     "rgbmatrix",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "touchio",
+     "ulab",
+     "usb_hid",
+     "usb_midi",
+     "vectorio",
+     "watchdog"
+    ],
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
@@ -335,6 +475,81 @@
     ],
     "stable": true,
     "version": "6.1.0"
+   },
+   {
+    "extensions": [
+     "bin",
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": [
+     "_bleio",
+     "_pixelbuf",
+     "alarm",
+     "analogio",
+     "audiobusio",
+     "audiocore",
+     "bitbangio",
+     "board",
+     "busio",
+     "canio",
+     "countio",
+     "digitalio",
+     "displayio",
+     "dualbank",
+     "framebufferio",
+     "frequencyio",
+     "gamepad",
+     "ipaddress",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "os",
+     "ps2io",
+     "pulseio",
+     "pwmio",
+     "random",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "socketpool",
+     "ssl",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "touchio",
+     "ulab",
+     "usb_hid",
+     "vectorio",
+     "watchdog",
+     "wifi"
+    ],
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
@@ -416,11 +631,120 @@
     ],
     "stable": true,
     "version": "6.1.0"
+   },
+   {
+    "extensions": [
+     "bin",
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": [
+     "_bleio",
+     "_pixelbuf",
+     "alarm",
+     "analogio",
+     "audiobusio",
+     "audiocore",
+     "bitbangio",
+     "board",
+     "busio",
+     "canio",
+     "countio",
+     "digitalio",
+     "displayio",
+     "dualbank",
+     "framebufferio",
+     "frequencyio",
+     "gamepad",
+     "ipaddress",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "os",
+     "ps2io",
+     "pulseio",
+     "pwmio",
+     "random",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "socketpool",
+     "ssl",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "touchio",
+     "ulab",
+     "usb_hid",
+     "vectorio",
+     "watchdog",
+     "wifi"
+    ],
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 383,
+  "downloads": 0,
+  "id": "adafruit_feather_rp2040",
+  "versions": [
+   {
+    "extensions": [
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": "[]",
+    "stable": false,
+    "version": "6.2.0-beta.0"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
   "id": "adafruit_magtag_2.9_grayscale",
   "versions": [
    {
@@ -497,11 +821,86 @@
     ],
     "stable": true,
     "version": "6.1.0"
+   },
+   {
+    "extensions": [
+     "bin",
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": [
+     "_bleio",
+     "_pixelbuf",
+     "alarm",
+     "analogio",
+     "audiobusio",
+     "audiocore",
+     "bitbangio",
+     "board",
+     "busio",
+     "canio",
+     "countio",
+     "digitalio",
+     "displayio",
+     "dualbank",
+     "framebufferio",
+     "frequencyio",
+     "gamepad",
+     "ipaddress",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "os",
+     "ps2io",
+     "pulseio",
+     "pwmio",
+     "random",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "socketpool",
+     "ssl",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "touchio",
+     "ulab",
+     "usb_hid",
+     "vectorio",
+     "watchdog",
+     "wifi"
+    ],
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 170,
+  "downloads": 0,
   "id": "adafruit_metro_esp32s2",
   "versions": [
    {
@@ -510,24 +909,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -576,8 +975,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -651,13 +1050,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 90,
+  "downloads": 0,
   "id": "aloriumtech_evo_m51",
   "versions": [
    {
@@ -665,24 +1064,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -729,8 +1128,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -801,13 +1200,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 83,
+  "downloads": 0,
   "id": "aramcon_badge_2019",
   "versions": [
    {
@@ -815,24 +1214,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -877,8 +1276,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -947,13 +1346,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 29,
+  "downloads": 0,
   "id": "arduino_mkr1300",
   "versions": [
    {
@@ -962,24 +1361,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -1004,8 +1403,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -1055,13 +1454,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 69,
+  "downloads": 0,
   "id": "arduino_mkrzero",
   "versions": [
    {
@@ -1070,24 +1469,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -1112,8 +1511,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -1163,85 +1562,15 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 121,
+  "downloads": 0,
   "id": "arduino_nano_33_ble",
   "versions": [
-   {
-    "extensions": [
-     "uf2"
-    ],
-    "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
-     "cs",
-     "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
-     "it_IT",
-     "de_DE"
-    ],
-    "modules": [
-     "_bleio",
-     "_pixelbuf",
-     "aesio",
-     "analogio",
-     "audiobusio",
-     "audiocore",
-     "audiomixer",
-     "audiomp3",
-     "audiopwmio",
-     "bitbangio",
-     "board",
-     "busio",
-     "digitalio",
-     "displayio",
-     "framebufferio",
-     "gamepad",
-     "math",
-     "microcontroller",
-     "msgpack",
-     "neopixel_write",
-     "nvm",
-     "os",
-     "pulseio",
-     "pwmio",
-     "random",
-     "rgbmatrix",
-     "rotaryio",
-     "rtc",
-     "sdcardio",
-     "sharpdisplay",
-     "storage",
-     "struct",
-     "supervisor",
-     "terminalio",
-     "time",
-     "touchio",
-     "ulab",
-     "usb_hid",
-     "usb_midi",
-     "vectorio",
-     "watchdog"
-    ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
-   },
    {
     "extensions": [
      "uf2"
@@ -1311,11 +1640,81 @@
     ],
     "stable": true,
     "version": "6.1.0"
+   },
+   {
+    "extensions": [
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": [
+     "_bleio",
+     "_pixelbuf",
+     "aesio",
+     "analogio",
+     "audiobusio",
+     "audiocore",
+     "audiomixer",
+     "audiomp3",
+     "audiopwmio",
+     "bitbangio",
+     "board",
+     "busio",
+     "digitalio",
+     "displayio",
+     "framebufferio",
+     "gamepad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "os",
+     "pulseio",
+     "pwmio",
+     "random",
+     "rgbmatrix",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "touchio",
+     "ulab",
+     "usb_hid",
+     "usb_midi",
+     "vectorio",
+     "watchdog"
+    ],
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 55,
+  "downloads": 0,
   "id": "arduino_nano_33_iot",
   "versions": [
    {
@@ -1324,24 +1723,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -1366,8 +1765,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -1417,13 +1816,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 72,
+  "downloads": 0,
   "id": "arduino_zero",
   "versions": [
    {
@@ -1432,24 +1831,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -1474,8 +1873,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -1525,65 +1924,15 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 144,
+  "downloads": 0,
   "id": "bast_pro_mini_m0",
   "versions": [
-   {
-    "extensions": [
-     "uf2"
-    ],
-    "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
-     "cs",
-     "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
-     "it_IT",
-     "de_DE"
-    ],
-    "modules": [
-     "analogio",
-     "board",
-     "busio",
-     "digitalio",
-     "math",
-     "microcontroller",
-     "neopixel_write",
-     "nvm",
-     "os",
-     "pulseio",
-     "pwmio",
-     "random",
-     "rotaryio",
-     "rtc",
-     "storage",
-     "struct",
-     "supervisor",
-     "time",
-     "touchio",
-     "usb_hid",
-     "usb_midi"
-    ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
-   },
    {
     "extensions": [
      "uf2"
@@ -1633,11 +1982,61 @@
     ],
     "stable": true,
     "version": "6.1.0"
+   },
+   {
+    "extensions": [
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": [
+     "analogio",
+     "board",
+     "busio",
+     "digitalio",
+     "math",
+     "microcontroller",
+     "neopixel_write",
+     "nvm",
+     "os",
+     "pulseio",
+     "pwmio",
+     "random",
+     "rotaryio",
+     "rtc",
+     "storage",
+     "struct",
+     "supervisor",
+     "time",
+     "touchio",
+     "usb_hid",
+     "usb_midi"
+    ],
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 31,
+  "downloads": 0,
   "id": "bastble",
   "versions": [
    {
@@ -1709,11 +2108,81 @@
     ],
     "stable": true,
     "version": "6.1.0"
+   },
+   {
+    "extensions": [
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": [
+     "_bleio",
+     "_pixelbuf",
+     "aesio",
+     "analogio",
+     "audiobusio",
+     "audiocore",
+     "audiomixer",
+     "audiomp3",
+     "audiopwmio",
+     "bitbangio",
+     "board",
+     "busio",
+     "digitalio",
+     "displayio",
+     "framebufferio",
+     "gamepad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "os",
+     "pulseio",
+     "pwmio",
+     "random",
+     "rgbmatrix",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "touchio",
+     "ulab",
+     "usb_hid",
+     "usb_midi",
+     "vectorio",
+     "watchdog"
+    ],
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 153,
+  "downloads": 0,
   "id": "bdmicro_vina_d21",
   "versions": [
    {
@@ -1721,24 +2190,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -1770,8 +2239,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -1827,13 +2296,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 61,
+  "downloads": 0,
   "id": "bdmicro_vina_d51",
   "versions": [
    {
@@ -1841,24 +2310,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -1905,8 +2374,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -1977,8 +2446,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
@@ -1988,7 +2457,7 @@
   "versions": []
  },
  {
-  "downloads": 208,
+  "downloads": 0,
   "id": "bless_dev_board_multi_sensor",
   "versions": [
    {
@@ -1996,24 +2465,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -2058,8 +2527,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -2128,13 +2597,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 85,
+  "downloads": 0,
   "id": "blm_badge",
   "versions": [
    {
@@ -2142,24 +2611,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -2182,8 +2651,8 @@
      "touchio",
      "usb_hid"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -2230,13 +2699,13 @@
      "touchio",
      "usb_hid"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 108,
+  "downloads": 0,
   "id": "capablerobot_usbhub",
   "versions": [
    {
@@ -2244,24 +2713,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -2307,8 +2776,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -2378,13 +2847,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 76,
+  "downloads": 0,
   "id": "catwan_usbstick",
   "versions": [
    {
@@ -2392,24 +2861,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -2433,8 +2902,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -2482,13 +2951,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 58,
+  "downloads": 0,
   "id": "circuitbrains_basic_m0",
   "versions": [
    {
@@ -2496,24 +2965,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -2546,8 +3015,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -2604,13 +3073,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 94,
+  "downloads": 0,
   "id": "circuitbrains_deluxe_m4",
   "versions": [
    {
@@ -2618,24 +3087,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -2682,8 +3151,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -2754,13 +3223,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 268,
+  "downloads": 0,
   "id": "circuitplayground_bluefruit",
   "versions": [
    {
@@ -2768,24 +3237,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -2830,8 +3299,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -2900,13 +3369,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 368,
+  "downloads": 0,
   "id": "circuitplayground_express",
   "versions": [
    {
@@ -2914,24 +3383,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -2963,8 +3432,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -3020,13 +3489,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 173,
+  "downloads": 0,
   "id": "circuitplayground_express_4h",
   "versions": [
    {
@@ -3034,28 +3503,28 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": "[]",
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -3082,13 +3551,13 @@
      "fil"
     ],
     "modules": "[]",
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 130,
+  "downloads": 0,
   "id": "circuitplayground_express_crickit",
   "versions": [
    {
@@ -3096,24 +3565,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -3142,8 +3611,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -3196,13 +3665,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 21,
+  "downloads": 0,
   "id": "circuitplayground_express_digikey_pycon2019",
   "versions": [
    {
@@ -3210,28 +3679,28 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": "[]",
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -3258,13 +3727,13 @@
      "fil"
     ],
     "modules": "[]",
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 149,
+  "downloads": 0,
   "id": "circuitplayground_express_displayio",
   "versions": [
    {
@@ -3272,24 +3741,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -3318,8 +3787,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -3372,13 +3841,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 192,
+  "downloads": 0,
   "id": "clue_nrf52840_express",
   "versions": [
    {
@@ -3386,24 +3855,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -3448,8 +3917,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -3518,13 +3987,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 108,
+  "downloads": 0,
   "id": "cp32-m4",
   "versions": [
    {
@@ -3532,24 +4001,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -3595,8 +4064,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -3666,13 +4135,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 65,
+  "downloads": 0,
   "id": "cp_sapling_m0",
   "versions": [
    {
@@ -3724,6 +4193,56 @@
     ],
     "stable": true,
     "version": "6.1.0"
+   },
+   {
+    "extensions": [
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": [
+     "analogio",
+     "board",
+     "busio",
+     "digitalio",
+     "math",
+     "microcontroller",
+     "neopixel_write",
+     "nvm",
+     "os",
+     "pulseio",
+     "pwmio",
+     "random",
+     "rotaryio",
+     "rtc",
+     "storage",
+     "struct",
+     "supervisor",
+     "time",
+     "touchio",
+     "usb_hid",
+     "usb_midi"
+    ],
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
@@ -3786,6 +4305,62 @@
     ],
     "stable": true,
     "version": "6.1.0"
+   },
+   {
+    "extensions": [
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": [
+     "_pixelbuf",
+     "analogio",
+     "board",
+     "busio",
+     "digitalio",
+     "displayio",
+     "gamepad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "os",
+     "pulseio",
+     "pwmio",
+     "random",
+     "rotaryio",
+     "rtc",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "touchio",
+     "usb_hid",
+     "usb_midi",
+     "vectorio"
+    ],
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
@@ -3798,24 +4373,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -3862,8 +4437,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -3934,13 +4509,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 48,
+  "downloads": 0,
   "id": "datum_distance",
   "versions": [
    {
@@ -3948,24 +4523,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -3990,8 +4565,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -4040,13 +4615,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 90,
+  "downloads": 0,
   "id": "datum_imu",
   "versions": [
    {
@@ -4054,24 +4629,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -4096,8 +4671,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -4146,13 +4721,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 46,
+  "downloads": 0,
   "id": "datum_light",
   "versions": [
    {
@@ -4160,24 +4735,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -4202,8 +4777,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -4252,13 +4827,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 49,
+  "downloads": 0,
   "id": "datum_weather",
   "versions": [
    {
@@ -4266,24 +4841,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -4308,8 +4883,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -4358,13 +4933,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 58,
+  "downloads": 0,
   "id": "dynossat_edu_eps",
   "versions": [
    {
@@ -4372,24 +4947,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -4419,8 +4994,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -4474,13 +5049,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 79,
+  "downloads": 0,
   "id": "dynossat_edu_obc",
   "versions": [
    {
@@ -4488,24 +5063,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -4552,8 +5127,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -4624,13 +5199,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 114,
+  "downloads": 0,
   "id": "edgebadge",
   "versions": [
    {
@@ -4638,28 +5213,28 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": "[]",
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -4686,13 +5261,13 @@
      "fil"
     ],
     "modules": "[]",
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 33,
+  "downloads": 0,
   "id": "electroniccats_bastwifi",
   "versions": [
    {
@@ -4701,24 +5276,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -4766,8 +5341,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -4840,13 +5415,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 98,
+  "downloads": 0,
   "id": "electronut_labs_blip",
   "versions": [
    {
@@ -4854,24 +5429,24 @@
      "hex"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -4917,8 +5492,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -4988,13 +5563,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 134,
+  "downloads": 0,
   "id": "electronut_labs_papyr",
   "versions": [
    {
@@ -5002,24 +5577,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -5064,8 +5639,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -5134,13 +5709,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 90,
+  "downloads": 0,
   "id": "escornabot_makech",
   "versions": [
    {
@@ -5148,24 +5723,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -5189,8 +5764,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -5238,13 +5813,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 55,
+  "downloads": 0,
   "id": "espressif_kaluga_1",
   "versions": [
    {
@@ -5253,24 +5828,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -5319,8 +5894,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -5394,13 +5969,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 112,
+  "downloads": 0,
   "id": "espressif_saola_1_wroom",
   "versions": [
    {
@@ -5409,24 +5984,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -5475,8 +6050,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -5550,13 +6125,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 107,
+  "downloads": 0,
   "id": "espressif_saola_1_wrover",
   "versions": [
    {
@@ -5565,24 +6140,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -5631,8 +6206,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -5706,13 +6281,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 44,
+  "downloads": 0,
   "id": "espruino_pico",
   "versions": [
    {
@@ -5720,24 +6295,24 @@
      "bin"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -5768,8 +6343,8 @@
      "touchio",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -5824,13 +6399,13 @@
      "touchio",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 11,
+  "downloads": 0,
   "id": "espruino_wifi",
   "versions": [
    {
@@ -5838,24 +6413,24 @@
      "bin"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -5887,8 +6462,8 @@
      "ulab",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -5944,85 +6519,15 @@
      "ulab",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 232,
+  "downloads": 0,
   "id": "feather_bluefruit_sense",
   "versions": [
-   {
-    "extensions": [
-     "uf2"
-    ],
-    "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
-     "cs",
-     "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
-     "it_IT",
-     "de_DE"
-    ],
-    "modules": [
-     "_bleio",
-     "_pixelbuf",
-     "aesio",
-     "analogio",
-     "audiobusio",
-     "audiocore",
-     "audiomixer",
-     "audiomp3",
-     "audiopwmio",
-     "bitbangio",
-     "board",
-     "busio",
-     "digitalio",
-     "displayio",
-     "framebufferio",
-     "gamepad",
-     "math",
-     "microcontroller",
-     "msgpack",
-     "neopixel_write",
-     "nvm",
-     "os",
-     "pulseio",
-     "pwmio",
-     "random",
-     "rgbmatrix",
-     "rotaryio",
-     "rtc",
-     "sdcardio",
-     "sharpdisplay",
-     "storage",
-     "struct",
-     "supervisor",
-     "terminalio",
-     "time",
-     "touchio",
-     "ulab",
-     "usb_hid",
-     "usb_midi",
-     "vectorio",
-     "watchdog"
-    ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
-   },
    {
     "extensions": [
      "uf2"
@@ -6092,11 +6597,81 @@
     ],
     "stable": true,
     "version": "6.1.0"
+   },
+   {
+    "extensions": [
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": [
+     "_bleio",
+     "_pixelbuf",
+     "aesio",
+     "analogio",
+     "audiobusio",
+     "audiocore",
+     "audiomixer",
+     "audiomp3",
+     "audiopwmio",
+     "bitbangio",
+     "board",
+     "busio",
+     "digitalio",
+     "displayio",
+     "framebufferio",
+     "gamepad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "os",
+     "pulseio",
+     "pwmio",
+     "random",
+     "rgbmatrix",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "touchio",
+     "ulab",
+     "usb_hid",
+     "usb_midi",
+     "vectorio",
+     "watchdog"
+    ],
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 75,
+  "downloads": 0,
   "id": "feather_m0_adalogger",
   "versions": [
    {
@@ -6105,24 +6680,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -6147,8 +6722,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -6198,13 +6773,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 85,
+  "downloads": 0,
   "id": "feather_m0_basic",
   "versions": [
    {
@@ -6213,24 +6788,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -6255,8 +6830,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -6306,13 +6881,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 211,
+  "downloads": 0,
   "id": "feather_m0_express",
   "versions": [
    {
@@ -6320,24 +6895,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -6369,8 +6944,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -6426,13 +7001,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 62,
+  "downloads": 0,
   "id": "feather_m0_express_crickit",
   "versions": [
    {
@@ -6440,24 +7015,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -6487,8 +7062,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -6542,13 +7117,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 54,
+  "downloads": 0,
   "id": "feather_m0_rfm69",
   "versions": [
    {
@@ -6557,24 +7132,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -6592,8 +7167,8 @@
      "supervisor",
      "time"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -6636,13 +7211,13 @@
      "supervisor",
      "time"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 76,
+  "downloads": 0,
   "id": "feather_m0_rfm9x",
   "versions": [
    {
@@ -6651,24 +7226,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -6686,8 +7261,8 @@
      "supervisor",
      "time"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -6730,13 +7305,13 @@
      "supervisor",
      "time"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 91,
+  "downloads": 0,
   "id": "feather_m0_supersized",
   "versions": [
    {
@@ -6744,24 +7319,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -6793,8 +7368,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -6850,13 +7425,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 106,
+  "downloads": 0,
   "id": "feather_m4_can",
   "versions": [
    {
@@ -6864,24 +7439,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -6927,8 +7502,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -6998,13 +7573,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 302,
+  "downloads": 0,
   "id": "feather_m4_express",
   "versions": [
    {
@@ -7012,24 +7587,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -7076,8 +7651,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -7148,13 +7723,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 39,
+  "downloads": 0,
   "id": "feather_m7_1011",
   "versions": [
    {
@@ -7163,24 +7738,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -7214,8 +7789,8 @@
      "usb_hid",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -7274,13 +7849,13 @@
      "usb_hid",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 36,
+  "downloads": 0,
   "id": "feather_mimxrt1011",
   "versions": [
    {
@@ -7289,24 +7864,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -7340,8 +7915,8 @@
      "usb_hid",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -7400,13 +7975,13 @@
      "usb_hid",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 47,
+  "downloads": 0,
   "id": "feather_mimxrt1062",
   "versions": [
    {
@@ -7415,24 +7990,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -7466,8 +8041,8 @@
      "usb_hid",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -7526,13 +8101,13 @@
      "usb_hid",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 212,
+  "downloads": 0,
   "id": "feather_nrf52840_express",
   "versions": [
    {
@@ -7540,24 +8115,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -7602,8 +8177,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -7672,13 +8247,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 86,
+  "downloads": 0,
   "id": "feather_radiofruit_zigbee",
   "versions": [
    {
@@ -7686,24 +8261,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -7733,8 +8308,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -7788,13 +8363,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 82,
+  "downloads": 0,
   "id": "feather_stm32f405_express",
   "versions": [
    {
@@ -7802,24 +8377,24 @@
      "bin"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -7854,8 +8429,8 @@
      "ulab",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -7914,13 +8489,13 @@
      "ulab",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 89,
+  "downloads": 0,
   "id": "fluff_m0",
   "versions": [
    {
@@ -7928,24 +8503,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -7970,8 +8545,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -8020,61 +8595,15 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 72,
+  "downloads": 0,
   "id": "fomu",
   "versions": [
-   {
-    "extensions": [
-     "dfu"
-    ],
-    "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
-     "cs",
-     "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
-     "it_IT",
-     "de_DE"
-    ],
-    "modules": [
-     "_pixelbuf",
-     "digitalio",
-     "gamepad",
-     "math",
-     "microcontroller",
-     "msgpack",
-     "neopixel_write",
-     "os",
-     "random",
-     "storage",
-     "struct",
-     "supervisor",
-     "time",
-     "touchio",
-     "ulab",
-     "usb_hid",
-     "usb_midi"
-    ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
-   },
    {
     "extensions": [
      "dfu"
@@ -8120,6 +8649,52 @@
     ],
     "stable": true,
     "version": "6.1.0"
+   },
+   {
+    "extensions": [
+     "dfu"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": [
+     "_pixelbuf",
+     "digitalio",
+     "gamepad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "os",
+     "random",
+     "storage",
+     "struct",
+     "supervisor",
+     "time",
+     "touchio",
+     "ulab",
+     "usb_hid",
+     "usb_midi"
+    ],
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
@@ -8129,7 +8704,7 @@
   "versions": []
  },
  {
-  "downloads": 150,
+  "downloads": 0,
   "id": "gemma_m0",
   "versions": [
    {
@@ -8137,24 +8712,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -8179,8 +8754,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -8229,13 +8804,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 56,
+  "downloads": 0,
   "id": "gemma_m0_pycon2018",
   "versions": [
    {
@@ -8243,28 +8818,28 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": "[]",
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -8291,13 +8866,13 @@
      "fil"
     ],
     "modules": "[]",
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 121,
+  "downloads": 0,
   "id": "grandcentral_m4_express",
   "versions": [
    {
@@ -8305,24 +8880,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -8370,8 +8945,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -8443,13 +9018,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 136,
+  "downloads": 0,
   "id": "hallowing_m0_express",
   "versions": [
    {
@@ -8457,24 +9032,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -8503,8 +9078,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -8557,13 +9132,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 91,
+  "downloads": 0,
   "id": "hallowing_m4_express",
   "versions": [
    {
@@ -8571,24 +9146,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -8635,8 +9210,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -8707,13 +9282,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 112,
+  "downloads": 0,
   "id": "hiibot_bluefi",
   "versions": [
    {
@@ -8721,24 +9296,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -8783,8 +9358,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -8853,13 +9428,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 61,
+  "downloads": 0,
   "id": "ikigaisense_vita",
   "versions": [
    {
@@ -8867,24 +9442,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -8929,8 +9504,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -8999,13 +9574,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 41,
+  "downloads": 0,
   "id": "imxrt1010_evk",
   "versions": [
    {
@@ -9014,24 +9589,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -9065,8 +9640,8 @@
      "usb_hid",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -9125,13 +9700,13 @@
      "usb_hid",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 40,
+  "downloads": 0,
   "id": "imxrt1020_evk",
   "versions": [
    {
@@ -9140,24 +9715,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -9191,8 +9766,8 @@
      "usb_hid",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -9251,13 +9826,13 @@
      "usb_hid",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 41,
+  "downloads": 0,
   "id": "imxrt1060_evk",
   "versions": [
    {
@@ -9266,24 +9841,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -9317,8 +9892,8 @@
      "usb_hid",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -9377,13 +9952,13 @@
      "usb_hid",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 134,
+  "downloads": 0,
   "id": "itsybitsy_m0_express",
   "versions": [
    {
@@ -9391,24 +9966,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -9438,8 +10013,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -9493,13 +10068,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 171,
+  "downloads": 0,
   "id": "itsybitsy_m4_express",
   "versions": [
    {
@@ -9507,24 +10082,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -9570,8 +10145,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -9641,13 +10216,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 238,
+  "downloads": 0,
   "id": "itsybitsy_nrf52840_express",
   "versions": [
    {
@@ -9655,24 +10230,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -9717,8 +10292,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -9787,13 +10362,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 69,
+  "downloads": 0,
   "id": "kicksat-sprite",
   "versions": [
    {
@@ -9801,24 +10376,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -9854,8 +10429,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -9915,13 +10490,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 54,
+  "downloads": 0,
   "id": "loc_ber_m4_base_board",
   "versions": [
    {
@@ -9929,24 +10504,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -9972,8 +10547,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -10023,13 +10598,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 148,
+  "downloads": 0,
   "id": "makerdiary_m60_keyboard",
   "versions": [
    {
@@ -10037,24 +10612,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -10099,8 +10674,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -10169,13 +10744,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 176,
+  "downloads": 0,
   "id": "makerdiary_nrf52840_m2_devkit",
   "versions": [
    {
@@ -10183,24 +10758,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -10245,8 +10820,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -10315,85 +10890,15 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 71,
+  "downloads": 0,
   "id": "makerdiary_nrf52840_mdk",
   "versions": [
-   {
-    "extensions": [
-     "hex"
-    ],
-    "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
-     "cs",
-     "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
-     "it_IT",
-     "de_DE"
-    ],
-    "modules": [
-     "_bleio",
-     "_pixelbuf",
-     "aesio",
-     "analogio",
-     "audiobusio",
-     "audiocore",
-     "audiomixer",
-     "audiomp3",
-     "audiopwmio",
-     "bitbangio",
-     "board",
-     "busio",
-     "digitalio",
-     "displayio",
-     "framebufferio",
-     "gamepad",
-     "math",
-     "microcontroller",
-     "msgpack",
-     "neopixel_write",
-     "nvm",
-     "os",
-     "pulseio",
-     "pwmio",
-     "random",
-     "rgbmatrix",
-     "rotaryio",
-     "rtc",
-     "sdcardio",
-     "sharpdisplay",
-     "storage",
-     "struct",
-     "supervisor",
-     "terminalio",
-     "time",
-     "touchio",
-     "ulab",
-     "usb_hid",
-     "usb_midi",
-     "vectorio",
-     "watchdog"
-    ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
-   },
    {
     "extensions": [
      "hex"
@@ -10463,11 +10968,81 @@
     ],
     "stable": true,
     "version": "6.1.0"
+   },
+   {
+    "extensions": [
+     "hex"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": [
+     "_bleio",
+     "_pixelbuf",
+     "aesio",
+     "analogio",
+     "audiobusio",
+     "audiocore",
+     "audiomixer",
+     "audiomp3",
+     "audiopwmio",
+     "bitbangio",
+     "board",
+     "busio",
+     "digitalio",
+     "displayio",
+     "framebufferio",
+     "gamepad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "os",
+     "pulseio",
+     "pwmio",
+     "random",
+     "rgbmatrix",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "touchio",
+     "ulab",
+     "usb_hid",
+     "usb_midi",
+     "vectorio",
+     "watchdog"
+    ],
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 92,
+  "downloads": 0,
   "id": "makerdiary_nrf52840_mdk_usb_dongle",
   "versions": [
    {
@@ -10476,24 +11051,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -10538,8 +11113,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -10609,13 +11184,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 299,
+  "downloads": 0,
   "id": "matrixportal_m4",
   "versions": [
    {
@@ -10623,24 +11198,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -10687,8 +11262,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -10759,13 +11334,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 146,
+  "downloads": 0,
   "id": "meowbit_v121",
   "versions": [
    {
@@ -10773,24 +11348,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -10821,8 +11396,8 @@
      "touchio",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -10877,13 +11452,13 @@
      "touchio",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 109,
+  "downloads": 0,
   "id": "meowmeow",
   "versions": [
    {
@@ -10891,24 +11466,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -10931,8 +11506,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -10979,13 +11554,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 155,
+  "downloads": 0,
   "id": "metro_m0_express",
   "versions": [
    {
@@ -10993,24 +11568,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -11042,8 +11617,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -11099,13 +11674,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 193,
+  "downloads": 0,
   "id": "metro_m4_airlift_lite",
   "versions": [
    {
@@ -11113,24 +11688,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -11177,8 +11752,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -11249,13 +11824,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 139,
+  "downloads": 0,
   "id": "metro_m4_express",
   "versions": [
    {
@@ -11263,24 +11838,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -11327,8 +11902,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -11399,13 +11974,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 46,
+  "downloads": 0,
   "id": "metro_m7_1011",
   "versions": [
    {
@@ -11414,24 +11989,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -11465,8 +12040,8 @@
      "usb_hid",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -11525,85 +12100,15 @@
      "usb_hid",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 90,
+  "downloads": 0,
   "id": "metro_nrf52840_express",
   "versions": [
-   {
-    "extensions": [
-     "uf2"
-    ],
-    "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
-     "cs",
-     "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
-     "it_IT",
-     "de_DE"
-    ],
-    "modules": [
-     "_bleio",
-     "_pixelbuf",
-     "aesio",
-     "analogio",
-     "audiobusio",
-     "audiocore",
-     "audiomixer",
-     "audiomp3",
-     "audiopwmio",
-     "bitbangio",
-     "board",
-     "busio",
-     "digitalio",
-     "displayio",
-     "framebufferio",
-     "gamepad",
-     "math",
-     "microcontroller",
-     "msgpack",
-     "neopixel_write",
-     "nvm",
-     "os",
-     "pulseio",
-     "pwmio",
-     "random",
-     "rgbmatrix",
-     "rotaryio",
-     "rtc",
-     "sdcardio",
-     "sharpdisplay",
-     "storage",
-     "struct",
-     "supervisor",
-     "terminalio",
-     "time",
-     "touchio",
-     "ulab",
-     "usb_hid",
-     "usb_midi",
-     "vectorio",
-     "watchdog"
-    ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
-   },
    {
     "extensions": [
      "uf2"
@@ -11673,11 +12178,81 @@
     ],
     "stable": true,
     "version": "6.1.0"
+   },
+   {
+    "extensions": [
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": [
+     "_bleio",
+     "_pixelbuf",
+     "aesio",
+     "analogio",
+     "audiobusio",
+     "audiocore",
+     "audiomixer",
+     "audiomp3",
+     "audiopwmio",
+     "bitbangio",
+     "board",
+     "busio",
+     "digitalio",
+     "displayio",
+     "framebufferio",
+     "gamepad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "os",
+     "pulseio",
+     "pwmio",
+     "random",
+     "rgbmatrix",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "touchio",
+     "ulab",
+     "usb_hid",
+     "usb_midi",
+     "vectorio",
+     "watchdog"
+    ],
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 62,
+  "downloads": 0,
   "id": "microdev_micro_s2",
   "versions": [
    {
@@ -11686,24 +12261,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -11752,8 +12327,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -11827,13 +12402,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 138,
+  "downloads": 0,
   "id": "mini_sam_m4",
   "versions": [
    {
@@ -11841,24 +12416,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -11904,8 +12479,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -11975,13 +12550,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 82,
+  "downloads": 0,
   "id": "monster_m4sk",
   "versions": [
    {
@@ -11989,24 +12564,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -12053,8 +12628,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -12125,13 +12700,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 105,
+  "downloads": 0,
   "id": "muselab_nanoesp32_s2",
   "versions": [
    {
@@ -12140,24 +12715,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -12206,8 +12781,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -12281,65 +12856,15 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 45,
+  "downloads": 0,
   "id": "ndgarage_ndbit6",
   "versions": [
-   {
-    "extensions": [
-     "uf2"
-    ],
-    "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
-     "cs",
-     "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
-     "it_IT",
-     "de_DE"
-    ],
-    "modules": [
-     "analogio",
-     "board",
-     "busio",
-     "digitalio",
-     "math",
-     "microcontroller",
-     "neopixel_write",
-     "nvm",
-     "os",
-     "pulseio",
-     "pwmio",
-     "random",
-     "rotaryio",
-     "rtc",
-     "storage",
-     "struct",
-     "supervisor",
-     "time",
-     "touchio",
-     "usb_hid",
-     "usb_midi"
-    ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
-   },
    {
     "extensions": [
      "uf2"
@@ -12389,6 +12914,56 @@
     ],
     "stable": true,
     "version": "6.1.0"
+   },
+   {
+    "extensions": [
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": [
+     "analogio",
+     "board",
+     "busio",
+     "digitalio",
+     "math",
+     "microcontroller",
+     "neopixel_write",
+     "nvm",
+     "os",
+     "pulseio",
+     "pwmio",
+     "random",
+     "rotaryio",
+     "rtc",
+     "storage",
+     "struct",
+     "supervisor",
+     "time",
+     "touchio",
+     "usb_hid",
+     "usb_midi"
+    ],
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
@@ -12401,24 +12976,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -12443,8 +13018,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -12493,8 +13068,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
@@ -12545,11 +13120,55 @@
     ],
     "stable": true,
     "version": "6.1.0"
+   },
+   {
+    "extensions": [
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": [
+     "_pixelbuf",
+     "board",
+     "digitalio",
+     "math",
+     "microcontroller",
+     "neopixel_write",
+     "nvm",
+     "os",
+     "random",
+     "struct",
+     "supervisor",
+     "time",
+     "touchio",
+     "usb_hid",
+     "usb_midi"
+    ],
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 104,
+  "downloads": 0,
   "id": "nfc_copy_cat",
   "versions": [
    {
@@ -12557,24 +13176,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -12599,8 +13218,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -12649,13 +13268,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 84,
+  "downloads": 0,
   "id": "nice_nano",
   "versions": [
    {
@@ -12663,24 +13282,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -12725,8 +13344,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -12795,13 +13414,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 18,
+  "downloads": 0,
   "id": "nucleo_f746zg",
   "versions": [
    {
@@ -12809,24 +13428,24 @@
      "bin"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -12856,8 +13475,8 @@
      "ulab",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -12911,13 +13530,13 @@
      "ulab",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 27,
+  "downloads": 0,
   "id": "nucleo_f767zi",
   "versions": [
    {
@@ -12925,24 +13544,24 @@
      "bin"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -12972,8 +13591,8 @@
      "ulab",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -13027,13 +13646,13 @@
      "ulab",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 20,
+  "downloads": 0,
   "id": "nucleo_h743zi_2",
   "versions": [
    {
@@ -13041,24 +13660,24 @@
      "bin"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -13086,8 +13705,8 @@
      "ulab",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -13139,13 +13758,13 @@
      "ulab",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 106,
+  "downloads": 0,
   "id": "ohs2020_badge",
   "versions": [
    {
@@ -13153,24 +13772,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -13215,8 +13834,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -13285,13 +13904,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 138,
+  "downloads": 0,
   "id": "openbook_m4",
   "versions": [
    {
@@ -13299,24 +13918,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -13364,8 +13983,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -13437,13 +14056,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 18,
+  "downloads": 0,
   "id": "openmv_h7",
   "versions": [
    {
@@ -13451,24 +14070,24 @@
      "bin"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -13496,8 +14115,8 @@
      "ulab",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -13549,13 +14168,13 @@
      "ulab",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 114,
+  "downloads": 0,
   "id": "particle_argon",
   "versions": [
    {
@@ -13563,24 +14182,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -13625,8 +14244,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -13695,13 +14314,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 75,
+  "downloads": 0,
   "id": "particle_boron",
   "versions": [
    {
@@ -13709,24 +14328,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -13771,8 +14390,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -13841,13 +14460,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 110,
+  "downloads": 0,
   "id": "particle_xenon",
   "versions": [
    {
@@ -13855,24 +14474,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -13917,8 +14536,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -13987,8 +14606,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
@@ -13998,7 +14617,7 @@
   "versions": []
  },
  {
-  "downloads": 66,
+  "downloads": 0,
   "id": "pca10056",
   "versions": [
    {
@@ -14007,24 +14626,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -14069,8 +14688,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -14140,13 +14759,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 89,
+  "downloads": 0,
   "id": "pca10059",
   "versions": [
    {
@@ -14155,24 +14774,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -14217,8 +14836,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -14288,13 +14907,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 128,
+  "downloads": 0,
   "id": "pca10100",
   "versions": [
    {
@@ -14302,24 +14921,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -14347,8 +14966,8 @@
      "usb_midi",
      "watchdog"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -14400,13 +15019,13 @@
      "usb_midi",
      "watchdog"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 94,
+  "downloads": 0,
   "id": "pewpew10",
   "versions": [
    {
@@ -14414,24 +15033,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pew",
@@ -14454,8 +15073,8 @@
      "touchio",
      "usb_hid"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -14502,13 +15121,13 @@
      "touchio",
      "usb_hid"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 49,
+  "downloads": 0,
   "id": "pewpew13",
   "versions": [
    {
@@ -14516,28 +15135,28 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": "[]",
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -14564,13 +15183,13 @@
      "fil"
     ],
     "modules": "[]",
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 139,
+  "downloads": 0,
   "id": "pewpew_m4",
   "versions": [
    {
@@ -14578,24 +15197,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_stage",
@@ -14621,8 +15240,8 @@
      "terminalio",
      "time"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -14672,13 +15291,13 @@
      "terminalio",
      "time"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 114,
+  "downloads": 0,
   "id": "picoplanet",
   "versions": [
    {
@@ -14686,24 +15305,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -14728,8 +15347,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -14778,13 +15397,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 67,
+  "downloads": 0,
   "id": "pirkey_m0",
   "versions": [
    {
@@ -14792,24 +15411,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "board",
@@ -14828,8 +15447,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -14872,13 +15491,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 98,
+  "downloads": 0,
   "id": "pitaya_go",
   "versions": [
    {
@@ -14886,24 +15505,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -14948,8 +15567,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -15018,13 +15637,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 16,
+  "downloads": 0,
   "id": "pyb_nano_v2",
   "versions": [
    {
@@ -15032,24 +15651,24 @@
      "bin"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -15081,8 +15700,8 @@
      "ulab",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -15138,13 +15757,13 @@
      "ulab",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 127,
+  "downloads": 0,
   "id": "pybadge",
   "versions": [
    {
@@ -15152,24 +15771,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -15218,8 +15837,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -15292,13 +15911,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 84,
+  "downloads": 0,
   "id": "pybadge_airlift",
   "versions": [
    {
@@ -15306,24 +15925,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -15372,8 +15991,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -15446,13 +16065,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 34,
+  "downloads": 0,
   "id": "pyboard_v11",
   "versions": [
    {
@@ -15460,24 +16079,24 @@
      "bin"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -15512,8 +16131,8 @@
      "ulab",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -15572,13 +16191,13 @@
      "ulab",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 102,
+  "downloads": 0,
   "id": "pycubed",
   "versions": [
    {
@@ -15586,24 +16205,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -15641,8 +16260,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -15704,13 +16323,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 52,
+  "downloads": 0,
   "id": "pycubed_mram",
   "versions": [
    {
@@ -15718,24 +16337,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -15773,8 +16392,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -15836,13 +16455,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 92,
+  "downloads": 0,
   "id": "pygamer",
   "versions": [
    {
@@ -15850,24 +16469,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -15916,8 +16535,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -15990,13 +16609,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 105,
+  "downloads": 0,
   "id": "pygamer_advance",
   "versions": [
    {
@@ -16004,24 +16623,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -16070,8 +16689,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -16144,13 +16763,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 241,
+  "downloads": 0,
   "id": "pyportal",
   "versions": [
    {
@@ -16158,24 +16777,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -16222,8 +16841,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -16294,13 +16913,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 125,
+  "downloads": 0,
   "id": "pyportal_pynt",
   "versions": [
    {
@@ -16308,28 +16927,28 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": "[]",
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -16356,13 +16975,13 @@
      "fil"
     ],
     "modules": "[]",
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 150,
+  "downloads": 0,
   "id": "pyportal_titano",
   "versions": [
    {
@@ -16370,24 +16989,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -16434,8 +17053,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -16506,13 +17125,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 111,
+  "downloads": 0,
   "id": "pyruler",
   "versions": [
    {
@@ -16520,24 +17139,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -16561,8 +17180,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -16610,13 +17229,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 251,
+  "downloads": 0,
   "id": "qtpy_m0",
   "versions": [
    {
@@ -16624,24 +17243,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -16666,8 +17285,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -16716,13 +17335,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 174,
+  "downloads": 0,
   "id": "qtpy_m0_haxpress",
   "versions": [
    {
@@ -16730,24 +17349,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -16779,8 +17398,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -16836,13 +17455,47 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 140,
+  "downloads": 0,
+  "id": "raspberry_pi_pico",
+  "versions": [
+   {
+    "extensions": [
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": "[]",
+    "stable": false,
+    "version": "6.2.0-beta.0"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
   "id": "raytac_mdbt50q-db-40",
   "versions": [
    {
@@ -16850,24 +17503,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -16912,8 +17565,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -16982,13 +17635,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 75,
+  "downloads": 0,
   "id": "robohatmm1_m4",
   "versions": [
    {
@@ -16996,24 +17649,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -17052,8 +17705,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -17116,13 +17769,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 72,
+  "downloads": 0,
   "id": "sam32",
   "versions": [
    {
@@ -17130,24 +17783,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -17194,8 +17847,8 @@
      "ustack",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -17266,13 +17919,13 @@
      "ustack",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 42,
+  "downloads": 0,
   "id": "same54_xplained",
   "versions": [
    {
@@ -17280,24 +17933,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -17344,8 +17997,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -17416,13 +18069,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 234,
+  "downloads": 0,
   "id": "seeeduino_wio_terminal",
   "versions": [
    {
@@ -17430,24 +18083,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -17494,8 +18147,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -17566,13 +18219,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 386,
+  "downloads": 0,
   "id": "seeeduino_xiao",
   "versions": [
    {
@@ -17580,24 +18233,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -17622,8 +18275,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -17672,13 +18325,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 157,
+  "downloads": 0,
   "id": "serpente",
   "versions": [
    {
@@ -17686,24 +18339,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -17738,8 +18391,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -17798,13 +18451,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 24,
+  "downloads": 0,
   "id": "shirtty",
   "versions": [
    {
@@ -17812,24 +18465,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -17854,8 +18507,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -17904,13 +18557,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 61,
+  "downloads": 0,
   "id": "simmel",
   "versions": [
    {
@@ -17918,24 +18571,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -17964,8 +18617,8 @@
      "usb_midi",
      "watchdog"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -18018,13 +18671,13 @@
      "usb_midi",
      "watchdog"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 109,
+  "downloads": 0,
   "id": "snekboard",
   "versions": [
    {
@@ -18032,24 +18685,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -18081,8 +18734,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -18138,13 +18791,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 92,
+  "downloads": 0,
   "id": "sparkfun_lumidrive",
   "versions": [
    {
@@ -18152,24 +18805,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -18202,8 +18855,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -18260,13 +18913,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 205,
+  "downloads": 0,
   "id": "sparkfun_nrf52840_mini",
   "versions": [
    {
@@ -18274,24 +18927,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -18336,8 +18989,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -18406,13 +19059,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 50,
+  "downloads": 0,
   "id": "sparkfun_qwiic_micro_no_flash",
   "versions": [
    {
@@ -18420,24 +19073,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -18462,8 +19115,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -18512,13 +19165,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 196,
+  "downloads": 0,
   "id": "sparkfun_qwiic_micro_with_flash",
   "versions": [
    {
@@ -18526,24 +19179,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -18568,8 +19221,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -18618,13 +19271,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 149,
+  "downloads": 0,
   "id": "sparkfun_redboard_turbo",
   "versions": [
    {
@@ -18632,24 +19285,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -18680,8 +19333,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -18736,13 +19389,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 136,
+  "downloads": 0,
   "id": "sparkfun_samd21_dev",
   "versions": [
    {
@@ -18750,24 +19403,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -18792,8 +19445,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -18842,13 +19495,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 138,
+  "downloads": 0,
   "id": "sparkfun_samd21_mini",
   "versions": [
    {
@@ -18856,24 +19509,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -18898,8 +19551,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -18948,13 +19601,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 93,
+  "downloads": 0,
   "id": "sparkfun_samd51_thing_plus",
   "versions": [
    {
@@ -18962,24 +19615,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -19026,8 +19679,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -19098,43 +19751,15 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 144,
+  "downloads": 0,
   "id": "spresense",
   "versions": [
-   {
-    "extensions": [
-     "spk"
-    ],
-    "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
-     "cs",
-     "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
-     "it_IT",
-     "de_DE"
-    ],
-    "modules": "[]",
-    "stable": false,
-    "version": "6.1.0-rc.1"
-   },
    {
     "extensions": [
      "spk"
@@ -19162,6 +19787,34 @@
     "modules": "[]",
     "stable": true,
     "version": "6.1.0"
+   },
+   {
+    "extensions": [
+     "spk"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": "[]",
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
@@ -19225,11 +19878,68 @@
     ],
     "stable": true,
     "version": "6.1.0"
+   },
+   {
+    "extensions": [
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": [
+     "_pixelbuf",
+     "analogio",
+     "audiobusio",
+     "audiocore",
+     "audioio",
+     "board",
+     "busio",
+     "digitalio",
+     "displayio",
+     "gamepad",
+     "math",
+     "microcontroller",
+     "neopixel_write",
+     "nvm",
+     "os",
+     "pulseio",
+     "pwmio",
+     "random",
+     "rotaryio",
+     "rtc",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "touchio",
+     "usb_hid",
+     "usb_midi"
+    ],
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 60,
+  "downloads": 0,
   "id": "stm32f411ce_blackpill",
   "versions": [
    {
@@ -19237,24 +19947,24 @@
      "bin"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -19286,8 +19996,8 @@
      "ulab",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -19343,13 +20053,76 @@
      "ulab",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 24,
+  "downloads": 0,
+  "id": "stm32f411ce_blackpill_with_flash",
+  "versions": [
+   {
+    "extensions": [
+     "bin"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": [
+     "_bleio",
+     "_pixelbuf",
+     "analogio",
+     "bitbangio",
+     "board",
+     "busio",
+     "digitalio",
+     "displayio",
+     "framebufferio",
+     "gamepad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "os",
+     "pulseio",
+     "pwmio",
+     "random",
+     "sdcardio",
+     "sharpdisplay",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "touchio",
+     "ulab",
+     "vectorio"
+    ],
+    "stable": false,
+    "version": "6.2.0-beta.0"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
   "id": "stm32f411ve_discovery",
   "versions": [
    {
@@ -19357,24 +20130,24 @@
      "bin"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -19406,8 +20179,8 @@
      "ulab",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -19463,13 +20236,13 @@
      "ulab",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 12,
+  "downloads": 0,
   "id": "stm32f412zg_discovery",
   "versions": [
    {
@@ -19477,24 +20250,24 @@
      "bin"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -19527,8 +20300,8 @@
      "usb_hid",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -19585,13 +20358,13 @@
      "usb_hid",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 27,
+  "downloads": 0,
   "id": "stm32f4_discovery",
   "versions": [
    {
@@ -19599,24 +20372,24 @@
      "bin"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -19648,8 +20421,8 @@
      "ulab",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -19705,13 +20478,13 @@
      "ulab",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 20,
+  "downloads": 0,
   "id": "stm32f746g_discovery",
   "versions": [
    {
@@ -19719,24 +20492,24 @@
      "bin"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -19766,8 +20539,8 @@
      "ulab",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -19821,71 +20594,15 @@
      "ulab",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 83,
+  "downloads": 0,
   "id": "stringcar_m0_express",
   "versions": [
-   {
-    "extensions": [
-     "uf2"
-    ],
-    "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
-     "cs",
-     "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
-     "it_IT",
-     "de_DE"
-    ],
-    "modules": [
-     "_pixelbuf",
-     "analogio",
-     "audiocore",
-     "audioio",
-     "board",
-     "busio",
-     "countio",
-     "digitalio",
-     "displayio",
-     "math",
-     "microcontroller",
-     "msgpack",
-     "neopixel_write",
-     "nvm",
-     "os",
-     "pulseio",
-     "pwmio",
-     "random",
-     "rotaryio",
-     "storage",
-     "struct",
-     "supervisor",
-     "terminalio",
-     "time",
-     "touchio",
-     "usb_hid",
-     "usb_midi"
-    ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
-   },
    {
     "extensions": [
      "uf2"
@@ -19941,11 +20658,67 @@
     ],
     "stable": true,
     "version": "6.1.0"
+   },
+   {
+    "extensions": [
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": [
+     "_pixelbuf",
+     "analogio",
+     "audiocore",
+     "audioio",
+     "board",
+     "busio",
+     "countio",
+     "digitalio",
+     "displayio",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "os",
+     "pulseio",
+     "pwmio",
+     "random",
+     "rotaryio",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "touchio",
+     "usb_hid",
+     "usb_midi"
+    ],
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 42,
+  "downloads": 0,
   "id": "targett_module_clip_wroom",
   "versions": [
    {
@@ -20022,11 +20795,86 @@
     ],
     "stable": true,
     "version": "6.1.0"
+   },
+   {
+    "extensions": [
+     "bin",
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": [
+     "_bleio",
+     "_pixelbuf",
+     "alarm",
+     "analogio",
+     "audiobusio",
+     "audiocore",
+     "bitbangio",
+     "board",
+     "busio",
+     "canio",
+     "countio",
+     "digitalio",
+     "displayio",
+     "dualbank",
+     "framebufferio",
+     "frequencyio",
+     "gamepad",
+     "ipaddress",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "os",
+     "ps2io",
+     "pulseio",
+     "pwmio",
+     "random",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "socketpool",
+     "ssl",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "touchio",
+     "ulab",
+     "usb_hid",
+     "vectorio",
+     "watchdog",
+     "wifi"
+    ],
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 36,
+  "downloads": 0,
   "id": "targett_module_clip_wrover",
   "versions": [
    {
@@ -20103,11 +20951,86 @@
     ],
     "stable": true,
     "version": "6.1.0"
+   },
+   {
+    "extensions": [
+     "bin",
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": [
+     "_bleio",
+     "_pixelbuf",
+     "alarm",
+     "analogio",
+     "audiobusio",
+     "audiocore",
+     "bitbangio",
+     "board",
+     "busio",
+     "canio",
+     "countio",
+     "digitalio",
+     "displayio",
+     "dualbank",
+     "framebufferio",
+     "frequencyio",
+     "gamepad",
+     "ipaddress",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "os",
+     "ps2io",
+     "pulseio",
+     "pwmio",
+     "random",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "socketpool",
+     "ssl",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "touchio",
+     "ulab",
+     "usb_hid",
+     "vectorio",
+     "watchdog",
+     "wifi"
+    ],
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 161,
+  "downloads": 0,
   "id": "teensy40",
   "versions": [
    {
@@ -20116,24 +21039,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -20167,8 +21090,8 @@
      "usb_hid",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -20227,13 +21150,13 @@
      "usb_hid",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 144,
+  "downloads": 0,
   "id": "teensy41",
   "versions": [
    {
@@ -20242,24 +21165,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -20293,8 +21216,8 @@
      "usb_hid",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -20353,85 +21276,15 @@
      "usb_hid",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 18,
+  "downloads": 0,
   "id": "teknikio_bluebird",
   "versions": [
-   {
-    "extensions": [
-     "uf2"
-    ],
-    "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
-     "cs",
-     "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
-     "it_IT",
-     "de_DE"
-    ],
-    "modules": [
-     "_bleio",
-     "_pixelbuf",
-     "aesio",
-     "analogio",
-     "audiobusio",
-     "audiocore",
-     "audiomixer",
-     "audiomp3",
-     "audiopwmio",
-     "bitbangio",
-     "board",
-     "busio",
-     "digitalio",
-     "displayio",
-     "framebufferio",
-     "gamepad",
-     "math",
-     "microcontroller",
-     "msgpack",
-     "neopixel_write",
-     "nvm",
-     "os",
-     "pulseio",
-     "pwmio",
-     "random",
-     "rgbmatrix",
-     "rotaryio",
-     "rtc",
-     "sdcardio",
-     "sharpdisplay",
-     "storage",
-     "struct",
-     "supervisor",
-     "terminalio",
-     "time",
-     "touchio",
-     "ulab",
-     "usb_hid",
-     "usb_midi",
-     "vectorio",
-     "watchdog"
-    ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
-   },
    {
     "extensions": [
      "uf2"
@@ -20501,6 +21354,76 @@
     ],
     "stable": true,
     "version": "6.1.0"
+   },
+   {
+    "extensions": [
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": [
+     "_bleio",
+     "_pixelbuf",
+     "aesio",
+     "analogio",
+     "audiobusio",
+     "audiocore",
+     "audiomixer",
+     "audiomp3",
+     "audiopwmio",
+     "bitbangio",
+     "board",
+     "busio",
+     "digitalio",
+     "displayio",
+     "framebufferio",
+     "gamepad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "os",
+     "pulseio",
+     "pwmio",
+     "random",
+     "rgbmatrix",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "touchio",
+     "ulab",
+     "usb_hid",
+     "usb_midi",
+     "vectorio",
+     "watchdog"
+    ],
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
@@ -20568,6 +21491,62 @@
     ],
     "stable": true,
     "version": "6.1.0"
+   },
+   {
+    "extensions": [
+     "bin"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": [
+     "_pixelbuf",
+     "analogio",
+     "bitbangio",
+     "board",
+     "busio",
+     "digitalio",
+     "displayio",
+     "framebufferio",
+     "gamepad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "os",
+     "pulseio",
+     "pwmio",
+     "random",
+     "sdcardio",
+     "sharpdisplay",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "touchio",
+     "vectorio"
+    ],
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
@@ -20631,11 +21610,68 @@
     ],
     "stable": true,
     "version": "6.1.0"
+   },
+   {
+    "extensions": [
+     "bin"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": [
+     "_pixelbuf",
+     "analogio",
+     "bitbangio",
+     "board",
+     "busio",
+     "digitalio",
+     "displayio",
+     "framebufferio",
+     "gamepad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "os",
+     "pulseio",
+     "pwmio",
+     "random",
+     "sdcardio",
+     "sharpdisplay",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "touchio",
+     "ulab",
+     "vectorio"
+    ],
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 78,
+  "downloads": 0,
   "id": "tinkeringtech_scoutmakes_azul",
   "versions": [
    {
@@ -20643,24 +21679,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -20705,8 +21741,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -20775,13 +21811,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 182,
+  "downloads": 0,
   "id": "trellis_m4_express",
   "versions": [
    {
@@ -20789,24 +21825,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -20852,8 +21888,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -20923,13 +21959,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 347,
+  "downloads": 0,
   "id": "trinket_m0",
   "versions": [
    {
@@ -20937,24 +21973,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -20979,8 +22015,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -21029,13 +22065,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 131,
+  "downloads": 0,
   "id": "trinket_m0_haxpress",
   "versions": [
    {
@@ -21043,24 +22079,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -21092,8 +22128,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -21149,13 +22185,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 126,
+  "downloads": 0,
   "id": "uartlogger2",
   "versions": [
    {
@@ -21163,24 +22199,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -21227,8 +22263,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -21299,13 +22335,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 27,
+  "downloads": 0,
   "id": "uchip",
   "versions": [
    {
@@ -21314,24 +22350,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "analogio",
@@ -21356,8 +22392,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -21407,69 +22443,15 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 88,
+  "downloads": 0,
   "id": "ugame10",
   "versions": [
-   {
-    "extensions": [
-     "uf2"
-    ],
-    "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
-     "cs",
-     "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
-     "it_IT",
-     "de_DE"
-    ],
-    "modules": [
-     "_stage",
-     "analogio",
-     "audiocore",
-     "audioio",
-     "board",
-     "busio",
-     "countio",
-     "digitalio",
-     "displayio",
-     "gamepad",
-     "math",
-     "microcontroller",
-     "msgpack",
-     "nvm",
-     "os",
-     "pulseio",
-     "pwmio",
-     "random",
-     "rotaryio",
-     "storage",
-     "struct",
-     "supervisor",
-     "terminalio",
-     "time",
-     "vectorio"
-    ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
-   },
    {
     "extensions": [
      "uf2"
@@ -21523,11 +22505,65 @@
     ],
     "stable": true,
     "version": "6.1.0"
+   },
+   {
+    "extensions": [
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "cs",
+     "pl",
+     "nl",
+     "sv",
+     "it_IT",
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
+    ],
+    "modules": [
+     "_stage",
+     "analogio",
+     "audiocore",
+     "audioio",
+     "board",
+     "busio",
+     "countio",
+     "digitalio",
+     "displayio",
+     "gamepad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "nvm",
+     "os",
+     "pulseio",
+     "pwmio",
+     "random",
+     "rotaryio",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "vectorio"
+    ],
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 239,
+  "downloads": 0,
   "id": "unexpectedmaker_feathers2",
   "versions": [
    {
@@ -21536,24 +22572,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -21602,8 +22638,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -21677,13 +22713,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 34,
+  "downloads": 0,
   "id": "unexpectedmaker_feathers2_prerelease",
   "versions": [
    {
@@ -21692,24 +22728,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_bleio",
@@ -21758,8 +22794,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -21833,13 +22869,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 117,
+  "downloads": 0,
   "id": "winterbloom_big_honking_button",
   "versions": [
    {
@@ -21847,24 +22883,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -21890,8 +22926,8 @@
      "supervisor",
      "time"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -21941,13 +22977,13 @@
      "supervisor",
      "time"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 93,
+  "downloads": 0,
   "id": "winterbloom_sol",
   "versions": [
    {
@@ -21955,24 +22991,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "_pixelbuf",
@@ -22002,8 +23038,8 @@
      "ulab",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -22057,13 +23093,13 @@
      "ulab",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 36,
+  "downloads": 0,
   "id": "xinabox_cc03",
   "versions": [
    {
@@ -22071,24 +23107,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "board",
@@ -22107,8 +23143,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -22151,13 +23187,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  },
  {
-  "downloads": 19,
+  "downloads": 0,
   "id": "xinabox_cs11",
   "versions": [
    {
@@ -22165,24 +23201,24 @@
      "uf2"
     ],
     "languages": [
-     "ko",
-     "hi",
-     "sv",
-     "pt_BR",
-     "fr",
-     "es",
-     "nl",
-     "el",
+     "de_DE",
      "cs",
      "pl",
-     "ja",
-     "en_US",
-     "zh_Latn_pinyin",
-     "en_x_pirate",
-     "ID",
-     "fil",
+     "nl",
+     "sv",
      "it_IT",
-     "de_DE"
+     "ID",
+     "el",
+     "hi",
+     "ko",
+     "fr",
+     "zh_Latn_pinyin",
+     "ja",
+     "pt_BR",
+     "en_US",
+     "es",
+     "en_x_pirate",
+     "fil"
     ],
     "modules": [
      "board",
@@ -22199,8 +23235,8 @@
      "time",
      "usb_hid"
     ],
-    "stable": false,
-    "version": "6.1.0-rc.1"
+    "stable": true,
+    "version": "6.1.0"
    },
    {
     "extensions": [
@@ -22241,8 +23277,8 @@
      "time",
      "usb_hid"
     ],
-    "stable": true,
-    "version": "6.1.0"
+    "stable": false,
+    "version": "6.2.0-beta.0"
    }
   ]
  }


### PR DESCRIPTION
Automated website update for release 6.2.0-beta.0 by Blinka.

New boards:
* adafruit_feather_rp2040
* raspberry_pi_pico
* stm32f411ce_blackpill_with_flash

New languages:
* sv
* nl
* ko
* fr
* pl
* it_IT
* de_DE
* en_x_pirate
* zh_Latn_pinyin
* hi
* pt_BR
* es
* en_US
* fil
* ID
* cs
* el
* ja
