### PR TITLE
Add Breadboard-Friendly and Arduino Shield Compatible.

### DIFF
--- a/_board/adafruit_feather_esp32s2_nopsram.md
+++ b/_board/adafruit_feather_esp32s2_nopsram.md
@@ -8,7 +8,12 @@ board_url: ""
 board_image: "adafruit_feather_esp32s2_nopsram.jpg"
 date_added: 2021-4-6
 features:
+  - Feather-Compatible
+  - Battery Charging
+  - STEMMA QT/QWIIC
+  - Wi-Fi
   - USB-C
+  - Breadboard-Friendly
 ---
 
 Coming Soon!

--- a/_board/adafruit_feather_rp2040.md
+++ b/_board/adafruit_feather_rp2040.md
@@ -10,7 +10,9 @@ date_added: 2021-1-21
 features:
   - Feather-Compatible
   - Battery Charging
+  - STEMMA QT/QWIIC
   - USB-C
+  - Breadboard-Friendly
 ---
 
 A new chip means a new Feather, and the Raspberry Pi RP2040 is no exception. When we saw this chip we thought "this chip is going to be awesome when we give it the Feather Treatment" and so we did! This Feather features the **RP2040**, and all niceties you know and love about Feather

--- a/_board/adafruit_itsybitsy_rp2040.md
+++ b/_board/adafruit_itsybitsy_rp2040.md
@@ -8,7 +8,7 @@ board_url: "https://www.adafruit.com/product/4888"
 board_image: "adafruit_itsybitsy_rp2040.jpg"
 date_added: 2021-4-6
 features:
-
+  - Breadboard-Friendly
 ---
 
 A new chip means a new ItsyBitsy, and the Raspberry Pi RP2040 is no exception. When we saw this chip we thought "this chip is going to be awesome when we give it the ItsyBitsy teensy-weensy Treatment" and so we did! This Itsy' features the RP2040, [and all niceties you know and love about the ItsyBitsy family](https://www.adafruit.com/category/1008)

--- a/_board/adafruit_macropad_rp2040.md
+++ b/_board/adafruit_macropad_rp2040.md
@@ -9,6 +9,7 @@ board_image: "adafruit_macropad_rp2040.jpg"
 date_added: 2021-6-4
 features:
   - USB-C
+  - STEMMA QT/QWIIC
 ---
 
 Strap yourself in, we're launching in T-minus 10 seconds...Destination? A new Class M planet called MACROPAD! M here, stands for Microcontroller because this 3x4 keyboard controller features the newest technology from the Raspberry Pi sector: say hello to the RP2040. It's speedy little microcontroller with lots of GPIO pins and a 64 times more RAM than the Apollo Guidance Computer. We added 8 MB of flash memory for plenty of storage.

--- a/_board/adafruit_metro_esp32s2.md
+++ b/_board/adafruit_metro_esp32s2.md
@@ -12,6 +12,7 @@ features:
   - Battery Charging
   - STEMMA QT/QWIIC
   - USB-C
+  - Arduino Shield Compatible
 ---
 
 What's Metro shaped and has an ESP32-S2 WiFi module? What has a STEMMA QT connector for I2C devices, and a Lipoly charger circuit? What's finishing up testing and nearly ready for fabrication? That's right - its the new Adafruit Metro ESP32-S2! With native USB and a load of PSRAM this board is perfect for use with CircuitPython or Arduino, to add low-cost WiFi while keeping shield-compatibility

--- a/_board/adafruit_qtpy_rp2040.md
+++ b/_board/adafruit_qtpy_rp2040.md
@@ -10,6 +10,7 @@ date_added: 2021-4-6
 features:
   - STEMMA QT/QWIIC
   - USB-C
+  - Breadboard-Friendly
 ---
 
 What a cutie pie! Or is it... a QT Py? This diminutive dev board comes with one of our new favorite chip, the RP2040. It's been made famous in the new [Raspberry Pi Pico](https://www.adafruit.com/pico) *and* our [Feather RP2040](http://www.adafruit.com/product/4884) and [ItsyBitsy RP2040](http://www.adafruit.com/product/4888), but what if we wanted something really *smol?*

--- a/_board/aloriumtech_evo_m51.md
+++ b/_board/aloriumtech_evo_m51.md
@@ -13,7 +13,7 @@ features:
   - Feather-Compatible
   - Battery Charging
   - STEMMA QT/QWIIC
-
+  - Breadboard-Friendly
 ---
 
 The Evo M51 is an FPGA-enhanced Feather compatible compute module from Alorium Technology that features a 32-bit SAMD51 microcontroller along with an Intel MAX 10 FPGA.  

--- a/_board/arduino_mkr1300.md
+++ b/_board/arduino_mkr1300.md
@@ -7,6 +7,8 @@ manufacturer: "Arduino"
 board_url: "https://www.arduino.cc/en/Guide/MKRWAN1300"
 board_image: "arduino_mkr1300_01.jpg"
 date_added: 2018-12-13
+features:
+  - Breadboard-Friendly
 ---
 
 Arduino MKR WAN 1300 has been designed to offer a practical and cost effective solution for makers seeking to add Lo-Ra connectivity to their projects with minimal previous experience in networking. It is based on the Microchip SAMD21 and a Murata  CMWX1ZZABZ Lo-Ra module. 

--- a/_board/arduino_mkrzero.md
+++ b/_board/arduino_mkrzero.md
@@ -9,6 +9,7 @@ board_image: "arduino_mkr_zero.jpg"
 date_added: 2019-3-9
 features:
   - Battery Charging
+  - Breadboard-Friendly
 ---
 
 The Arduino MKR ZERO brings you the power of a Zero in the smaller format established by the MKR form factor. The MKR ZERO board acts as a great educational tool for learning about 32-bit application development. The board is powered by Microchip’s SAMD21 MCU, which features a 32-bit ARM Cortex® M0+ core.

--- a/_board/arduino_nano_33_ble.md
+++ b/_board/arduino_nano_33_ble.md
@@ -7,6 +7,9 @@ manufacturer: "Arduino"
 board_url: "https://www.arduino.cc/en/Guide/NANO33BLE"
 board_image: "arduino_nano_33_ble.jpg"
 date_added: 2019-10-26
+features:
+  - Bluetooth/BTLE
+  - Breadboard-Friendly
 ---
 
 This compact and reliable NANO board is built around the NINA B306 module, based on Nordic nRF 52840 and containing a powerful Cortex M4F. Its architecture, fully compatible with Arduino IDE Online and Offline, has a 9 axis Inertial Measurement Unit (IMU) and a reduced power consumption compared to other same size boards.

