### PR TITLE
Add "Install/Repair UF2 Bootloader" section for ESP32-S2 boards

### DIFF
--- a/_board/lolin_s2_mini.md
+++ b/_board/lolin_s2_mini.md
@@ -19,10 +19,10 @@ features:
     - 320 KB SRAM
     - 4 MB Flash
     - 2 MB PSRAM
-    - 2 × 13-bit SAR ADCs, up to 20 channels (2 channels not available on ADC2 due to USB)
+    - 2 × 13-bit SAR ADCs, up to 20 channels (2 channels not available on ADC2 due to USB D+/D-)
     - 2 × 8-bit DAC
     - 14 × touch sensing IOs
-    - 4 × SPI (2 useable due to embedded flash & psram)
+    - 4 × SPI (2 usable due to embedded flash & PSRAM)
     - 1 × I2S
     - 2 × I2C
     - 2 × UART
@@ -33,9 +33,9 @@ features:
     - LED PWM controller, up to 8 channels
     - USB OTG 1.1 controller and PHY, with host and device support
 - USB Type-C connector, for built-in ROM USB bootloader, serial port debugging, and USB device mode
-- 27 × GPIO pins, outer 16 pins compatible with LOLIN D1 mini shields
-- Compatible with CircuitPython, MicroPython, Arduino and ESP-IDF
-- Default firmware: MicroPython
+- 27 × GPIO pins
+    - 16 × pins (outer) compatible with WEMOS/LOLIN D1 mini shields
+- Compatible with CircuitPython, MicroPython (default firmware), Arduino and ESP-IDF
 
 ## Purchase
 
