### PR TITLE
Add USB-C as a feature filter

### DIFF
--- a/_board/TG-Watch.md
+++ b/_board/TG-Watch.md
@@ -11,6 +11,7 @@ features:
   - Display
   - Bluetooth/BTLE
   - Battery Charging
+  - USB-C
 ---
 
 Why buy an apple watch when you can spend your weekends building a microcontroller based "smart" watch instead? the TG-Watch is an open source, not-dumb watch meant for makers who want to hack on their watch, people who want to bring python with them everywhere, or as a great starting point to learn about programming.

--- a/_board/adafruit_feather_esp32s2_nopsram.md
+++ b/_board/adafruit_feather_esp32s2_nopsram.md
@@ -8,7 +8,7 @@ board_url: ""
 board_image: "adafruit_feather_esp32s2_nopsram.jpg"
 date_added: 2021-4-6
 features:
-
+  - USB-C
 ---
 
 Coming Soon!

--- a/_board/adafruit_feather_rp2040.md
+++ b/_board/adafruit_feather_rp2040.md
@@ -10,6 +10,7 @@ date_added: 2021-1-21
 features:
   - Feather-Compatible
   - Battery Charging
+  - USB-C
 ---
 
 A new chip means a new Feather, and the Raspberry Pi RP2040 is no exception. When we saw this chip we thought "this chip is going to be awesome when we give it the Feather Treatment" and so we did! This Feather features the **RP2040**, and all niceties you know and love about Feather

--- a/_board/adafruit_funhouse.md
+++ b/_board/adafruit_funhouse.md
@@ -12,6 +12,7 @@ features:
   - STEMMA QT/QWIIC
   - Speaker
   - Display
+  - USB-C
 ---
 
 Home is where the heart is...it's also where all we keep all our electronic bits. So why not wire it up with sensors and actuators to turn our house into an electronic wonderland. Whether it's tracking the environmental temperature and humidity in your laundry room, or notifying you when someone is detected in the kitchen, to sensing when a window was left open, or logging when your cat leaves through the pet door, this board is designed to make it way easy to make WiFi-connected home automation projects.

--- a/_board/adafruit_macropad_rp2040.md
+++ b/_board/adafruit_macropad_rp2040.md
@@ -8,7 +8,7 @@ board_url: "https://www.adafruit.com/product/5128"
 board_image: "adafruit_macropad_rp2040.jpg"
 date_added: 2021-6-4
 features:
-
+  - USB-C
 ---
 
 Strap yourself in, we're launching in T-minus 10 seconds...Destination? A new Class M planet called MACROPAD! M here, stands for Microcontroller because this 3x4 keyboard controller features the newest technology from the Raspberry Pi sector: say hello to the RP2040. It's speedy little microcontroller with lots of GPIO pins and a 64 times more RAM than the Apollo Guidance Computer. We added 8 MB of flash memory for plenty of storage.

--- a/_board/adafruit_magtag_2.9_grayscale.md
+++ b/_board/adafruit_magtag_2.9_grayscale.md
@@ -13,6 +13,7 @@ features:
   - STEMMA QT/QWIIC
   - Speaker
   - Display
+  - USB-C
 ---
 
 The Adafruit MagTag combines the new ESP32-S2 wireless module and a 2.9" grayscale E-Ink display to make a low-power IoT display that can show data on its screen even when power is removed! The ESP32-S2 is great because it builds on the years of code and support for the ESP32 and also adds native USB support so you can use this board with Arduino _or_ CircuitPython!

--- a/_board/adafruit_metro_esp32s2.md
+++ b/_board/adafruit_metro_esp32s2.md
@@ -11,6 +11,7 @@ features:
   - Wi-Fi
   - Battery Charging
   - STEMMA QT/QWIIC
