### PR TITLE
Automated website update for release 6.2.0-beta.2

### DIFF
--- a/_data/files.json
+++ b/_data/files.json
@@ -1,6 +1,6 @@
 [
  {
-  "downloads": 0,
+  "downloads": 143,
   "id": "8086_commander",
   "versions": [
    {
@@ -256,7 +256,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 12,
   "id": "TG-Watch",
   "versions": [
    {
@@ -726,7 +726,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 18,
   "id": "adafruit_feather_rp2040",
   "versions": [
    {
@@ -796,7 +796,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 524,
   "id": "adafruit_magtag_2.9_grayscale",
   "versions": [
    {
@@ -956,7 +956,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 218,
   "id": "adafruit_metro_esp32s2",
   "versions": [
    {
@@ -1116,7 +1116,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 125,
   "id": "aloriumtech_evo_m51",
   "versions": [
    {
@@ -1270,7 +1270,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 126,
   "id": "aramcon_badge_2019",
   "versions": [
    {
@@ -1420,7 +1420,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 32,
   "id": "arduino_mkr1300",
   "versions": [
    {
@@ -1528,7 +1528,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 75,
   "id": "arduino_mkrzero",
   "versions": [
    {
@@ -1636,7 +1636,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 195,
   "id": "arduino_nano_33_ble",
   "versions": [
    {
@@ -1786,7 +1786,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 70,
   "id": "arduino_nano_33_iot",
   "versions": [
    {
@@ -1894,7 +1894,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 97,
   "id": "arduino_zero",
   "versions": [
    {
@@ -2002,7 +2002,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 157,
   "id": "bast_pro_mini_m0",
   "versions": [
    {
@@ -2108,7 +2108,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 51,
   "id": "bastble",
   "versions": [
    {
@@ -2258,7 +2258,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 179,
   "id": "bdmicro_vina_d21",
   "versions": [
    {
@@ -2380,7 +2380,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 124,
   "id": "bdmicro_vina_d51",
   "versions": [
    {
@@ -2539,7 +2539,7 @@
   "versions": []
  },
  {
-  "downloads": 0,
+  "downloads": 224,
   "id": "bless_dev_board_multi_sensor",
   "versions": [
    {
@@ -2689,7 +2689,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 94,
   "id": "blm_badge",
   "versions": [
    {
@@ -2791,7 +2791,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 142,
   "id": "capablerobot_usbhub",
   "versions": [
    {
@@ -2943,7 +2943,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 139,
   "id": "catwan_usbstick",
   "versions": [
    {
@@ -3047,7 +3047,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 79,
   "id": "circuitbrains_basic_m0",
   "versions": [
    {
@@ -3171,7 +3171,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 135,
   "id": "circuitbrains_deluxe_m4",
   "versions": [
    {
@@ -3325,7 +3325,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 335,
   "id": "circuitplayground_bluefruit",
   "versions": [
    {
@@ -3475,7 +3475,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 493,
   "id": "circuitplayground_express",
   "versions": [
    {
@@ -3597,7 +3597,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 233,
   "id": "circuitplayground_express_4h",
   "versions": [
    {
@@ -3659,7 +3659,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 170,
   "id": "circuitplayground_express_crickit",
   "versions": [
    {
@@ -3775,7 +3775,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 34,
   "id": "circuitplayground_express_digikey_pycon2019",
   "versions": [
    {
@@ -3837,7 +3837,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 206,
   "id": "circuitplayground_express_displayio",
   "versions": [
    {
@@ -3952,7 +3952,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 256,
   "id": "clue_nrf52840_express",
   "versions": [
    {
@@ -4102,7 +4102,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 103,
   "id": "cp32-m4",
   "versions": [
    {
@@ -4254,7 +4254,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 88,
   "id": "cp_sapling_m0",
   "versions": [
    {
@@ -4480,7 +4480,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 52,
   "id": "datalore_ip_m4",
   "versions": [
    {
@@ -4634,7 +4634,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 66,
   "id": "datum_distance",
   "versions": [
    {
@@ -4740,7 +4740,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 91,
   "id": "datum_imu",
   "versions": [
    {
@@ -4846,7 +4846,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 52,
   "id": "datum_light",
   "versions": [
    {
@@ -4952,7 +4952,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 57,
   "id": "datum_weather",
   "versions": [
    {
@@ -5114,7 +5114,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 113,
   "id": "dynossat_edu_eps",
   "versions": [
    {
@@ -5232,7 +5232,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 104,
   "id": "dynossat_edu_obc",
   "versions": [
    {
@@ -5386,7 +5386,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 144,
   "id": "edgebadge",
   "versions": [
    {
@@ -5448,7 +5448,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 49,
   "id": "electroniccats_bastwifi",
   "versions": [
    {
@@ -5606,7 +5606,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 175,
   "id": "electronut_labs_blip",
   "versions": [
    {
@@ -5758,7 +5758,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 172,
   "id": "electronut_labs_papyr",
   "versions": [
    {
@@ -5908,7 +5908,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 166,
   "id": "escornabot_makech",
   "versions": [
    {
@@ -6012,7 +6012,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 69,
   "id": "espressif_kaluga_1",
   "versions": [
    {
@@ -6172,7 +6172,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 163,
   "id": "espressif_saola_1_wroom",
   "versions": [
    {
@@ -6332,7 +6332,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 144,
   "id": "espressif_saola_1_wrover",
   "versions": [
    {
@@ -6492,7 +6492,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 38,
   "id": "espruino_pico",
   "versions": [
    {
@@ -6614,7 +6614,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 16,
   "id": "espruino_wifi",
   "versions": [
    {
@@ -6738,7 +6738,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 275,
   "id": "feather_bluefruit_sense",
   "versions": [
    {
@@ -6888,7 +6888,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 101,
   "id": "feather_m0_adalogger",
   "versions": [
    {
@@ -6996,7 +6996,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 116,
   "id": "feather_m0_basic",
   "versions": [
    {
@@ -7104,7 +7104,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 272,
   "id": "feather_m0_express",
   "versions": [
    {
@@ -7226,7 +7226,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 128,
   "id": "feather_m0_express_crickit",
   "versions": [
    {
@@ -7344,7 +7344,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 70,
   "id": "feather_m0_rfm69",
   "versions": [
    {
@@ -7438,7 +7438,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 84,
   "id": "feather_m0_rfm9x",
   "versions": [
    {
@@ -7532,7 +7532,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 101,
   "id": "feather_m0_supersized",
   "versions": [
    {
@@ -7654,7 +7654,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 144,
   "id": "feather_m4_can",
   "versions": [
    {
@@ -7806,7 +7806,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 402,
   "id": "feather_m4_express",
   "versions": [
    {
@@ -7960,7 +7960,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 46,
   "id": "feather_m7_1011",
   "versions": [
    {
@@ -8090,7 +8090,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 44,
   "id": "feather_mimxrt1011",
   "versions": [
    {
@@ -8220,7 +8220,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 77,
   "id": "feather_mimxrt1062",
   "versions": [
    {
@@ -8350,7 +8350,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 268,
   "id": "feather_nrf52840_express",
   "versions": [
    {
@@ -8500,7 +8500,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 88,
   "id": "feather_radiofruit_zigbee",
   "versions": [
    {
@@ -8618,7 +8618,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 96,
   "id": "feather_stm32f405_express",
   "versions": [
    {
@@ -8748,7 +8748,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 104,
   "id": "fluff_m0",
   "versions": [
    {
@@ -8854,7 +8854,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 123,
   "id": "fomu",
   "versions": [
    {
@@ -8961,7 +8961,7 @@
   "versions": []
  },
  {
-  "downloads": 0,
+  "downloads": 175,
   "id": "gemma_m0",
   "versions": [
    {
@@ -9067,7 +9067,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 119,
   "id": "gemma_m0_pycon2018",
   "versions": [
    {
@@ -9129,7 +9129,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 173,
   "id": "grandcentral_m4_express",
   "versions": [
    {
@@ -9285,7 +9285,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 173,
   "id": "hallowing_m0_express",
   "versions": [
    {
@@ -9401,7 +9401,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 152,
   "id": "hallowing_m4_express",
   "versions": [
    {
@@ -9555,7 +9555,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 172,
   "id": "hiibot_bluefi",
   "versions": [
    {
@@ -9705,7 +9705,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 78,
   "id": "ikigaisense_vita",
   "versions": [
    {
@@ -9855,7 +9855,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 50,
   "id": "imxrt1010_evk",
   "versions": [
    {
@@ -9985,7 +9985,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 55,
   "id": "imxrt1020_evk",
   "versions": [
    {
@@ -10115,7 +10115,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 50,
   "id": "imxrt1060_evk",
   "versions": [
    {
@@ -10245,7 +10245,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 187,
   "id": "itsybitsy_m0_express",
   "versions": [
    {
@@ -10363,7 +10363,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 222,
   "id": "itsybitsy_m4_express",
   "versions": [
    {
@@ -10515,7 +10515,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 229,
   "id": "itsybitsy_nrf52840_express",
   "versions": [
    {
@@ -10665,7 +10665,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 125,
   "id": "kicksat-sprite",
   "versions": [
    {
@@ -10882,7 +10882,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 81,
   "id": "loc_ber_m4_base_board",
   "versions": [
    {
@@ -10990,7 +10990,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 183,
   "id": "makerdiary_m60_keyboard",
   "versions": [
    {
@@ -11140,7 +11140,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 222,
   "id": "makerdiary_nrf52840_m2_devkit",
   "versions": [
    {
@@ -11290,7 +11290,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 79,
   "id": "makerdiary_nrf52840_mdk",
   "versions": [
    {
@@ -11440,7 +11440,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 101,
   "id": "makerdiary_nrf52840_mdk_usb_dongle",
   "versions": [
    {
@@ -11592,7 +11592,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 389,
   "id": "matrixportal_m4",
   "versions": [
    {
@@ -11746,7 +11746,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 204,
   "id": "meowbit_v121",
   "versions": [
    {
@@ -11868,7 +11868,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 161,
   "id": "meowmeow",
   "versions": [
    {
@@ -11970,7 +11970,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 196,
   "id": "metro_m0_express",
   "versions": [
    {
@@ -12092,7 +12092,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 243,
   "id": "metro_m4_airlift_lite",
   "versions": [
    {
@@ -12246,7 +12246,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 191,
   "id": "metro_m4_express",
   "versions": [
    {
@@ -12400,7 +12400,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 68,
   "id": "metro_m7_1011",
   "versions": [
    {
@@ -12530,7 +12530,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 106,
   "id": "metro_nrf52840_express",
   "versions": [
    {
@@ -12680,7 +12680,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 75,
   "id": "microdev_micro_s2",
   "versions": [
    {
@@ -12840,7 +12840,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 163,
   "id": "mini_sam_m4",
   "versions": [
    {
@@ -12992,7 +12992,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 138,
   "id": "monster_m4sk",
   "versions": [
    {
@@ -13146,7 +13146,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 135,
   "id": "muselab_nanoesp32_s2",
   "versions": [
    {
@@ -13306,7 +13306,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 63,
   "id": "ndgarage_ndbit6",
   "versions": [
    {
@@ -13412,7 +13412,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 2,
   "id": "ndgarage_ndbit6_v2",
   "versions": [
    {
@@ -13612,7 +13612,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 164,
   "id": "nfc_copy_cat",
   "versions": [
    {
@@ -13718,7 +13718,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 94,
   "id": "nice_nano",
   "versions": [
    {
@@ -13868,7 +13868,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 23,
   "id": "nucleo_f746zg",
   "versions": [
    {
@@ -13988,7 +13988,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 31,
   "id": "nucleo_f767zi",
   "versions": [
    {
@@ -14108,7 +14108,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 21,
   "id": "nucleo_h743zi_2",
   "versions": [
    {
@@ -14224,7 +14224,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 144,
   "id": "ohs2020_badge",
   "versions": [
    {
@@ -14374,7 +14374,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 183,
   "id": "openbook_m4",
   "versions": [
    {
@@ -14530,7 +14530,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 19,
   "id": "openmv_h7",
   "versions": [
    {
@@ -14646,7 +14646,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 156,
   "id": "particle_argon",
   "versions": [
    {
@@ -14796,7 +14796,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 92,
   "id": "particle_boron",
   "versions": [
    {
@@ -14946,7 +14946,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 159,
   "id": "particle_xenon",
   "versions": [
    {
@@ -15101,7 +15101,7 @@
   "versions": []
  },
  {
-  "downloads": 0,
+  "downloads": 80,
   "id": "pca10056",
   "versions": [
    {
@@ -15253,7 +15253,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 108,
   "id": "pca10059",
   "versions": [
    {
@@ -15405,7 +15405,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 185,
   "id": "pca10100",
   "versions": [
    {
@@ -15521,7 +15521,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 101,
   "id": "pewpew10",
   "versions": [
    {
@@ -15623,7 +15623,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 86,
   "id": "pewpew13",
   "versions": [
    {
@@ -15685,7 +15685,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 159,
   "id": "pewpew_m4",
   "versions": [
    {
@@ -15793,7 +15793,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 156,
   "id": "picoplanet",
   "versions": [
    {
@@ -15899,7 +15899,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 96,
   "id": "pirkey_m0",
   "versions": [
    {
@@ -15993,7 +15993,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 130,
   "id": "pitaya_go",
   "versions": [
    {
@@ -16143,7 +16143,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 30,
   "id": "pyb_nano_v2",
   "versions": [
    {
@@ -16267,7 +16267,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 149,
   "id": "pybadge",
   "versions": [
    {
@@ -16425,7 +16425,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 162,
   "id": "pybadge_airlift",
   "versions": [
    {
@@ -16583,7 +16583,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 62,
   "id": "pyboard_v11",
   "versions": [
    {
@@ -16713,7 +16713,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 163,
   "id": "pycubed",
   "versions": [
    {
@@ -16849,7 +16849,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 87,
   "id": "pycubed_mram",
   "versions": [
    {
@@ -16985,7 +16985,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 135,
   "id": "pygamer",
   "versions": [
    {
@@ -17143,7 +17143,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 177,
   "id": "pygamer_advance",
   "versions": [
    {
@@ -17301,7 +17301,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 300,
   "id": "pyportal",
   "versions": [
    {
@@ -17455,7 +17455,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 158,
   "id": "pyportal_pynt",
   "versions": [
    {
@@ -17517,7 +17517,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 224,
   "id": "pyportal_titano",
   "versions": [
    {
@@ -17671,7 +17671,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 151,
   "id": "pyruler",
   "versions": [
    {
@@ -17775,7 +17775,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 317,
   "id": "qtpy_m0",
   "versions": [
    {
@@ -17881,7 +17881,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 212,
   "id": "qtpy_m0_haxpress",
   "versions": [
    {
@@ -18003,7 +18003,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 267,
   "id": "raspberry_pi_pico",
   "versions": [
    {
@@ -18073,7 +18073,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 188,
   "id": "raytac_mdbt50q-db-40",
   "versions": [
    {
@@ -18223,7 +18223,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 104,
   "id": "robohatmm1_m4",
   "versions": [
    {
@@ -18361,7 +18361,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 69,
   "id": "sam32",
   "versions": [
    {
@@ -18515,7 +18515,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 78,
   "id": "same54_xplained",
   "versions": [
    {
@@ -18669,7 +18669,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 272,
   "id": "seeeduino_wio_terminal",
   "versions": [
    {
@@ -18823,7 +18823,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 523,
   "id": "seeeduino_xiao",
   "versions": [
    {
@@ -18929,7 +18929,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 171,
   "id": "serpente",
   "versions": [
    {
@@ -19057,7 +19057,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 66,
   "id": "shirtty",
   "versions": [
    {
@@ -19245,7 +19245,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 67,
   "id": "simmel",
   "versions": [
    {
@@ -19361,7 +19361,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 118,
   "id": "snekboard",
   "versions": [
    {
@@ -19483,7 +19483,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 149,
   "id": "sparkfun_lumidrive",
   "versions": [
    {
@@ -19607,7 +19607,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 250,
   "id": "sparkfun_nrf52840_mini",
   "versions": [
    {
@@ -19757,7 +19757,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 40,
   "id": "sparkfun_qwiic_micro_no_flash",
   "versions": [
    {
@@ -19863,7 +19863,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 209,
   "id": "sparkfun_qwiic_micro_with_flash",
   "versions": [
    {
@@ -19969,7 +19969,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 203,
   "id": "sparkfun_redboard_turbo",
   "versions": [
    {
@@ -20089,7 +20089,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 154,
   "id": "sparkfun_samd21_dev",
   "versions": [
    {
@@ -20195,7 +20195,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 174,
   "id": "sparkfun_samd21_mini",
   "versions": [
    {
@@ -20301,7 +20301,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 146,
   "id": "sparkfun_samd51_thing_plus",
   "versions": [
    {
@@ -20455,7 +20455,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 204,
   "id": "spresense",
   "versions": [
    {
@@ -20667,7 +20667,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 94,
   "id": "stm32f411ce_blackpill",
   "versions": [
    {
@@ -20791,7 +20791,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 1,
   "id": "stm32f411ce_blackpill_with_flash",
   "versions": [
    {
@@ -20858,7 +20858,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 32,
   "id": "stm32f411ve_discovery",
   "versions": [
    {
@@ -20982,7 +20982,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 15,
   "id": "stm32f412zg_discovery",
   "versions": [
    {
@@ -21108,7 +21108,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 44,
   "id": "stm32f4_discovery",
   "versions": [
    {
@@ -21232,7 +21232,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 31,
   "id": "stm32f746g_discovery",
   "versions": [
    {
@@ -21352,7 +21352,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 136,
   "id": "stringcar_m0_express",
   "versions": [
    {
@@ -21472,7 +21472,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 62,
   "id": "targett_module_clip_wroom",
   "versions": [
    {
@@ -21632,7 +21632,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 54,
   "id": "targett_module_clip_wrover",
   "versions": [
    {
@@ -21792,7 +21792,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 209,
   "id": "teensy40",
   "versions": [
    {
@@ -21922,7 +21922,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 200,
   "id": "teensy41",
   "versions": [
    {
@@ -22052,7 +22052,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 44,
   "id": "teknikio_bluebird",
   "versions": [
    {
@@ -22202,7 +22202,7 @@
   ]
  },
  {
-  "downloads": 8,
+  "downloads": 9,
   "id": "thunderpack",
   "versions": []
  },
@@ -22453,7 +22453,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 81,
   "id": "tinkeringtech_scoutmakes_azul",
   "versions": [
    {
@@ -22603,7 +22603,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 195,
   "id": "trellis_m4_express",
   "versions": [
    {
@@ -22755,7 +22755,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 383,
   "id": "trinket_m0",
   "versions": [
    {
@@ -22861,7 +22861,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 181,
   "id": "trinket_m0_haxpress",
   "versions": [
    {
@@ -22983,7 +22983,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 166,
   "id": "uartlogger2",
   "versions": [
    {
@@ -23137,7 +23137,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 33,
   "id": "uchip",
   "versions": [
    {
@@ -23245,7 +23245,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 83,
   "id": "ugame10",
   "versions": [
    {
@@ -23361,7 +23361,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 275,
   "id": "unexpectedmaker_feathers2",
   "versions": [
    {
@@ -23521,7 +23521,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 41,
   "id": "unexpectedmaker_feathers2_prerelease",
   "versions": [
    {
@@ -23681,7 +23681,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 138,
   "id": "winterbloom_big_honking_button",
   "versions": [
    {
@@ -23791,7 +23791,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 124,
   "id": "winterbloom_sol",
   "versions": [
    {
@@ -23911,7 +23911,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 43,
   "id": "xinabox_cc03",
   "versions": [
    {
@@ -24005,7 +24005,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 23,
   "id": "xinabox_cs11",
   "versions": [
    {

--- a/_data/files.json
+++ b/_data/files.json
@@ -1,6 +1,6 @@
 [
  {
-  "downloads": 158,
+  "downloads": 0,
   "id": "8086_commander",
   "versions": [
    {
@@ -58,24 +58,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -101,7 +101,7 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
@@ -184,24 +184,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -251,12 +251,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 6,
+  "downloads": 0,
   "id": "TG-Watch",
   "versions": [
    {
@@ -334,24 +334,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -401,7 +401,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
@@ -490,24 +490,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -561,7 +561,7 @@
      "wifi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
@@ -650,24 +650,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -721,12 +721,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 10,
+  "downloads": 0,
   "id": "adafruit_feather_rp2040",
   "versions": [
    {
@@ -734,24 +734,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -775,6 +775,7 @@
      "pwmio",
      "random",
      "re",
+     "rtc",
      "sdcardio",
      "sharpdisplay",
      "storage",
@@ -786,15 +787,16 @@
      "ulab",
      "usb_hid",
      "usb_midi",
-     "vectorio"
+     "vectorio",
+     "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 514,
+  "downloads": 0,
   "id": "adafruit_magtag_2.9_grayscale",
   "versions": [
    {
@@ -878,24 +880,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -949,12 +951,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 226,
+  "downloads": 0,
   "id": "adafruit_metro_esp32s2",
   "versions": [
    {
@@ -1038,24 +1040,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -1109,12 +1111,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 118,
+  "downloads": 0,
   "id": "aloriumtech_evo_m51",
   "versions": [
    {
@@ -1194,24 +1196,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -1263,12 +1265,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 114,
+  "downloads": 0,
   "id": "aramcon_badge_2019",
   "versions": [
    {
@@ -1346,24 +1348,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -1413,12 +1415,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 38,
+  "downloads": 0,
   "id": "arduino_mkr1300",
   "versions": [
    {
@@ -1478,24 +1480,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -1521,12 +1523,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 84,
+  "downloads": 0,
   "id": "arduino_mkrzero",
   "versions": [
    {
@@ -1586,24 +1588,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -1629,12 +1631,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 163,
+  "downloads": 0,
   "id": "arduino_nano_33_ble",
   "versions": [
    {
@@ -1712,24 +1714,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -1779,12 +1781,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 77,
+  "downloads": 0,
   "id": "arduino_nano_33_iot",
   "versions": [
    {
@@ -1844,24 +1846,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -1887,12 +1889,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 97,
+  "downloads": 0,
   "id": "arduino_zero",
   "versions": [
    {
@@ -1952,24 +1954,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -1995,12 +1997,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 168,
+  "downloads": 0,
   "id": "bast_pro_mini_m0",
   "versions": [
    {
@@ -2058,24 +2060,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -2101,12 +2103,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 52,
+  "downloads": 0,
   "id": "bastble",
   "versions": [
    {
@@ -2184,24 +2186,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -2251,12 +2253,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 204,
+  "downloads": 0,
   "id": "bdmicro_vina_d21",
   "versions": [
    {
@@ -2321,24 +2323,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_pixelbuf",
@@ -2373,12 +2375,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 88,
+  "downloads": 0,
   "id": "bdmicro_vina_d51",
   "versions": [
    {
@@ -2458,24 +2460,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -2527,7 +2529,7 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
@@ -2537,7 +2539,7 @@
   "versions": []
  },
  {
-  "downloads": 253,
+  "downloads": 0,
   "id": "bless_dev_board_multi_sensor",
   "versions": [
    {
@@ -2615,24 +2617,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -2682,12 +2684,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 102,
+  "downloads": 0,
   "id": "blm_badge",
   "versions": [
    {
@@ -2743,24 +2745,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -2784,12 +2786,12 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 144,
+  "downloads": 0,
   "id": "capablerobot_usbhub",
   "versions": [
    {
@@ -2868,24 +2870,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -2936,12 +2938,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 133,
+  "downloads": 0,
   "id": "catwan_usbstick",
   "versions": [
    {
@@ -2998,24 +3000,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -3040,12 +3042,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 86,
+  "downloads": 0,
   "id": "circuitbrains_basic_m0",
   "versions": [
    {
@@ -3111,24 +3113,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_pixelbuf",
@@ -3164,12 +3166,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 112,
+  "downloads": 0,
   "id": "circuitbrains_deluxe_m4",
   "versions": [
    {
@@ -3249,24 +3251,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -3318,12 +3320,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 354,
+  "downloads": 0,
   "id": "circuitplayground_bluefruit",
   "versions": [
    {
@@ -3401,24 +3403,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -3468,12 +3470,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 492,
+  "downloads": 0,
   "id": "circuitplayground_express",
   "versions": [
    {
@@ -3538,24 +3540,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_pixelbuf",
@@ -3590,12 +3592,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 219,
+  "downloads": 0,
   "id": "circuitplayground_express_4h",
   "versions": [
    {
@@ -3631,33 +3633,33 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": "[]",
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 181,
+  "downloads": 0,
   "id": "circuitplayground_express_crickit",
   "versions": [
    {
@@ -3719,24 +3721,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_pixelbuf",
@@ -3768,12 +3770,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 37,
+  "downloads": 0,
   "id": "circuitplayground_express_digikey_pycon2019",
   "versions": [
    {
@@ -3809,33 +3811,33 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": "[]",
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 197,
+  "downloads": 0,
   "id": "circuitplayground_express_displayio",
   "versions": [
    {
@@ -3897,24 +3899,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -3945,12 +3947,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 259,
+  "downloads": 0,
   "id": "clue_nrf52840_express",
   "versions": [
    {
@@ -4028,24 +4030,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -4095,12 +4097,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 122,
+  "downloads": 0,
   "id": "cp32-m4",
   "versions": [
    {
@@ -4179,24 +4181,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -4247,12 +4249,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 94,
+  "downloads": 0,
   "id": "cp_sapling_m0",
   "versions": [
    {
@@ -4310,24 +4312,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -4353,7 +4355,7 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
@@ -4422,24 +4424,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_pixelbuf",
@@ -4473,12 +4475,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 27,
+  "downloads": 0,
   "id": "datalore_ip_m4",
   "versions": [
    {
@@ -4558,24 +4560,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -4627,12 +4629,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 71,
+  "downloads": 0,
   "id": "datum_distance",
   "versions": [
    {
@@ -4690,24 +4692,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -4733,12 +4735,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 116,
+  "downloads": 0,
   "id": "datum_imu",
   "versions": [
    {
@@ -4796,24 +4798,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -4839,12 +4841,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 55,
+  "downloads": 0,
   "id": "datum_light",
   "versions": [
    {
@@ -4902,24 +4904,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -4945,12 +4947,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 59,
+  "downloads": 0,
   "id": "datum_weather",
   "versions": [
    {
@@ -5008,24 +5010,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -5051,12 +5053,68 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 84,
+  "downloads": 0,
+  "id": "dynalora_usb",
+  "versions": [
+   {
+    "extensions": [
+     "uf2"
+    ],
+    "languages": [
+     "it_IT",
+     "en_x_pirate",
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
+    ],
+    "modules": [
+     "analogio",
+     "board",
+     "busio",
+     "digitalio",
+     "math",
+     "microcontroller",
+     "neopixel_write",
+     "nvm",
+     "os",
+     "pulseio",
+     "pwmio",
+     "random",
+     "rotaryio",
+     "rtc",
+     "storage",
+     "struct",
+     "supervisor",
+     "time",
+     "touchio",
+     "usb_hid",
+     "usb_midi"
+    ],
+    "stable": false,
+    "version": "6.2.0-beta.2"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
   "id": "dynossat_edu_eps",
   "versions": [
    {
@@ -5119,24 +5177,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_pixelbuf",
@@ -5169,12 +5227,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 101,
+  "downloads": 0,
   "id": "dynossat_edu_obc",
   "versions": [
    {
@@ -5254,24 +5312,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -5323,12 +5381,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 143,
+  "downloads": 0,
   "id": "edgebadge",
   "versions": [
    {
@@ -5364,33 +5422,33 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": "[]",
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 49,
+  "downloads": 0,
   "id": "electroniccats_bastwifi",
   "versions": [
    {
@@ -5473,24 +5531,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -5543,12 +5601,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 147,
+  "downloads": 0,
   "id": "electronut_labs_blip",
   "versions": [
    {
@@ -5627,24 +5685,24 @@
      "hex"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -5695,12 +5753,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 183,
+  "downloads": 0,
   "id": "electronut_labs_papyr",
   "versions": [
    {
@@ -5778,24 +5836,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -5845,12 +5903,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 144,
+  "downloads": 0,
   "id": "escornabot_makech",
   "versions": [
    {
@@ -5907,24 +5965,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -5949,12 +6007,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 71,
+  "downloads": 0,
   "id": "espressif_kaluga_1",
   "versions": [
    {
@@ -6038,24 +6096,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -6103,18 +6161,18 @@
      "time",
      "touchio",
      "ulab",
-     "usb_hid",
+     "usb_midi",
      "vectorio",
      "watchdog",
      "wifi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 159,
+  "downloads": 0,
   "id": "espressif_saola_1_wroom",
   "versions": [
    {
@@ -6198,24 +6256,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -6269,12 +6327,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 146,
+  "downloads": 0,
   "id": "espressif_saola_1_wrover",
   "versions": [
    {
@@ -6358,24 +6416,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -6429,12 +6487,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 50,
+  "downloads": 0,
   "id": "espruino_pico",
   "versions": [
    {
@@ -6498,24 +6556,24 @@
      "bin"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -6551,12 +6609,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 16,
+  "downloads": 0,
   "id": "espruino_wifi",
   "versions": [
    {
@@ -6621,24 +6679,24 @@
      "bin"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -6675,12 +6733,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 300,
+  "downloads": 0,
   "id": "feather_bluefruit_sense",
   "versions": [
    {
@@ -6758,24 +6816,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -6825,12 +6883,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 97,
+  "downloads": 0,
   "id": "feather_m0_adalogger",
   "versions": [
    {
@@ -6890,24 +6948,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -6933,12 +6991,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 117,
+  "downloads": 0,
   "id": "feather_m0_basic",
   "versions": [
    {
@@ -6998,24 +7056,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -7041,12 +7099,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 283,
+  "downloads": 0,
   "id": "feather_m0_express",
   "versions": [
    {
@@ -7111,24 +7169,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_pixelbuf",
@@ -7163,12 +7221,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 83,
+  "downloads": 0,
   "id": "feather_m0_express_crickit",
   "versions": [
    {
@@ -7231,24 +7289,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_pixelbuf",
@@ -7281,12 +7339,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 78,
+  "downloads": 0,
   "id": "feather_m0_rfm69",
   "versions": [
    {
@@ -7339,24 +7397,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -7375,12 +7433,12 @@
      "time"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 93,
+  "downloads": 0,
   "id": "feather_m0_rfm9x",
   "versions": [
    {
@@ -7433,24 +7491,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -7469,12 +7527,12 @@
      "time"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 108,
+  "downloads": 0,
   "id": "feather_m0_supersized",
   "versions": [
    {
@@ -7539,24 +7597,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_pixelbuf",
@@ -7591,12 +7649,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 154,
+  "downloads": 0,
   "id": "feather_m4_can",
   "versions": [
    {
@@ -7675,24 +7733,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -7743,12 +7801,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 409,
+  "downloads": 0,
   "id": "feather_m4_express",
   "versions": [
    {
@@ -7828,24 +7886,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -7897,12 +7955,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 47,
+  "downloads": 0,
   "id": "feather_m7_1011",
   "versions": [
    {
@@ -7971,24 +8029,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -8027,12 +8085,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 46,
+  "downloads": 0,
   "id": "feather_mimxrt1011",
   "versions": [
    {
@@ -8101,24 +8159,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -8157,12 +8215,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 77,
+  "downloads": 0,
   "id": "feather_mimxrt1062",
   "versions": [
    {
@@ -8231,24 +8289,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -8287,12 +8345,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 277,
+  "downloads": 0,
   "id": "feather_nrf52840_express",
   "versions": [
    {
@@ -8370,24 +8428,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -8437,12 +8495,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 98,
+  "downloads": 0,
   "id": "feather_radiofruit_zigbee",
   "versions": [
    {
@@ -8505,24 +8563,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_pixelbuf",
@@ -8555,12 +8613,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 104,
+  "downloads": 0,
   "id": "feather_stm32f405_express",
   "versions": [
    {
@@ -8628,24 +8686,24 @@
      "bin"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -8685,12 +8743,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 116,
+  "downloads": 0,
   "id": "fluff_m0",
   "versions": [
    {
@@ -8748,24 +8806,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -8791,12 +8849,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 123,
+  "downloads": 0,
   "id": "fomu",
   "versions": [
    {
@@ -8850,24 +8908,24 @@
      "dfu"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_pixelbuf",
@@ -8893,7 +8951,7 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
@@ -8903,7 +8961,7 @@
   "versions": []
  },
  {
-  "downloads": 185,
+  "downloads": 0,
   "id": "gemma_m0",
   "versions": [
    {
@@ -8961,24 +9019,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -9004,12 +9062,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 104,
+  "downloads": 0,
   "id": "gemma_m0_pycon2018",
   "versions": [
    {
@@ -9045,33 +9103,33 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": "[]",
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 178,
+  "downloads": 0,
   "id": "grandcentral_m4_express",
   "versions": [
    {
@@ -9152,24 +9210,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -9222,12 +9280,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 179,
+  "downloads": 0,
   "id": "hallowing_m0_express",
   "versions": [
    {
@@ -9289,24 +9347,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_pixelbuf",
@@ -9338,12 +9396,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 151,
+  "downloads": 0,
   "id": "hallowing_m4_express",
   "versions": [
    {
@@ -9423,24 +9481,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -9492,12 +9550,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 176,
+  "downloads": 0,
   "id": "hiibot_bluefi",
   "versions": [
    {
@@ -9575,24 +9633,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -9642,12 +9700,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 82,
+  "downloads": 0,
   "id": "ikigaisense_vita",
   "versions": [
    {
@@ -9725,24 +9783,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -9792,12 +9850,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 54,
+  "downloads": 0,
   "id": "imxrt1010_evk",
   "versions": [
    {
@@ -9866,24 +9924,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -9922,12 +9980,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 53,
+  "downloads": 0,
   "id": "imxrt1020_evk",
   "versions": [
    {
@@ -9996,24 +10054,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -10052,12 +10110,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 51,
+  "downloads": 0,
   "id": "imxrt1060_evk",
   "versions": [
    {
@@ -10126,24 +10184,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -10182,12 +10240,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 202,
+  "downloads": 0,
   "id": "itsybitsy_m0_express",
   "versions": [
    {
@@ -10250,24 +10308,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_pixelbuf",
@@ -10300,12 +10358,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 224,
+  "downloads": 0,
   "id": "itsybitsy_m4_express",
   "versions": [
    {
@@ -10384,24 +10442,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -10452,12 +10510,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 285,
+  "downloads": 0,
   "id": "itsybitsy_nrf52840_express",
   "versions": [
    {
@@ -10535,24 +10593,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -10602,12 +10660,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 132,
+  "downloads": 0,
   "id": "kicksat-sprite",
   "versions": [
    {
@@ -10676,24 +10734,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_pixelbuf",
@@ -10734,12 +10792,97 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 61,
+  "downloads": 0,
+  "id": "lilygo_ttgo_t8_s2_st7789",
+  "versions": [
+   {
+    "extensions": [
+     "bin",
+     "uf2"
+    ],
+    "languages": [
+     "it_IT",
+     "en_x_pirate",
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
+    ],
+    "modules": [
+     "_bleio",
+     "_pixelbuf",
+     "alarm",
+     "analogio",
+     "audiobusio",
+     "audiocore",
+     "binascii",
+     "bitbangio",
+     "board",
+     "busio",
+     "canio",
+     "countio",
+     "digitalio",
+     "displayio",
+     "dualbank",
+     "errno",
+     "framebufferio",
+     "frequencyio",
+     "gamepad",
+     "ipaddress",
+     "json",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "os",
+     "ps2io",
+     "pulseio",
+     "pwmio",
+     "random",
+     "re",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "socketpool",
+     "ssl",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "touchio",
+     "ulab",
+     "usb_hid",
+     "vectorio",
+     "watchdog",
+     "wifi"
+    ],
+    "stable": false,
+    "version": "6.2.0-beta.2"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
   "id": "loc_ber_m4_base_board",
   "versions": [
    {
@@ -10798,24 +10941,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -10842,12 +10985,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 192,
+  "downloads": 0,
   "id": "makerdiary_m60_keyboard",
   "versions": [
    {
@@ -10925,24 +11068,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -10992,12 +11135,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 242,
+  "downloads": 0,
   "id": "makerdiary_nrf52840_m2_devkit",
   "versions": [
    {
@@ -11075,24 +11218,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -11142,12 +11285,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 95,
+  "downloads": 0,
   "id": "makerdiary_nrf52840_mdk",
   "versions": [
    {
@@ -11225,24 +11368,24 @@
      "hex"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -11292,12 +11435,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 115,
+  "downloads": 0,
   "id": "makerdiary_nrf52840_mdk_usb_dongle",
   "versions": [
    {
@@ -11377,24 +11520,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -11444,12 +11587,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 403,
+  "downloads": 0,
   "id": "matrixportal_m4",
   "versions": [
    {
@@ -11529,24 +11672,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -11598,12 +11741,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 189,
+  "downloads": 0,
   "id": "meowbit_v121",
   "versions": [
    {
@@ -11667,24 +11810,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -11720,12 +11863,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 151,
+  "downloads": 0,
   "id": "meowmeow",
   "versions": [
    {
@@ -11781,24 +11924,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -11822,12 +11965,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 204,
+  "downloads": 0,
   "id": "metro_m0_express",
   "versions": [
    {
@@ -11892,24 +12035,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_pixelbuf",
@@ -11944,12 +12087,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 270,
+  "downloads": 0,
   "id": "metro_m4_airlift_lite",
   "versions": [
    {
@@ -12029,24 +12172,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -12098,12 +12241,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 180,
+  "downloads": 0,
   "id": "metro_m4_express",
   "versions": [
    {
@@ -12183,24 +12326,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -12252,12 +12395,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 65,
+  "downloads": 0,
   "id": "metro_m7_1011",
   "versions": [
    {
@@ -12326,24 +12469,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -12382,12 +12525,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 131,
+  "downloads": 0,
   "id": "metro_nrf52840_express",
   "versions": [
    {
@@ -12465,24 +12608,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -12532,12 +12675,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 79,
+  "downloads": 0,
   "id": "microdev_micro_s2",
   "versions": [
    {
@@ -12621,24 +12764,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -12692,12 +12835,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 172,
+  "downloads": 0,
   "id": "mini_sam_m4",
   "versions": [
    {
@@ -12776,24 +12919,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -12844,12 +12987,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 148,
+  "downloads": 0,
   "id": "monster_m4sk",
   "versions": [
    {
@@ -12929,24 +13072,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -12998,12 +13141,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 132,
+  "downloads": 0,
   "id": "muselab_nanoesp32_s2",
   "versions": [
    {
@@ -13087,24 +13230,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -13158,12 +13301,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 59,
+  "downloads": 0,
   "id": "ndgarage_ndbit6",
   "versions": [
    {
@@ -13221,24 +13364,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -13264,12 +13407,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 2,
+  "downloads": 0,
   "id": "ndgarage_ndbit6_v2",
   "versions": [
    {
@@ -13327,24 +13470,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -13370,7 +13513,7 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
@@ -13427,24 +13570,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_pixelbuf",
@@ -13464,12 +13607,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 177,
+  "downloads": 0,
   "id": "nfc_copy_cat",
   "versions": [
    {
@@ -13527,24 +13670,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -13570,12 +13713,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 96,
+  "downloads": 0,
   "id": "nice_nano",
   "versions": [
    {
@@ -13653,24 +13796,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -13720,12 +13863,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 24,
+  "downloads": 0,
   "id": "nucleo_f746zg",
   "versions": [
    {
@@ -13788,24 +13931,24 @@
      "bin"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -13840,12 +13983,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 33,
+  "downloads": 0,
   "id": "nucleo_f767zi",
   "versions": [
    {
@@ -13908,24 +14051,24 @@
      "bin"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -13960,12 +14103,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 23,
+  "downloads": 0,
   "id": "nucleo_h743zi_2",
   "versions": [
    {
@@ -14026,24 +14169,24 @@
      "bin"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -14076,12 +14219,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 149,
+  "downloads": 0,
   "id": "ohs2020_badge",
   "versions": [
    {
@@ -14159,24 +14302,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -14226,12 +14369,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 205,
+  "downloads": 0,
   "id": "openbook_m4",
   "versions": [
    {
@@ -14312,24 +14455,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -14382,12 +14525,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 20,
+  "downloads": 0,
   "id": "openmv_h7",
   "versions": [
    {
@@ -14448,24 +14591,24 @@
      "bin"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -14498,12 +14641,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 152,
+  "downloads": 0,
   "id": "particle_argon",
   "versions": [
    {
@@ -14581,24 +14724,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -14648,12 +14791,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 108,
+  "downloads": 0,
   "id": "particle_boron",
   "versions": [
    {
@@ -14731,24 +14874,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -14798,12 +14941,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 162,
+  "downloads": 0,
   "id": "particle_xenon",
   "versions": [
    {
@@ -14881,24 +15024,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -14948,7 +15091,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
@@ -14958,7 +15101,7 @@
   "versions": []
  },
  {
-  "downloads": 81,
+  "downloads": 0,
   "id": "pca10056",
   "versions": [
    {
@@ -15038,24 +15181,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -15105,12 +15248,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 116,
+  "downloads": 0,
   "id": "pca10059",
   "versions": [
    {
@@ -15190,24 +15333,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -15257,12 +15400,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 169,
+  "downloads": 0,
   "id": "pca10100",
   "versions": [
    {
@@ -15323,24 +15466,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -15373,12 +15516,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 124,
+  "downloads": 0,
   "id": "pewpew10",
   "versions": [
    {
@@ -15434,24 +15577,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_pew",
@@ -15475,12 +15618,12 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 86,
+  "downloads": 0,
   "id": "pewpew13",
   "versions": [
    {
@@ -15516,33 +15659,33 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": "[]",
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 174,
+  "downloads": 0,
   "id": "pewpew_m4",
   "versions": [
    {
@@ -15601,24 +15744,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_stage",
@@ -15645,12 +15788,12 @@
      "time"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 158,
+  "downloads": 0,
   "id": "picoplanet",
   "versions": [
    {
@@ -15708,24 +15851,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -15751,12 +15894,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 101,
+  "downloads": 0,
   "id": "pirkey_m0",
   "versions": [
    {
@@ -15808,24 +15951,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "board",
@@ -15845,12 +15988,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 127,
+  "downloads": 0,
   "id": "pitaya_go",
   "versions": [
    {
@@ -15928,24 +16071,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -15995,12 +16138,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 22,
+  "downloads": 0,
   "id": "pyb_nano_v2",
   "versions": [
    {
@@ -16065,24 +16208,24 @@
      "bin"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -16119,12 +16262,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 161,
+  "downloads": 0,
   "id": "pybadge",
   "versions": [
    {
@@ -16206,24 +16349,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -16277,12 +16420,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 137,
+  "downloads": 0,
   "id": "pybadge_airlift",
   "versions": [
    {
@@ -16364,24 +16507,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -16435,12 +16578,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 54,
+  "downloads": 0,
   "id": "pyboard_v11",
   "versions": [
    {
@@ -16508,24 +16651,24 @@
      "bin"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -16565,12 +16708,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 136,
+  "downloads": 0,
   "id": "pycubed",
   "versions": [
    {
@@ -16641,24 +16784,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -16701,12 +16844,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 100,
+  "downloads": 0,
   "id": "pycubed_mram",
   "versions": [
    {
@@ -16777,24 +16920,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -16837,12 +16980,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 124,
+  "downloads": 0,
   "id": "pygamer",
   "versions": [
    {
@@ -16924,24 +17067,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -16995,12 +17138,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 164,
+  "downloads": 0,
   "id": "pygamer_advance",
   "versions": [
    {
@@ -17082,24 +17225,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -17153,12 +17296,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 304,
+  "downloads": 0,
   "id": "pyportal",
   "versions": [
    {
@@ -17238,24 +17381,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -17307,12 +17450,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 166,
+  "downloads": 0,
   "id": "pyportal_pynt",
   "versions": [
    {
@@ -17348,33 +17491,33 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": "[]",
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 216,
+  "downloads": 0,
   "id": "pyportal_titano",
   "versions": [
    {
@@ -17454,24 +17597,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -17523,12 +17666,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 142,
+  "downloads": 0,
   "id": "pyruler",
   "versions": [
    {
@@ -17585,24 +17728,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -17627,12 +17770,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 341,
+  "downloads": 0,
   "id": "qtpy_m0",
   "versions": [
    {
@@ -17690,24 +17833,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -17733,12 +17876,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 228,
+  "downloads": 0,
   "id": "qtpy_m0_haxpress",
   "versions": [
    {
@@ -17803,24 +17946,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_pixelbuf",
@@ -17855,12 +17998,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 120,
+  "downloads": 0,
   "id": "raspberry_pi_pico",
   "versions": [
    {
@@ -17868,24 +18011,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -17909,6 +18052,7 @@
      "pwmio",
      "random",
      "re",
+     "rtc",
      "sdcardio",
      "sharpdisplay",
      "storage",
@@ -17920,15 +18064,16 @@
      "ulab",
      "usb_hid",
      "usb_midi",
-     "vectorio"
+     "vectorio",
+     "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 187,
+  "downloads": 0,
   "id": "raytac_mdbt50q-db-40",
   "versions": [
    {
@@ -18006,24 +18151,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -18073,12 +18218,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 111,
+  "downloads": 0,
   "id": "robohatmm1_m4",
   "versions": [
    {
@@ -18150,24 +18295,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -18211,12 +18356,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 82,
+  "downloads": 0,
   "id": "sam32",
   "versions": [
    {
@@ -18296,24 +18441,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -18365,12 +18510,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 72,
+  "downloads": 0,
   "id": "same54_xplained",
   "versions": [
    {
@@ -18450,24 +18595,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -18519,12 +18664,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 304,
+  "downloads": 0,
   "id": "seeeduino_wio_terminal",
   "versions": [
    {
@@ -18604,24 +18749,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -18673,12 +18818,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 518,
+  "downloads": 0,
   "id": "seeeduino_xiao",
   "versions": [
    {
@@ -18736,24 +18881,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -18779,12 +18924,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 181,
+  "downloads": 0,
   "id": "serpente",
   "versions": [
    {
@@ -18852,24 +18997,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_pixelbuf",
@@ -18907,12 +19052,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 61,
+  "downloads": 0,
   "id": "shirtty",
   "versions": [
    {
@@ -18970,24 +19115,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -19013,12 +19158,94 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 69,
+  "downloads": 0,
+  "id": "silicognition-m4-shim",
+  "versions": [
+   {
+    "extensions": [
+     "uf2"
+    ],
+    "languages": [
+     "it_IT",
+     "en_x_pirate",
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
+    ],
+    "modules": [
+     "_bleio",
+     "_pixelbuf",
+     "analogio",
+     "audiobusio",
+     "audiocore",
+     "audioio",
+     "audiomixer",
+     "audiomp3",
+     "binascii",
+     "bitbangio",
+     "board",
+     "busio",
+     "countio",
+     "digitalio",
+     "displayio",
+     "errno",
+     "framebufferio",
+     "frequencyio",
+     "gamepad",
+     "i2cperipheral",
+     "json",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "os",
+     "ps2io",
+     "pulseio",
+     "pwmio",
+     "random",
+     "re",
+     "rgbmatrix",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "touchio",
+     "ulab",
+     "usb_hid",
+     "usb_midi",
+     "vectorio"
+    ],
+    "stable": false,
+    "version": "6.2.0-beta.2"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
   "id": "simmel",
   "versions": [
    {
@@ -19080,24 +19307,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -19126,16 +19353,15 @@
      "supervisor",
      "time",
      "usb_hid",
-     "usb_midi",
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 125,
+  "downloads": 0,
   "id": "snekboard",
   "versions": [
    {
@@ -19200,24 +19426,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_pixelbuf",
@@ -19252,12 +19478,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 141,
+  "downloads": 0,
   "id": "sparkfun_lumidrive",
   "versions": [
    {
@@ -19323,24 +19549,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_pixelbuf",
@@ -19376,12 +19602,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 265,
+  "downloads": 0,
   "id": "sparkfun_nrf52840_mini",
   "versions": [
    {
@@ -19459,24 +19685,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -19526,12 +19752,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 57,
+  "downloads": 0,
   "id": "sparkfun_qwiic_micro_no_flash",
   "versions": [
    {
@@ -19589,24 +19815,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -19632,12 +19858,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 229,
+  "downloads": 0,
   "id": "sparkfun_qwiic_micro_with_flash",
   "versions": [
    {
@@ -19695,24 +19921,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -19738,12 +19964,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 210,
+  "downloads": 0,
   "id": "sparkfun_redboard_turbo",
   "versions": [
    {
@@ -19807,24 +20033,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_pixelbuf",
@@ -19858,12 +20084,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 171,
+  "downloads": 0,
   "id": "sparkfun_samd21_dev",
   "versions": [
    {
@@ -19921,24 +20147,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -19964,12 +20190,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 181,
+  "downloads": 0,
   "id": "sparkfun_samd21_mini",
   "versions": [
    {
@@ -20027,24 +20253,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -20070,12 +20296,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 141,
+  "downloads": 0,
   "id": "sparkfun_samd51_thing_plus",
   "versions": [
    {
@@ -20155,24 +20381,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -20224,12 +20450,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 182,
+  "downloads": 0,
   "id": "spresense",
   "versions": [
    {
@@ -20265,24 +20491,24 @@
      "spk"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -20314,7 +20540,7 @@
      "ulab"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
@@ -20384,24 +20610,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_pixelbuf",
@@ -20436,12 +20662,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 84,
+  "downloads": 0,
   "id": "stm32f411ce_blackpill",
   "versions": [
    {
@@ -20506,24 +20732,24 @@
      "bin"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -20560,12 +20786,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 1,
+  "downloads": 0,
   "id": "stm32f411ce_blackpill_with_flash",
   "versions": [
    {
@@ -20573,24 +20799,24 @@
      "bin"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -20627,12 +20853,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 32,
+  "downloads": 0,
   "id": "stm32f411ve_discovery",
   "versions": [
    {
@@ -20697,24 +20923,24 @@
      "bin"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -20751,12 +20977,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 15,
+  "downloads": 0,
   "id": "stm32f412zg_discovery",
   "versions": [
    {
@@ -20822,24 +21048,24 @@
      "bin"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -20877,12 +21103,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 40,
+  "downloads": 0,
   "id": "stm32f4_discovery",
   "versions": [
    {
@@ -20947,24 +21173,24 @@
      "bin"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -21001,12 +21227,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 30,
+  "downloads": 0,
   "id": "stm32f746g_discovery",
   "versions": [
    {
@@ -21069,24 +21295,24 @@
      "bin"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -21121,12 +21347,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 116,
+  "downloads": 0,
   "id": "stringcar_m0_express",
   "versions": [
    {
@@ -21190,24 +21416,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_pixelbuf",
@@ -21241,12 +21467,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 66,
+  "downloads": 0,
   "id": "targett_module_clip_wroom",
   "versions": [
    {
@@ -21330,24 +21556,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -21401,12 +21627,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 57,
+  "downloads": 0,
   "id": "targett_module_clip_wrover",
   "versions": [
    {
@@ -21490,24 +21716,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -21561,12 +21787,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 214,
+  "downloads": 0,
   "id": "teensy40",
   "versions": [
    {
@@ -21635,24 +21861,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -21691,12 +21917,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 199,
+  "downloads": 0,
   "id": "teensy41",
   "versions": [
    {
@@ -21765,24 +21991,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -21821,12 +22047,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 34,
+  "downloads": 0,
   "id": "teknikio_bluebird",
   "versions": [
    {
@@ -21904,24 +22130,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -21971,7 +22197,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
@@ -22045,24 +22271,24 @@
      "bin"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_pixelbuf",
@@ -22098,7 +22324,7 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
@@ -22168,24 +22394,24 @@
      "bin"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_pixelbuf",
@@ -22222,12 +22448,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 98,
+  "downloads": 0,
   "id": "tinkeringtech_scoutmakes_azul",
   "versions": [
    {
@@ -22305,24 +22531,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -22372,12 +22598,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 231,
+  "downloads": 0,
   "id": "trellis_m4_express",
   "versions": [
    {
@@ -22456,24 +22682,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -22524,12 +22750,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 449,
+  "downloads": 0,
   "id": "trinket_m0",
   "versions": [
    {
@@ -22587,24 +22813,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -22630,12 +22856,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 187,
+  "downloads": 0,
   "id": "trinket_m0_haxpress",
   "versions": [
    {
@@ -22700,24 +22926,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_pixelbuf",
@@ -22752,12 +22978,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 156,
+  "downloads": 0,
   "id": "uartlogger2",
   "versions": [
    {
@@ -22837,24 +23063,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -22906,12 +23132,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 36,
+  "downloads": 0,
   "id": "uchip",
   "versions": [
    {
@@ -22971,24 +23197,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "analogio",
@@ -23014,12 +23240,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 102,
+  "downloads": 0,
   "id": "ugame10",
   "versions": [
    {
@@ -23081,24 +23307,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_stage",
@@ -23130,12 +23356,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 309,
+  "downloads": 0,
   "id": "unexpectedmaker_feathers2",
   "versions": [
    {
@@ -23219,24 +23445,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -23290,12 +23516,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 42,
+  "downloads": 0,
   "id": "unexpectedmaker_feathers2_prerelease",
   "versions": [
    {
@@ -23379,24 +23605,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_bleio",
@@ -23450,12 +23676,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 153,
+  "downloads": 0,
   "id": "winterbloom_big_honking_button",
   "versions": [
    {
@@ -23514,24 +23740,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_pixelbuf",
@@ -23560,12 +23786,12 @@
      "time"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 127,
+  "downloads": 0,
   "id": "winterbloom_sol",
   "versions": [
    {
@@ -23628,24 +23854,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "_pixelbuf",
@@ -23680,12 +23906,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 47,
+  "downloads": 0,
   "id": "xinabox_cc03",
   "versions": [
    {
@@ -23737,24 +23963,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "board",
@@ -23774,12 +24000,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  },
  {
-  "downloads": 23,
+  "downloads": 0,
   "id": "xinabox_cs11",
   "versions": [
    {
@@ -23829,24 +24055,24 @@
      "uf2"
     ],
     "languages": [
-     "de_DE",
-     "cs",
-     "pl",
-     "nl",
-     "sv",
      "it_IT",
-     "ID",
-     "el",
-     "hi",
-     "ko",
-     "fr",
-     "zh_Latn_pinyin",
-     "ja",
-     "pt_BR",
-     "en_US",
-     "es",
      "en_x_pirate",
-     "fil"
+     "zh_Latn_pinyin",
+     "nl",
+     "de_DE",
+     "el",
+     "en_US",
+     "hi",
+     "pt_BR",
+     "cs",
+     "fil",
+     "ja",
+     "ID",
+     "pl",
+     "es",
+     "ko",
+     "sv",
+     "fr"
     ],
     "modules": [
      "board",
@@ -23864,7 +24090,7 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "6.2.0-beta.1"
+    "version": "6.2.0-beta.2"
    }
   ]
  }


### PR DESCRIPTION
Automated website update for release 6.2.0-beta.2 by Blinka.

New boards:
* dynalora_usb
* silicognition-m4-shim
* lilygo_ttgo_t8_s2_st7789


