### PR TITLE
remove 5.x bundle boilerplate

### DIFF
--- a/libraries/index.html
+++ b/libraries/index.html
@@ -50,13 +50,6 @@ permalink: /libraries
             CircuitPython 6, please download this bundle.
           </p>
         </div>
-        <div id="adafruit-circuitpython-bundle-5.x-mpy">
-          <h3>Bundle Version 5.x</h3>
-          <p>
-            This bundle is built for use with CircuitPython 5.x.x. If you are using
-            CircuitPython 5, please download this bundle.
-          </p>
-        </div>
         <div id="adafruit-circuitpython-bundle-py">
           <h3>Bundle Version py</h3>
           <p>


### PR DESCRIPTION
The text about the bundle was there, but there was no link.

This might be automated in the future, but fixing quickly for now.