### PR TITLE
Updated the link to the correct place to order this version.

### DIFF
--- a/_board/atmegazero_esp32s2.md
+++ b/_board/atmegazero_esp32s2.md
@@ -29,7 +29,7 @@ Introducing the new ATMegaZero ESP32-S2
 * [ATMegaZero Official Website](https://www.atmegazero.com)
 
 ## Purchase
-* [ATMegaZero Store](https://shop.atmegazero.com)
+* [Pre-Order on GroupGets.com](https://groupgets.com/campaigns/936-atmegazero-esp32-s2)
 
 ## Contribute
 


### PR DESCRIPTION
I'm currently crowdfunding this version on GroupGets.com. The link was taking people to the older version which doesn't support circuitpython.