### PR TITLE
Revert "Bump kramdown from 2.3.0 to 2.3.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,7 +199,7 @@ GEM
       gemoji (~> 3.0)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
-    kramdown (2.3.1)
+    kramdown (2.3.0)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)


### PR DESCRIPTION
Reverts adafruit/circuitpython-org#660. kramdown 2.3.1 breaks github-pages-207. github-pages-214 fixes that but it has other changes. This is temporary.