### PR TITLE
Update qtpy_m0.md

### DIFF
--- a/_board/qtpy_m0.md
+++ b/_board/qtpy_m0.md
@@ -11,6 +11,8 @@ features:
   - STEMMA QT/QWIIC
 ---
 
+> **Note:** If you soldered the [optional SOIC-8 SPI Flash chip](https://www.adafruit.com/product/4763) on to your QT Py, see the ["QT Py Haxpress"](../qtpy_m0_haxpress/) page to make use of the extra space!
+
 What a cutie pie! Or is it... a QT Py? This diminutive dev board comes with our favorite lil chip, the SAMD21 (as made famous in our GEMMA M0 and Trinket M0 boards).
 
 This time it comes with [our favorite connector - the STEMMA QT](http://adafruit.com/stemma), a chainable I2C port that can be used with [any of our STEMMA QT sensors and accessories](https://www.adafruit.com/category/620).


### PR DESCRIPTION
Link to the QT Py Haxpress build from the regular QT Py page.
I'm always clicking the wrong one, and have to go back to the main boards list, where
the sorting/order is unknown so the haxpress version isn't next to the regular one.

I tried to make this generic (relative URL, etc), since I don't know if it's used anywhere other than https://circuitpython.org/board/qtpy_m0/ - but this was a bit of a usability papercut for me as I inexplicably keep upgrading the version I have on the board next to me :) No idea if this is the best way to display this or not, but if you don't like the specific way I added it, consider this a "request for enhancement" to add a "see also" section or something 👍 