### PR TITLE
Fix typo in Trinket M0 page

### DIFF
--- a/_board/trinket_m0.md
+++ b/_board/trinket_m0.md
@@ -46,7 +46,7 @@ Each is fully assembled and tested Trinket M0 with CircuitPython & example code 
 So what are you waiting for? Pick up a Trinket M0 today and be amazed at how easy and fast it is to get started with Trinket and CircuitPython!
 
 ## Tutorials
-* [Trinket MO Overview](https://learn.adafruit.com/adafruit-trinket-m0-circuitpython-arduino)
+* [Trinket M0 Overview](https://learn.adafruit.com/adafruit-trinket-m0-circuitpython-arduino)
 
 ## Purchase
 


### PR DESCRIPTION
Hi, I found a little typo on the Trinket M0 page. At the bottom, it says MO instead of M0. I hope I did this pull request right, I'm new to the more collaborative features of GitHub ;)