--- a/_board/arduino_nano_33_iot.md
+++ b/_board/arduino_nano_33_iot.md
@@ -7,6 +7,9 @@ manufacturer: "Arduino"
 board_url: "https://www.arduino.cc/en/Guide/NANO33IoT"
 board_image: "arduino_nano_33_iot.jpg"
 date_added: 2020-2-27
+features:
+  - Wi-Fi
+  - Breadboard-Friendly
 ---
 
 Arduino NANO 33 IoT board has been designed to offer a practical and cost effective solution for makers seeking to add Wi-Fi connectivity to their projects (using Arduino) with minimal previous experience in networking. Learn how to set up the programming environment and get the hardware up and running, ready for your projects, in minutes.

--- a/_board/arduino_nano_rp2040_connect.md
+++ b/_board/arduino_nano_rp2040_connect.md
@@ -10,6 +10,7 @@ date_added: 2021-5-24
 features:
   - Wi-Fi
   - Bluetooth/BTLE
+  - Breadboard-Friendly
 ---
 
 Meet the only connected RP2040 board. It fits the Arduino Nano form factor, making it a small board with BIG features.

--- a/_board/arduino_zero.md
+++ b/_board/arduino_zero.md
@@ -7,6 +7,8 @@ manufacturer: "Arduino"
 board_url: "https://www.arduino.cc/en/Guide/ArduinoZero"
 board_image: "arduino_zero.jpg"
 date_added: 2019-3-9
+features:
+  - Arduino Shield Compatible
 ---
 
 The Arduino Zero is a simple and powerful 32-bit extension of the platform established by the UNO. The Zero board expands the family by providing increased performance, enabling a variety of project opportunities for devices, and acts as a great educational tool for learning about 32-bit application development.  

--- a/_board/bast_pro_mini_m0.md
+++ b/_board/bast_pro_mini_m0.md
@@ -8,6 +8,7 @@ board_url: "https://electroniccats.com/store/bast-pro-mini-m0/"
 board_image: "bast_pro_mini_m0.jpg"
 date_added: 2019-4-13
 features:
+  - Breadboard-Friendly
 ---
 
 Is she the goddess of cats? 

--- a/_board/bastble.md
+++ b/_board/bastble.md
@@ -13,6 +13,7 @@ features:
   - Bluetooth/BTLE
   - Battery Charging
   - USB-C
+  - Breadboard-Friendly
 ---
 
 The Bast BLE is the new Feather family member with Bluetooth Low Energy and native USB-C support featuring the nRF52840!  

--- a/_board/cp_sapling_m0.md
+++ b/_board/cp_sapling_m0.md
@@ -9,6 +9,7 @@ board_image: "cp_sapling_m0.jpg"
 date_added: 2020-11-23
 features:
   - STEMMA QT/QWIIC
+  - Breadboard-Friendly
 ---
 
 Finally, a tree that runs CircuitPython? YEP! Now you can get working in CircuitPython fast with our new CircuitPython compatible development board featuring the popular Microchip AT SAM D21 microcontroller.

--- a/_board/cp_sapling_m0_revb.md
+++ b/_board/cp_sapling_m0_revb.md
@@ -9,6 +9,7 @@ board_image: "cp_sapling_m0_revb.jpg"
 date_added: 2021-6-4
 features:
   - STEMMA QT/QWIIC
+  - Breadboard-Friendly
 ---
 
 Finally, a tree that runs CircuitPython? YEP and it's better than ever! Now you can get working in CircuitPython fast with our new CircuitPython compatible development board featuring the popular Microchip AT SAM D21 microcontroller.

--- a/_board/cp_sapling_m0_spiflash.md
+++ b/_board/cp_sapling_m0_spiflash.md
@@ -9,6 +9,7 @@ board_image: "cp_sapling_m0.jpg"
 date_added: 2021-4-6
 features:
   - STEMMA QT/QWIIC
+  - Breadboard-Friendly
 ---
 
 Finally, a tree that runs CircuitPython? YEP! Now you can get working in CircuitPython fast with our new CircuitPython compatible development board featuring the popular Microchip AT SAM D21 microcontroller.

--- a/_board/datum_distance.md
+++ b/_board/datum_distance.md
@@ -7,6 +7,8 @@ manufacturer: "J&J Studios"
 board_url: "https://jandjstudios.io/datum/datum-Distance/"
 board_image: "datum_distance.jpg"
 date_added: 2019-7-12
+features:
+  - Breadboard-Friendly
 ---
 
 The datum-Distance sensor combines the same SAMD21G18 microcontroller used on the Arduino Zero with the VL53LX1 distance sensor from ST Microelectronics to create the simplest, easiest to use distance sensor for your application.

--- a/_board/datum_imu.md
+++ b/_board/datum_imu.md
@@ -7,6 +7,8 @@ manufacturer: "J&J Studios"
 board_url: "https://jandjstudios.io/datum/datum-IMU/"
 board_image: "datum_imu.jpg"
 date_added: 2019-7-12
+features:
+  - Breadboard-Friendly
 ---
 
 The datum-IMU sensor combines the same SAMD21G18 microcontroller used on the Arduino Zero with the LSM9DS1 IMU sensor from ST Microelectronics to create the simplest, easiest to use IMU sensor for your application.

--- a/_board/datum_light.md
+++ b/_board/datum_light.md
@@ -7,6 +7,8 @@ manufacturer: "J&J Studios"
 board_url: "https://jandjstudios.io/datum/datum-Light/"
 board_image: "datum_light.jpg"
 date_added: 2019-7-12
+features:
+  - Breadboard-Friendly
 ---
 
 The datum-Light sensor combines the same SAMD21G18 microcontroller used on the Arduino Zero with the APDS-9960 light sensor from Broadcom to create the simplest, easiest to use light sensor for your application.

--- a/_board/datum_weather.md
+++ b/_board/datum_weather.md
@@ -7,6 +7,8 @@ manufacturer: "J&J Studios"
 board_url: "https://jandjstudios.io/datum/datum-Weather/"
 board_image: "datum_weather.jpg"
 date_added: 2019-7-12
+features:
+  - Breadboard-Friendly
 ---
 
 The datum-Weather sensor combines the same SAMD21G18 microcontroller used on the Arduino Zero with the BME280 environmental sensor from Bosch Sensortec to create the simplest, easiest to use weather sensor for your application.

--- a/_board/electroniccats_bastwifi.md
+++ b/_board/electroniccats_bastwifi.md
@@ -13,7 +13,7 @@ features:
   - Wi-Fi
   - Battery Charging
   - USB-C
-
+  - Breadboard-Friendly
 ---
 
 The Bast WiFi includes the newer ESP32-S2 module, which is like a little brother to the ESP32 where only one core instead of 2 has cores, it has no BLE implemented, but gains a native USB, a new processor and crypto accelerators for better performance protection against physical fault injection attacks and more improvements over the SoC.