@@ -44,34 +44,6 @@ features:
 ## Learn More
 
 * [Manufacturer Specifications](https://www.wemos.cc/en/latest/s2/s2_mini.html)
-
-### Flashing UF2 Bootloader
-
-***Important***: *this will erase previously flashed firmware & sketches from the board, but needs to be perfomed only once.*
-
-- Download the latest `tinyuf2-lolin_s2_mini-......zip` from [TinyUF2 releases](https://github.com/adafruit/tinyuf2/releases),
-    - Unzip to find the file `combined.bin`.
-- Place board in bootloader mode:
-    - Plug board into a USB port on your computer using a data/sync cable. Make sure it is the only board plugged in, and that a charge-only cable is not being used.
-    - Press and hold the `0` button down. Don't let go of it yet!
-    - Press and release the `RST` button. You should have the `0` button pressed while you do this.
-    - Release the `0` button.
-- Use the Adafruit WebSerial ESPTool to upload `combined.bin` (Google Chrome 89 or newer):
-    - Open a new web browser window or tab to the [Adafruit WebSerial ESPTool](https://adafruit.github.io/Adafruit_WebSerial_ESPTool/).
-    - Select `460800 Baud` from the pull-down menu at the top-right of the page.
-    - Click the `Connect` button at the top-right of the page.
-    - Select the COM or Serial port from the pop-up window.
-    - After successful connection, click the `Erase` button.
-    - After successful erase, click the first `Choose a file...` button, locate the `combined.bin` file unzipped earlier, click `Ok`.
-    - After successfully choosing the `combined.bin` file, click the `Program` button.
-    - After the TinyUF2 firmware update is complete, press the `RST` button on the board. A new drive `S2MINIBOOT` should be visible in your file browser.
-
-### Flashing CircuitPython
-
-- Flash the UF2 bootloader using the instructions above.
-- Download the `.UF2` file from this page.
-- In your file browser, Drag & Drop the `.UF2` file to the `S2MINIBOOT` drive.
-- Your board should reboot automatically into CircuitPython. The `S2MINIBOOT` drive should disappear and be replaced with a new drive `CIRCUITPY`.
 
 ## Contribute
 

--- a/_data/bootloaders.json
+++ b/_data/bootloaders.json
@@ -6,6 +6,9 @@
         "atmel-samd": {
             "version": "v3.13.0",
         },
+        "esp32s2": {
+            "version": "0.5.2",
+        },
         "stm": {
         },
         "cxd56": {
@@ -17,6 +20,26 @@
         "8086_commander": {
             "family": "atmel-samd",
             "bootloader_id": "8086_commander",
+        },
+        "adafruit_feather_esp32s2_nopsram": {
+            "family": "esp32s2",
+            "bootloader_id": "adafruit_feather_esp32s2",
+        },
+        "adafruit_feather_esp32s2_tftback_nopsram": {
+            "family": "esp32s2",
+            "bootloader_id": "adafruit_feather_esp32s2_tft",
+        },
+        "adafruit_funhouse": {
+            "family": "esp32s2",
+            "bootloader_id": "adafruit_funhouse_esp32s2",
+        },
+        "adafruit_magtag_2.9_grayscale": {
+            "family": "esp32s2",
+            "bootloader_id": "adafruit_magtag_29gray",
+        },
+        "adafruit_metro_esp32s2": {
+            "family": "esp32s2",
+            "bootloader_id": "adafruit_metro_esp32s2",
         },
         "aramcon_badge_2019": {
             "family": "nrf52840",
@@ -41,6 +64,14 @@
         "arduino_zero": {
             "family": "atmel-samd",
             "bootloader_id": "zero",
+        },
+        "artisense_rd00": {
+            "family": "esp32s2",
+            "bootloader_id": "artisense_rd00",
+        },
+        "atmegazero_esp32s2": {
+            "family": "esp32s2",
+            "bootloader_id": "atmegazero_esp32s2",
         },
         "bast_pro_mini_m0": {
             "family": "atmel-samd",
@@ -122,6 +153,22 @@
         },
         "escornabot_makech": {
             "family": "atmel-samd",
+        },
+        "espressif_hmi_devkit_1": {
+            "family": "esp32s2",
+            "bootloader_id": "espressif_hmi_1",
+        },
+        "espressif_kaluga_1": {
+            "family": "esp32s2",
+            "bootloader_id": "espressif_kaluga_1",
+        },
+        "espressif_saola_1_wroom": {
+            "family": "esp32s2",
+            "bootloader_id": "espressif_saola_1_wroom",
+        },
+        "espressif_saola_1_wrover": {
+            "family": "esp32s2",
+            "bootloader_id": "espressif_saola_1_wrover",
         },
         "espruino_pico": {
             "family": "stm",
@@ -236,6 +283,14 @@
             "family": "atmel-samd",
             "bootloader_id": "itsybitsy_m0",
         },
+        "lilygo_ttgo_t8_s2_st7789": {
+            "family": "esp32s2",
+            "bootloader_id": "lilygo_ttgo_t8_s2_st7789",
+        },
+        "lolin_s2_mini": {
+            "family": "esp32s2",
+            "bootloader_id": "lolin_s2_mini",
+        },
         "makerdiary_nrf52840_mdk": {
             "family": "nrf52840",
         },
@@ -266,9 +321,25 @@
             "family": "nrf52840",
             "bootloader_id": "metro_nrf52840_express",
         },
+        "microdev_micro_s2": {
+            "family": "esp32s2",
+            "bootloader_id": "microdev_micro_s2",
+        },
         "monster_m4sk": {
             "family": "atmel-samd",
             "bootloader_id": "hallowing_mask",
+        },
+        "morpheans_morphesp-240": {
+            "family": "esp32s2",
+            "bootloader_id": "morpheans_morphesp-240",
+        },
+        "muselab_nanoesp32_s2_wroom": {
+            "family": "esp32s2",
+            "bootloader_id": "muselab_nanoesp32-s2_wroom",
+        },
+        "muselab_nanoesp32_s2_wrover": {
+            "family": "esp32s2",
+            "bootloader_id": "muselab_nanoesp32-s2_wrover",
         },
         "ndgarage_ndbit6": {
             "family": "atmel-samd",
@@ -436,6 +507,14 @@
         "stringcar_m0_express": {
             "family": "atmel-samd",
         },
+        "targett_module_clip_wroom": {
+            "family": "esp32s2",
+            "bootloader_id": "targett_mcb_wroom",
+        },
+        "targett_module_clip_wrover": {
+            "family": "esp32s2",
+            "bootloader_id": "targett_mcb_wrover",
+        },
         "teensy40": {
             "family": "stm",
         },
@@ -467,6 +546,18 @@
         "ugame10": {
             "family": "atmel-samd",
             "bootloader_id": "trinket_m0",
+        },
+        "unexpectedmaker_feathers2": {
+            "family": "esp32s2",
+            "bootloader_id": "unexpectedmaker_feathers2",
+        },
+        "unexpectedmaker_feathers2_neo": {
+            "family": "esp32s2",
+            "bootloader_id": "unexpectedmaker_feathers2_neo",
+        },
+        "unexpectedmaker_tinys2": {
+            "family": "esp32s2",
+            "bootloader_id": "unexpectedmaker_tinys2",
         },
         "unknown": {
         },

--- a/_includes/download/board.html
+++ b/_includes/download/board.html
@@ -168,11 +168,11 @@ By the way, boolean operation precedence is right to left! (yeesh)
     <strong>The bootloader allows you to load CircuitPython, Makecode, and Arduino programs.
       The bootloader is not CircuitPython.</strong>
   </p>
+
+{% if bootloader_board.family == 'esp32s2' %}
   <p>
     It is not necessary to reinstall the bootloader unless a BOOT drive is not visible when in UF2 bootloader mode (FTHRS2BOOT, MAGTAGBOOT, HOUSEBOOT, etc.), in which case the UF2 bootloader may need to be repaired.
   </p>
-
-{% if bootloader_board.family == 'esp32s2' %}
   <p>
     If a UF2 bootloader has never been installed on the board, or the UF2 bootloader was removed by erasing or overwriting the flash, the UF2 bootloader should be installed in order to flash .uf2 files onto the board.
   </p>

--- a/_includes/download/board.html
+++ b/_includes/download/board.html
@@ -160,7 +160,61 @@ By the way, boolean operation precedence is right to left! (yeesh)
 {% assign bootloader_id = bootloader_board.bootloader_id %}
 {% if bootloader_version and bootloader_id and bootloader_board %}
 <div class="section unrecommended">
-  <h3>UF2 Bootloader</h3>
+  <h3>Install/Repair UF2 Bootloader</h3>
+  <p>
+    Latest version: {{ bootloader_version }}
+  </p>
+  <p>
+    <strong>The bootloader allows you to load CircuitPython, Makecode, and Arduino programs.
+      The bootloader is not CircuitPython.</strong>
+  </p>
+  <p>
+    It is not necessary to reinstall the bootloader unless a BOOT drive is not visible when in UF2 bootloader mode (FTHRS2BOOT, MAGTAGBOOT, HOUSEBOOT, etc.), in which case the UF2 bootloader may need to be repaired.
+  </p>
+  <p>
+    If a UF2 bootloader has never been installed on the board, or the UF2 bootloader was overwritten by erasing or overwriting the flash, the UF2 bootloader should be installed in order to flash .uf2 files onto the board.
+  </p>
+
+{% if bootloader_board.family == 'esp32s2' %}
+
+ <p><strong><em>Important</em></strong>: 
+  <em>this will erase previously flashed firmware &amp; sketches from the board, but needs to be perfomed only once.</em></p>
+
+ <ul>
+  <li>Unzip to find the file <code class="language-plaintext highlighter-rouge">combined.bin</code>.</li>
+  <li>Place board in bootloader mode:
+   <ul>
+    <li>Plug board into a USB port on your computer using a data/sync cable. Make sure it is the only board plugged in, and that a charge-only cable is not being used.</li>
+    <li>Press and <strong>hold down</strong> the <code class="language-plaintext highlighter-rouge">BOOT</code> or <code class="language-plaintext highlighter-rouge">0</code> button.</li>
+    <li>Press and <strong>release</strong> the <code class="language-plaintext highlighter-rouge">RESET</code> or <code class="language-plaintext highlighter-rouge">RST</code> button.</li>
+    <li>Release the <code class="language-plaintext highlighter-rouge">BOOT</code> button.</li>
+   </ul>
+  </li>
+  <li>Upload <code class="language-plaintext highlighter-rouge">combined.bin</code> (Google Chrome 89 or newer):
+   <ul>
+    <li>Open <a href="https://adafruit.github.io/Adafruit_WebSerial_ESPTool/">Adafruit WebSerial ESPTool</a> in a new window/tab.</li>
+    <li>Select <code class="language-plaintext highlighter-rouge">460800 Baud</code> from the pull-down menu (top-right).</li>
+    <li>Click <code class="language-plaintext highlighter-rouge">Connect</code> (top-right).</li>
+    <li>Select the COM or Serial port from the pop-up window.</li>
+    <li>After successful connection, click <code class="language-plaintext highlighter-rouge">Erase</code>.</li>
+    <li>After successful erase, click any <code class="language-plaintext highlighter-rouge">Choose a file...</code>, then locate and select the <code class="language-plaintext highlighter-rouge">combined.bin</code> file unzipped earlier.</li>
+    <li>After successfully choosing <code class="language-plaintext highlighter-rouge">combined.bin</code>, click <code class="language-plaintext highlighter-rouge">Program</code>.</li>
+    <li>After the TinyUF2 firmware update is complete, press the <code class="language-plaintext highlighter-rouge">RESET</code> button on the board. A new drive <code class="language-plaintext highlighter-rouge">BOARDBOOT</code> (where BOARD is an abbreviation of your board's name) should be visible in your file browser.</li>
+   </ul>
+  </li>
+ </ul>
+ <p>
+ After you update, check INFO_UF2.TXT to verify that the bootloader version has been updated.
+ Then you will need to load or reload CircuitPython using the .uf2 file.
+ </p>
+ <div>
+    <a class="download-button" href="https://github.com/adafruit/tinyuf2/releases/download/{{ bootloader_version }}/tinyuf2-{{ bootloader_id }}-{{ bootloader_version }}.zip">DOWNLOAD BOOTLOADER ZIP<i class="fas fa-download" aria-hidden="true"></i></a>
+  </div>
+{% endif %}
+</div>
+
+<div class="section unrecommended">
+  <h3>Update UF2 Bootloader</h3>
   <p>
     Latest version: {{ bootloader_version }}
   </p>
@@ -170,6 +224,19 @@ By the way, boolean operation precedence is right to left! (yeesh)
     You can check the current version of your bootloader by looking in
     the INFO_UF2.TXT file when the BOOT drive is visible (FEATHERBOOT, CPLAYBOOT, etc.).
   </p>
+
+{% if bootloader_board.family == 'esp32s2' %}
+  <p>
+  <em>update.uf2 files are not currently working on ESP32-S2 boards.</em>
+  </p>
+  <ul>
+   <li>Save the contents of CIRCUITPY, just in case.</li>
+   <li>Follow instructions in the <strong>Install/Repair UF2 Bootloader</strong> section above.</li>
+   <li>Check INFO_UF2.TXT to verify that the bootloader version has been updated.</li>
+   <li>Reload CircuitPython.</li>
+  </ul>
+  </p>
+{% endif %}
 
 {% if bootloader_board.family == 'nrf52840' %}
   <p>

--- a/_includes/download/board.html
+++ b/_includes/download/board.html
@@ -171,14 +171,15 @@ By the way, boolean operation precedence is right to left! (yeesh)
   <p>
     It is not necessary to reinstall the bootloader unless a BOOT drive is not visible when in UF2 bootloader mode (FTHRS2BOOT, MAGTAGBOOT, HOUSEBOOT, etc.), in which case the UF2 bootloader may need to be repaired.
   </p>
-  <p>
-    If a UF2 bootloader has never been installed on the board, or the UF2 bootloader was overwritten by erasing or overwriting the flash, the UF2 bootloader should be installed in order to flash .uf2 files onto the board.
-  </p>
 
 {% if bootloader_board.family == 'esp32s2' %}
+  <p>
+    If a UF2 bootloader has never been installed on the board, or the UF2 bootloader was removed by erasing or overwriting the flash, the UF2 bootloader should be installed in order to flash .uf2 files onto the board.
+  </p>
 
- <p><strong><em>Important</em></strong>: 
-  <em>this will erase previously flashed firmware &amp; sketches from the board, but needs to be perfomed only once.</em></p>
+  <p><strong><em>Important</em></strong>: 
+  <em>this will erase previously flashed firmware &amp; sketches from the board, but needs to be perfomed only once.</em>
+  </p>
 
  <ul>
   <li>Unzip to find the file <code class="language-plaintext highlighter-rouge">combined.bin</code>.</li>
@@ -235,7 +236,6 @@ By the way, boolean operation precedence is right to left! (yeesh)
    <li>Check INFO_UF2.TXT to verify that the bootloader version has been updated.</li>
    <li>Reload CircuitPython.</li>
   </ul>
-  </p>
 {% endif %}
 
 {% if bootloader_board.family == 'nrf52840' %}


### PR DESCRIPTION
Fixes #752

Checked for typos, tested with `bundle exec jekyll serve`, and verified that download links are correctly generated on the Lolin S2 Mini page. Have not manually tested the other affected 21 pages for ESP32-S2 boards, but mappings in bootloaders.json should be correct.