### PR TITLE
Automated website update for release 7.0.0-rc.0

### DIFF
--- a/_data/files.json
+++ b/_data/files.json
@@ -1,6 +1,6 @@
 [
  {
-  "downloads": 162,
+  "downloads": 0,
   "id": "8086_commander",
   "versions": [
    {
@@ -99,12 +99,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 112,
+  "downloads": 0,
   "id": "ADM_B_NRF52840_1",
   "versions": [
    {
@@ -234,6 +234,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -260,12 +261,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 197,
+  "downloads": 0,
   "id": "TG-Watch",
   "versions": [
    {
@@ -395,6 +396,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -421,12 +423,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 209,
+  "downloads": 0,
   "id": "adafruit_feather_esp32s2_nopsram",
   "versions": [
    {
@@ -564,6 +566,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -595,12 +598,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 136,
+  "downloads": 0,
   "id": "adafruit_feather_esp32s2_tftback_nopsram",
   "versions": [
    {
@@ -738,6 +741,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -769,12 +773,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 746,
+  "downloads": 0,
   "id": "adafruit_feather_rp2040",
   "versions": [
    {
@@ -905,6 +909,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "qrio",
@@ -932,12 +937,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 662,
+  "downloads": 0,
   "id": "adafruit_funhouse",
   "versions": [
    {
@@ -1075,6 +1080,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -1106,12 +1112,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 303,
+  "downloads": 0,
   "id": "adafruit_itsybitsy_rp2040",
   "versions": [
    {
@@ -1242,6 +1248,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "qrio",
@@ -1269,12 +1276,102 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 543,
+  "downloads": 0,
+  "id": "adafruit_led_glasses_nrf52840",
+  "versions": [
+   {
+    "extensions": [
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "en_GB",
+     "en_US",
+     "en_x_pirate",
+     "es",
+     "fil",
+     "fr",
+     "ID",
+     "it_IT",
+     "ja",
+     "nl",
+     "pl",
+     "pt_BR",
+     "sv",
+     "zh_Latn_pinyin"
+    ],
+    "modules": [
+     "_bleio",
+     "adafruit_bus_device",
+     "adafruit_pixelbuf",
+     "aesio",
+     "alarm",
+     "analogio",
+     "atexit",
+     "audiobusio",
+     "audiocore",
+     "audiomixer",
+     "audiomp3",
+     "audiopwmio",
+     "binascii",
+     "bitbangio",
+     "bitmaptools",
+     "board",
+     "busio",
+     "countio",
+     "digitalio",
+     "displayio",
+     "errno",
+     "fontio",
+     "framebufferio",
+     "getpass",
+     "json",
+     "keypad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "onewireio",
+     "os",
+     "paralleldisplay",
+     "pulseio",
+     "pwmio",
+     "rainbowio",
+     "random",
+     "re",
+     "rgbmatrix",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "storage",
+     "struct",
+     "supervisor",
+     "synthio",
+     "terminalio",
+     "time",
+     "touchio",
+     "traceback",
+     "ulab",
+     "usb_cdc",
+     "usb_hid",
+     "usb_midi",
+     "vectorio",
+     "watchdog"
+    ],
+    "stable": false,
+    "version": "7.0.0-rc.0"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
   "id": "adafruit_macropad_rp2040",
   "versions": [
    {
@@ -1333,6 +1430,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "qrio",
@@ -1360,12 +1458,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 924,
+  "downloads": 0,
   "id": "adafruit_magtag_2.9_grayscale",
   "versions": [
    {
@@ -1503,6 +1601,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -1534,12 +1633,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 375,
+  "downloads": 0,
   "id": "adafruit_metro_esp32s2",
   "versions": [
    {
@@ -1677,6 +1776,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -1708,12 +1808,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 295,
+  "downloads": 0,
   "id": "adafruit_neokey_trinkey_m0",
   "versions": [
    {
@@ -1800,12 +1900,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 204,
+  "downloads": 0,
   "id": "adafruit_proxlight_trinkey_m0",
   "versions": [
    {
@@ -1895,12 +1995,12 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 351,
+  "downloads": 0,
   "id": "adafruit_qt2040_trinkey",
   "versions": [
    {
@@ -2031,6 +2131,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "qrio",
@@ -2058,12 +2159,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 525,
+  "downloads": 0,
   "id": "adafruit_qtpy_rp2040",
   "versions": [
    {
@@ -2194,6 +2295,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "qrio",
@@ -2221,12 +2323,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 275,
+  "downloads": 0,
   "id": "adafruit_rotary_trinkey_m0",
   "versions": [
    {
@@ -2315,12 +2417,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 245,
+  "downloads": 0,
   "id": "adafruit_slide_trinkey_m0",
   "versions": [
    {
@@ -2409,7 +2511,7 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
@@ -2475,6 +2577,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -2506,12 +2609,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 176,
+  "downloads": 0,
   "id": "aloriumtech_evo_m51",
   "versions": [
    {
@@ -2643,6 +2746,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -2669,12 +2773,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 125,
+  "downloads": 0,
   "id": "aramcon2_badge",
   "versions": [
    {
@@ -2804,6 +2908,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -2830,12 +2935,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 128,
+  "downloads": 0,
   "id": "aramcon_badge_2019",
   "versions": [
    {
@@ -2965,6 +3070,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -2991,12 +3097,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 137,
+  "downloads": 0,
   "id": "arduino_mkr1300",
   "versions": [
    {
@@ -3095,12 +3201,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 171,
+  "downloads": 0,
   "id": "arduino_mkrzero",
   "versions": [
    {
@@ -3199,12 +3305,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 322,
+  "downloads": 0,
   "id": "arduino_nano_33_ble",
   "versions": [
    {
@@ -3334,6 +3440,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -3360,12 +3467,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 197,
+  "downloads": 0,
   "id": "arduino_nano_33_iot",
   "versions": [
    {
@@ -3464,12 +3571,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 590,
+  "downloads": 0,
   "id": "arduino_nano_rp2040_connect",
   "versions": [
    {
@@ -3600,6 +3707,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "qrio",
@@ -3627,12 +3735,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 180,
+  "downloads": 0,
   "id": "arduino_zero",
   "versions": [
    {
@@ -3731,12 +3839,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 52,
+  "downloads": 0,
   "id": "artisense_rd00",
   "versions": [
    {
@@ -3874,6 +3982,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -3905,12 +4014,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 43,
+  "downloads": 0,
   "id": "atmegazero_esp32s2",
   "versions": [
    {
@@ -3971,6 +4080,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -4002,12 +4112,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 180,
+  "downloads": 0,
   "id": "bast_pro_mini_m0",
   "versions": [
    {
@@ -4104,12 +4214,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 142,
+  "downloads": 0,
   "id": "bastble",
   "versions": [
    {
@@ -4239,6 +4349,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -4265,12 +4376,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 136,
+  "downloads": 0,
   "id": "bdmicro_vina_d21",
   "versions": [
    {
@@ -4370,6 +4481,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -4388,12 +4500,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 250,
+  "downloads": 0,
   "id": "bdmicro_vina_d51",
   "versions": [
    {
@@ -4525,6 +4637,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -4551,12 +4664,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 171,
+  "downloads": 0,
   "id": "bdmicro_vina_d51_pcb7",
   "versions": [
    {
@@ -4688,6 +4801,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -4714,12 +4828,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 269,
+  "downloads": 0,
   "id": "bless_dev_board_multi_sensor",
   "versions": [
    {
@@ -4849,6 +4963,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -4875,12 +4990,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 141,
+  "downloads": 0,
   "id": "blm_badge",
   "versions": [
    {
@@ -4974,12 +5089,12 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 15,
+  "downloads": 0,
   "id": "bluemicro840",
   "versions": [
    {
@@ -5037,6 +5152,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -5063,12 +5179,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 294,
+  "downloads": 0,
   "id": "capablerobot_usbhub",
   "versions": [
    {
@@ -5198,6 +5314,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -5224,12 +5341,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 202,
+  "downloads": 0,
   "id": "catwan_usbstick",
   "versions": [
    {
@@ -5325,12 +5442,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 157,
+  "downloads": 0,
   "id": "circuitbrains_basic_m0",
   "versions": [
    {
@@ -5431,6 +5548,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -5449,12 +5567,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 165,
+  "downloads": 0,
   "id": "circuitbrains_deluxe_m4",
   "versions": [
    {
@@ -5586,6 +5704,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -5612,12 +5731,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 701,
+  "downloads": 0,
   "id": "circuitplayground_bluefruit",
   "versions": [
    {
@@ -5747,6 +5866,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -5773,12 +5893,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 1150,
+  "downloads": 0,
   "id": "circuitplayground_express",
   "versions": [
    {
@@ -5896,12 +6016,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 164,
+  "downloads": 0,
   "id": "circuitplayground_express_4h",
   "versions": [
    {
@@ -6019,12 +6139,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 205,
+  "downloads": 0,
   "id": "circuitplayground_express_crickit",
   "versions": [
    {
@@ -6137,12 +6257,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 171,
+  "downloads": 0,
   "id": "circuitplayground_express_digikey_pycon2019",
   "versions": [
    {
@@ -6260,12 +6380,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 202,
+  "downloads": 0,
   "id": "circuitplayground_express_displayio",
   "versions": [
    {
@@ -6375,12 +6495,12 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 553,
+  "downloads": 0,
   "id": "clue_nrf52840_express",
   "versions": [
    {
@@ -6510,6 +6630,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -6536,12 +6657,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 98,
+  "downloads": 0,
   "id": "cp32-m4",
   "versions": [
    {
@@ -6671,6 +6792,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -6697,12 +6819,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 148,
+  "downloads": 0,
   "id": "cp_sapling_m0",
   "versions": [
    {
@@ -6799,12 +6921,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 25,
+  "downloads": 0,
   "id": "cp_sapling_m0_revb",
   "versions": [
    {
@@ -6854,12 +6976,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 114,
+  "downloads": 0,
   "id": "cp_sapling_m0_spiflash",
   "versions": [
    {
@@ -6955,6 +7077,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -6973,7 +7096,7 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
@@ -7039,6 +7162,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -7070,12 +7194,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 88,
+  "downloads": 0,
   "id": "cytron_maker_pi_rp2040",
   "versions": [
    {
@@ -7134,6 +7258,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "qrio",
@@ -7161,12 +7286,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 43,
+  "downloads": 0,
   "id": "datalore_ip_m4",
   "versions": [
    {
@@ -7298,6 +7423,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -7324,12 +7450,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 143,
+  "downloads": 0,
   "id": "datum_distance",
   "versions": [
    {
@@ -7426,12 +7552,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 115,
+  "downloads": 0,
   "id": "datum_imu",
   "versions": [
    {
@@ -7528,12 +7654,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 146,
+  "downloads": 0,
   "id": "datum_light",
   "versions": [
    {
@@ -7630,12 +7756,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 101,
+  "downloads": 0,
   "id": "datum_weather",
   "versions": [
    {
@@ -7732,12 +7858,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 118,
+  "downloads": 0,
   "id": "dynalora_usb",
   "versions": [
    {
@@ -7835,12 +7961,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 130,
+  "downloads": 0,
   "id": "dynossat_edu_eps",
   "versions": [
    {
@@ -7938,6 +8064,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -7954,12 +8081,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 146,
+  "downloads": 0,
   "id": "dynossat_edu_obc",
   "versions": [
    {
@@ -8091,6 +8218,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -8117,12 +8245,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 223,
+  "downloads": 0,
   "id": "edgebadge",
   "versions": [
    {
@@ -8258,6 +8386,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -8284,12 +8413,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 90,
+  "downloads": 0,
   "id": "electroniccats_bastwifi",
   "versions": [
    {
@@ -8425,6 +8554,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -8456,12 +8586,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 157,
+  "downloads": 0,
   "id": "electronut_labs_blip",
   "versions": [
    {
@@ -8593,6 +8723,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -8619,12 +8750,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 153,
+  "downloads": 0,
   "id": "electronut_labs_papyr",
   "versions": [
    {
@@ -8754,6 +8885,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -8780,12 +8912,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 191,
+  "downloads": 0,
   "id": "escornabot_makech",
   "versions": [
    {
@@ -8880,12 +9012,110 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 183,
+  "downloads": 0,
+  "id": "espressif_hmi_devkit_1",
+  "versions": [
+   {
+    "extensions": [
+     "bin",
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "en_GB",
+     "en_US",
+     "en_x_pirate",
+     "es",
+     "fil",
+     "fr",
+     "ID",
+     "it_IT",
+     "ja",
+     "nl",
+     "pl",
+     "pt_BR",
+     "sv",
+     "zh_Latn_pinyin"
+    ],
+    "modules": [
+     "_bleio",
+     "adafruit_bus_device",
+     "adafruit_pixelbuf",
+     "alarm",
+     "analogio",
+     "atexit",
+     "audiobusio",
+     "audiocore",
+     "audiomixer",
+     "binascii",
+     "bitbangio",
+     "bitmaptools",
+     "board",
+     "busio",
+     "canio",
+     "countio",
+     "digitalio",
+     "displayio",
+     "dualbank",
+     "errno",
+     "fontio",
+     "framebufferio",
+     "frequencyio",
+     "getpass",
+     "imagecapture",
+     "ipaddress",
+     "json",
+     "keypad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "onewireio",
+     "os",
+     "paralleldisplay",
+     "ps2io",
+     "pulseio",
+     "pwmio",
+     "qrio",
+     "rainbowio",
+     "random",
+     "re",
+     "rgbmatrix",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "socketpool",
+     "ssl",
+     "storage",
+     "struct",
+     "supervisor",
+     "synthio",
+     "terminalio",
+     "time",
+     "touchio",
+     "traceback",
+     "ulab",
+     "usb_cdc",
+     "usb_hid",
+     "usb_midi",
+     "vectorio",
+     "watchdog",
+     "wifi"
+    ],
+    "stable": false,
+    "version": "7.0.0-rc.0"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
   "id": "espressif_kaluga_1",
   "versions": [
    {
@@ -9023,6 +9253,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -9054,12 +9285,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 67,
+  "downloads": 0,
   "id": "espressif_kaluga_1.3",
   "versions": [
    {
@@ -9120,6 +9351,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -9151,12 +9383,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 313,
+  "downloads": 0,
   "id": "espressif_saola_1_wroom",
   "versions": [
    {
@@ -9294,6 +9526,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -9325,12 +9558,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 394,
+  "downloads": 0,
   "id": "espressif_saola_1_wrover",
   "versions": [
    {
@@ -9468,6 +9701,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -9499,12 +9733,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 36,
+  "downloads": 0,
   "id": "espruino_pico",
   "versions": [
    {
@@ -9621,12 +9855,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 25,
+  "downloads": 0,
   "id": "espruino_wifi",
   "versions": [
    {
@@ -9754,12 +9988,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 437,
+  "downloads": 0,
   "id": "feather_bluefruit_sense",
   "versions": [
    {
@@ -9889,6 +10123,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -9915,12 +10150,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 239,
+  "downloads": 0,
   "id": "feather_m0_adalogger",
   "versions": [
    {
@@ -10019,12 +10254,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 232,
+  "downloads": 0,
   "id": "feather_m0_basic",
   "versions": [
    {
@@ -10123,12 +10358,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 532,
+  "downloads": 0,
   "id": "feather_m0_express",
   "versions": [
    {
@@ -10228,6 +10463,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -10246,12 +10482,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 151,
+  "downloads": 0,
   "id": "feather_m0_express_crickit",
   "versions": [
    {
@@ -10364,12 +10600,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 181,
+  "downloads": 0,
   "id": "feather_m0_rfm69",
   "versions": [
    {
@@ -10457,12 +10693,12 @@
      "usb_cdc"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 248,
+  "downloads": 0,
   "id": "feather_m0_rfm9x",
   "versions": [
    {
@@ -10550,12 +10786,12 @@
      "usb_cdc"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 212,
+  "downloads": 0,
   "id": "feather_m0_supersized",
   "versions": [
    {
@@ -10655,6 +10891,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -10673,12 +10910,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 239,
+  "downloads": 0,
   "id": "feather_m4_can",
   "versions": [
    {
@@ -10810,6 +11047,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -10836,12 +11074,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 794,
+  "downloads": 0,
   "id": "feather_m4_express",
   "versions": [
    {
@@ -10973,6 +11211,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -10999,12 +11238,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 116,
+  "downloads": 0,
   "id": "feather_m7_1011",
   "versions": [
    {
@@ -11138,12 +11377,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 154,
+  "downloads": 0,
   "id": "feather_mimxrt1011",
   "versions": [
    {
@@ -11277,12 +11516,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 163,
+  "downloads": 0,
   "id": "feather_mimxrt1062",
   "versions": [
    {
@@ -11416,12 +11655,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 490,
+  "downloads": 0,
   "id": "feather_nrf52840_express",
   "versions": [
    {
@@ -11551,6 +11790,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -11577,7 +11817,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
@@ -11642,7 +11882,7 @@
   ]
  },
  {
-  "downloads": 181,
+  "downloads": 0,
   "id": "feather_stm32f405_express",
   "versions": [
    {
@@ -11782,12 +12022,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 191,
+  "downloads": 0,
   "id": "fluff_m0",
   "versions": [
    {
@@ -11884,12 +12124,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 185,
+  "downloads": 0,
   "id": "fomu",
   "versions": [
    {
@@ -11989,12 +12229,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 113,
+  "downloads": 0,
   "id": "franzininho_wifi_wroom",
   "versions": [
    {
@@ -12132,6 +12372,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -12163,12 +12404,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 145,
+  "downloads": 0,
   "id": "franzininho_wifi_wrover",
   "versions": [
    {
@@ -12306,6 +12547,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -12337,12 +12579,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 385,
+  "downloads": 0,
   "id": "gemma_m0",
   "versions": [
    {
@@ -12439,12 +12681,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 153,
+  "downloads": 0,
   "id": "gemma_m0_pycon2018",
   "versions": [
    {
@@ -12541,12 +12783,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 401,
+  "downloads": 0,
   "id": "grandcentral_m4_express",
   "versions": [
    {
@@ -12680,6 +12922,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -12708,12 +12951,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 28,
+  "downloads": 0,
   "id": "gravitech_cucumber_m",
   "versions": [
    {
@@ -12774,6 +13017,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -12805,12 +13049,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 26,
+  "downloads": 0,
   "id": "gravitech_cucumber_ms",
   "versions": [
    {
@@ -12871,6 +13115,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -12902,12 +13147,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 18,
+  "downloads": 0,
   "id": "gravitech_cucumber_r",
   "versions": [
    {
@@ -12968,6 +13213,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -12999,12 +13245,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 26,
+  "downloads": 0,
   "id": "gravitech_cucumber_rs",
   "versions": [
    {
@@ -13065,6 +13311,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -13096,12 +13343,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 284,
+  "downloads": 0,
   "id": "hallowing_m0_express",
   "versions": [
    {
@@ -13198,6 +13445,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -13216,12 +13464,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 259,
+  "downloads": 0,
   "id": "hallowing_m4_express",
   "versions": [
    {
@@ -13353,6 +13601,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -13379,12 +13628,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 253,
+  "downloads": 0,
   "id": "hiibot_bluefi",
   "versions": [
    {
@@ -13514,6 +13763,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -13540,12 +13790,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 133,
+  "downloads": 0,
   "id": "huntercat_nfc",
   "versions": [
    {
@@ -13632,6 +13882,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -13650,12 +13901,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 120,
+  "downloads": 0,
   "id": "ikigaisense_vita",
   "versions": [
    {
@@ -13785,6 +14036,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -13811,12 +14063,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 179,
+  "downloads": 0,
   "id": "imxrt1010_evk",
   "versions": [
    {
@@ -13950,12 +14202,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 154,
+  "downloads": 0,
   "id": "imxrt1020_evk",
   "versions": [
    {
@@ -14089,12 +14341,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 171,
+  "downloads": 0,
   "id": "imxrt1060_evk",
   "versions": [
    {
@@ -14228,12 +14480,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 426,
+  "downloads": 0,
   "id": "itsybitsy_m0_express",
   "versions": [
    {
@@ -14331,6 +14583,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pwmio",
      "rainbowio",
      "random",
@@ -14348,12 +14601,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 458,
+  "downloads": 0,
   "id": "itsybitsy_m4_express",
   "versions": [
    {
@@ -14483,6 +14736,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -14509,12 +14763,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 351,
+  "downloads": 0,
   "id": "itsybitsy_nrf52840_express",
   "versions": [
    {
@@ -14644,6 +14898,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -14670,12 +14925,104 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 142,
+  "downloads": 0,
+  "id": "jpconstantineau_encoderpad_rp2040",
+  "versions": [
+   {
+    "extensions": [
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "en_GB",
+     "en_US",
+     "en_x_pirate",
+     "es",
+     "fil",
+     "fr",
+     "ID",
+     "it_IT",
+     "ja",
+     "nl",
+     "pl",
+     "pt_BR",
+     "sv",
+     "zh_Latn_pinyin"
+    ],
+    "modules": [
+     "_bleio",
+     "adafruit_bus_device",
+     "adafruit_pixelbuf",
+     "alarm",
+     "analogio",
+     "atexit",
+     "audiobusio",
+     "audiocore",
+     "audiomixer",
+     "audiomp3",
+     "audiopwmio",
+     "binascii",
+     "bitbangio",
+     "bitmaptools",
+     "bitops",
+     "board",
+     "busio",
+     "countio",
+     "digitalio",
+     "displayio",
+     "errno",
+     "fontio",
+     "framebufferio",
+     "getpass",
+     "imagecapture",
+     "json",
+     "keypad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "onewireio",
+     "os",
+     "paralleldisplay",
+     "pulseio",
+     "pwmio",
+     "qrio",
+     "rainbowio",
+     "random",
+     "re",
+     "rgbmatrix",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "storage",
+     "struct",
+     "supervisor",
+     "synthio",
+     "terminalio",
+     "time",
+     "touchio",
+     "traceback",
+     "ulab",
+     "usb_cdc",
+     "usb_hid",
+     "usb_midi",
+     "vectorio",
+     "watchdog"
+    ],
+    "stable": false,
+    "version": "7.0.0-rc.0"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
   "id": "kicksat-sprite",
   "versions": [
    {
@@ -14803,12 +15150,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 249,
+  "downloads": 0,
   "id": "lilygo_ttgo_t8_s2_st7789",
   "versions": [
    {
@@ -14946,6 +15293,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -14977,12 +15325,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 122,
+  "downloads": 0,
   "id": "loc_ber_m4_base_board",
   "versions": [
    {
@@ -15081,12 +15429,110 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 254,
+  "downloads": 0,
+  "id": "lolin_s2_mini",
+  "versions": [
+   {
+    "extensions": [
+     "bin",
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "en_GB",
+     "en_US",
+     "en_x_pirate",
+     "es",
+     "fil",
+     "fr",
+     "ID",
+     "it_IT",
+     "ja",
+     "nl",
+     "pl",
+     "pt_BR",
+     "sv",
+     "zh_Latn_pinyin"
+    ],
+    "modules": [
+     "_bleio",
+     "adafruit_bus_device",
+     "adafruit_pixelbuf",
+     "alarm",
+     "analogio",
+     "atexit",
+     "audiobusio",
+     "audiocore",
+     "audiomixer",
+     "binascii",
+     "bitbangio",
+     "bitmaptools",
+     "board",
+     "busio",
+     "canio",
+     "countio",
+     "digitalio",
+     "displayio",
+     "dualbank",
+     "errno",
+     "fontio",
+     "framebufferio",
+     "frequencyio",
+     "getpass",
+     "imagecapture",
+     "ipaddress",
+     "json",
+     "keypad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "onewireio",
+     "os",
+     "paralleldisplay",
+     "ps2io",
+     "pulseio",
+     "pwmio",
+     "qrio",
+     "rainbowio",
+     "random",
+     "re",
+     "rgbmatrix",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "socketpool",
+     "ssl",
+     "storage",
+     "struct",
+     "supervisor",
+     "synthio",
+     "terminalio",
+     "time",
+     "touchio",
+     "traceback",
+     "ulab",
+     "usb_cdc",
+     "usb_hid",
+     "usb_midi",
+     "vectorio",
+     "watchdog",
+     "wifi"
+    ],
+    "stable": false,
+    "version": "7.0.0-rc.0"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
   "id": "makerdiary_m60_keyboard",
   "versions": [
    {
@@ -15216,6 +15662,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -15242,12 +15689,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 121,
+  "downloads": 0,
   "id": "makerdiary_nrf52840_m2_devkit",
   "versions": [
    {
@@ -15377,6 +15824,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -15403,12 +15851,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 157,
+  "downloads": 0,
   "id": "makerdiary_nrf52840_mdk",
   "versions": [
    {
@@ -15538,6 +15986,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -15564,12 +16013,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 210,
+  "downloads": 0,
   "id": "makerdiary_nrf52840_mdk_usb_dongle",
   "versions": [
    {
@@ -15701,6 +16150,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -15727,12 +16177,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 725,
+  "downloads": 0,
   "id": "matrixportal_m4",
   "versions": [
    {
@@ -15864,6 +16314,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -15890,12 +16341,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 201,
+  "downloads": 0,
   "id": "meowbit_v121",
   "versions": [
    {
@@ -15978,6 +16429,7 @@
      "zh_Latn_pinyin"
     ],
     "modules": [
+     "_stage",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "analogio",
@@ -16025,12 +16477,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 162,
+  "downloads": 0,
   "id": "meowmeow",
   "versions": [
    {
@@ -16124,12 +16576,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 403,
+  "downloads": 0,
   "id": "metro_m0_express",
   "versions": [
    {
@@ -16229,6 +16681,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -16247,12 +16700,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 356,
+  "downloads": 0,
   "id": "metro_m4_airlift_lite",
   "versions": [
    {
@@ -16384,6 +16837,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -16410,12 +16864,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 349,
+  "downloads": 0,
   "id": "metro_m4_express",
   "versions": [
    {
@@ -16547,6 +17001,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -16573,12 +17028,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 108,
+  "downloads": 0,
   "id": "metro_m7_1011",
   "versions": [
    {
@@ -16712,12 +17167,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 227,
+  "downloads": 0,
   "id": "metro_nrf52840_express",
   "versions": [
    {
@@ -16847,6 +17302,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -16873,7 +17329,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
@@ -16935,12 +17391,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 118,
+  "downloads": 0,
   "id": "microdev_micro_s2",
   "versions": [
    {
@@ -17078,6 +17534,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -17109,12 +17566,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 230,
+  "downloads": 0,
   "id": "mini_sam_m4",
   "versions": [
    {
@@ -17244,6 +17701,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -17270,12 +17728,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 334,
+  "downloads": 0,
   "id": "monster_m4sk",
   "versions": [
    {
@@ -17407,6 +17865,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -17433,7 +17892,7 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
@@ -17499,6 +17958,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -17530,12 +17990,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 618,
+  "downloads": 0,
   "id": "muselab_nanoesp32_s2_wroom",
   "versions": [
    {
@@ -17673,6 +18133,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -17704,12 +18165,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 498,
+  "downloads": 0,
   "id": "muselab_nanoesp32_s2_wrover",
   "versions": [
    {
@@ -17847,6 +18308,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -17878,12 +18340,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 94,
+  "downloads": 0,
   "id": "ndgarage_ndbit6",
   "versions": [
    {
@@ -17980,12 +18442,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 54,
+  "downloads": 0,
   "id": "ndgarage_ndbit6_v2",
   "versions": [
    {
@@ -18082,12 +18544,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 390,
+  "downloads": 0,
   "id": "neopixel_trinkey_m0",
   "versions": [
    {
@@ -18174,12 +18636,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 227,
+  "downloads": 0,
   "id": "nfc_copy_cat",
   "versions": [
    {
@@ -18276,12 +18738,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 201,
+  "downloads": 0,
   "id": "nice_nano",
   "versions": [
    {
@@ -18411,6 +18873,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -18437,12 +18900,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 35,
+  "downloads": 0,
   "id": "nucleo_f746zg",
   "versions": [
    {
@@ -18567,12 +19030,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 49,
+  "downloads": 0,
   "id": "nucleo_f767zi",
   "versions": [
    {
@@ -18697,12 +19160,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 37,
+  "downloads": 0,
   "id": "nucleo_h743zi_2",
   "versions": [
    {
@@ -18823,7 +19286,7 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
@@ -18889,6 +19352,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -18920,12 +19384,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 204,
+  "downloads": 0,
   "id": "ohs2020_badge",
   "versions": [
    {
@@ -19055,6 +19519,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -19081,12 +19546,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 194,
+  "downloads": 0,
   "id": "openbook_m4",
   "versions": [
    {
@@ -19220,6 +19685,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -19246,12 +19712,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 32,
+  "downloads": 0,
   "id": "openmv_h7",
   "versions": [
    {
@@ -19372,12 +19838,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 210,
+  "downloads": 0,
   "id": "particle_argon",
   "versions": [
    {
@@ -19507,6 +19973,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -19533,12 +20000,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 124,
+  "downloads": 0,
   "id": "particle_boron",
   "versions": [
    {
@@ -19668,6 +20135,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -19694,12 +20162,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 234,
+  "downloads": 0,
   "id": "particle_xenon",
   "versions": [
    {
@@ -19829,6 +20297,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -19855,12 +20324,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 160,
+  "downloads": 0,
   "id": "pca10056",
   "versions": [
    {
@@ -19992,6 +20461,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -20018,12 +20488,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 256,
+  "downloads": 0,
   "id": "pca10059",
   "versions": [
    {
@@ -20155,6 +20625,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -20181,12 +20652,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 177,
+  "downloads": 0,
   "id": "pca10100",
   "versions": [
    {
@@ -20298,12 +20769,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 122,
+  "downloads": 0,
   "id": "pewpew10",
   "versions": [
    {
@@ -20396,12 +20867,12 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 89,
+  "downloads": 0,
   "id": "pewpew13",
   "versions": [
    {
@@ -20494,12 +20965,12 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 179,
+  "downloads": 0,
   "id": "pewpew_m4",
   "versions": [
    {
@@ -20599,12 +21070,12 @@
      "usb_cdc"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 116,
+  "downloads": 0,
   "id": "picoplanet",
   "versions": [
    {
@@ -20701,7 +21172,7 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
@@ -20765,6 +21236,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "qrio",
@@ -20792,12 +21264,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 348,
+  "downloads": 0,
   "id": "pimoroni_keybow2040",
   "versions": [
    {
@@ -20928,6 +21400,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "qrio",
@@ -20955,12 +21428,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 38,
+  "downloads": 0,
   "id": "pimoroni_pga2040",
   "versions": [
    {
@@ -21019,6 +21492,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "qrio",
@@ -21046,12 +21520,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 327,
+  "downloads": 0,
   "id": "pimoroni_picolipo_16mb",
   "versions": [
    {
@@ -21182,6 +21656,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "qrio",
@@ -21209,12 +21684,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 235,
+  "downloads": 0,
   "id": "pimoroni_picolipo_4mb",
   "versions": [
    {
@@ -21345,6 +21820,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "qrio",
@@ -21372,12 +21848,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 207,
+  "downloads": 0,
   "id": "pimoroni_picosystem",
   "versions": [
    {
@@ -21508,6 +21984,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "qrio",
@@ -21535,7 +22012,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
@@ -21599,6 +22076,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "qrio",
@@ -21626,12 +22104,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 436,
+  "downloads": 0,
   "id": "pimoroni_tiny2040",
   "versions": [
    {
@@ -21762,6 +22240,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "qrio",
@@ -21789,7 +22268,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
@@ -21841,7 +22320,7 @@
   ]
  },
  {
-  "downloads": 181,
+  "downloads": 0,
   "id": "pitaya_go",
   "versions": [
    {
@@ -21971,6 +22450,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -21997,12 +22477,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 36,
+  "downloads": 0,
   "id": "pyb_nano_v2",
   "versions": [
    {
@@ -22128,12 +22608,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 397,
+  "downloads": 0,
   "id": "pybadge",
   "versions": [
    {
@@ -22269,6 +22749,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -22295,7 +22776,7 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
@@ -22382,7 +22863,7 @@
   ]
  },
  {
-  "downloads": 93,
+  "downloads": 0,
   "id": "pyboard_v11",
   "versions": [
    {
@@ -22522,12 +23003,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 183,
+  "downloads": 0,
   "id": "pycubed",
   "versions": [
    {
@@ -22664,12 +23145,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 174,
+  "downloads": 0,
   "id": "pycubed_mram",
   "versions": [
    {
@@ -22806,12 +23287,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 402,
+  "downloads": 0,
   "id": "pygamer",
   "versions": [
    {
@@ -22947,6 +23428,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -22973,7 +23455,7 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
@@ -23060,7 +23542,7 @@
   ]
  },
  {
-  "downloads": 549,
+  "downloads": 0,
   "id": "pyportal",
   "versions": [
    {
@@ -23192,6 +23674,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -23218,12 +23701,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 227,
+  "downloads": 0,
   "id": "pyportal_pynt",
   "versions": [
    {
@@ -23355,6 +23838,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -23381,12 +23865,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 310,
+  "downloads": 0,
   "id": "pyportal_titano",
   "versions": [
    {
@@ -23518,6 +24002,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -23544,12 +24029,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 295,
+  "downloads": 0,
   "id": "pyruler",
   "versions": [
    {
@@ -23645,12 +24130,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 616,
+  "downloads": 0,
   "id": "qtpy_m0",
   "versions": [
    {
@@ -23747,12 +24232,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 355,
+  "downloads": 0,
   "id": "qtpy_m0_haxpress",
   "versions": [
    {
@@ -23852,6 +24337,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -23870,12 +24356,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 3249,
+  "downloads": 0,
   "id": "raspberry_pi_pico",
   "versions": [
    {
@@ -24006,6 +24492,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "qrio",
@@ -24033,12 +24520,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 127,
+  "downloads": 0,
   "id": "raytac_mdbt50q-db-40",
   "versions": [
    {
@@ -24168,6 +24655,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -24194,12 +24682,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 22,
+  "downloads": 0,
   "id": "raytac_mdbt50q-rx",
   "versions": [
    {
@@ -24257,6 +24745,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -24283,12 +24772,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 212,
+  "downloads": 0,
   "id": "robohatmm1_m4",
   "versions": [
    {
@@ -24427,12 +24916,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 159,
+  "downloads": 0,
   "id": "sam32",
   "versions": [
    {
@@ -24564,6 +25053,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -24590,12 +25080,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 168,
+  "downloads": 0,
   "id": "same54_xplained",
   "versions": [
    {
@@ -24728,6 +25218,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -24753,12 +25244,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 499,
+  "downloads": 0,
   "id": "seeeduino_wio_terminal",
   "versions": [
    {
@@ -24890,6 +25381,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -24916,12 +25408,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 877,
+  "downloads": 0,
   "id": "seeeduino_xiao",
   "versions": [
    {
@@ -25018,12 +25510,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 29,
+  "downloads": 0,
   "id": "sensebox_mcu",
   "versions": [
    {
@@ -25072,12 +25564,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 186,
+  "downloads": 0,
   "id": "serpente",
   "versions": [
    {
@@ -25180,6 +25672,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -25198,12 +25691,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 183,
+  "downloads": 0,
   "id": "shirtty",
   "versions": [
    {
@@ -25300,12 +25793,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 116,
+  "downloads": 0,
   "id": "silicognition-m4-shim",
   "versions": [
    {
@@ -25437,6 +25930,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -25463,12 +25957,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 137,
+  "downloads": 0,
   "id": "simmel",
   "versions": [
    {
@@ -25579,12 +26073,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 141,
+  "downloads": 0,
   "id": "snekboard",
   "versions": [
    {
@@ -25684,6 +26178,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -25702,12 +26197,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 155,
+  "downloads": 0,
   "id": "sparkfun_lumidrive",
   "versions": [
    {
@@ -25805,6 +26300,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -25823,12 +26319,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 236,
+  "downloads": 0,
   "id": "sparkfun_micromod_rp2040",
   "versions": [
    {
@@ -25959,6 +26455,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "qrio",
@@ -25986,12 +26483,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 198,
+  "downloads": 0,
   "id": "sparkfun_nrf52840_micromod",
   "versions": [
    {
@@ -26121,6 +26618,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -26147,12 +26645,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 184,
+  "downloads": 0,
   "id": "sparkfun_nrf52840_mini",
   "versions": [
    {
@@ -26282,6 +26780,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -26308,12 +26807,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 245,
+  "downloads": 0,
   "id": "sparkfun_pro_micro_rp2040",
   "versions": [
    {
@@ -26444,6 +26943,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "qrio",
@@ -26471,12 +26971,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 133,
+  "downloads": 0,
   "id": "sparkfun_qwiic_micro_no_flash",
   "versions": [
    {
@@ -26573,12 +27073,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 179,
+  "downloads": 0,
   "id": "sparkfun_qwiic_micro_with_flash",
   "versions": [
    {
@@ -26675,12 +27175,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 234,
+  "downloads": 0,
   "id": "sparkfun_redboard_turbo",
   "versions": [
    {
@@ -26779,6 +27279,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -26797,12 +27298,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 203,
+  "downloads": 0,
   "id": "sparkfun_samd21_dev",
   "versions": [
    {
@@ -26899,12 +27400,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 212,
+  "downloads": 0,
   "id": "sparkfun_samd21_mini",
   "versions": [
    {
@@ -27001,12 +27502,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 33,
+  "downloads": 0,
   "id": "sparkfun_samd51_micromod",
   "versions": [
    {
@@ -27064,6 +27565,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -27090,12 +27592,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 272,
+  "downloads": 0,
   "id": "sparkfun_samd51_thing_plus",
   "versions": [
    {
@@ -27227,6 +27729,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -27253,12 +27756,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 3,
+  "downloads": 0,
   "id": "sparkfun_stm32f405_micromod",
   "versions": [
    {
@@ -27336,12 +27839,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 285,
+  "downloads": 0,
   "id": "sparkfun_thing_plus_rp2040",
   "versions": [
    {
@@ -27472,6 +27975,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "qrio",
@@ -27499,12 +28003,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 175,
+  "downloads": 0,
   "id": "spresense",
   "versions": [
    {
@@ -27618,12 +28122,12 @@
      "usb_cdc"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 162,
+  "downloads": 0,
   "id": "stackrduino_m0_pro",
   "versions": [
    {
@@ -27723,6 +28227,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -27741,12 +28246,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 131,
+  "downloads": 0,
   "id": "stm32f411ce_blackpill",
   "versions": [
    {
@@ -27874,12 +28379,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 72,
+  "downloads": 0,
   "id": "stm32f411ce_blackpill_with_flash",
   "versions": [
    {
@@ -28011,12 +28516,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 44,
+  "downloads": 0,
   "id": "stm32f411ve_discovery",
   "versions": [
    {
@@ -28142,12 +28647,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 35,
+  "downloads": 0,
   "id": "stm32f412zg_discovery",
   "versions": [
    {
@@ -28280,12 +28785,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 66,
+  "downloads": 0,
   "id": "stm32f4_discovery",
   "versions": [
    {
@@ -28423,12 +28928,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 38,
+  "downloads": 0,
   "id": "stm32f746g_discovery",
   "versions": [
    {
@@ -28553,12 +29058,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 183,
+  "downloads": 0,
   "id": "stringcar_m0_express",
   "versions": [
    {
@@ -28657,6 +29162,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -28675,12 +29181,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 163,
+  "downloads": 0,
   "id": "targett_module_clip_wroom",
   "versions": [
    {
@@ -28818,6 +29324,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -28849,12 +29356,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 138,
+  "downloads": 0,
   "id": "targett_module_clip_wrover",
   "versions": [
    {
@@ -28992,6 +29499,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -29023,12 +29531,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 382,
+  "downloads": 0,
   "id": "teensy40",
   "versions": [
    {
@@ -29162,12 +29670,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 381,
+  "downloads": 0,
   "id": "teensy41",
   "versions": [
    {
@@ -29301,12 +29809,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 205,
+  "downloads": 0,
   "id": "teknikio_bluebird",
   "versions": [
    {
@@ -29436,6 +29944,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -29462,12 +29971,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 23,
+  "downloads": 0,
   "id": "thunderpack_v11",
   "versions": [
    {
@@ -29594,16 +30103,15 @@
      "traceback",
      "usb_cdc",
      "usb_hid",
-     "usb_midi",
-     "vectorio"
+     "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 28,
+  "downloads": 0,
   "id": "thunderpack_v12",
   "versions": [
    {
@@ -29735,12 +30243,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 194,
+  "downloads": 0,
   "id": "tinkeringtech_scoutmakes_azul",
   "versions": [
    {
@@ -29870,6 +30378,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -29896,12 +30405,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 392,
+  "downloads": 0,
   "id": "trellis_m4_express",
   "versions": [
    {
@@ -30031,6 +30540,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -30057,12 +30567,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 819,
+  "downloads": 0,
   "id": "trinket_m0",
   "versions": [
    {
@@ -30159,12 +30669,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 184,
+  "downloads": 0,
   "id": "trinket_m0_haxpress",
   "versions": [
    {
@@ -30264,6 +30774,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "pulseio",
      "pwmio",
      "rainbowio",
@@ -30282,12 +30793,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 110,
+  "downloads": 0,
   "id": "uartlogger2",
   "versions": [
    {
@@ -30419,6 +30930,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -30445,12 +30957,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 149,
+  "downloads": 0,
   "id": "uchip",
   "versions": [
    {
@@ -30549,12 +31061,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 110,
+  "downloads": 0,
   "id": "ugame10",
   "versions": [
    {
@@ -30660,12 +31172,12 @@
      "usb_cdc"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 528,
+  "downloads": 0,
   "id": "unexpectedmaker_feathers2",
   "versions": [
    {
@@ -30803,6 +31315,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -30834,12 +31347,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 73,
+  "downloads": 0,
   "id": "unexpectedmaker_feathers2_prerelease",
   "versions": [
    {
@@ -30977,6 +31490,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -31008,12 +31522,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 189,
+  "downloads": 0,
   "id": "unexpectedmaker_tinys2",
   "versions": [
    {
@@ -31151,6 +31665,7 @@
      "nvm",
      "onewireio",
      "os",
+     "paralleldisplay",
      "ps2io",
      "pulseio",
      "pwmio",
@@ -31182,12 +31697,102 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 219,
+  "downloads": 0,
+  "id": "warmbit_bluepixel",
+  "versions": [
+   {
+    "extensions": [
+     "uf2"
+    ],
+    "languages": [
+     "de_DE",
+     "en_GB",
+     "en_US",
+     "en_x_pirate",
+     "es",
+     "fil",
+     "fr",
+     "ID",
+     "it_IT",
+     "ja",
+     "nl",
+     "pl",
+     "pt_BR",
+     "sv",
+     "zh_Latn_pinyin"
+    ],
+    "modules": [
+     "_bleio",
+     "adafruit_bus_device",
+     "adafruit_pixelbuf",
+     "aesio",
+     "alarm",
+     "analogio",
+     "atexit",
+     "audiobusio",
+     "audiocore",
+     "audiomixer",
+     "audiomp3",
+     "audiopwmio",
+     "binascii",
+     "bitbangio",
+     "bitmaptools",
+     "board",
+     "busio",
+     "countio",
+     "digitalio",
+     "displayio",
+     "errno",
+     "fontio",
+     "framebufferio",
+     "getpass",
+     "json",
+     "keypad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "onewireio",
+     "os",
+     "paralleldisplay",
+     "pulseio",
+     "pwmio",
+     "rainbowio",
+     "random",
+     "re",
+     "rgbmatrix",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "storage",
+     "struct",
+     "supervisor",
+     "synthio",
+     "terminalio",
+     "time",
+     "touchio",
+     "traceback",
+     "ulab",
+     "usb_cdc",
+     "usb_hid",
+     "usb_midi",
+     "vectorio",
+     "watchdog"
+    ],
+    "stable": false,
+    "version": "7.0.0-rc.0"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
   "id": "winterbloom_big_honking_button",
   "versions": [
    {
@@ -31291,12 +31896,12 @@
      "usb_cdc"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 229,
+  "downloads": 0,
   "id": "winterbloom_sol",
   "versions": [
    {
@@ -31416,12 +32021,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 182,
+  "downloads": 0,
   "id": "xinabox_cc03",
   "versions": [
    {
@@ -31509,12 +32114,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  },
  {
-  "downloads": 187,
+  "downloads": 0,
   "id": "xinabox_cs11",
   "versions": [
    {
@@ -31599,7 +32204,7 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "7.0.0-beta.0"
+    "version": "7.0.0-rc.0"
    }
   ]
  }


### PR DESCRIPTION
Automated website update for release 7.0.0-rc.0 by Blinka.

New boards:
* espressif_hmi_devkit_1
* lolin_s2_mini
* adafruit_led_glasses_nrf52840
* warmbit_bluepixel
* jpconstantineau_encoderpad_rp2040