--- a/_board/espressif_saola_1_wroom.md
+++ b/_board/espressif_saola_1_wroom.md
@@ -9,6 +9,7 @@ board_image: "espressif_saola_1_wroom.jpg"
 date_added: 2020-05-15
 features:
   - Wi-Fi
+  - Breadboard-Friendly
 ---
 
 This is the Saola dev board with a WROOM ESP32-S2 module.

--- a/_board/espressif_saola_1_wrover.md
+++ b/_board/espressif_saola_1_wrover.md
@@ -9,6 +9,7 @@ board_image: "espressif_saola_1_wrover.jpg"
 date_added: 2020-05-15
 features:
   - Wi-Fi
+  - Breadboard-Friendly
 ---
 
 **ESP32-S2 Saola-1** is a small-sized ESP32-S2 based development board produced by Espressif. Just about all of the I/O pins are broken out to the pin headers on both sides for easy interfacing. Developers can either connect peripherals with jumper wires or mount ESP32-S2 Saola-1 on a breadboard - we recommend two breadboards 'side-by-side' since the Saola is a bit wide and you won't have extra holes on one side for wiring.

--- a/_board/espruino_wifi.md
+++ b/_board/espruino_wifi.md
@@ -9,6 +9,7 @@ board_image: "espruino_wifi.jpg"
 date_added: 2020-2-13
 features:
   - Wi-Fi
+  - Breadboard-Friendly
 ---
 
 Try the JavaScript of things with the **Espruino WiFi** - the world's first open-source JavaScript microcontroller, this time with built in WiFi! This little board has an STM32 microcontroller pre-programmed with Espruino all ready to go so you can start playing with Javascript-microcontrollers. It also comes with an ESP8266 WiFi module, so you can connect to the Internet using Espruino. **Warning:** if you only use Assembly and think that even embedded C/C++ is for wimps, this device might explode your head.

--- a/_board/feather_bluefruit_sense.md
+++ b/_board/feather_bluefruit_sense.md
@@ -11,6 +11,7 @@ features:
   - Feather-Compatible
   - Battery Charging
   - Bluetooth/BTLE
