### PR TITLE
update libraries page and header links

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,12 +8,10 @@
         <a href="https://blog.adafruit.com/category/circuitpython">News</a>
         <a {% if current[1] == 'awesome' %}class='active'{% endif %} href="{{ "/awesome" | relative_url  }}">Awesome</a>
         <a href="https://www.adafruitdaily.com/category/circuitpython">Newsletter</a>
-        <a href="https://circuitpython.readthedocs.io/">API</a>
-        <a href="https://forums.adafruit.com/viewforum.php?f=60">Help</a>
-        <span>
-            <a href="https://adafru.it/discord" aria-label="Discord"><i class="fab fa-discord"></i></a>
-            <a href="{{ '/feed.rss' | relative_url  }}" type="application/rss+xml" aria-label="RSS Feed"><i class="fas fa-rss-square"></i></a>
-        </span>
+        <a href="https://circuitpython.readthedocs.io/">Documentation</a>
+        <a href="https://forums.adafruit.com/viewforum.php?f=60">Forums</a>
+        <a href="https://adafru.it/discord" aria-label="Discord"><i class="fab fa-discord"></i> Discord</a>
+        <a href="{{ '/feed.rss' | relative_url  }}" type="application/rss+xml" aria-label="RSS Feed"><i class="fas fa-rss-square"></i> RSS</a>
       </div>
     </div>
   </nav>

--- a/_includes/header_mobile.html
+++ b/_includes/header_mobile.html
@@ -35,11 +35,10 @@
                                   href="{{ "/awesome" | relative_url  }}">Awesome</a></li>
         <li><a href="https://www.adafruitdaily.com/category/circuitpython">Newsletter</a></li>
         <li><a href="https://learn.adafruit.com/welcome-to-circuitpython">Get Started</a></li>
-        <li><a href="https://forums.adafruit.com/viewforum.php?f=60">Help</a></li>
-        <li><a href="https://adafru.it/discord">Discord</a></li>
+        <li><a href="https://forums.adafruit.com/viewforum.php?f=60">Forums</a></li>
+        <li><a href="https://adafru.it/discord" aria-label="Discord"><i class="fab fa-discord"></i> Discord</a></li>
       </ul>
     </nav>
   </div>
   <div class="bottom-bar"></div>
 </header>
-

--- a/libraries/index.html
+++ b/libraries/index.html
@@ -11,62 +11,87 @@ permalink: /libraries
       CircuitPython. They are designed for use with CircuitPython and may or may not
       work with MicroPython. The bundle options are explained below.
     <p>
-      CircuitPython libraries are separate files designed to work with CircuitPython code.
-      CircuitPython programs require a lot of information to run. CircuitPython is so simple
-      to use because most of this information is processed in the background and stored in
-      libraries. Some libraries are built into CircuitPython. Others are downloaded and
-      stored on your CIRCUITPY drive in a folder called lib.
+      CircuitPython libraries are written in Python. They provide additional functionality
+      and support external devices, beyond what is in CircuitPython itself.
+      Libraries are stored on your <b>CIRCUITPY</b> drive in a folder called <b>lib</b>.
+      For more information on using and managing libraries, see the
+      <a href="https://learn.adafruit.com/welcome-to-circuitpython/circuitpython-libraries">Welcome To CircuitPython Guide</a>.
     </p>
-    <p>
-      The full list of all the CircuitPython libraries contained in the following bundles
-      can be found on the
-      <a href="https://circuitpython.readthedocs.io/projects/bundle/en/latest/drivers.html" title="">libraries page</a>.
     <section>
+      <h2>Documentation</h2>
+      <p>
+        The
+        <a href="https://circuitpython.readthedocs.io/projects/bundle/en/latest/drivers.html" title="">libraries documentation page</a>
+        contains a categorized list of all the CircuitPython libraries included in the following bundles,
+        with links to the documentation for every library.
       <h2>Download and Installation Instructions</h2>
       <p>
-        The libraries in each release are compiled to .mpy for all recent major versions
-        of CircuitPython. Please download the bundle that matches the major version
-        of your CircuitPython. For example, if you are running 6.0.0 you should
-        download the 6.x bundle. The .mpy files are designed to take up less space on
-        your CIRCUITPY drive. Unless you have a specific reason, choose the appropiate
-        .mpy library bundle!
+        You can download all the available libraries in a zip-file bundle for all recent major
+        versions of CircuitPython. These bundles are updated daily, whenever any included library is updated.
+      </p>
+      <p>
+        The libraries in each release are supplied as <b>.mpy</b> files, which are compiled
+        versions of Python source code.
+        <strong>Make sure to download the bundle that matches the major version
+        of your CircuitPython</strong>, because the <b>.mpy</b> files can change between versions.
+        For example, if you are running 6.3.0 you should download the 6.x bundle.
+      </p>
+      <p>
+        The precompiled <b>.mpy</b> files take up less space on your CIRCUITPY drive than the <b>.py</b> files.
+        They also load faster, and for some low-RAM boards, are required because the <b>.py</b> files
+        are too large to compile on the board itself.
+        <strong>Unless you need the source version, choose the appropiate <b>.mpy</b> library bundle!</strong>
+        If you need to compile <b>.py</b> files to <b>.mpy</b>, you can
+        <a href="https://learn.adafruit.com/welcome-to-circuitpython/frequently-asked-questions#how-can-i-create-my-own-mpy-files-3020687-11">run the <b>mpy-cross</b>
+        cross-compiler yourself</a>.
       </p>
       <p>
         <b>To install</b>, download the appropriate bundle for your version of CircuitPython.
