### PR TITLE
Lazy load images if browsers support the loading attribute

### DIFF
--- a/_includes/downloads/board_image.html
+++ b/_includes/downloads/board_image.html
@@ -9,7 +9,7 @@
                {{ "/assets/images/boards/large/" | append: include.board_image | relative_url }} 700w"
        sizes="(max-width: 1024px) 700px,
               300px"
-       src="{{ "/assets/images/boards/original/" | append: include.board_image | relative_url }}" alt="Image of Board">
+       src="{{ "/assets/images/boards/original/" | append: include.board_image | relative_url }}" alt="Image of Board" loading="lazy">
 {% else %}
-  <img src="{{ "/assets/images/boards/original/" | append: include.board_image | relative_url }}" alt="Image of Board">
+  <img src="{{ "/assets/images/boards/original/" | append: include.board_image | relative_url }}" alt="Image of Board" loading="lazy">
 {% endif %}


### PR DESCRIPTION
Speeds up downloads and blinka page loading times on slower connections. Older browsers will just ignore the new attribute.

Browsers supported: https://caniuse.com/loading-lazy-attr