+  - USB-C
 ---
 
 What's Metro shaped and has an ESP32-S2 WiFi module? What has a STEMMA QT connector for I2C devices, and a Lipoly charger circuit? What's finishing up testing and nearly ready for fabrication? That's right - its the new Adafruit Metro ESP32-S2! With native USB and a load of PSRAM this board is perfect for use with CircuitPython or Arduino, to add low-cost WiFi while keeping shield-compatibility

--- a/_board/adafruit_qtpy_rp2040.md
+++ b/_board/adafruit_qtpy_rp2040.md
@@ -9,6 +9,7 @@ board_image: "adafruit_qtpy_rp2040.jpg"
 date_added: 2021-4-6
 features:
   - STEMMA QT/QWIIC
+  - USB-C
 ---
 
 What a cutie pie! Or is it... a QT Py? This diminutive dev board comes with one of our new favorite chip, the RP2040. It's been made famous in the new [Raspberry Pi Pico](https://www.adafruit.com/pico) *and* our [Feather RP2040](http://www.adafruit.com/product/4884) and [ItsyBitsy RP2040](http://www.adafruit.com/product/4888), but what if we wanted something really *smol?*

--- a/_board/arduino_nano_rp2040_connect.md
+++ b/_board/arduino_nano_rp2040_connect.md
@@ -8,8 +8,8 @@ board_url: ""
 board_image: "arduino_nano_rp2040_connect.jpg"
 date_added: 2021-5-24
 features:
-    Wi-Fi
-    Bluetooth/BTLE
+  - Wi-Fi
+  - Bluetooth/BTLE
 ---
 
 Meet the only connected RP2040 board. It fits the Arduino Nano form factor, making it a small board with BIG features.

--- a/_board/bastble.md
+++ b/_board/bastble.md
@@ -12,6 +12,7 @@ features:
   - Feather-Compatible
   - Bluetooth/BTLE
   - Battery Charging
+  - USB-C
 ---
 
 The Bast BLE is the new Feather family member with Bluetooth Low Energy and native USB-C support featuring the nRF52840!  

--- a/_board/blm_badge.md
+++ b/_board/blm_badge.md
@@ -9,6 +9,7 @@ board_image: "blmbadge.jpg"
 date_added: 2020-9-1
 features:
   - STEMMA QT/QWIIC