-        Unzip the file, open the resulting folder and find the lib folder. Open the lib
-        folder and find the library files you need to load. Create a lib folder on your
-        CIRCUITPY drive. Copy the individual library files you need to the lib folder
-        on your CIRCUITPY drive.
+        Unzip the file, open the resulting folder and find the <b>lib</b> folder. Open the lib
+        folder and find the library files you need to load. Create a <b>lib</b> folder on your
+        CIRCUITPY drive. Copy the individual library files you need to the <b>lib</b> folder
+        on your CIRCUITPY drive. More details are available
+        <a href="https://learn.adafruit.com/welcome-to-circuitpython/circuitpython-libraries">here</a>.
       </p>
       <p>
         You can always find the
         <a href="https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/latest">latest releases of the libraries bundle</a>
         on GitHub.
+      </p>
+      <p>
+        An alternative way to download and update libraries on your board is to use the
+        <a href="https://learn.adafruit.com/keep-your-circuitpython-libraries-on-devices-up-to-date-with-circup">CircUp tool</a>,
+        which is under development.
+      </p>
+    </section>
+    <section>
+      <h2>Bundles</h2>
       <div class="release-section">
         <div id="adafruit-circuitpython-bundle-6.x-mpy">
-          <h3>Bundle Version 6.x</h3>
+          <h3>Bundle for Version 6.x</h3>
           <p>
             This bundle is built for use with CircuitPython 6.x.x. If you are using
             CircuitPython 6, please download this bundle.
           </p>
         </div>
         <div id="adafruit-circuitpython-bundle-7.x-mpy">
-            <h3>Bundle Version 7.x</h3>
+            <h3>Bundle for Version 7.x</h3>
             <p>
                 This bundle is built for use with CircuitPython 7.x.x. If you are using
-                CircuitPython 7, please download this bundle.
+                CircuitPython 7, please download this bundle. The .mpy format has
+                changed for CircuitPython 7; 6.x .mpy files are not compatible.
             </p>
         </div>
         <div id="adafruit-circuitpython-bundle-py">
-          <h3>Bundle Version py</h3>
+          <h3>Python Source Bundle</h3>
           <p>
-            This bundle is the uncompiled source code for every library. It is not
+            This bundle is the uncompiled Python source code for every library. It is not
             intended for general use! It is only recommended if you need to edit
-            a library file. This bundle works with all versions of CircuitPython.
+            a library file. This bundle works with all supported versions of CircuitPython.
           </p>
         </div>
         <div id="adafruit-circuitpython-bundle-examples">
-          <h3>Bundle Examples</h3>
+          <h3>Examples Bundle</h3>
           <p>
             Every CircuitPython library has examples to go along with it. This bundle
             contains every library example. This bundle will have examples that
@@ -75,6 +100,14 @@ permalink: /libraries
           </p>
         </div>
       </div>
+    </section>
+    <section>
+      <h2>The Community Bundle</h2>
+      <p>
+      The libraries in the bundles above are officially supported.
+      Additional libraries written and supported by community members are available in the
+      <a href="https://github.com/circuitpython/CircuitPython_Org_Bundle">Community Bundle</a>.
+      </p>
     </section>
     <section>
       <h2>Contributing</h2>


### PR DESCRIPTION
I did some rewriting on the libraries page:
- Added link to readthedocs for all libraries.
- Reworked the .mpy explanation and other text.
- Added link to Libraries page in Welcome guide in two places
- Mentioned CircUp.
- Mentioned and linked to the Community Bundle. This could be expanded later.
- Redid headings a bit

I also revamped the top links a bit, renaming "API to "Documentation" "Help" to "Forums", and labelling the Discord and RSS links more explicitly.
The mobile header was also updated.
OLD:
![image](https://user-images.githubusercontent.com/2847802/130100389-d36747b6-74f8-460f-8026-b77b02256336.png)
NEW:
![image](https://user-images.githubusercontent.com/2847802/130100320-731cbb9d-0cda-48a8-aa23-cac42f52067e.png)

Fixes #53 
Fixes #526 
Fixes #633

I tested the HTML and the looks locally.