### PR TITLE
Revert github pages dependency changes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,7 @@ GEM
       liquid (= 4.0.3)
       mercenary (~> 0.3)
       minima (= 2.5.1)
-      nokogiri (>= 1.11.0.rc4, < 2.0)
+      nokogiri (>= 1.10.4, < 2.0)
       rouge (= 3.19.0)
       terminal-table (~> 1.4)
     github-pages-health-check (1.16.1)


### PR DESCRIPTION
Ok, trying to decrypt the error message, I think what it is saying is that the dependency versions under github pages don't match, so I likely modified this in the wrong place, so I'm reverting that one change I did manually.