### PR TITLE
Automated website update for release 7.0.0-alpha.4

### DIFF
--- a/_data/files.json
+++ b/_data/files.json
@@ -1,6 +1,6 @@
 [
  {
-  "downloads": 115,
+  "downloads": 0,
   "id": "8086_commander",
   "versions": [
    {
@@ -97,12 +97,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 19,
+  "downloads": 0,
   "id": "ADM_B_NRF52840_1",
   "versions": [
    {
@@ -221,8 +221,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -253,12 +253,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 54,
+  "downloads": 0,
   "id": "TG-Watch",
   "versions": [
    {
@@ -377,8 +377,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -409,12 +409,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 159,
+  "downloads": 0,
   "id": "adafruit_feather_esp32s2_nopsram",
   "versions": [
    {
@@ -524,6 +524,7 @@
      "analogio",
      "audiobusio",
      "audiocore",
+     "audiomixer",
      "binascii",
      "bitbangio",
      "bitmaptools",
@@ -538,9 +539,10 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
+     "imagecapture",
      "ipaddress",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -575,12 +577,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 87,
+  "downloads": 0,
   "id": "adafruit_feather_esp32s2_tftback_nopsram",
   "versions": [
    {
@@ -690,6 +692,7 @@
      "analogio",
      "audiobusio",
      "audiocore",
+     "audiomixer",
      "binascii",
      "bitbangio",
      "bitmaptools",
@@ -704,9 +707,10 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
+     "imagecapture",
      "ipaddress",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -741,12 +745,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 584,
+  "downloads": 0,
   "id": "adafruit_feather_rp2040",
   "versions": [
    {
@@ -846,6 +850,7 @@
      "_bleio",
      "_pixelbuf",
      "adafruit_bus_device",
+     "alarm",
      "analogio",
      "audiobusio",
      "audiocore",
@@ -864,9 +869,9 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "imagecapture",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -897,12 +902,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 556,
+  "downloads": 0,
   "id": "adafruit_funhouse",
   "versions": [
    {
@@ -1012,6 +1017,7 @@
      "analogio",
      "audiobusio",
      "audiocore",
+     "audiomixer",
      "binascii",
      "bitbangio",
      "bitmaptools",
@@ -1026,9 +1032,10 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
+     "imagecapture",
      "ipaddress",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -1063,12 +1070,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 191,
+  "downloads": 0,
   "id": "adafruit_itsybitsy_rp2040",
   "versions": [
    {
@@ -1168,6 +1175,7 @@
      "_bleio",
      "_pixelbuf",
      "adafruit_bus_device",
+     "alarm",
      "analogio",
      "audiobusio",
      "audiocore",
@@ -1186,9 +1194,9 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "imagecapture",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -1219,7 +1227,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
@@ -1252,6 +1260,7 @@
      "_bleio",
      "_pixelbuf",
      "adafruit_bus_device",
+     "alarm",
      "analogio",
      "audiobusio",
      "audiocore",
@@ -1270,9 +1279,9 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "imagecapture",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -1303,12 +1312,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 679,
+  "downloads": 0,
   "id": "adafruit_magtag_2.9_grayscale",
   "versions": [
    {
@@ -1418,6 +1427,7 @@
      "analogio",
      "audiobusio",
      "audiocore",
+     "audiomixer",
      "binascii",
      "bitbangio",
      "bitmaptools",
@@ -1432,9 +1442,10 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
+     "imagecapture",
      "ipaddress",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -1469,12 +1480,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 284,
+  "downloads": 0,
   "id": "adafruit_metro_esp32s2",
   "versions": [
    {
@@ -1584,6 +1595,7 @@
      "analogio",
      "audiobusio",
      "audiocore",
+     "audiomixer",
      "binascii",
      "bitbangio",
      "bitmaptools",
@@ -1598,9 +1610,10 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
+     "imagecapture",
      "ipaddress",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -1635,12 +1648,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 24,
+  "downloads": 0,
   "id": "adafruit_neokey_trinkey_m0",
   "versions": [
    {
@@ -1726,12 +1739,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 6,
+  "downloads": 0,
   "id": "adafruit_proxlight_trinkey_m0",
   "versions": [
    {
@@ -1818,12 +1831,12 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 9,
+  "downloads": 0,
   "id": "adafruit_qt2040_trinkey",
   "versions": [
    {
@@ -1923,6 +1936,7 @@
      "_bleio",
      "_pixelbuf",
      "adafruit_bus_device",
+     "alarm",
      "analogio",
      "audiobusio",
      "audiocore",
@@ -1941,9 +1955,9 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "imagecapture",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -1974,12 +1988,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 321,
+  "downloads": 0,
   "id": "adafruit_qtpy_rp2040",
   "versions": [
    {
@@ -2079,6 +2093,7 @@
      "_bleio",
      "_pixelbuf",
      "adafruit_bus_device",
+     "alarm",
      "analogio",
      "audiobusio",
      "audiocore",
@@ -2097,9 +2112,9 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "imagecapture",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -2130,12 +2145,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 216,
+  "downloads": 0,
   "id": "adafruit_rotary_trinkey_m0",
   "versions": [
    {
@@ -2223,12 +2238,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 6,
+  "downloads": 0,
   "id": "adafruit_slide_trinkey_m0",
   "versions": [
    {
@@ -2316,12 +2331,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 110,
+  "downloads": 0,
   "id": "aloriumtech_evo_m51",
   "versions": [
    {
@@ -2441,9 +2456,9 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -2474,12 +2489,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 1,
+  "downloads": 0,
   "id": "aramcon2_badge",
   "versions": [
    {
@@ -2598,8 +2613,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -2630,12 +2645,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 119,
+  "downloads": 0,
   "id": "aramcon_badge_2019",
   "versions": [
    {
@@ -2754,8 +2769,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -2786,12 +2801,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 85,
+  "downloads": 0,
   "id": "arduino_mkr1300",
   "versions": [
    {
@@ -2888,12 +2903,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 109,
+  "downloads": 0,
   "id": "arduino_mkrzero",
   "versions": [
    {
@@ -2990,12 +3005,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 184,
+  "downloads": 0,
   "id": "arduino_nano_33_ble",
   "versions": [
    {
@@ -3114,8 +3129,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -3146,12 +3161,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 123,
+  "downloads": 0,
   "id": "arduino_nano_33_iot",
   "versions": [
    {
@@ -3248,12 +3263,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 90,
+  "downloads": 0,
   "id": "arduino_nano_rp2040_connect",
   "versions": [
    {
@@ -3353,6 +3368,7 @@
      "_bleio",
      "_pixelbuf",
      "adafruit_bus_device",
+     "alarm",
      "analogio",
      "audiobusio",
      "audiocore",
@@ -3371,9 +3387,9 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "imagecapture",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -3404,12 +3420,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 146,
+  "downloads": 0,
   "id": "arduino_zero",
   "versions": [
    {
@@ -3506,7 +3522,7 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
@@ -3621,6 +3637,7 @@
      "analogio",
      "audiobusio",
      "audiocore",
+     "audiomixer",
      "binascii",
      "bitbangio",
      "bitmaptools",
@@ -3635,9 +3652,10 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
+     "imagecapture",
      "ipaddress",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -3672,7 +3690,7 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
@@ -3710,6 +3728,7 @@
      "analogio",
      "audiobusio",
      "audiocore",
+     "audiomixer",
      "binascii",
      "bitbangio",
      "bitmaptools",
@@ -3724,9 +3743,10 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
+     "imagecapture",
      "ipaddress",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -3761,12 +3781,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 98,
+  "downloads": 0,
   "id": "bast_pro_mini_m0",
   "versions": [
    {
@@ -3861,12 +3881,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 103,
+  "downloads": 0,
   "id": "bastble",
   "versions": [
    {
@@ -3985,8 +4005,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -4017,12 +4037,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 117,
+  "downloads": 0,
   "id": "bdmicro_vina_d21",
   "versions": [
    {
@@ -4114,7 +4134,6 @@
      "displayio",
      "errno",
      "fontio",
-     "gamepad",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -4136,12 +4155,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 127,
+  "downloads": 0,
   "id": "bdmicro_vina_d51",
   "versions": [
    {
@@ -4261,9 +4280,9 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -4294,12 +4313,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 7,
+  "downloads": 0,
   "id": "bdmicro_vina_d51_pcb7",
   "versions": [
    {
@@ -4419,9 +4438,9 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -4452,12 +4471,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 111,
+  "downloads": 0,
   "id": "bless_dev_board_multi_sensor",
   "versions": [
    {
@@ -4576,8 +4595,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -4608,12 +4627,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 99,
+  "downloads": 0,
   "id": "blm_badge",
   "versions": [
    {
@@ -4705,12 +4724,12 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 128,
+  "downloads": 0,
   "id": "capablerobot_usbhub",
   "versions": [
    {
@@ -4828,9 +4847,9 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -4861,12 +4880,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 113,
+  "downloads": 0,
   "id": "catwan_usbstick",
   "versions": [
    {
@@ -4960,12 +4979,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 83,
+  "downloads": 0,
   "id": "circuitbrains_basic_m0",
   "versions": [
    {
@@ -5058,7 +5077,6 @@
      "displayio",
      "errno",
      "fontio",
-     "gamepad",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -5080,12 +5098,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 79,
+  "downloads": 0,
   "id": "circuitbrains_deluxe_m4",
   "versions": [
    {
@@ -5205,9 +5223,9 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -5238,12 +5256,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 561,
+  "downloads": 0,
   "id": "circuitplayground_bluefruit",
   "versions": [
    {
@@ -5362,8 +5380,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -5394,12 +5412,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 897,
+  "downloads": 0,
   "id": "circuitplayground_express",
   "versions": [
    {
@@ -5492,7 +5510,6 @@
      "countio",
      "digitalio",
      "errno",
-     "gamepad",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -5513,12 +5530,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 116,
+  "downloads": 0,
   "id": "circuitplayground_express_4h",
   "versions": [
    {
@@ -5611,7 +5628,6 @@
      "countio",
      "digitalio",
      "errno",
-     "gamepad",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -5632,12 +5648,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 151,
+  "downloads": 0,
   "id": "circuitplayground_express_crickit",
   "versions": [
    {
@@ -5725,7 +5741,6 @@
      "busio",
      "digitalio",
      "errno",
-     "gamepad",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -5746,12 +5761,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 32,
+  "downloads": 0,
   "id": "circuitplayground_express_digikey_pycon2019",
   "versions": [
    {
@@ -5844,7 +5859,6 @@
      "countio",
      "digitalio",
      "errno",
-     "gamepad",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -5865,12 +5879,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 123,
+  "downloads": 0,
   "id": "circuitplayground_express_displayio",
   "versions": [
    {
@@ -5957,7 +5971,6 @@
      "displayio",
      "errno",
      "fontio",
-     "gamepad",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -5976,12 +5989,12 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 369,
+  "downloads": 0,
   "id": "clue_nrf52840_express",
   "versions": [
    {
@@ -6100,8 +6113,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -6132,12 +6145,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 23,
+  "downloads": 0,
   "id": "cp32-m4",
   "versions": [
    {
@@ -6255,9 +6268,9 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -6288,12 +6301,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 108,
+  "downloads": 0,
   "id": "cp_sapling_m0",
   "versions": [
    {
@@ -6388,7 +6401,7 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
@@ -6441,12 +6454,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 113,
+  "downloads": 0,
   "id": "cp_sapling_m0_spiflash",
   "versions": [
    {
@@ -6534,7 +6547,6 @@
      "displayio",
      "errno",
      "fontio",
-     "gamepad",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -6556,7 +6568,7 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
@@ -6589,6 +6601,7 @@
      "_bleio",
      "_pixelbuf",
      "adafruit_bus_device",
+     "alarm",
      "analogio",
      "audiobusio",
      "audiocore",
@@ -6607,9 +6620,9 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "imagecapture",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -6640,12 +6653,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 48,
+  "downloads": 0,
   "id": "datalore_ip_m4",
   "versions": [
    {
@@ -6765,9 +6778,9 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -6798,12 +6811,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 108,
+  "downloads": 0,
   "id": "datum_distance",
   "versions": [
    {
@@ -6898,12 +6911,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 41,
+  "downloads": 0,
   "id": "datum_imu",
   "versions": [
    {
@@ -6998,12 +7011,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 115,
+  "downloads": 0,
   "id": "datum_light",
   "versions": [
    {
@@ -7098,12 +7111,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 21,
+  "downloads": 0,
   "id": "datum_weather",
   "versions": [
    {
@@ -7198,12 +7211,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 107,
+  "downloads": 0,
   "id": "dynalora_usb",
   "versions": [
    {
@@ -7299,12 +7312,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 104,
+  "downloads": 0,
   "id": "dynossat_edu_eps",
   "versions": [
    {
@@ -7394,7 +7407,6 @@
      "displayio",
      "errno",
      "fontio",
-     "gamepad",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -7414,12 +7426,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 109,
+  "downloads": 0,
   "id": "dynossat_edu_obc",
   "versions": [
    {
@@ -7539,9 +7551,9 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -7572,12 +7584,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 157,
+  "downloads": 0,
   "id": "edgebadge",
   "versions": [
    {
@@ -7704,6 +7716,7 @@
      "gamepadshift",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -7734,12 +7747,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 69,
+  "downloads": 0,
   "id": "electroniccats_bastwifi",
   "versions": [
    {
@@ -7848,6 +7861,7 @@
      "analogio",
      "audiobusio",
      "audiocore",
+     "audiomixer",
      "binascii",
      "bitbangio",
      "bitmaptools",
@@ -7862,9 +7876,10 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
+     "imagecapture",
      "ipaddress",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -7898,12 +7913,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 128,
+  "downloads": 0,
   "id": "electronut_labs_blip",
   "versions": [
    {
@@ -8026,6 +8041,7 @@
      "framebufferio",
      "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -8056,12 +8072,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 115,
+  "downloads": 0,
   "id": "electronut_labs_papyr",
   "versions": [
    {
@@ -8180,8 +8196,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -8212,12 +8228,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 48,
+  "downloads": 0,
   "id": "escornabot_makech",
   "versions": [
    {
@@ -8311,12 +8327,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 164,
+  "downloads": 0,
   "id": "espressif_kaluga_1",
   "versions": [
    {
@@ -8426,6 +8442,7 @@
      "analogio",
      "audiobusio",
      "audiocore",
+     "audiomixer",
      "binascii",
      "bitbangio",
      "bitmaptools",
@@ -8440,9 +8457,10 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
+     "imagecapture",
      "ipaddress",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -8476,12 +8494,102 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 268,
+  "downloads": 0,
+  "id": "espressif_kaluga_1.3",
+  "versions": [
+   {
+    "extensions": [
+     "bin",
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "en_GB",
+     "en_US",
+     "en_x_pirate",
+     "es",
+     "fil",
+     "fr",
+     "ID",
+     "it_IT",
+     "ja",
+     "nl",
+     "pl",
+     "pt_BR",
+     "sv",
+     "zh_Latn_pinyin"
+    ],
+    "modules": [
+     "_bleio",
+     "_pixelbuf",
+     "adafruit_bus_device",
+     "alarm",
+     "analogio",
+     "audiobusio",
+     "audiocore",
+     "audiomixer",
+     "binascii",
+     "bitbangio",
+     "bitmaptools",
+     "board",
+     "busio",
+     "canio",
+     "countio",
+     "digitalio",
+     "displayio",
+     "dualbank",
+     "errno",
+     "fontio",
+     "framebufferio",
+     "frequencyio",
+     "imagecapture",
+     "ipaddress",
+     "json",
+     "keypad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "os",
+     "ps2io",
+     "pulseio",
+     "pwmio",
+     "random",
+     "re",
+     "rgbmatrix",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "socketpool",
+     "ssl",
+     "storage",
+     "struct",
+     "supervisor",
+     "synthio",
+     "terminalio",
+     "time",
+     "touchio",
+     "ulab",
+     "usb_cdc",
+     "usb_midi",
+     "vectorio",
+     "watchdog",
+     "wifi"
+    ],
+    "stable": false,
+    "version": "7.0.0-alpha.4"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
   "id": "espressif_saola_1_wroom",
   "versions": [
    {
@@ -8591,6 +8699,7 @@
      "analogio",
      "audiobusio",
      "audiocore",
+     "audiomixer",
      "binascii",
      "bitbangio",
      "bitmaptools",
@@ -8605,9 +8714,10 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
+     "imagecapture",
      "ipaddress",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -8642,12 +8752,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 290,
+  "downloads": 0,
   "id": "espressif_saola_1_wrover",
   "versions": [
    {
@@ -8757,6 +8867,7 @@
      "analogio",
      "audiobusio",
      "audiocore",
+     "audiomixer",
      "binascii",
      "bitbangio",
      "bitmaptools",
@@ -8771,9 +8882,10 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
+     "imagecapture",
      "ipaddress",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -8808,12 +8920,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 26,
+  "downloads": 0,
   "id": "espruino_pico",
   "versions": [
    {
@@ -8904,7 +9016,6 @@
      "displayio",
      "errno",
      "fontio",
-     "gamepad",
      "json",
      "math",
      "microcontroller",
@@ -8926,12 +9037,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 22,
+  "downloads": 0,
   "id": "espruino_wifi",
   "versions": [
    {
@@ -9029,8 +9140,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -9048,19 +9159,18 @@
      "terminalio",
      "time",
      "touchio",
-     "ulab",
      "usb_cdc",
      "usb_hid",
      "usb_midi",
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 237,
+  "downloads": 0,
   "id": "feather_bluefruit_sense",
   "versions": [
    {
@@ -9179,8 +9289,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -9211,12 +9321,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 150,
+  "downloads": 0,
   "id": "feather_m0_adalogger",
   "versions": [
    {
@@ -9313,12 +9423,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 158,
+  "downloads": 0,
   "id": "feather_m0_basic",
   "versions": [
    {
@@ -9415,12 +9525,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 352,
+  "downloads": 0,
   "id": "feather_m0_express",
   "versions": [
    {
@@ -9512,7 +9622,6 @@
      "displayio",
      "errno",
      "fontio",
-     "gamepad",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -9534,12 +9643,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 28,
+  "downloads": 0,
   "id": "feather_m0_express_crickit",
   "versions": [
    {
@@ -9627,7 +9736,6 @@
      "busio",
      "digitalio",
      "errno",
-     "gamepad",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -9648,12 +9756,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 134,
+  "downloads": 0,
   "id": "feather_m0_rfm69",
   "versions": [
    {
@@ -9739,12 +9847,12 @@
      "usb_cdc"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 133,
+  "downloads": 0,
   "id": "feather_m0_rfm9x",
   "versions": [
    {
@@ -9830,12 +9938,12 @@
      "usb_cdc"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 112,
+  "downloads": 0,
   "id": "feather_m0_supersized",
   "versions": [
    {
@@ -9927,7 +10035,6 @@
      "displayio",
      "errno",
      "fontio",
-     "gamepad",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -9949,12 +10056,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 183,
+  "downloads": 0,
   "id": "feather_m4_can",
   "versions": [
    {
@@ -10074,9 +10181,9 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -10107,12 +10214,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 613,
+  "downloads": 0,
   "id": "feather_m4_express",
   "versions": [
    {
@@ -10232,9 +10339,9 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -10265,12 +10372,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 64,
+  "downloads": 0,
   "id": "feather_m7_1011",
   "versions": [
    {
@@ -10373,8 +10480,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -10400,12 +10507,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 66,
+  "downloads": 0,
   "id": "feather_mimxrt1011",
   "versions": [
    {
@@ -10508,8 +10615,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -10535,12 +10642,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 91,
+  "downloads": 0,
   "id": "feather_mimxrt1062",
   "versions": [
    {
@@ -10643,8 +10750,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -10670,12 +10777,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 331,
+  "downloads": 0,
   "id": "feather_nrf52840_express",
   "versions": [
    {
@@ -10794,8 +10901,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -10826,7 +10933,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
@@ -10891,7 +10998,7 @@
   ]
  },
  {
-  "downloads": 145,
+  "downloads": 0,
   "id": "feather_stm32f405_express",
   "versions": [
    {
@@ -10997,8 +11104,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -11026,12 +11133,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 56,
+  "downloads": 0,
   "id": "fluff_m0",
   "versions": [
    {
@@ -11126,12 +11233,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 100,
+  "downloads": 0,
   "id": "fomu",
   "versions": [
    {
@@ -11207,8 +11314,8 @@
      "binascii",
      "digitalio",
      "errno",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -11227,12 +11334,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 89,
+  "downloads": 0,
   "id": "franzininho_wifi_wroom",
   "versions": [
    {
@@ -11342,6 +11449,7 @@
      "analogio",
      "audiobusio",
      "audiocore",
+     "audiomixer",
      "binascii",
      "bitbangio",
      "bitmaptools",
@@ -11356,9 +11464,10 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
+     "imagecapture",
      "ipaddress",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -11393,12 +11502,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 77,
+  "downloads": 0,
   "id": "franzininho_wifi_wrover",
   "versions": [
    {
@@ -11508,6 +11617,7 @@
      "analogio",
      "audiobusio",
      "audiocore",
+     "audiomixer",
      "binascii",
      "bitbangio",
      "bitmaptools",
@@ -11522,9 +11632,10 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
+     "imagecapture",
      "ipaddress",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -11559,12 +11670,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 268,
+  "downloads": 0,
   "id": "gemma_m0",
   "versions": [
    {
@@ -11659,12 +11770,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 41,
+  "downloads": 0,
   "id": "gemma_m0_pycon2018",
   "versions": [
    {
@@ -11759,12 +11870,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 291,
+  "downloads": 0,
   "id": "grandcentral_m4_express",
   "versions": [
    {
@@ -11885,10 +11996,10 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
      "i2cperipheral",
      "imagecapture",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -11920,12 +12031,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 171,
+  "downloads": 0,
   "id": "hallowing_m0_express",
   "versions": [
    {
@@ -12035,12 +12146,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 150,
+  "downloads": 0,
   "id": "hallowing_m4_express",
   "versions": [
    {
@@ -12160,9 +12271,9 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -12193,12 +12304,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 107,
+  "downloads": 0,
   "id": "hiibot_bluefi",
   "versions": [
    {
@@ -12317,8 +12428,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -12349,12 +12460,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 4,
+  "downloads": 0,
   "id": "huntercat_nfc",
   "versions": [
    {
@@ -12433,7 +12544,6 @@
      "displayio",
      "errno",
      "fontio",
-     "gamepad",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -12455,12 +12565,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 112,
+  "downloads": 0,
   "id": "ikigaisense_vita",
   "versions": [
    {
@@ -12579,8 +12689,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -12611,12 +12721,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 65,
+  "downloads": 0,
   "id": "imxrt1010_evk",
   "versions": [
    {
@@ -12719,8 +12829,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -12746,12 +12856,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 72,
+  "downloads": 0,
   "id": "imxrt1020_evk",
   "versions": [
    {
@@ -12854,8 +12964,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -12881,12 +12991,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 77,
+  "downloads": 0,
   "id": "imxrt1060_evk",
   "versions": [
    {
@@ -12989,8 +13099,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -13016,12 +13126,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 204,
+  "downloads": 0,
   "id": "itsybitsy_m0_express",
   "versions": [
    {
@@ -13111,7 +13221,6 @@
      "displayio",
      "errno",
      "fontio",
-     "gamepad",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -13132,12 +13241,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 289,
+  "downloads": 0,
   "id": "itsybitsy_m4_express",
   "versions": [
    {
@@ -13255,9 +13364,9 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -13288,12 +13397,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 249,
+  "downloads": 0,
   "id": "itsybitsy_nrf52840_express",
   "versions": [
    {
@@ -13412,8 +13521,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -13444,12 +13553,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 34,
+  "downloads": 0,
   "id": "kicksat-sprite",
   "versions": [
    {
@@ -13550,7 +13659,6 @@
      "digitalio",
      "errno",
      "frequencyio",
-     "gamepad",
      "i2cperipheral",
      "json",
      "math",
@@ -13574,12 +13682,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 206,
+  "downloads": 0,
   "id": "lilygo_ttgo_t8_s2_st7789",
   "versions": [
    {
@@ -13689,6 +13797,7 @@
      "analogio",
      "audiobusio",
      "audiocore",
+     "audiomixer",
      "binascii",
      "bitbangio",
      "bitmaptools",
@@ -13703,9 +13812,10 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
+     "imagecapture",
      "ipaddress",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -13740,12 +13850,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 9,
+  "downloads": 0,
   "id": "loc_ber_m4_base_board",
   "versions": [
    {
@@ -13842,12 +13952,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 122,
+  "downloads": 0,
   "id": "makerdiary_m60_keyboard",
   "versions": [
    {
@@ -13966,8 +14076,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -13998,12 +14108,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 55,
+  "downloads": 0,
   "id": "makerdiary_nrf52840_m2_devkit",
   "versions": [
    {
@@ -14122,8 +14232,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -14154,12 +14264,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 153,
+  "downloads": 0,
   "id": "makerdiary_nrf52840_mdk",
   "versions": [
    {
@@ -14278,8 +14388,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -14310,12 +14420,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 158,
+  "downloads": 0,
   "id": "makerdiary_nrf52840_mdk_usb_dongle",
   "versions": [
    {
@@ -14436,8 +14546,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -14468,12 +14578,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 476,
+  "downloads": 0,
   "id": "matrixportal_m4",
   "versions": [
    {
@@ -14593,9 +14703,9 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -14626,12 +14736,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 187,
+  "downloads": 0,
   "id": "meowbit_v121",
   "versions": [
    {
@@ -14714,7 +14824,6 @@
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "_pixelbuf",
      "adafruit_bus_device",
      "analogio",
@@ -14731,8 +14840,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -14757,12 +14866,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 143,
+  "downloads": 0,
   "id": "meowmeow",
   "versions": [
    {
@@ -14841,7 +14950,6 @@
      "neopixel_write",
      "nvm",
      "os",
-     "pwmio",
      "random",
      "rotaryio",
      "rtc",
@@ -14855,12 +14963,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 297,
+  "downloads": 0,
   "id": "metro_m0_express",
   "versions": [
    {
@@ -14952,7 +15060,6 @@
      "displayio",
      "errno",
      "fontio",
-     "gamepad",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -14974,12 +15081,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 224,
+  "downloads": 0,
   "id": "metro_m4_airlift_lite",
   "versions": [
    {
@@ -15099,9 +15206,9 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -15132,12 +15239,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 270,
+  "downloads": 0,
   "id": "metro_m4_express",
   "versions": [
    {
@@ -15257,9 +15364,9 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -15290,12 +15397,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 61,
+  "downloads": 0,
   "id": "metro_m7_1011",
   "versions": [
    {
@@ -15398,8 +15505,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -15425,12 +15532,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 93,
+  "downloads": 0,
   "id": "metro_nrf52840_express",
   "versions": [
    {
@@ -15549,8 +15656,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -15581,12 +15688,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 79,
+  "downloads": 0,
   "id": "microdev_micro_s2",
   "versions": [
    {
@@ -15696,6 +15803,7 @@
      "analogio",
      "audiobusio",
      "audiocore",
+     "audiomixer",
      "binascii",
      "bitbangio",
      "bitmaptools",
@@ -15710,9 +15818,10 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
+     "imagecapture",
      "ipaddress",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -15747,12 +15856,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 143,
+  "downloads": 0,
   "id": "mini_sam_m4",
   "versions": [
    {
@@ -15870,9 +15979,9 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -15903,12 +16012,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 177,
+  "downloads": 0,
   "id": "monster_m4sk",
   "versions": [
    {
@@ -16028,9 +16137,9 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -16061,12 +16170,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 36,
+  "downloads": 0,
   "id": "muselab_nanoesp32_s2_wroom",
   "versions": [
    {
@@ -16176,6 +16285,7 @@
      "analogio",
      "audiobusio",
      "audiocore",
+     "audiomixer",
      "binascii",
      "bitbangio",
      "bitmaptools",
@@ -16190,9 +16300,10 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
+     "imagecapture",
      "ipaddress",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -16227,12 +16338,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 16,
+  "downloads": 0,
   "id": "muselab_nanoesp32_s2_wrover",
   "versions": [
    {
@@ -16342,6 +16453,7 @@
      "analogio",
      "audiobusio",
      "audiocore",
+     "audiomixer",
      "binascii",
      "bitbangio",
      "bitmaptools",
@@ -16356,9 +16468,10 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
+     "imagecapture",
      "ipaddress",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -16393,12 +16506,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 101,
+  "downloads": 0,
   "id": "ndgarage_ndbit6",
   "versions": [
    {
@@ -16493,12 +16606,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 55,
+  "downloads": 0,
   "id": "ndgarage_ndbit6_v2",
   "versions": [
    {
@@ -16593,12 +16706,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 354,
+  "downloads": 0,
   "id": "neopixel_trinkey_m0",
   "versions": [
    {
@@ -16684,12 +16797,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 140,
+  "downloads": 0,
   "id": "nfc_copy_cat",
   "versions": [
    {
@@ -16784,12 +16897,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 123,
+  "downloads": 0,
   "id": "nice_nano",
   "versions": [
    {
@@ -16908,8 +17021,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -16940,12 +17053,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 26,
+  "downloads": 0,
   "id": "nucleo_f746zg",
   "versions": [
    {
@@ -17040,8 +17153,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -17065,12 +17178,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 39,
+  "downloads": 0,
   "id": "nucleo_f767zi",
   "versions": [
    {
@@ -17165,8 +17278,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -17190,12 +17303,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 24,
+  "downloads": 0,
   "id": "nucleo_h743zi_2",
   "versions": [
    {
@@ -17288,8 +17401,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -17311,12 +17424,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 115,
+  "downloads": 0,
   "id": "ohs2020_badge",
   "versions": [
    {
@@ -17435,8 +17548,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -17467,12 +17580,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 137,
+  "downloads": 0,
   "id": "openbook_m4",
   "versions": [
    {
@@ -17593,10 +17706,10 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
      "gamepadshift",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -17627,12 +17740,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 28,
+  "downloads": 0,
   "id": "openmv_h7",
   "versions": [
    {
@@ -17725,8 +17838,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -17748,12 +17861,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 161,
+  "downloads": 0,
   "id": "particle_argon",
   "versions": [
    {
@@ -17872,8 +17985,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -17904,12 +18017,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 113,
+  "downloads": 0,
   "id": "particle_boron",
   "versions": [
    {
@@ -18028,8 +18141,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -18060,12 +18173,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 158,
+  "downloads": 0,
   "id": "particle_xenon",
   "versions": [
    {
@@ -18184,8 +18297,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -18216,12 +18329,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 86,
+  "downloads": 0,
   "id": "pca10056",
   "versions": [
    {
@@ -18342,8 +18455,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -18374,12 +18487,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 163,
+  "downloads": 0,
   "id": "pca10059",
   "versions": [
    {
@@ -18500,8 +18613,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -18532,12 +18645,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 141,
+  "downloads": 0,
   "id": "pca10100",
   "versions": [
    {
@@ -18626,7 +18739,6 @@
      "busio",
      "digitalio",
      "errno",
-     "gamepad",
      "math",
      "microcontroller",
      "os",
@@ -18643,16 +18755,15 @@
      "touchio",
      "usb_cdc",
      "usb_hid",
-     "usb_midi",
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 118,
+  "downloads": 0,
   "id": "pewpew10",
   "versions": [
    {
@@ -18743,12 +18854,12 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 109,
+  "downloads": 0,
   "id": "pewpew13",
   "versions": [
    {
@@ -18839,12 +18950,12 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 109,
+  "downloads": 0,
   "id": "pewpew_m4",
   "versions": [
    {
@@ -18927,12 +19038,11 @@
      "digitalio",
      "displayio",
      "fontio",
-     "gamepad",
+     "keypad",
      "math",
      "microcontroller",
      "nvm",
      "os",
-     "pwmio",
      "random",
      "storage",
      "struct",
@@ -18943,12 +19053,12 @@
      "usb_cdc"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 106,
+  "downloads": 0,
   "id": "picoplanet",
   "versions": [
    {
@@ -19043,12 +19153,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 190,
+  "downloads": 0,
   "id": "pimoroni_keybow2040",
   "versions": [
    {
@@ -19148,6 +19258,7 @@
      "_bleio",
      "_pixelbuf",
      "adafruit_bus_device",
+     "alarm",
      "analogio",
      "audiobusio",
      "audiocore",
@@ -19166,9 +19277,9 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "imagecapture",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -19199,12 +19310,97 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 10,
+  "downloads": 0,
+  "id": "pimoroni_pga2040",
+  "versions": [
+   {
+    "extensions": [
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "en_GB",
+     "en_US",
+     "en_x_pirate",
+     "es",
+     "fil",
+     "fr",
+     "ID",
+     "it_IT",
+     "ja",
+     "nl",
+     "pl",
+     "pt_BR",
+     "sv",
+     "zh_Latn_pinyin"
+    ],
+    "modules": [
+     "_bleio",
+     "_pixelbuf",
+     "adafruit_bus_device",
+     "alarm",
+     "analogio",
+     "audiobusio",
+     "audiocore",
+     "audiomixer",
+     "audiomp3",
+     "audiopwmio",
+     "binascii",
+     "bitbangio",
+     "bitmaptools",
+     "bitops",
+     "board",
+     "busio",
+     "countio",
+     "digitalio",
+     "displayio",
+     "errno",
+     "fontio",
+     "framebufferio",
+     "imagecapture",
+     "json",
+     "keypad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "os",
+     "pulseio",
+     "pwmio",
+     "random",
+     "re",
+     "rgbmatrix",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "storage",
+     "struct",
+     "supervisor",
+     "synthio",
+     "terminalio",
+     "time",
+     "touchio",
+     "ulab",
+     "usb_cdc",
+     "usb_hid",
+     "usb_midi",
+     "vectorio",
+     "watchdog"
+    ],
+    "stable": false,
+    "version": "7.0.0-alpha.4"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
   "id": "pimoroni_picolipo_16mb",
   "versions": [
    {
@@ -19304,6 +19500,7 @@
      "_bleio",
      "_pixelbuf",
      "adafruit_bus_device",
+     "alarm",
      "analogio",
      "audiobusio",
      "audiocore",
@@ -19322,9 +19519,9 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "imagecapture",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -19355,12 +19552,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 6,
+  "downloads": 0,
   "id": "pimoroni_picolipo_4mb",
   "versions": [
    {
@@ -19460,6 +19657,7 @@
      "_bleio",
      "_pixelbuf",
      "adafruit_bus_device",
+     "alarm",
      "analogio",
      "audiobusio",
      "audiocore",
@@ -19478,9 +19676,9 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "imagecapture",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -19511,12 +19709,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 107,
+  "downloads": 0,
   "id": "pimoroni_picosystem",
   "versions": [
    {
@@ -19616,6 +19814,7 @@
      "_bleio",
      "_pixelbuf",
      "adafruit_bus_device",
+     "alarm",
      "analogio",
      "audiobusio",
      "audiocore",
@@ -19634,9 +19833,9 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "imagecapture",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -19667,12 +19866,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 315,
+  "downloads": 0,
   "id": "pimoroni_tiny2040",
   "versions": [
    {
@@ -19772,6 +19971,7 @@
      "_bleio",
      "_pixelbuf",
      "adafruit_bus_device",
+     "alarm",
      "analogio",
      "audiobusio",
      "audiocore",
@@ -19790,9 +19990,9 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "imagecapture",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -19823,7 +20023,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
@@ -19875,7 +20075,7 @@
   ]
  },
  {
-  "downloads": 116,
+  "downloads": 0,
   "id": "pitaya_go",
   "versions": [
    {
@@ -19994,8 +20194,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -20026,12 +20226,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 26,
+  "downloads": 0,
   "id": "pyb_nano_v2",
   "versions": [
    {
@@ -20129,7 +20329,6 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
      "math",
      "microcontroller",
@@ -20154,12 +20353,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 257,
+  "downloads": 0,
   "id": "pybadge",
   "versions": [
    {
@@ -20286,6 +20485,7 @@
      "gamepadshift",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -20316,7 +20516,7 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
@@ -20403,7 +20603,7 @@
   ]
  },
  {
-  "downloads": 75,
+  "downloads": 0,
   "id": "pyboard_v11",
   "versions": [
    {
@@ -20509,8 +20709,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -20538,12 +20738,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 115,
+  "downloads": 0,
   "id": "pycubed",
   "versions": [
    {
@@ -20675,12 +20875,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 111,
+  "downloads": 0,
   "id": "pycubed_mram",
   "versions": [
    {
@@ -20812,12 +21012,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 208,
+  "downloads": 0,
   "id": "pygamer",
   "versions": [
    {
@@ -20944,6 +21144,7 @@
      "gamepadshift",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -20974,7 +21175,7 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
@@ -21061,7 +21262,7 @@
   ]
  },
  {
-  "downloads": 369,
+  "downloads": 0,
   "id": "pyportal",
   "versions": [
    {
@@ -21181,9 +21382,9 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -21214,12 +21415,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 156,
+  "downloads": 0,
   "id": "pyportal_pynt",
   "versions": [
    {
@@ -21339,9 +21540,9 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -21372,12 +21573,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 249,
+  "downloads": 0,
   "id": "pyportal_titano",
   "versions": [
    {
@@ -21497,9 +21698,9 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -21530,12 +21731,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 167,
+  "downloads": 0,
   "id": "pyruler",
   "versions": [
    {
@@ -21629,12 +21830,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 473,
+  "downloads": 0,
   "id": "qtpy_m0",
   "versions": [
    {
@@ -21729,12 +21930,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 264,
+  "downloads": 0,
   "id": "qtpy_m0_haxpress",
   "versions": [
    {
@@ -21826,7 +22027,6 @@
      "displayio",
      "errno",
      "fontio",
-     "gamepad",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -21848,12 +22048,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 2364,
+  "downloads": 0,
   "id": "raspberry_pi_pico",
   "versions": [
    {
@@ -21953,6 +22153,7 @@
      "_bleio",
      "_pixelbuf",
      "adafruit_bus_device",
+     "alarm",
      "analogio",
      "audiobusio",
      "audiocore",
@@ -21971,9 +22172,9 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "imagecapture",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -22004,12 +22205,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 74,
+  "downloads": 0,
   "id": "raytac_mdbt50q-db-40",
   "versions": [
    {
@@ -22128,8 +22329,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -22160,12 +22361,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 119,
+  "downloads": 0,
   "id": "robohatmm1_m4",
   "versions": [
    {
@@ -22270,9 +22471,9 @@
      "countio",
      "digitalio",
      "errno",
-     "gamepad",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -22299,12 +22500,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 124,
+  "downloads": 0,
   "id": "sam32",
   "versions": [
    {
@@ -22424,9 +22625,9 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -22457,12 +22658,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 103,
+  "downloads": 0,
   "id": "same54_xplained",
   "versions": [
    {
@@ -22583,9 +22784,9 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -22615,12 +22816,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 345,
+  "downloads": 0,
   "id": "seeeduino_wio_terminal",
   "versions": [
    {
@@ -22740,9 +22941,9 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -22773,12 +22974,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 681,
+  "downloads": 0,
   "id": "seeeduino_xiao",
   "versions": [
    {
@@ -22873,7 +23074,7 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
@@ -22926,12 +23127,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 123,
+  "downloads": 0,
   "id": "serpente",
   "versions": [
    {
@@ -23026,7 +23227,6 @@
      "displayio",
      "errno",
      "fontio",
-     "gamepad",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -23048,12 +23248,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 117,
+  "downloads": 0,
   "id": "shirtty",
   "versions": [
    {
@@ -23148,12 +23348,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 29,
+  "downloads": 0,
   "id": "silicognition-m4-shim",
   "versions": [
    {
@@ -23273,9 +23473,9 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -23306,12 +23506,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 92,
+  "downloads": 0,
   "id": "simmel",
   "versions": [
    {
@@ -23417,12 +23617,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 96,
+  "downloads": 0,
   "id": "snekboard",
   "versions": [
    {
@@ -23514,7 +23714,6 @@
      "displayio",
      "errno",
      "fontio",
-     "gamepad",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -23536,12 +23735,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 100,
+  "downloads": 0,
   "id": "sparkfun_lumidrive",
   "versions": [
    {
@@ -23631,7 +23830,6 @@
      "displayio",
      "errno",
      "fontio",
-     "gamepad",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -23653,12 +23851,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 13,
+  "downloads": 0,
   "id": "sparkfun_micromod_rp2040",
   "versions": [
    {
@@ -23758,6 +23956,7 @@
      "_bleio",
      "_pixelbuf",
      "adafruit_bus_device",
+     "alarm",
      "analogio",
      "audiobusio",
      "audiocore",
@@ -23776,9 +23975,9 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "imagecapture",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -23809,12 +24008,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 118,
+  "downloads": 0,
   "id": "sparkfun_nrf52840_micromod",
   "versions": [
    {
@@ -23933,8 +24132,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -23965,12 +24164,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 103,
+  "downloads": 0,
   "id": "sparkfun_nrf52840_mini",
   "versions": [
    {
@@ -24089,8 +24288,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -24121,12 +24320,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 180,
+  "downloads": 0,
   "id": "sparkfun_pro_micro_rp2040",
   "versions": [
    {
@@ -24226,6 +24425,7 @@
      "_bleio",
      "_pixelbuf",
      "adafruit_bus_device",
+     "alarm",
      "analogio",
      "audiobusio",
      "audiocore",
@@ -24244,9 +24444,9 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "imagecapture",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -24277,12 +24477,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 32,
+  "downloads": 0,
   "id": "sparkfun_qwiic_micro_no_flash",
   "versions": [
    {
@@ -24377,12 +24577,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 110,
+  "downloads": 0,
   "id": "sparkfun_qwiic_micro_with_flash",
   "versions": [
    {
@@ -24477,12 +24677,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 116,
+  "downloads": 0,
   "id": "sparkfun_redboard_turbo",
   "versions": [
    {
@@ -24573,7 +24773,6 @@
      "displayio",
      "errno",
      "fontio",
-     "gamepad",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -24595,12 +24794,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 99,
+  "downloads": 0,
   "id": "sparkfun_samd21_dev",
   "versions": [
    {
@@ -24695,12 +24894,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 134,
+  "downloads": 0,
   "id": "sparkfun_samd21_mini",
   "versions": [
    {
@@ -24795,7 +24994,7 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
@@ -24846,9 +25045,9 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -24879,12 +25078,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 176,
+  "downloads": 0,
   "id": "sparkfun_samd51_thing_plus",
   "versions": [
    {
@@ -25004,9 +25203,9 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -25037,12 +25236,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 157,
+  "downloads": 0,
   "id": "sparkfun_thing_plus_rp2040",
   "versions": [
    {
@@ -25142,6 +25341,7 @@
      "_bleio",
      "_pixelbuf",
      "adafruit_bus_device",
+     "alarm",
      "analogio",
      "audiobusio",
      "audiocore",
@@ -25160,9 +25360,9 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "imagecapture",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -25193,12 +25393,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 124,
+  "downloads": 0,
   "id": "spresense",
   "versions": [
    {
@@ -25289,6 +25489,7 @@
      "errno",
      "gnss",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "os",
@@ -25307,12 +25508,12 @@
      "usb_cdc"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 137,
+  "downloads": 0,
   "id": "stackrduino_m0_pro",
   "versions": [
    {
@@ -25404,7 +25605,6 @@
      "displayio",
      "errno",
      "fontio",
-     "gamepad",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -25426,12 +25626,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 136,
+  "downloads": 0,
   "id": "stm32f411ce_blackpill",
   "versions": [
    {
@@ -25529,8 +25729,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -25548,19 +25748,18 @@
      "terminalio",
      "time",
      "touchio",
-     "ulab",
      "usb_cdc",
      "usb_hid",
      "usb_midi",
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 85,
+  "downloads": 0,
   "id": "stm32f411ce_blackpill_with_flash",
   "versions": [
    {
@@ -25657,8 +25856,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -25682,12 +25881,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 28,
+  "downloads": 0,
   "id": "stm32f411ve_discovery",
   "versions": [
    {
@@ -25785,7 +25984,6 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
      "math",
      "microcontroller",
@@ -25810,12 +26008,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 24,
+  "downloads": 0,
   "id": "stm32f412zg_discovery",
   "versions": [
    {
@@ -25916,8 +26114,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -25943,12 +26141,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 52,
+  "downloads": 0,
   "id": "stm32f4_discovery",
   "versions": [
    {
@@ -26053,8 +26251,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -26081,12 +26279,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 36,
+  "downloads": 0,
   "id": "stm32f746g_discovery",
   "versions": [
    {
@@ -26181,8 +26379,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -26206,12 +26404,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 87,
+  "downloads": 0,
   "id": "stringcar_m0_express",
   "versions": [
    {
@@ -26302,7 +26500,6 @@
      "displayio",
      "errno",
      "fontio",
-     "gamepad",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -26324,12 +26521,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 114,
+  "downloads": 0,
   "id": "targett_module_clip_wroom",
   "versions": [
    {
@@ -26439,6 +26636,7 @@
      "analogio",
      "audiobusio",
      "audiocore",
+     "audiomixer",
      "binascii",
      "bitbangio",
      "bitmaptools",
@@ -26453,9 +26651,10 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
+     "imagecapture",
      "ipaddress",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -26490,12 +26689,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 99,
+  "downloads": 0,
   "id": "targett_module_clip_wrover",
   "versions": [
    {
@@ -26605,6 +26804,7 @@
      "analogio",
      "audiobusio",
      "audiocore",
+     "audiomixer",
      "binascii",
      "bitbangio",
      "bitmaptools",
@@ -26619,9 +26819,10 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
+     "imagecapture",
      "ipaddress",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -26656,12 +26857,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 238,
+  "downloads": 0,
   "id": "teensy40",
   "versions": [
    {
@@ -26764,8 +26965,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -26791,12 +26992,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 247,
+  "downloads": 0,
   "id": "teensy41",
   "versions": [
    {
@@ -26899,8 +27100,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -26926,12 +27127,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 31,
+  "downloads": 0,
   "id": "teknikio_bluebird",
   "versions": [
    {
@@ -27050,8 +27251,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -27082,12 +27283,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 30,
+  "downloads": 0,
   "id": "thunderpack_v11",
   "versions": [
    {
@@ -27186,8 +27387,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -27213,12 +27414,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 28,
+  "downloads": 0,
   "id": "thunderpack_v12",
   "versions": [
    {
@@ -27318,8 +27519,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -27345,12 +27546,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 134,
+  "downloads": 0,
   "id": "tinkeringtech_scoutmakes_azul",
   "versions": [
    {
@@ -27469,8 +27670,8 @@
      "errno",
      "fontio",
      "framebufferio",
-     "gamepad",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -27501,12 +27702,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 254,
+  "downloads": 0,
   "id": "trellis_m4_express",
   "versions": [
    {
@@ -27624,9 +27825,9 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -27657,12 +27858,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 546,
+  "downloads": 0,
   "id": "trinket_m0",
   "versions": [
    {
@@ -27757,12 +27958,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 142,
+  "downloads": 0,
   "id": "trinket_m0_haxpress",
   "versions": [
    {
@@ -27854,7 +28055,6 @@
      "displayio",
      "errno",
      "fontio",
-     "gamepad",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -27876,12 +28076,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 78,
+  "downloads": 0,
   "id": "uartlogger2",
   "versions": [
    {
@@ -28001,9 +28201,9 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
      "i2cperipheral",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -28034,12 +28234,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 76,
+  "downloads": 0,
   "id": "uchip",
   "versions": [
    {
@@ -28136,12 +28336,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 87,
+  "downloads": 0,
   "id": "ugame10",
   "versions": [
    {
@@ -28243,12 +28443,12 @@
      "usb_cdc"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 436,
+  "downloads": 0,
   "id": "unexpectedmaker_feathers2",
   "versions": [
    {
@@ -28358,6 +28558,7 @@
      "analogio",
      "audiobusio",
      "audiocore",
+     "audiomixer",
      "binascii",
      "bitbangio",
      "bitmaptools",
@@ -28372,9 +28573,10 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
+     "imagecapture",
      "ipaddress",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -28409,12 +28611,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 45,
+  "downloads": 0,
   "id": "unexpectedmaker_feathers2_prerelease",
   "versions": [
    {
@@ -28524,6 +28726,7 @@
      "analogio",
      "audiobusio",
      "audiocore",
+     "audiomixer",
      "binascii",
      "bitbangio",
      "bitmaptools",
@@ -28538,9 +28741,10 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
+     "imagecapture",
      "ipaddress",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -28575,12 +28779,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 120,
+  "downloads": 0,
   "id": "unexpectedmaker_tinys2",
   "versions": [
    {
@@ -28690,6 +28894,7 @@
      "analogio",
      "audiobusio",
      "audiocore",
+     "audiomixer",
      "binascii",
      "bitbangio",
      "bitmaptools",
@@ -28704,9 +28909,10 @@
      "fontio",
      "framebufferio",
      "frequencyio",
-     "gamepad",
+     "imagecapture",
      "ipaddress",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -28741,12 +28947,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 121,
+  "downloads": 0,
   "id": "winterbloom_big_honking_button",
   "versions": [
    {
@@ -28845,12 +29051,12 @@
      "usb_cdc"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 105,
+  "downloads": 0,
   "id": "winterbloom_sol",
   "versions": [
    {
@@ -28943,6 +29149,7 @@
      "errno",
      "frequencyio",
      "json",
+     "keypad",
      "math",
      "microcontroller",
      "msgpack",
@@ -28965,12 +29172,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 104,
+  "downloads": 0,
   "id": "xinabox_cc03",
   "versions": [
    {
@@ -29056,12 +29263,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  },
  {
-  "downloads": 94,
+  "downloads": 0,
   "id": "xinabox_cs11",
   "versions": [
    {
@@ -29144,7 +29351,7 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "7.0.0-alpha.3"
+    "version": "7.0.0-alpha.4"
    }
   ]
  }

--- a/_data/files.json
+++ b/_data/files.json
@@ -1,6 +1,6 @@
 [
  {
-  "downloads": 0,
+  "downloads": 129,
   "id": "8086_commander",
   "versions": [
    {
@@ -102,7 +102,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 27,
   "id": "ADM_B_NRF52840_1",
   "versions": [
    {
@@ -258,7 +258,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 104,
   "id": "TG-Watch",
   "versions": [
    {
@@ -414,7 +414,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 104,
   "id": "adafruit_feather_esp32s2_nopsram",
   "versions": [
    {
@@ -582,7 +582,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 71,
   "id": "adafruit_feather_esp32s2_tftback_nopsram",
   "versions": [
    {
@@ -750,7 +750,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 459,
   "id": "adafruit_feather_rp2040",
   "versions": [
    {
@@ -907,7 +907,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 357,
   "id": "adafruit_funhouse",
   "versions": [
    {
@@ -1075,7 +1075,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 174,
   "id": "adafruit_itsybitsy_rp2040",
   "versions": [
    {
@@ -1232,7 +1232,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 135,
   "id": "adafruit_macropad_rp2040",
   "versions": [
    {
@@ -1317,7 +1317,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 422,
   "id": "adafruit_magtag_2.9_grayscale",
   "versions": [
    {
@@ -1485,7 +1485,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 174,
   "id": "adafruit_metro_esp32s2",
   "versions": [
    {
@@ -1653,7 +1653,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 176,
   "id": "adafruit_neokey_trinkey_m0",
   "versions": [
    {
@@ -1744,7 +1744,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 141,
   "id": "adafruit_proxlight_trinkey_m0",
   "versions": [
    {
@@ -1836,7 +1836,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 216,
   "id": "adafruit_qt2040_trinkey",
   "versions": [
    {
@@ -1993,7 +1993,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 332,
   "id": "adafruit_qtpy_rp2040",
   "versions": [
    {
@@ -2150,7 +2150,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 182,
   "id": "adafruit_rotary_trinkey_m0",
   "versions": [
    {
@@ -2243,7 +2243,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 154,
   "id": "adafruit_slide_trinkey_m0",
   "versions": [
    {
@@ -2336,7 +2336,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 111,
   "id": "aloriumtech_evo_m51",
   "versions": [
    {
@@ -2494,7 +2494,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 87,
   "id": "aramcon2_badge",
   "versions": [
    {
@@ -2650,7 +2650,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 106,
   "id": "aramcon_badge_2019",
   "versions": [
    {
@@ -2806,7 +2806,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 90,
   "id": "arduino_mkr1300",
   "versions": [
    {
@@ -2908,7 +2908,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 115,
   "id": "arduino_mkrzero",
   "versions": [
    {
@@ -3010,7 +3010,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 222,
   "id": "arduino_nano_33_ble",
   "versions": [
    {
@@ -3166,7 +3166,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 92,
   "id": "arduino_nano_33_iot",
   "versions": [
    {
@@ -3268,7 +3268,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 331,
   "id": "arduino_nano_rp2040_connect",
   "versions": [
    {
@@ -3425,7 +3425,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 141,
   "id": "arduino_zero",
   "versions": [
    {
@@ -3527,7 +3527,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 16,
   "id": "artisense_rd00",
   "versions": [
    {
@@ -3695,7 +3695,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 40,
   "id": "atmegazero_esp32s2",
   "versions": [
    {
@@ -3786,7 +3786,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 83,
   "id": "bast_pro_mini_m0",
   "versions": [
    {
@@ -3886,7 +3886,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 74,
   "id": "bastble",
   "versions": [
    {
@@ -4042,7 +4042,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 86,
   "id": "bdmicro_vina_d21",
   "versions": [
    {
@@ -4160,7 +4160,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 161,
   "id": "bdmicro_vina_d51",
   "versions": [
    {
@@ -4318,7 +4318,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 150,
   "id": "bdmicro_vina_d51_pcb7",
   "versions": [
    {
@@ -4476,7 +4476,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 188,
   "id": "bless_dev_board_multi_sensor",
   "versions": [
    {
@@ -4632,7 +4632,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 99,
   "id": "blm_badge",
   "versions": [
    {
@@ -4729,7 +4729,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 194,
   "id": "capablerobot_usbhub",
   "versions": [
    {
@@ -4885,7 +4885,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 142,
   "id": "catwan_usbstick",
   "versions": [
    {
@@ -4984,7 +4984,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 113,
   "id": "circuitbrains_basic_m0",
   "versions": [
    {
@@ -5103,7 +5103,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 105,
   "id": "circuitbrains_deluxe_m4",
   "versions": [
    {
@@ -5261,7 +5261,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 330,
   "id": "circuitplayground_bluefruit",
   "versions": [
    {
@@ -5417,7 +5417,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 591,
   "id": "circuitplayground_express",
   "versions": [
    {
@@ -5535,7 +5535,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 115,
   "id": "circuitplayground_express_4h",
   "versions": [
    {
@@ -5653,7 +5653,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 131,
   "id": "circuitplayground_express_crickit",
   "versions": [
    {
@@ -5766,7 +5766,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 108,
   "id": "circuitplayground_express_digikey_pycon2019",
   "versions": [
    {
@@ -5884,7 +5884,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 140,
   "id": "circuitplayground_express_displayio",
   "versions": [
    {
@@ -5994,7 +5994,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 303,
   "id": "clue_nrf52840_express",
   "versions": [
    {
@@ -6150,7 +6150,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 105,
   "id": "cp32-m4",
   "versions": [
    {
@@ -6306,7 +6306,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 119,
   "id": "cp_sapling_m0",
   "versions": [
    {
@@ -6406,7 +6406,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 89,
   "id": "cp_sapling_m0_revb",
   "versions": [
    {
@@ -6459,7 +6459,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 42,
   "id": "cp_sapling_m0_spiflash",
   "versions": [
    {
@@ -6573,7 +6573,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 165,
   "id": "cytron_maker_pi_rp2040",
   "versions": [
    {
@@ -6658,7 +6658,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 2,
   "id": "datalore_ip_m4",
   "versions": [
    {
@@ -6816,7 +6816,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 117,
   "id": "datum_distance",
   "versions": [
    {
@@ -6916,7 +6916,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 85,
   "id": "datum_imu",
   "versions": [
    {
@@ -7016,7 +7016,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 125,
   "id": "datum_light",
   "versions": [
    {
@@ -7116,7 +7116,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 72,
   "id": "datum_weather",
   "versions": [
    {
@@ -7216,7 +7216,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 92,
   "id": "dynalora_usb",
   "versions": [
    {
@@ -7317,7 +7317,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 131,
   "id": "dynossat_edu_eps",
   "versions": [
    {
@@ -7431,7 +7431,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 172,
   "id": "dynossat_edu_obc",
   "versions": [
    {
@@ -7589,7 +7589,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 100,
   "id": "edgebadge",
   "versions": [
    {
@@ -7752,7 +7752,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 41,
   "id": "electroniccats_bastwifi",
   "versions": [
    {
@@ -7918,7 +7918,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 133,
   "id": "electronut_labs_blip",
   "versions": [
    {
@@ -8077,7 +8077,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 120,
   "id": "electronut_labs_papyr",
   "versions": [
    {
@@ -8233,7 +8233,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 139,
   "id": "escornabot_makech",
   "versions": [
    {
@@ -8332,7 +8332,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 109,
   "id": "espressif_kaluga_1",
   "versions": [
    {
@@ -8589,7 +8589,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 171,
   "id": "espressif_saola_1_wroom",
   "versions": [
    {
@@ -8757,7 +8757,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 199,
   "id": "espressif_saola_1_wrover",
   "versions": [
    {
@@ -8925,7 +8925,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 18,
   "id": "espruino_pico",
   "versions": [
    {
@@ -9042,7 +9042,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 20,
   "id": "espruino_wifi",
   "versions": [
    {
@@ -9170,7 +9170,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 207,
   "id": "feather_bluefruit_sense",
   "versions": [
    {
@@ -9326,7 +9326,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 132,
   "id": "feather_m0_adalogger",
   "versions": [
    {
@@ -9428,7 +9428,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 102,
   "id": "feather_m0_basic",
   "versions": [
    {
@@ -9530,7 +9530,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 286,
   "id": "feather_m0_express",
   "versions": [
    {
@@ -9648,7 +9648,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 71,
   "id": "feather_m0_express_crickit",
   "versions": [
    {
@@ -9761,7 +9761,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 101,
   "id": "feather_m0_rfm69",
   "versions": [
    {
@@ -9852,7 +9852,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 107,
   "id": "feather_m0_rfm9x",
   "versions": [
    {
@@ -9943,7 +9943,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 83,
   "id": "feather_m0_supersized",
   "versions": [
    {
@@ -10061,7 +10061,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 69,
   "id": "feather_m4_can",
   "versions": [
    {
@@ -10219,7 +10219,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 472,
   "id": "feather_m4_express",
   "versions": [
    {
@@ -10377,7 +10377,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 83,
   "id": "feather_m7_1011",
   "versions": [
    {
@@ -10512,7 +10512,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 96,
   "id": "feather_mimxrt1011",
   "versions": [
    {
@@ -10647,7 +10647,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 97,
   "id": "feather_mimxrt1062",
   "versions": [
    {
@@ -10782,7 +10782,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 277,
   "id": "feather_nrf52840_express",
   "versions": [
    {
@@ -10938,7 +10938,7 @@
   ]
  },
  {
-  "downloads": 34,
+  "downloads": 2,
   "id": "feather_radiofruit_zigbee",
   "versions": [
    {
@@ -10998,7 +10998,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 72,
   "id": "feather_stm32f405_express",
   "versions": [
    {
@@ -11138,7 +11138,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 90,
   "id": "fluff_m0",
   "versions": [
    {
@@ -11238,7 +11238,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 147,
   "id": "fomu",
   "versions": [
    {
@@ -11339,7 +11339,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 65,
   "id": "franzininho_wifi_wroom",
   "versions": [
    {
@@ -11507,7 +11507,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 74,
   "id": "franzininho_wifi_wrover",
   "versions": [
    {
@@ -11675,7 +11675,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 270,
   "id": "gemma_m0",
   "versions": [
    {
@@ -11775,7 +11775,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 79,
   "id": "gemma_m0_pycon2018",
   "versions": [
    {
@@ -11875,7 +11875,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 241,
   "id": "grandcentral_m4_express",
   "versions": [
    {
@@ -12036,7 +12036,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 195,
   "id": "hallowing_m0_express",
   "versions": [
    {
@@ -12151,7 +12151,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 178,
   "id": "hallowing_m4_express",
   "versions": [
    {
@@ -12309,7 +12309,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 194,
   "id": "hiibot_bluefi",
   "versions": [
    {
@@ -12465,7 +12465,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 123,
   "id": "huntercat_nfc",
   "versions": [
    {
@@ -12570,7 +12570,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 137,
   "id": "ikigaisense_vita",
   "versions": [
    {
@@ -12726,7 +12726,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 103,
   "id": "imxrt1010_evk",
   "versions": [
    {
@@ -12861,7 +12861,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 123,
   "id": "imxrt1020_evk",
   "versions": [
    {
@@ -12996,7 +12996,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 136,
   "id": "imxrt1060_evk",
   "versions": [
    {
@@ -13131,7 +13131,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 256,
   "id": "itsybitsy_m0_express",
   "versions": [
    {
@@ -13246,7 +13246,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 237,
   "id": "itsybitsy_m4_express",
   "versions": [
    {
@@ -13402,7 +13402,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 217,
   "id": "itsybitsy_nrf52840_express",
   "versions": [
    {
@@ -13558,7 +13558,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 42,
   "id": "kicksat-sprite",
   "versions": [
    {
@@ -13687,7 +13687,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 141,
   "id": "lilygo_ttgo_t8_s2_st7789",
   "versions": [
    {
@@ -13855,7 +13855,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 41,
   "id": "loc_ber_m4_base_board",
   "versions": [
    {
@@ -13957,7 +13957,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 170,
   "id": "makerdiary_m60_keyboard",
   "versions": [
    {
@@ -14113,7 +14113,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 99,
   "id": "makerdiary_nrf52840_m2_devkit",
   "versions": [
    {
@@ -14269,7 +14269,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 131,
   "id": "makerdiary_nrf52840_mdk",
   "versions": [
    {
@@ -14425,7 +14425,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 129,
   "id": "makerdiary_nrf52840_mdk_usb_dongle",
   "versions": [
    {
@@ -14583,7 +14583,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 338,
   "id": "matrixportal_m4",
   "versions": [
    {
@@ -14741,7 +14741,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 195,
   "id": "meowbit_v121",
   "versions": [
    {
@@ -14871,7 +14871,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 97,
   "id": "meowmeow",
   "versions": [
    {
@@ -14968,7 +14968,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 254,
   "id": "metro_m0_express",
   "versions": [
    {
@@ -15086,7 +15086,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 215,
   "id": "metro_m4_airlift_lite",
   "versions": [
    {
@@ -15244,7 +15244,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 219,
   "id": "metro_m4_express",
   "versions": [
    {
@@ -15402,7 +15402,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 76,
   "id": "metro_m7_1011",
   "versions": [
    {
@@ -15537,7 +15537,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 156,
   "id": "metro_nrf52840_express",
   "versions": [
    {
@@ -15693,7 +15693,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 72,
   "id": "microdev_micro_s2",
   "versions": [
    {
@@ -15861,7 +15861,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 158,
   "id": "mini_sam_m4",
   "versions": [
    {
@@ -16017,7 +16017,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 249,
   "id": "monster_m4sk",
   "versions": [
    {
@@ -16175,7 +16175,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 273,
   "id": "muselab_nanoesp32_s2_wroom",
   "versions": [
    {
@@ -16343,7 +16343,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 225,
   "id": "muselab_nanoesp32_s2_wrover",
   "versions": [
    {
@@ -16511,7 +16511,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 110,
   "id": "ndgarage_ndbit6",
   "versions": [
    {
@@ -16611,7 +16611,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 19,
   "id": "ndgarage_ndbit6_v2",
   "versions": [
    {
@@ -16711,7 +16711,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 278,
   "id": "neopixel_trinkey_m0",
   "versions": [
    {
@@ -16802,7 +16802,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 171,
   "id": "nfc_copy_cat",
   "versions": [
    {
@@ -16902,7 +16902,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 162,
   "id": "nice_nano",
   "versions": [
    {
@@ -17058,7 +17058,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 18,
   "id": "nucleo_f746zg",
   "versions": [
    {
@@ -17183,7 +17183,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 16,
   "id": "nucleo_f767zi",
   "versions": [
    {
@@ -17308,7 +17308,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 24,
   "id": "nucleo_h743zi_2",
   "versions": [
    {
@@ -17429,7 +17429,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 132,
   "id": "ohs2020_badge",
   "versions": [
    {
@@ -17585,7 +17585,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 134,
   "id": "openbook_m4",
   "versions": [
    {
@@ -17745,7 +17745,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 16,
   "id": "openmv_h7",
   "versions": [
    {
@@ -17866,7 +17866,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 106,
   "id": "particle_argon",
   "versions": [
    {
@@ -18022,7 +18022,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 52,
   "id": "particle_boron",
   "versions": [
    {
@@ -18178,7 +18178,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 138,
   "id": "particle_xenon",
   "versions": [
    {
@@ -18334,7 +18334,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 115,
   "id": "pca10056",
   "versions": [
    {
@@ -18492,7 +18492,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 152,
   "id": "pca10059",
   "versions": [
    {
@@ -18650,7 +18650,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 117,
   "id": "pca10100",
   "versions": [
    {
@@ -18763,7 +18763,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 37,
   "id": "pewpew10",
   "versions": [
    {
@@ -18859,7 +18859,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 159,
   "id": "pewpew13",
   "versions": [
    {
@@ -18955,7 +18955,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 124,
   "id": "pewpew_m4",
   "versions": [
    {
@@ -19058,7 +19058,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 76,
   "id": "picoplanet",
   "versions": [
    {
@@ -19158,7 +19158,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 220,
   "id": "pimoroni_keybow2040",
   "versions": [
    {
@@ -19400,7 +19400,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 196,
   "id": "pimoroni_picolipo_16mb",
   "versions": [
    {
@@ -19557,7 +19557,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 143,
   "id": "pimoroni_picolipo_4mb",
   "versions": [
    {
@@ -19714,7 +19714,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 137,
   "id": "pimoroni_picosystem",
   "versions": [
    {
@@ -19871,7 +19871,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 255,
   "id": "pimoroni_tiny2040",
   "versions": [
    {
@@ -20028,7 +20028,7 @@
   ]
  },
  {
-  "downloads": 101,
+  "downloads": 71,
   "id": "pirkey_m0",
   "versions": [
    {
@@ -20075,7 +20075,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 109,
   "id": "pitaya_go",
   "versions": [
    {
@@ -20231,7 +20231,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 19,
   "id": "pyb_nano_v2",
   "versions": [
    {
@@ -20358,7 +20358,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 174,
   "id": "pybadge",
   "versions": [
    {
@@ -20521,7 +20521,7 @@
   ]
  },
  {
-  "downloads": 125,
+  "downloads": 74,
   "id": "pybadge_airlift",
   "versions": [
    {
@@ -20603,7 +20603,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 53,
   "id": "pyboard_v11",
   "versions": [
    {
@@ -20743,7 +20743,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 144,
   "id": "pycubed",
   "versions": [
    {
@@ -20880,7 +20880,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 131,
   "id": "pycubed_mram",
   "versions": [
    {
@@ -21017,7 +21017,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 290,
   "id": "pygamer",
   "versions": [
    {
@@ -21180,7 +21180,7 @@
   ]
  },
  {
-  "downloads": 99,
+  "downloads": 106,
   "id": "pygamer_advance",
   "versions": [
    {
@@ -21262,7 +21262,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 292,
   "id": "pyportal",
   "versions": [
    {
@@ -21420,7 +21420,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 157,
   "id": "pyportal_pynt",
   "versions": [
    {
@@ -21578,7 +21578,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 250,
   "id": "pyportal_titano",
   "versions": [
    {
@@ -21736,7 +21736,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 183,
   "id": "pyruler",
   "versions": [
    {
@@ -21835,7 +21835,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 314,
   "id": "qtpy_m0",
   "versions": [
    {
@@ -21935,7 +21935,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 227,
   "id": "qtpy_m0_haxpress",
   "versions": [
    {
@@ -22053,7 +22053,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 1690,
   "id": "raspberry_pi_pico",
   "versions": [
    {
@@ -22210,7 +22210,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 82,
   "id": "raytac_mdbt50q-db-40",
   "versions": [
    {
@@ -22366,7 +22366,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 143,
   "id": "robohatmm1_m4",
   "versions": [
    {
@@ -22505,7 +22505,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 115,
   "id": "sam32",
   "versions": [
    {
@@ -22663,7 +22663,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 128,
   "id": "same54_xplained",
   "versions": [
    {
@@ -22821,7 +22821,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 312,
   "id": "seeeduino_wio_terminal",
   "versions": [
    {
@@ -22979,7 +22979,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 490,
   "id": "seeeduino_xiao",
   "versions": [
    {
@@ -23079,7 +23079,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 79,
   "id": "sensebox_mcu",
   "versions": [
    {
@@ -23132,7 +23132,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 148,
   "id": "serpente",
   "versions": [
    {
@@ -23253,7 +23253,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 150,
   "id": "shirtty",
   "versions": [
    {
@@ -23353,7 +23353,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 114,
   "id": "silicognition-m4-shim",
   "versions": [
    {
@@ -23511,7 +23511,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 140,
   "id": "simmel",
   "versions": [
    {
@@ -23622,7 +23622,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 127,
   "id": "snekboard",
   "versions": [
    {
@@ -23740,7 +23740,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 123,
   "id": "sparkfun_lumidrive",
   "versions": [
    {
@@ -23856,7 +23856,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 125,
   "id": "sparkfun_micromod_rp2040",
   "versions": [
    {
@@ -24013,7 +24013,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 115,
   "id": "sparkfun_nrf52840_micromod",
   "versions": [
    {
@@ -24169,7 +24169,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 106,
   "id": "sparkfun_nrf52840_mini",
   "versions": [
    {
@@ -24325,7 +24325,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 146,
   "id": "sparkfun_pro_micro_rp2040",
   "versions": [
    {
@@ -24482,7 +24482,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 87,
   "id": "sparkfun_qwiic_micro_no_flash",
   "versions": [
    {
@@ -24582,7 +24582,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 87,
   "id": "sparkfun_qwiic_micro_with_flash",
   "versions": [
    {
@@ -24682,7 +24682,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 78,
   "id": "sparkfun_redboard_turbo",
   "versions": [
    {
@@ -24799,7 +24799,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 147,
   "id": "sparkfun_samd21_dev",
   "versions": [
    {
@@ -24899,7 +24899,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 145,
   "id": "sparkfun_samd21_mini",
   "versions": [
    {
@@ -24999,7 +24999,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 100,
   "id": "sparkfun_samd51_micromod",
   "versions": [
    {
@@ -25083,7 +25083,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 178,
   "id": "sparkfun_samd51_thing_plus",
   "versions": [
    {
@@ -25241,7 +25241,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 187,
   "id": "sparkfun_thing_plus_rp2040",
   "versions": [
    {
@@ -25398,7 +25398,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 133,
   "id": "spresense",
   "versions": [
    {
@@ -25513,7 +25513,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 117,
   "id": "stackrduino_m0_pro",
   "versions": [
    {
@@ -25631,7 +25631,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 72,
   "id": "stm32f411ce_blackpill",
   "versions": [
    {
@@ -25759,7 +25759,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 37,
   "id": "stm32f411ce_blackpill_with_flash",
   "versions": [
    {
@@ -25886,7 +25886,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 23,
   "id": "stm32f411ve_discovery",
   "versions": [
    {
@@ -26013,7 +26013,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 19,
   "id": "stm32f412zg_discovery",
   "versions": [
    {
@@ -26146,7 +26146,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 31,
   "id": "stm32f4_discovery",
   "versions": [
    {
@@ -26284,7 +26284,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 25,
   "id": "stm32f746g_discovery",
   "versions": [
    {
@@ -26409,7 +26409,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 152,
   "id": "stringcar_m0_express",
   "versions": [
    {
@@ -26526,7 +26526,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 79,
   "id": "targett_module_clip_wroom",
   "versions": [
    {
@@ -26694,7 +26694,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 74,
   "id": "targett_module_clip_wrover",
   "versions": [
    {
@@ -26862,7 +26862,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 221,
   "id": "teensy40",
   "versions": [
    {
@@ -26997,7 +26997,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 221,
   "id": "teensy41",
   "versions": [
    {
@@ -27132,7 +27132,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 139,
   "id": "teknikio_bluebird",
   "versions": [
    {
@@ -27288,7 +27288,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 13,
   "id": "thunderpack_v11",
   "versions": [
    {
@@ -27419,7 +27419,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 13,
   "id": "thunderpack_v12",
   "versions": [
    {
@@ -27551,7 +27551,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 145,
   "id": "tinkeringtech_scoutmakes_azul",
   "versions": [
    {
@@ -27707,7 +27707,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 206,
   "id": "trellis_m4_express",
   "versions": [
    {
@@ -27863,7 +27863,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 458,
   "id": "trinket_m0",
   "versions": [
    {
@@ -27963,7 +27963,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 151,
   "id": "trinket_m0_haxpress",
   "versions": [
    {
@@ -28081,7 +28081,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 9,
   "id": "uartlogger2",
   "versions": [
    {
@@ -28239,7 +28239,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 112,
   "id": "uchip",
   "versions": [
    {
@@ -28341,7 +28341,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 60,
   "id": "ugame10",
   "versions": [
    {
@@ -28448,7 +28448,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 279,
   "id": "unexpectedmaker_feathers2",
   "versions": [
    {
@@ -28616,7 +28616,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 35,
   "id": "unexpectedmaker_feathers2_prerelease",
   "versions": [
    {
@@ -28784,7 +28784,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 101,
   "id": "unexpectedmaker_tinys2",
   "versions": [
    {
@@ -28952,7 +28952,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 125,
   "id": "winterbloom_big_honking_button",
   "versions": [
    {
@@ -29056,7 +29056,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 158,
   "id": "winterbloom_sol",
   "versions": [
    {
@@ -29177,7 +29177,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 112,
   "id": "xinabox_cc03",
   "versions": [
    {
@@ -29268,7 +29268,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 103,
   "id": "xinabox_cs11",
   "versions": [
    {


### PR DESCRIPTION
Automated website update for release 7.0.0-alpha.4 by Blinka.

New boards:
* espressif_kaluga_1.3
* pimoroni_pga2040