+  - Breadboard-Friendly
 ---
 
 The **Adafruit Feather Bluefruit Sense** takes our popular [Feather nRF52840 Express](https://www.adafruit.com/product/4062) and adds a smorgasbord of sensors to make a great wireless sensor platform. This Feather microcontroller comes with Bluetooth Low Energy and native USB support featuring the nRF52840!  This Feather is an 'all-in-one' Arduino-compatible + Bluetooth Low Energy with built in USB plus battery charging. With native USB it works great with CircuitPython, too.

--- a/_board/feather_m0_adalogger.md
+++ b/_board/feather_m0_adalogger.md
@@ -10,6 +10,7 @@ date_added: 2019-3-9
 features:
   - Feather-Compatible
   - Battery Charging
+  - Breadboard-Friendly
 ---
 
 Feather is a development board from Adafruit, and like its namesake it is thin, light, and lets you fly! Adafruit designed Feather to be a new open standard for portable microcontroller cores.

--- a/_board/feather_m0_basic.md
+++ b/_board/feather_m0_basic.md
@@ -10,6 +10,7 @@ date_added: 2019-3-9
 features:
   - Feather-Compatible
   - Battery Charging
+  - Breadboard-Friendly
 ---
 Feather is thin, light, and lets you fly! Adafruit designed Feather to be a new open standard for portable microcontroller cores.
 

--- a/_board/feather_m0_express.md
+++ b/_board/feather_m0_express.md
@@ -10,6 +10,7 @@ date_added: 2019-3-8
 features:
   - Feather-Compatible
   - Battery Charging
+  - Breadboard-Friendly
 ---
 
 The Adafruit Feather M0 Express was one of the first development boards designed for CircuitPython by Adafruit. Unlike the original Feather M0 Basic, it added a NeoPixel status LED and external 2MB SPI Flash for storing CircuitPython code.

--- a/_board/feather_m0_rfm69.md
+++ b/_board/feather_m0_rfm69.md
@@ -11,6 +11,7 @@ features:
   - Feather-Compatible
   - Battery Charging
   - LoRa/Radio
+  - Breadboard-Friendly
 ---
 
 This is the** Adafruit Feather M0 RFM69 Packet Radio (433, 868, or 915 MHz)****.** Also called _RadioFruits**,**_ Adafruit's take on an microcontroller with a RFM69HCW packet radio transceiver plus built in USB and battery charging. Its an Adafruit Feather M0 with a VHF radio module cooked in!

--- a/_board/feather_m0_rfm9x.md
+++ b/_board/feather_m0_rfm9x.md
@@ -11,6 +11,7 @@ features:
   - Feather-Compatible
   - Battery Charging
   - LoRa/Radio
+  - Breadboard-Friendly
 ---
 
 This is the **Adafruit Feather M0 RFM96 LoRa Radio (433 MHz).** Also called _RadioFruits**,**_ Adafruit's take on an microcontroller with a "[Long Range (LoRa)](https://www.lora-alliance.org/)" packet radio transceiver with built in USB and battery charging. It is an Adafruit Feather M0 with a 433MHz radio module cooked in! Great for making wireless networks that are more flexible than Bluetooth LE and without the high power requirements of WiFi.

--- a/_board/feather_m0_supersized.md
+++ b/_board/feather_m0_supersized.md
@@ -10,6 +10,7 @@ date_added: 2019-3-19
 features:
   - Feather-Compatible
   - Battery Charging
+  - Breadboard-Friendly
 ---
 
 This is a [Feather M0 Express]({{ "/board/feather_m0_express/" | relative_url }}) that has been

--- a/_board/feather_m4_can.md
+++ b/_board/feather_m4_can.md
@@ -11,6 +11,7 @@ features:
   - Feather-Compatible
   - Battery Charging
   - USB-C
+  - Breadboard-Friendly
 ---
  
 One of our favorite Feathers, the Feather M4 Express, gets a glow-up here with an upgrade to the SAME51 chipset which has built-in CAN bus support! Like its SAMD51 cousin, the ATSAME51J19 comes with a 120MHz Cortex M4 with floating point support and 512KB Flash and 192KB RAM. Your code will zig and zag and zoom, and with a bunch of extra peripherals for support, this will for sure be your favorite new chipset for CAN interfacing projects.

--- a/_board/feather_m4_express.md
+++ b/_board/feather_m4_express.md
@@ -10,6 +10,7 @@ date_added: 2019-3-8
 features:
   - Feather-Compatible
   - Battery Charging
+  - Breadboard-Friendly
 ---
 
 This feather is powered by the ATSAMD51J19 -  with its 120MHz Cortex M4 with floating point support and 512KB Flash and 192KB RAM. Your code will zig and zag and zoom, and with a bunch of extra peripherals for support, this will for sure be your favorite new chipset.

--- a/_board/feather_m7_1011.md
+++ b/_board/feather_m7_1011.md
@@ -12,6 +12,7 @@ features:
   - Battery Charging
   - STEMMA QT/QWIIC
   - USB-C
+  - Breadboard-Friendly
 ---
 
 Coming Soon!

--- a/_board/feather_mimxrt1011.md
+++ b/_board/feather_mimxrt1011.md
@@ -11,7 +11,7 @@ features:
   - Feather-Compatible
   - Battery Charging
   - USB-C
-
+  - Breadboard-Friendly
 ---
 
 A Work-In-Progress Feather featuring the NXP i.MX RT1011 MCU and a ESP32.

--- a/_board/feather_mimxrt1062.md
+++ b/_board/feather_mimxrt1062.md
@@ -11,7 +11,7 @@ features:
   - Feather-Compatible
   - Battery Charging
   - USB-C
-
+  - Breadboard-Friendly
 ---
 
 A Work-In-Progress Feather featuring the NXP i.MX RT1062 MCU.

--- a/_board/feather_nrf52840_express.md
+++ b/_board/feather_nrf52840_express.md
@@ -11,6 +11,7 @@ features:
   - Feather-Compatible
   - Battery Charging
   - Bluetooth/BTLE
+  - Breadboard-Friendly
 ---
 
 The **Adafruit Feather nRF52840 Express** is the new Feather family member with Bluetooth Low Energy and _native USB support_ featuring the nRF52840!  It is Adafruit's take on an 'all-in-one' Bluetooth Low Energy device with built in USB plus battery charging. With native USB it's part of the CircuitPython party.

--- a/_board/feather_stm32f405_express.md
+++ b/_board/feather_stm32f405_express.md
@@ -12,6 +12,7 @@ features:
   - Battery Charging
   - STEMMA QT/QWIIC
   - USB-C
+  - Breadboard-Friendly
 ---
 
 ST takes flight in this upcoming Feather board. The new STM32F405 Feather (video) that we designed runs CircuitPython at a blistering 168MHz – our fastest CircuitPython board ever! We put a STEMMA QT / Qwiic port on the end, so you can really easily plug and play I2C sensors.

--- a/_board/fluff_m0.md
+++ b/_board/fluff_m0.md
@@ -10,6 +10,7 @@ date_added: 2020-5-22
 
 features:
   - USB-C
+  - Breadboard-Friendly
 ---
 A minimal CircuitPython board compatible with the Feather M0 Basic. Everything
 that is non-essential has been removed, and the smallest possible chip is used.

--- a/_board/grandcentral_m4_express.md
+++ b/_board/grandcentral_m4_express.md
@@ -7,6 +7,8 @@ manufacturer: "Adafruit"
 board_url: ""
 board_image: "grandcentral_m4_express.jpg"
 date_added: 2019-3-9
+features:
+  - Arduino Shield Compatible
 ---
 
 The **Adafruit Grand Central** features the **Microchip ATSAMD51**. This dev board is so big, it's not named after a Metro train, it's a whole freakin' _station_!

--- a/_board/hiibot_iots2.md
+++ b/_board/hiibot_iots2.md
@@ -13,6 +13,7 @@ features:
   - Battery Charging
   - STEMMA QT/QWIIC
   - USB-C
+  - Breadboard-Friendly
 ---
 
 Introducing the microS2 - An ESP32-S2 based development board with smaller size (25.4*45.9mm). Features:

--- a/_board/itsybitsy_m0_express.md
+++ b/_board/itsybitsy_m0_express.md
@@ -7,6 +7,8 @@ manufacturer: "Adafruit"
 board_url: "https://www.adafruit.com/product/3727"
 board_image: "itsybitsy_m0_express.jpg"
 date_added: 2019-3-9
+features:
+  - Breadboard-Friendly
 ---
 
 What's smaller than a Feather but larger than a Trinket? It's an **Adafruit ItsyBitsy M0 Express**! Small, powerful, with a rockin' ATSAMD21 Cortex M0 processor running at 48 MHz - this microcontroller board is perfect when you want something very compact, but still with a bunch of pins.

--- a/_board/itsybitsy_m4_express.md
+++ b/_board/itsybitsy_m4_express.md
@@ -7,6 +7,8 @@ manufacturer: "Adafruit"
 board_url: "https://www.adafruit.com/product/3800"
 board_image: "itsybitsy_m4_express.jpg"
 date_added: 2019-3-9
+features:
+  - Breadboard-Friendly
 ---
 
 What's smaller than a Feather but larger than a Trinket? It's an **Adafruit ItsyBitsy M4 Express** featuring the **Microchip ATSAMD51**! Small, powerful, with a ultra fast ATSAMD51 Cortex M4 processor running at 120 MHz - this microcontroller board is perfect when you want something very compact, with a ton of horsepower and a bunch of pins. This Itsy is like a bullet train, with it's **120MHz Cortex M4** with floating point support and **512KB Flash and 192KB RAM**. Your code will zig and zag and zoom, and with a bunch of extra peripherals for support, this will for sure be your favorite new chipset.

--- a/_board/itsybitsy_nrf52840_express.md
+++ b/_board/itsybitsy_nrf52840_express.md
@@ -9,6 +9,7 @@ board_image: "itsybitsy_nrf52840_express.jpg"
 date_added: 2019-11-4
 features:
   - Bluetooth/BTLE
+  - Breadboard-Friendly
 ---
 
 What's smaller than a Feather but larger than a Trinket? It's an **Adafruit ItsyBitsy nRF52840 Express** featuring the **Nordic nRF52840 Bluetooth LE** processor! Teensy & powerful, with an fast nRF52840 Cortex M4 processor running at 64 MHz and 1 MB of FLASH - this microcontroller board is perfect when you want something very compact, with a heap-load of memory and Bluetooth LE support This Itsy is your best option for tiny wireless connectivity - it can act as both a BLE central and peripheral, with support in both Arduino and CircuitPython

--- a/_board/lilygo_ttgo_t8_s2_st7789.md
+++ b/_board/lilygo_ttgo_t8_s2_st7789.md
@@ -11,6 +11,7 @@ features:
   - Display 
   - Battery Charging
   - USB-C
+  - Breadboard-Friendly
 ---
 
 **Features & Specifications:**

--- a/_board/makerdiary_nrf52840_m2_devkit.md
+++ b/_board/makerdiary_nrf52840_m2_devkit.md
@@ -12,6 +12,7 @@ features:
   - Display
   - Battery Charging
   - USB-C
+  - Arduino Shield Compatible
 ---
 
 nRF52840 M.2 Developer Kit is a versatile IoT prototyping platform, including the nRF52840 M.2 Module and M.2 Dock. You can use the developer kit to prototype your IoT products and then scale to production faster using the nRF52840 M.2 Module combined with your custom PCB hardware.

--- a/_board/makerdiary_nrf52840_mdk.md
+++ b/_board/makerdiary_nrf52840_mdk.md
@@ -10,6 +10,7 @@ date_added: 2019-3-9
 features:
   - Bluetooth/BTLE
   - USB-C
+  - Breadboard-Friendly
 ---
 
 The nRF52840-MDK is a versatile, easy-to-use IoT hardware platform for Bluetooth 5, Bluetooth Mesh, Thread, IEEE 802.15.4, ANT and 2.4GHz proprietary wireless applications using the nRF52840 SoC.

--- a/_board/makerdiary_nrf52840_mdk_usb_dongle.md
+++ b/_board/makerdiary_nrf52840_mdk_usb_dongle.md
@@ -9,6 +9,7 @@ board_image: "nRF52840_micro_dev_kit_usb_dongle.jpg"
 date_added: 2019-3-9
 features:
   - Bluetooth/BTLE
+  - Breadboard-Friendly
 ---
 
 The nRF52840 Micro Dev Kit USB Dongle is a small and low-cost development platform enabled by the nRF52840 multi-protocol SoC in a convenient USB dongle form factor.

--- a/_board/metro_m0_express.md
+++ b/_board/metro_m0_express.md
@@ -7,6 +7,8 @@ manufacturer: "Adafruit"
 board_url: ""
 board_image: "metro_m0_express.jpg"
 date_added: 2019-3-9
+features:
+  - Arduino Shield Compatible
 ---
 
 This **Metro M0 Express** board looks a whole lot like the [original Metro 328](https://www.adafruit.com/product/2488), but with a huge upgrade. Instead of the ATmega328, this Metro features a ATSAMD21G18 chip, an ARM Cortex M0+. It's the first Adafruit Metro that is designed for use with CircuitPython! 

--- a/_board/metro_m4_airlift_lite.md
+++ b/_board/metro_m4_airlift_lite.md
@@ -9,6 +9,7 @@ board_image: "metro_m4_airlift_lite.jpg"
 date_added: 2019-4-13
 features:
   - Wi-Fi
+  - Arduino Shield Compatible
 ---
 
 Give your next project a lift with _AirLift_ - Adafruit's witty name for the ESP32 co-processor that graces this Metro M4. 

--- a/_board/metro_m4_express.md
+++ b/_board/metro_m4_express.md
@@ -7,6 +7,8 @@ manufacturer: "Adafruit"
 board_url: ""
 board_image: "metro_m4_express.jpg"
 date_added: 2019-3-9
+features:
+  - Arduino Shield Compatible
 ---
 
 The most powerful Metro at this time, the **Adafruit Metro M4** featuring the **Microchip ATSAMD51**. This Metro is like a bullet train, with it's 120MHz Cortex M4 with floating point support. Your code will zig and zag and zoom, and with a bunch of extra peripherals for support, this will for sure be your favorite new chipset.

--- a/_board/metro_m7_1011.md
+++ b/_board/metro_m7_1011.md
@@ -11,6 +11,7 @@ features:
   - Wi-Fi
   - STEMMA QT/QWIIC
   - USB-C
+  - Arduino Shield Compatible
 ---
 
 Watch Adafruit's Ask an Engineer on YouTube to learn more. 

--- a/_board/metro_nrf52840_express.md
+++ b/_board/metro_nrf52840_express.md
@@ -10,6 +10,7 @@ date_added: 2019-8-30
 features:
   - Bluetooth/BTLE
   - USB-C
+  - Arduino Shield Compatible
 ---
 
 The **Adafruit Metro nRF52840 Express** is a new Metro family member with Bluetooth Low Energy and _native USB support_ featuring the nRF52840! 

--- a/_board/muselab_nanoesp32_s2_wroom.md
+++ b/_board/muselab_nanoesp32_s2_wroom.md
@@ -10,6 +10,8 @@ date_added: 2020-09-16
 
 features:
   - USB-C
+  - Wi-Fi
+  - Breadboard-Friendly
 ---
 
 This is the nanoESP32-S2 board with a WROOM ESP32-S2 module.

--- a/_board/muselab_nanoesp32_s2_wrover.md
+++ b/_board/muselab_nanoesp32_s2_wrover.md
@@ -10,6 +10,8 @@ date_added: 2020-09-16
 
 features:
   - USB-C
+  - Wi-Fi
+  - Breadboard-Friendly
 ---
 
 This is the nanoESP32-S2 board with a WROVER ESP32-S2 module.

--- a/_board/nice_nano.md
+++ b/_board/nice_nano.md
@@ -10,6 +10,7 @@ date_added: 2020-06-05
 
 features: 
   - USB-C
+  - Breadboard-Friendly
 ---
 
 ## Learn More

--- a/_board/particle_argon.md
+++ b/_board/particle_argon.md
@@ -12,6 +12,7 @@ features:
   - Battery Charging
   - Wi-Fi
   - Bluetooth/BTLE
+  - Breadboard-Friendly
 ---
 
 This board hasn't been fully documented yet. Please make a pull request adding more info to this file.

--- a/_board/particle_boron.md
+++ b/_board/particle_boron.md
@@ -11,6 +11,7 @@ features:
   - Feather-Compatible
   - Battery Charging
   - Bluetooth/BTLE
+  - Breadboard-Friendly
 ---
 
 This board hasn't been fully documented yet. Please make a pull request adding more info to this file.

--- a/_board/particle_xenon.md
+++ b/_board/particle_xenon.md
@@ -11,6 +11,7 @@ features:
   - Feather-Compatible
   - Battery Charging
   - Bluetooth/BTLE
+  - Breadboard-Friendly
 ---
 
 This board hasn't been fully documented yet. Please make a pull request adding more info to this file.

--- a/_board/pca10056.md
+++ b/_board/pca10056.md
@@ -9,6 +9,7 @@ board_image: "nRF52840_dk.jpg"
 date_added: 2019-3-9
 features:
   - Bluetooth/BTLE
+  - Arduino Shield Compatible
 ---
 
 The Nordic nRF52840 kit is hardware compatible with the Arduino Uno Revision 3 standard for shields, making it possible to use 3rd-party shields that are compatible to this standard. An NFC antenna can be connected the kit to enable NFC tag functionality. The kit gives access to all I/O and interfaces via connectors and has 4 LEDs and 4 buttons which are user-programmable. It supports the standard Nordic Software Development Tool-chain using Segger Embedded Studio, Keil, IAR and GCC. Program/Debug options on the kit is Segger J-Link OB.

--- a/_board/pca10059.md
+++ b/_board/pca10059.md
@@ -9,6 +9,7 @@ board_image: "nRF52840_dongle.jpg"
 date_added: 2019-3-9
 features:
   - Bluetooth/BTLE
+  - Breadboard-Friendly
 ---
 
 The nRF52840 dongle from Nordic Semiconductor is a small, low-cost USB dongle for Bluetooth Low Energy, Bluetooth mesh, Thread, ZigBee, 802.15.4, ANT, and 2.4 GHz proprietary applications using the nRF52840 SoC. The dongle has been designed to be used as a wireless HW device together with nRF Connect for Desktop.

--- a/_board/pca10100.md
+++ b/_board/pca10100.md
@@ -9,6 +9,7 @@ board_image: "pca10100.jpg"
 date_added: 2019-05-04
 features:
   - Bluetooth/BTLE
+  - Arduino Shield Compatible
 ---
 
 The nRF52833 development kit from Nordic.

--- a/_board/pimoroni_picolipo_16mb.md
+++ b/_board/pimoroni_picolipo_16mb.md
@@ -10,6 +10,8 @@ date_added: 2021-5-12
 features:
   - Battery Charging
   - USB-C
+  - STEMMA QT/QWIIC
+  - Breadboard-Friendly
 ---
 
 A top of the line Pirate-brand RP2040-powered microcontroller with all the extras - lots of flash memory, USB-C, STEMMA QT/Qwiic and debug connectors... and onboard LiPo charging! Pimoroni Pico boards add extra functionality whilst keeping to the Pico footprint, ensuring compatibility with existing Pico addons.

--- a/_board/pimoroni_picolipo_4mb.md
+++ b/_board/pimoroni_picolipo_4mb.md
@@ -10,6 +10,8 @@ date_added: 2021-5-12
 features:
   - Battery Charging
   - USB-C
+  - STEMMA QT/QWIIC
+  - Breadboard-Friendly
 ---
 
 A top of the line Pirate-brand RP2040-powered microcontroller with all the extras - lots of flash memory, USB-C, STEMMA QT/Qwiic and debug connectors... and onboard LiPo charging! Pimoroni Pico boards add extra functionality whilst keeping to the Pico footprint, ensuring compatibility with existing Pico addons.

--- a/_board/pimoroni_tiny2040.md
+++ b/_board/pimoroni_tiny2040.md
@@ -10,6 +10,7 @@ date_added: 2021-2-24
 
 features:
   - USB-C
+  - Breadboard-Friendly
 ---
 
 A postage stamp sized RP2040 development board with a USB-C connection, perfect for portable projects, wearables, and embedding into devices. Tiny 2040 comes with 8MB of QSPI (XiP) flash on board so it can handle projects small and large with ease.

--- a/_board/pitaya_go.md
+++ b/_board/pitaya_go.md
@@ -10,6 +10,8 @@ date_added: 2019-05-11
 features:
   - Bluetooth/BTLE
   - USB-C
+  - Battery Charging
+  - Breadboard-Friendly
 ---
 
 BLE and Wifi board in a small for factor.

--- a/_board/pyb_nano_v2.md
+++ b/_board/pyb_nano_v2.md
@@ -7,6 +7,8 @@ manufacturer: "Elecrow"
 board_url: "https://www.elecrow.com/micropython-development-board-pyb-nano-compatible-with-python.html"
 board_image: "pyb_nano_v2.jpg"
 date_added: 2019-12-10
+features:
+  - Breadboard-Friendly
 ---
 
 DETAILS

--- a/_board/qtpy_m0.md
+++ b/_board/qtpy_m0.md
@@ -10,6 +10,7 @@ date_added: 2020-9-28
 features:
   - STEMMA QT/QWIIC
   - USB-C
+  - Breadboard-Friendly
 ---
 
 > **Note:** If you soldered the [optional SOIC-8 SPI Flash chip](https://www.adafruit.com/product/4763) on to your QT Py, see the ["QT Py Haxpress"](../qtpy_m0_haxpress/) page to make use of the extra space!

--- a/_board/qtpy_m0_haxpress.md
+++ b/_board/qtpy_m0_haxpress.md
@@ -10,7 +10,7 @@ date_added: 2020-9-28
 features:
   - STEMMA QT/QWIIC
   - USB-C
-
+  - Breadboard-Friendly
 ---
 
 This is the [QT Py board](https://www.adafruit.com/product/4600) with [the SOIC-8 2MB Flash chip](https://www.adafruit.com/product/4763) soldered on. Both are in the [Adafruit shop](https://adafruit.com).

--- a/_board/raspberry_pi_pico.md
+++ b/_board/raspberry_pi_pico.md
@@ -7,6 +7,8 @@ manufacturer: "Raspberry Pi"
 board_url: "https://www.adafruit.com/product/4883"
 board_image: "raspberry_pi_pico.jpg"
 date_added: 2021-1-21
+features:
+  - Breadboard-Friendly
 ---
 
 The Raspberry Pi foundation changed single-board computing when they released the Raspberry Pi computer, now they're ready to do the same for microcontrollers with the release of the brand new **Raspberry Pi Pico**. This low-cost microcontroller board features a powerful new chip, the **RP2040**, and all the fixin's to get started with embedded electronics projects at a stress-free price.

--- a/_board/sam32.md
+++ b/_board/sam32.md
@@ -8,6 +8,10 @@ board_url: "https://github.com/maholli/SAM32"
 board_image: "sam32.jpg"
 date_added: 2019-4-5
 features:
+  - Feather-Compatible
+  - Battery Charging
+  - Wi-Fi
+  - Breadboard-Friendly
 ---
  
 An open source "swiss army knife" for hardware and IoT applications. This board is designed for quickly prototyping a wide range of makerspace, university, and science-related projects. 

--- a/_board/seeeduino_xiao.md
+++ b/_board/seeeduino_xiao.md
@@ -10,6 +10,7 @@ date_added: 2020-1-17
 
 features:
   - USB-C
+  - Breadboard-Friendly
 ---
 # Seeduino XIAO:
 SEEED Studio's Seeeduino XIAO is a minimal, low-cost board that uses the Atmel ATSAMD21G18, a powerful 32-bit ARM Cortex®-M0+ processor running at 48MHz with 256KB Flash and 32KB SRAM.  The board is 20 x 17.5mm in size which is perfect for wearable devices and small projects. It has multiple interfaces including DAC output, SWD Bonding pad interface, I2C, UART and SPI interfaces. It's compatible with both Arduino IDE and CircuitPython and uses a USB-C connector.

--- a/_board/silicognition-m4-shim.md
+++ b/_board/silicognition-m4-shim.md
@@ -9,6 +9,7 @@ board_image: "silicognition-m4-shim.jpg"
 date_added: 2021-2-19
 features:
   - Feather-Compatible
+  - Breadboard-Friendly
 ---
 
 This board is a electrically a clone of the [Adafruit Feather M4 Express](https://www.adafruit.com/product/3857), but physically optimized to fit on top of the [PoE-FeatherWing](https://www.crowdsupply.com/silicognition/poe-featherwing), filling the empty space around the RJ45 and flyback transformer and allowing the creation of extremely compact Power over Ethernet systems.

--- a/_board/sparkfun_pro_micro_rp2040.md
+++ b/_board/sparkfun_pro_micro_rp2040.md
@@ -10,6 +10,7 @@ date_added: 2021-4-6
 features:
   - STEMMA QT/QWIIC
   - USB-C
+  - Breadboard-Friendly
 ---
 The SparkFun Pro Micro RP2040 is a low-cost, high performance board with flexible digital interfaces featuring the Raspberry Pi Foundation's RP2040 microcontroller. Besides the good 'ol Pro Micro footprint, the board also includes a WS2812B addressable LED, boot button, reset button, Qwiic connector, USB-C, resettable PTC fuse, and castellated pads.
 

--- a/_board/sparkfun_qwiic_micro_no_flash.md
+++ b/_board/sparkfun_qwiic_micro_no_flash.md
@@ -9,6 +9,7 @@ board_image: "sparkfun_qwiic_micro.jpg"
 date_added: 2019-11-4
 features:
   - STEMMA QT/QWIIC
+  - Breadboard-Friendly
 ---
 The **SparkFun Qwiic Micro** is an _1 x 1 inch_ microcontroller made for the [Qwiic Eco-system](https://sparkfun.com/qwiic). 
 It's SparkFun's smallest microcontroller to date that's made for integrating into small projects.

--- a/_board/sparkfun_qwiic_micro_with_flash.md
+++ b/_board/sparkfun_qwiic_micro_with_flash.md
@@ -9,6 +9,7 @@ board_image: "sparkfun_qwiic_micro.jpg"
 date_added: 2019-11-4
 features:
   - STEMMA QT/QWIIC
+  - Breadboard-Friendly
 ---
 The **SparkFun Qwiic Micro** is an _1 x 1 inch_ microcontroller made for the [Qwiic Eco-system](https://sparkfun.com/qwiic). 
 It's SparkFun's smallest microcontroller to date that's made for integrating into small projects.

--- a/_board/sparkfun_redboard_turbo.md
+++ b/_board/sparkfun_redboard_turbo.md
@@ -10,7 +10,7 @@ date_added: 2019-3-9
 features:
   - Battery Charging
   - STEMMA QT/QWIIC
-  
+  - Arduino Shield Compatible
 ---
 
 The RedBoard Turbo uses the ATSAMD21G18, which is an ARM Cortex M0+, 32-bit microcontroller that can run at up to 48MHz. With 4MB of external flash memory and a UF2 (USB Flashing Format) bootloader, the RedBoard Turbo provides an economical and easy to use development platform.

--- a/_board/sparkfun_samd21_dev.md
+++ b/_board/sparkfun_samd21_dev.md
@@ -7,6 +7,8 @@ manufacturer: "SparkFun"
 board_url: ""
 board_image: "sparkfun_samd21_dev.jpg"
 date_added: 2019-3-9
+features:
+  - Arduino Shield Compatible
 ---
 
 The SparkFun SAMD21 Dev Breakout is an Arduino-sized breakout for the Atmel ATSAMD21G18, a 32-bit ARM Cortex-M0+ processor with 256KB flash, 32KB SRAM, and an operating speed of up to 48MHz.

--- a/_board/sparkfun_samd21_mini.md
+++ b/_board/sparkfun_samd21_mini.md
@@ -7,6 +7,8 @@ manufacturer: "SparkFun"
 board_url: ""
 board_image: "sparkfun_samd21_mini.jpg"
 date_added: 2019-3-9
+features:
+  - Breadboard-Friendly
 ---
 
 The SAMD21 Mini Breakout is a Pro Mini-sized breakout for the Atmel ATSAMD21G18, a 32-bit ARM Cortex-M0+ processor with 256KB flash, 32KB SRAM, and an operating speed of up to 48MHz. 

--- a/_board/sparkfun_samd51_thing_plus.md
+++ b/_board/sparkfun_samd51_thing_plus.md
@@ -11,6 +11,7 @@ features:
   - Feather-Compatible
   - Battery Charging
   - STEMMA QT/QWIIC
+  - Breadboard-Friendly
 ---
 
 Is it power you seek? With a 32-bit ARM Cortex-M4F MCU, the SparkFun SAMD51 Thing Plus is one of our most powerful microcontroller boards yet! The SAMD51 Thing Plus provides you with an economical and easy to use development platform if you're needing more power with minimal working space. This Thing even comes flashed with the same convenient UF2 bootloader as the RedBoard Turbo. To make the Thing Plus even easier to use, we've moved a few pins around to make the board Feather compatible and it utilizes our handy Qwiic Connect System which means no soldering or shields are required to connect it to the rest of your system!

--- a/_board/sparkfun_thing_plus_rp2040.md
+++ b/_board/sparkfun_thing_plus_rp2040.md
@@ -12,6 +12,7 @@ features:
   - Battery Charging
   - STEMMA QT/QWIIC
   - USB-C
+  - Breadboard-Friendly
 ---
 
 The SparkFun Thing Plus - RP2040 is a low-cost, high performance board with flexible digital interfaces featuring the Raspberry Pi Foundation's RP2040 microcontroller. Besides the Thing Plus or *Feather* footprint (with 18 GPIO pins), the board also includes an SD card slot, 16MB (128Mbit) flash memory, a JST single cell battery connector (with a charging circuit and fuel gauge sensor), an addressable WS2812 RGB LED, JTAG PTH pins, four (4-40 screw) mounting holes, and our signature Qwiic connector.

--- a/_board/spresense.md
+++ b/_board/spresense.md
@@ -9,6 +9,7 @@ board_image: "spresense.jpg"
 date_added: 2019-10-23
 features:
   - GPS
+  - Arduino Shield Compatible
 ---
 
 The Spresense project consists of a Arduino compatible board with Sony’s high performance CXD5602 micro-controller. The CXD5602 has built-in GPS and high-resolution audio capabilities.

--- a/_board/stackrduino_m0_pro.md
+++ b/_board/stackrduino_m0_pro.md
@@ -11,6 +11,7 @@ features:
   - Battery Charging
   - STEMMA QT/QWIIC
   - USB-C
+  - Breadboard-Friendly
 ---
 
 StackRduino M0+ PRO is an open source Development board based on the ATSAMD21G18 for Arduino & Circuit-Python packed with features & comes with many stackable shields

--- a/_board/stm32f411ce_blackpill.md
+++ b/_board/stm32f411ce_blackpill.md
@@ -10,6 +10,7 @@ date_added: 2019-12-20
 
 features:
   - USB-C
+  - Breadboard-Friendly
 ---
 In the F401 series, the chip is the cheapest, even cheaper than some F1, and crushed F1 on the main frequency, and has a floating-point arithmetic module, the IO port contains all the basic functions. Therefore, it is possible to provide a learning platform with a very high cost performance for beginners. In practical applications, it is not because the computing power is insufficient, and the IO port is incomplete and hinders development.
 

--- a/_board/stm32f411ce_blackpill_with_flash.md
+++ b/_board/stm32f411ce_blackpill_with_flash.md
@@ -10,6 +10,7 @@ date_added: 2021-4-6
 
 features:
   - USB-C
+  - Breadboard-Friendly
 ---
 In the F401 series, the chip is the cheapest, even cheaper than some F1, and crushed F1 on the main frequency, and has a floating-point arithmetic module, the IO port contains all the basic functions. Therefore, it is possible to provide a learning platform with a very high cost performance for beginners. In practical applications, it is not because the computing power is insufficient, and the IO port is incomplete and hinders development.
 

--- a/_board/teensy40.md
+++ b/_board/teensy40.md
@@ -8,7 +8,7 @@ board_url: "https://www.pjrc.com/store/teensy40.html"
 board_image: "teensy40.jpg"
 date_added: 2020-1-31
 features:
-
+  - Breadboard-Friendly
 ---
 Who else could pack a 600 MHz microcontroller into such a Teensy little board? The Teensy 4.0 features an ARM Cortex-M7 processor at 600 MHz, with a NXP iMXRT1062 chip, the fastest microcontroller available today - [ten times faster than the Teensy 3.2](https://github.com/PaulStoffregen/CoreMark)! The NXP iMXRT1062 is a 'cross-over' processor, which has the functionality of a microcontroller, at the speeds of a microcomputer. It's perfect for when you need tons of flash, RAM and, to crunch lots of data, or when you need two full speed USB ports. It even has a graphics processor! All this for two sawbucks.
 

--- a/_board/teensy41.md
+++ b/_board/teensy41.md
@@ -8,7 +8,7 @@ board_url: "https://www.adafruit.com/product/4622"
 board_image: "teensy41.jpg"
 date_added: 2020-05-11
 features:
-
+  - Breadboard-Friendly
 ---
 
 The [Teensy](http://www.pjrc.com/teensy/index.html) 4.1, like the [4.0](http://www.adafruit.com/product/4323), also features an ARM Cortex-M7 processor at 600 MHz, with an NXP iMXRT1062 chip, the fastest microcontroller available today - [ten times faster than the Teensy 3.2](https://github.com/PaulStoffregen/CoreMark)! The NXP iMXRT1062 is a 'cross-over' processor, which has the functionality of a microcontroller, at the speeds of a microcomputer. It's perfect for when you need tons of flash, RAM and, to crunch lots of data, or when you need two full-speed USB ports. 

--- a/_board/trinket_m0.md
+++ b/_board/trinket_m0.md
@@ -7,6 +7,8 @@ manufacturer: "Adafruit"
 board_url: ""
 board_image: "trinket_m0.jpg"
 date_added: 2019-3-9
+features:
+  - Breadboard-Friendly
 ---
 
 The Adafruit Trinket M0 may be small, but do not be fooled by its size! It's a tiny microcontroller board, built around the Atmel ATSAMD21, a little chip with _a lot_ of power. Adafruit designed a microcontroller board that was small enough to fit into any project, and low cost enough to use without hesitation. Perfect for when you don't want to give up your expensive dev-board and you aren't willing to take apart the project you worked so hard to design. It's one of the lowest-cost CircuitPython programmable boards!

--- a/_board/trinket_m0_haxpress.md
+++ b/_board/trinket_m0_haxpress.md
@@ -7,6 +7,8 @@ manufacturer: "Dave Astels"
 board_url: ""
 board_image: "trinket_m0_haxpress.jpg"
 date_added: 2019-3-19
+features:
+  - Breadboard-Friendly
 ---
 
 This is a [Trinket M0]({{ "/board/trinket_m0/" | relative_url }}) that has been had a SPI flash

--- a/_board/uchip.md
+++ b/_board/uchip.md
@@ -7,6 +7,8 @@ manufacturer: "Itaca Innovation"
 board_url: ""
 board_image: "uchip.jpg"
 date_added: 2019-3-25
+features:
+  - Breadboard-Friendly
 ---
 
 **Small. Yet powerful!**

--- a/_board/unexpectedmaker_feathers2.md
+++ b/_board/unexpectedmaker_feathers2.md
@@ -13,6 +13,7 @@ features:
   - Wi-Fi
   - STEMMA QT/QWIIC
   - USB-C
+  - Breadboard-Friendly
 ---
 
 Introducing the FeatherS2 - The PRO ESP32-S2 based development board in a Feather format!

--- a/_board/unexpectedmaker_feathers2_prerelease.md
+++ b/_board/unexpectedmaker_feathers2_prerelease.md
@@ -13,6 +13,7 @@ features:
   - Wi-Fi
   - STEMMA QT/QWIIC
   - USB-C
+  - Breadboard-Friendly
 ---
 
 Pre-Release version of the FeatherS2

--- a/_board/unexpectedmaker_tinys2.md
+++ b/_board/unexpectedmaker_tinys2.md
@@ -11,6 +11,7 @@ features:
   - Battery Charging
   - Wi-Fi
   - USB-C
+  - Breadboard-Friendly
 ---
 
 Introducing the TinyS2 - The Mighty Tiny ESP32-S2 based development board!

--- a/template.md
+++ b/template.md
@@ -12,6 +12,7 @@ blinka: false
 download_instructions: "BLINKA ONLY - url"
 # Features are tags; they should be limited to the items in this list and spelled exactly the same.
 # Include only the features your board supports, and remove these comment lines before committing.
+# Breadboard-Friendly is a parallel pin layout with minimal non-critical perpendicular pins
 features:
   - Speaker
   - Solder-Free Alligator Clip
@@ -25,6 +26,8 @@ features:
   - GPS
   - STEMMA QT/QWIIC
   - USB-C
+  - Breadboard-Friendly  
+  - Arduino Shield Compatible
 ---
 
 This board hasn't been fully documented yet. Please make a pull request adding more info to this file.


### PR DESCRIPTION
Added Breadboard-Friendly and Arduino Shield Compatible features.

Breadboard-Friendly is defined as parallel pins with at least one socket open on each side of the board (Assuming single, standard breadboard) and minimal non-critical perpendicular pins.  (i.e. 3V3, Vcc, Vusb, GND, En, Reset not perpendicular)

As I worked through the boards, I found some boards definitions missing features and corrected those.