+  - USB-C
 ---
 
 The Black Lives Matter Education & Workshop Kit is an open-source design the Adafruit team published during the peaceful demonstrations for social justice in the summer of 2020 (https://github.com/adafruit/BLM-Badge-PCB). As a company and culture we came together to make our voices heard, share the pain we all had, the anger, and then work together for equality and justice in our communities (https://www.adafruit.com/blacklivesmatter). We listened to each other, we marched, we donated our time, resources, we distributed PPE at community events, we came together.

--- a/_board/dynossat_edu_eps.md
+++ b/_board/dynossat_edu_eps.md
@@ -7,6 +7,9 @@ manufacturer: "BH Dynamics"
 board_url: "https://bhdyn.com/newspace"
 board_image: "dynossat_edu_eps.jpg"
 downloads_display: true
+
+features:
+  - USB-C
 ---
 
 DynOSSAT-EDU is the first open source PocketQube educational kit compatible with CircuitPython and Arduino.

--- a/_board/dynossat_edu_obc.md
+++ b/_board/dynossat_edu_obc.md
@@ -7,6 +7,9 @@ manufacturer: "BH Dynamics"
 board_url: "https://bhdyn.com/newspace"
 board_image: "dynossat_edu_obc.jpg"
 downloads_display: true
+
+features:
+  - USB-C
 ---
 
 DynOSSAT-EDU is the first open source PocketQube educational kit compatible with CircuitPython and Arduino.

--- a/_board/electroniccats_bastwifi.md
+++ b/_board/electroniccats_bastwifi.md
@@ -12,6 +12,7 @@ features:
   - Feather-Compatible
   - Wi-Fi
   - Battery Charging
+  - USB-C
 
 ---
 

--- a/_board/feather_m4_can.md
+++ b/_board/feather_m4_can.md
@@ -10,6 +10,7 @@ date_added: 2020-9-28
 features:
   - Feather-Compatible
   - Battery Charging
+  - USB-C
 ---
  
 One of our favorite Feathers, the Feather M4 Express, gets a glow-up here with an upgrade to the SAME51 chipset which has built-in CAN bus support! Like its SAMD51 cousin, the ATSAME51J19 comes with a 120MHz Cortex M4 with floating point support and 512KB Flash and 192KB RAM. Your code will zig and zag and zoom, and with a bunch of extra peripherals for support, this will for sure be your favorite new chipset for CAN interfacing projects.

--- a/_board/feather_m7_1011.md
+++ b/_board/feather_m7_1011.md
@@ -11,6 +11,7 @@ features:
   - Feather-Compatible
   - Battery Charging
   - STEMMA QT/QWIIC
+  - USB-C
 ---
 
 Coming Soon!

--- a/_board/feather_mimxrt1011.md
+++ b/_board/feather_mimxrt1011.md
@@ -10,6 +10,7 @@ date_added: 2020-1-8
 features:
   - Feather-Compatible
   - Battery Charging
+  - USB-C
 
 ---
 

--- a/_board/feather_mimxrt1062.md
+++ b/_board/feather_mimxrt1062.md
@@ -10,6 +10,7 @@ date_added: 2020-1-8
 features:
   - Feather-Compatible
   - Battery Charging
+  - USB-C
 
 ---
 

--- a/_board/feather_stm32f405_express.md
+++ b/_board/feather_stm32f405_express.md
@@ -11,6 +11,7 @@ features:
   - Feather-Compatible
   - Battery Charging
   - STEMMA QT/QWIIC
+  - USB-C
 ---
 
 ST takes flight in this upcoming Feather board. The new STM32F405 Feather (video) that we designed runs CircuitPython at a blistering 168MHz – our fastest CircuitPython board ever! We put a STEMMA QT / Qwiic port on the end, so you can really easily plug and play I2C sensors.

--- a/_board/fluff_m0.md
+++ b/_board/fluff_m0.md
@@ -7,6 +7,9 @@ manufacturer: "Radomir Dopieralski"
 board_url: "https://hackaday.io/project/171381-fluff-m0"
 board_image: "fluff_m0.jpg"
 date_added: 2020-5-22
+
+features:
+  - USB-C
 ---
 A minimal CircuitPython board compatible with the Feather M0 Basic. Everything
 that is non-essential has been removed, and the smallest possible chip is used.

--- a/_board/hiibot_iots2.md
+++ b/_board/hiibot_iots2.md
@@ -12,6 +12,7 @@ features:
   - Wi-Fi
   - Battery Charging
   - STEMMA QT/QWIIC
+  - USB-C
 ---
 
 Introducing the microS2 - An ESP32-S2 based development board with smaller size (25.4*45.9mm). Features:

--- a/_board/huntercat_nfc.md
+++ b/_board/huntercat_nfc.md
@@ -8,6 +8,7 @@ board_url: "https://electroniccats.com/store/hunter-cat-nfc/"
 board_image: "huntercat_nfc.jpg"
 date_added: 2021-5-26
 features:
+  - USB-C
 ---
 
 The Hunter Cat NFC is the latest security tool for contactless (Near Field Communication) used in access control, identification and bank cards. Specially created to identify NFC readers and sniffing tools, with this tool you can audit, read or emulate cards of different types. 

--- a/_board/lilygo_ttgo_t8_s2_st7789.md
+++ b/_board/lilygo_ttgo_t8_s2_st7789.md
@@ -10,6 +10,7 @@ features:
   - Wi-Fi
   - Display 
   - Battery Charging
+  - USB-C
 ---
 
 **Features & Specifications:**

--- a/_board/makerdiary_m60_keyboard.md
+++ b/_board/makerdiary_m60_keyboard.md
@@ -9,6 +9,7 @@ board_image: "makerdiary_m60_keyboard.jpg"
 date_added: 2020-07-27
 features:
   - Bluetooth/BTLE
+  - USB-C
   
 ---
 

--- a/_board/makerdiary_nrf52840_m2_devkit.md
+++ b/_board/makerdiary_nrf52840_m2_devkit.md
@@ -11,6 +11,7 @@ features:
   - Bluetooth/BTLE
   - Display
   - Battery Charging
+  - USB-C
 ---
 
 nRF52840 M.2 Developer Kit is a versatile IoT prototyping platform, including the nRF52840 M.2 Module and M.2 Dock. You can use the developer kit to prototype your IoT products and then scale to production faster using the nRF52840 M.2 Module combined with your custom PCB hardware.

--- a/_board/makerdiary_nrf52840_mdk.md
+++ b/_board/makerdiary_nrf52840_mdk.md
@@ -9,6 +9,7 @@ board_image: "nRF52840_micro_dev_kit.jpg"
 date_added: 2019-3-9
 features:
   - Bluetooth/BTLE
+  - USB-C
 ---
 
 The nRF52840-MDK is a versatile, easy-to-use IoT hardware platform for Bluetooth 5, Bluetooth Mesh, Thread, IEEE 802.15.4, ANT and 2.4GHz proprietary wireless applications using the nRF52840 SoC.

--- a/_board/matrixportal_m4.md
+++ b/_board/matrixportal_m4.md
@@ -11,6 +11,7 @@ features:
   - Display
   - Wi-Fi
   - STEMMA QT/QWIIC
+  - USB-C
 ---
 
 Folks love our [wide selection of RGB matrices](https://www.adafruit.com/category/327) and accessories, for making custom colorful LED displays... and our RGB Matrix Shields and FeatherWings can be quickly soldered together to make the wiring much easier. But what if we made it even easier than that? **Like, no solder, no wiring, just instant plug-and-play?** Dream no more - with the **Adafruit Matrix Portal add-on for RGB Matrices**, there's never been an easier way to create powerful Internet-connected LED displays.

--- a/_board/metro_m7_1011.md
+++ b/_board/metro_m7_1011.md
@@ -10,6 +10,7 @@ date_added: 2020-10-16
 features:
   - Wi-Fi
   - STEMMA QT/QWIIC
+  - USB-C
 ---
 
 Watch Adafruit's Ask an Engineer on YouTube to learn more. 

--- a/_board/metro_nrf52840_express.md
+++ b/_board/metro_nrf52840_express.md
@@ -9,6 +9,7 @@ board_image: "metro_nrf52840_express.png"
 date_added: 2019-8-30
 features:
   - Bluetooth/BTLE
+  - USB-C
 ---
 
 The **Adafruit Metro nRF52840 Express** is a new Metro family member with Bluetooth Low Energy and _native USB support_ featuring the nRF52840! 

--- a/_board/muselab_nanoesp32_s2_wroom.md
+++ b/_board/muselab_nanoesp32_s2_wroom.md
@@ -7,6 +7,9 @@ manufacturer: "Muselab"
 board_url: "https://www.muselab-tech.com/nanoesp32-s2kai-fa-ban/"
 board_image: "muselab_nanoesp32_s2.jpg"
 date_added: 2020-09-16
+
+features:
+  - USB-C
 ---
 
 This is the nanoESP32-S2 board with a WROOM ESP32-S2 module.

--- a/_board/muselab_nanoesp32_s2_wrover.md
+++ b/_board/muselab_nanoesp32_s2_wrover.md
@@ -7,6 +7,9 @@ manufacturer: "Muselab"
 board_url: "https://www.muselab-tech.com/nanoesp32-s2kai-fa-ban/"
 board_image: "muselab_nanoesp32_s2.jpg"
 date_added: 2020-09-16
+
+features:
+  - USB-C
 ---
 
 This is the nanoESP32-S2 board with a WROVER ESP32-S2 module.

--- a/_board/nice_nano.md
+++ b/_board/nice_nano.md
@@ -7,6 +7,9 @@ manufacturer: "Nice Keyboards"
 board_url: "https://docs.nicekeyboards.com/#/nice!nano/"
 board_image: "nice_nano.jpg"
 date_added: 2020-06-05
+
+features: 
+  - USB-C
 ---
 
 ## Learn More

--- a/_board/picoplanet.md
+++ b/_board/picoplanet.md
@@ -10,6 +10,9 @@ date_added: 2020-3-31
 downloads_display: true
 blinka: false
 download_instructions: ""
+
+features:
+  - USB-C
 ---
 
 PicoPlanet is a procedurally generated series of PCBs. The three planets act as capacitive touch buttons. The board also has a RGB LED on top, a USB-C connector and 4 more pin pads on the bottom. The board's brain is a powerful SAMD21. The design also has stars that are not covered by  copper or soldermask and are perfect spots to place more LEDs.

--- a/_board/pimoroni_keybow2040.md
+++ b/_board/pimoroni_keybow2040.md
@@ -7,6 +7,8 @@ manufacturer: "Pimoroni"
 board_url: "https://shop.pimoroni.com/products/keybow-2040"
 board_image: "pimoroni_keybow2040.jpg"
 date_added: 2021-2-24
+features:
+  - USB-C
 ---
 
 A luxe 16 key USB-C keyboard with tactile mechanical switches and fully customisable RGB lighting, ideal for custom macro pads, midi controllers and stream decks. RP2040 gives Keybow 2040 low latency input, zero boot time and a new, compact footprint.

--- a/_board/pimoroni_picolipo_16mb.md
+++ b/_board/pimoroni_picolipo_16mb.md
@@ -9,6 +9,7 @@ board_image: "pimoroni_picolipo.jpg"
 date_added: 2021-5-12
 features:
   - Battery Charging
+  - USB-C
 ---
 
 A top of the line Pirate-brand RP2040-powered microcontroller with all the extras - lots of flash memory, USB-C, STEMMA QT/Qwiic and debug connectors... and onboard LiPo charging! Pimoroni Pico boards add extra functionality whilst keeping to the Pico footprint, ensuring compatibility with existing Pico addons.

--- a/_board/pimoroni_picolipo_4mb.md
+++ b/_board/pimoroni_picolipo_4mb.md
@@ -9,6 +9,7 @@ board_image: "pimoroni_picolipo.jpg"
 date_added: 2021-5-12
 features:
   - Battery Charging
+  - USB-C
 ---
 
 A top of the line Pirate-brand RP2040-powered microcontroller with all the extras - lots of flash memory, USB-C, STEMMA QT/Qwiic and debug connectors... and onboard LiPo charging! Pimoroni Pico boards add extra functionality whilst keeping to the Pico footprint, ensuring compatibility with existing Pico addons.

--- a/_board/pimoroni_picosystem.md
+++ b/_board/pimoroni_picosystem.md
@@ -11,6 +11,7 @@ features:
   - Speaker
   - Battery Charging
   - Display
+  - USB-C
 ---
 
 An all-in-one pocket sized games console with RP2040 at its heart, ready for filling up with all the most fun pixels! PicoSystem has a nice tactile joypad and buttons, a vibrant 240x240 screen and a lipo battery, neatly wrapped up in some shiny abstract PCB art.

--- a/_board/pimoroni_tiny2040.md
+++ b/_board/pimoroni_tiny2040.md
@@ -7,6 +7,9 @@ manufacturer: "Pimoroni"
 board_url: "https://shop.pimoroni.com/products/tiny-2040"
 board_image: "pimoroni_tiny2040.jpg"
 date_added: 2021-2-24
+
+features:
+  - USB-C
 ---
 
 A postage stamp sized RP2040 development board with a USB-C connection, perfect for portable projects, wearables, and embedding into devices. Tiny 2040 comes with 8MB of QSPI (XiP) flash on board so it can handle projects small and large with ease.

--- a/_board/pitaya_go.md
+++ b/_board/pitaya_go.md
@@ -9,6 +9,7 @@ board_image: "pitaya_go.jpg"
 date_added: 2019-05-11
 features:
   - Bluetooth/BTLE
+  - USB-C
 ---
 
 BLE and Wifi board in a small for factor.

--- a/_board/pyportal_titano.md
+++ b/_board/pyportal_titano.md
@@ -11,6 +11,7 @@ features:
   - Display
   - Speaker
   - Wi-Fi
+  - USB-C
 ---
 
 The **PyPortal Titano** is the big sister to our [popular PyPortal](https://www.adafruit.com/product/4116) now with _twice as many pixels!_ The PyPortal is our easy-to-use IoT device that allows you to create all the things for the “Internet of Things” in minutes. Make custom touch screen interface GUIs, all open-source, and Python-powered using tinyJSON / APIs to get news, stock, weather, cat photos, and more – all over Wi-Fi with the latest technologies. Create little pocket universes of joy that connect to something good. Rotate it 90 degrees, it’s a web-connected conference badge #badgelife.

--- a/_board/qtpy_m0.md
+++ b/_board/qtpy_m0.md
@@ -9,6 +9,7 @@ board_image: "qtpy_m0.jpg"
 date_added: 2020-9-28
 features:
   - STEMMA QT/QWIIC
+  - USB-C
 ---
 
 > **Note:** If you soldered the [optional SOIC-8 SPI Flash chip](https://www.adafruit.com/product/4763) on to your QT Py, see the ["QT Py Haxpress"](../qtpy_m0_haxpress/) page to make use of the extra space!

--- a/_board/qtpy_m0_haxpress.md
+++ b/_board/qtpy_m0_haxpress.md
@@ -9,6 +9,7 @@ board_image: "qtpy_m0_haxpress.jpg"
 date_added: 2020-9-28
 features:
   - STEMMA QT/QWIIC
+  - USB-C
 
 ---
 

--- a/_board/seeeduino_wio_terminal.md
+++ b/_board/seeeduino_wio_terminal.md
@@ -8,7 +8,8 @@ board_url: "https://www.seeedstudio.com/Wio-Terminal-p-4509.html"
 board_image: "seeeduino_wio_terminal.jpg"
 date_added: 2020-7-3
 features:
-    Display
+    - Display
+    - USB-C
 ---
 
 Instead of being a single embedded functional module, **Wio Terminal** is more of a complete system equipped with Screen + Development Board + Input/Output Interface + Enclosure. Because it uses the SAMD51, it is compatible with Arduino and CircuitPython - using the same Arduino & CircuitPython core we have developed here at Adafruit!

--- a/_board/seeeduino_xiao.md
+++ b/_board/seeeduino_xiao.md
@@ -7,6 +7,9 @@ manufacturer: "SEEED"
 board_url: "https://wiki.seeedstudio.com/Seeeduino-XIAO/"
 board_image: "seeeduino_xiao.jpg"
 date_added: 2020-1-17
+
+features:
+  - USB-C
 ---
 # Seeduino XIAO:
 SEEED Studio's Seeeduino XIAO is a minimal, low-cost board that uses the Atmel ATSAMD21G18, a powerful 32-bit ARM Cortex®-M0+ processor running at 48MHz with 256KB Flash and 32KB SRAM.  The board is 20 x 17.5mm in size which is perfect for wearable devices and small projects. It has multiple interfaces including DAC output, SWD Bonding pad interface, I2C, UART and SPI interfaces. It's compatible with both Arduino IDE and CircuitPython and uses a USB-C connector.

--- a/_board/sensebox_mcu.md
+++ b/_board/sensebox_mcu.md
@@ -7,6 +7,9 @@ manufacturer: "senseBox"
 board_url: "https://docs.sensebox.de/hardware/allgemein-sensebox-mcu/"
 board_image: "sensebox_mcu.jpg"
 date_added: 2021-4-12
+
+features:
+  - USB-C
 ---
 
 The senseBox-microcontroller (MCU) is specially designed and developed for the [senseBox project](https://sensebox.de/en/). The three main advantages and characteristics of the microcontroller are: expandability, speed, and efficiency.

--- a/_board/serpente.md
+++ b/_board/serpente.md
@@ -10,6 +10,9 @@ date_added: 2019-9-17
 downloads_display: true
 blinka: false
 download_instructions: ""
+
+features:
+  - USB-C
 ---
 
 There are two Serpente boards, they are both virtually the same, except for the USB connector. The standard Serpente board contains a USB Type-C connector, and the Serpente Plug uses the board itself as a Type-A USB plug.

--- a/_board/simmel.md
+++ b/_board/simmel.md
@@ -7,6 +7,9 @@ manufacturer: "Simmel Project"
 board_url: "https://github.com/simmel-project/frontpage"
 board_image: "simmel.jpg"
 date_added: 2020-04-29
+
+features:
+  - USB-C
 ---
 
 Simmel is a platform that enables COVID-19 contact tracing while preserving user privacy. It is a wearable hardware beacon and scanner which can broadcast and record randomized user IDs. Contacts are stored within the wearable device, so you retain full control of your trace history until you choose to share it.

--- a/_board/sparkfun_lumidrive.md
+++ b/_board/sparkfun_lumidrive.md
@@ -9,6 +9,7 @@ board_image: "sparkfun_lumidrive_01.jpg"
 date_added: 2019-3-9
 features:
   - Battery Charging
+  - USB-C
 ---
 
 The LumiDrive LED Driver is SparkFun's foray into all things Python on micro-controllers. With the SparkFun LumiDrive you will be able to control and personalize a whole strand of APA102s directly from the board itself. We've broken out a number of analog and digital pins from the on board SAMD21G-AU microcontroller to incorporate your own external buttons, switches, and other interfaces to interact with your addressable LED strip.

--- a/_board/sparkfun_pro_micro_rp2040.md
+++ b/_board/sparkfun_pro_micro_rp2040.md
@@ -9,6 +9,7 @@ board_image: "sparkfun_pro_micro_rp2040.jpg"
 date_added: 2021-4-6
 features:
   - STEMMA QT/QWIIC
+  - USB-C
 ---
 The SparkFun Pro Micro RP2040 is a low-cost, high performance board with flexible digital interfaces featuring the Raspberry Pi Foundation's RP2040 microcontroller. Besides the good 'ol Pro Micro footprint, the board also includes a WS2812B addressable LED, boot button, reset button, Qwiic connector, USB-C, resettable PTC fuse, and castellated pads.
 

--- a/_board/sparkfun_thing_plus_rp2040.md
+++ b/_board/sparkfun_thing_plus_rp2040.md
@@ -11,6 +11,7 @@ features:
   - Feather-Compatible
   - Battery Charging
   - STEMMA QT/QWIIC
+  - USB-C
 ---
 
 The SparkFun Thing Plus - RP2040 is a low-cost, high performance board with flexible digital interfaces featuring the Raspberry Pi Foundation's RP2040 microcontroller. Besides the Thing Plus or *Feather* footprint (with 18 GPIO pins), the board also includes an SD card slot, 16MB (128Mbit) flash memory, a JST single cell battery connector (with a charging circuit and fuel gauge sensor), an addressable WS2812 RGB LED, JTAG PTH pins, four (4-40 screw) mounting holes, and our signature Qwiic connector.

--- a/_board/stackrduino_m0_pro.md
+++ b/_board/stackrduino_m0_pro.md
@@ -10,6 +10,7 @@ date_added: 2021-4-6
 features:
   - Battery Charging
   - STEMMA QT/QWIIC
+  - USB-C
 ---
 
 StackRduino M0+ PRO is an open source Development board based on the ATSAMD21G18 for Arduino & Circuit-Python packed with features & comes with many stackable shields

--- a/_board/stm32f411ce_blackpill.md
+++ b/_board/stm32f411ce_blackpill.md
@@ -7,6 +7,9 @@ manufacturer: "WeAct Studio"
 board_url: "https://www.aliexpress.com/item/1005001456186625.html"
 board_image: "stm32f411ce_blackpill.jpg"
 date_added: 2019-12-20
+
+features:
+  - USB-C
 ---
 In the F401 series, the chip is the cheapest, even cheaper than some F1, and crushed F1 on the main frequency, and has a floating-point arithmetic module, the IO port contains all the basic functions. Therefore, it is possible to provide a learning platform with a very high cost performance for beginners. In practical applications, it is not because the computing power is insufficient, and the IO port is incomplete and hinders development.
 

--- a/_board/stm32f411ce_blackpill_with_flash.md
+++ b/_board/stm32f411ce_blackpill_with_flash.md
@@ -7,6 +7,9 @@ manufacturer: "WeAct Studio"
 board_url: "https://www.aliexpress.com/item/1005001456186625.html"
 board_image: "stm32f411ce_blackpill.jpg"
 date_added: 2021-4-6
+
+features:
+  - USB-C
 ---
 In the F401 series, the chip is the cheapest, even cheaper than some F1, and crushed F1 on the main frequency, and has a floating-point arithmetic module, the IO port contains all the basic functions. Therefore, it is possible to provide a learning platform with a very high cost performance for beginners. In practical applications, it is not because the computing power is insufficient, and the IO port is incomplete and hinders development.
 

--- a/_board/tinkeringtech_scoutmakes_azul.md
+++ b/_board/tinkeringtech_scoutmakes_azul.md
@@ -12,6 +12,7 @@ features:
   - Battery Charging
   - Bluetooth/BTLE
   - Display
+  - USB-C
 ---
 
 The **ScoutMakes Azul** is an open source Bluetooth (BLE) development platform featuring the nRF52840 (32bit ARM Cortex-M4 processor) from Nordic semiconductors enabling excellent Bluetooth development capabilities for your project. It conforms to the Adafruit feather format, runs CircuitPython, Arduino. The platform also has native USB support.

--- a/_board/unexpectedmaker_feathers2.md
+++ b/_board/unexpectedmaker_feathers2.md
@@ -12,6 +12,7 @@ features:
   - Battery Charging
   - Wi-Fi
   - STEMMA QT/QWIIC
+  - USB-C
 ---
 
 Introducing the FeatherS2 - The PRO ESP32-S2 based development board in a Feather format!

--- a/_board/unexpectedmaker_feathers2_prerelease.md
+++ b/_board/unexpectedmaker_feathers2_prerelease.md
@@ -12,6 +12,7 @@ features:
   - Battery Charging
   - Wi-Fi
   - STEMMA QT/QWIIC
+  - USB-C
 ---
 
 Pre-Release version of the FeatherS2

--- a/_board/unexpectedmaker_tinys2.md
+++ b/_board/unexpectedmaker_tinys2.md
@@ -10,6 +10,7 @@ date_added: 2021-03-20
 features:
   - Battery Charging
   - Wi-Fi
+  - USB-C
 ---
 
 Introducing the TinyS2 - The Mighty Tiny ESP32-S2 based development board!

--- a/template.md
+++ b/template.md
@@ -23,6 +23,8 @@ features:
   - Robotics
   - LoRa/Radio
   - GPS
+  - STEMMA QT/QWIIC
+  - USB-C
 ---
 
 This board hasn't been fully documented yet. Please make a pull request adding more info to this file.


### PR DESCRIPTION
USB-C is a pretty notable feature to search on.

I also considered a feature for USB Micro, but then I felt it would be excluding USB A, USB Mini, Castellated, and pin headers.  I felt adding each possible USB connectivity would make the filter list lengthier and a little awkward.

I also corrected the markdown syntax on a board to remove the "Wi-Fi Bluetooth/BTLE" category. It now filters into each category correctly.