### PR TITLE
Note error on Lolin S2 Mini v1.0 board silkscreen

### DIFF
--- a/_board/lolin_s2_mini.md
+++ b/_board/lolin_s2_mini.md
@@ -57,6 +57,10 @@ features:
     - `GPIO15` LED (blue status LED)
 - Compatible with CircuitPython, MicroPython (default firmware), Arduino and ESP-IDF
 
+## Notes
+
+- There is an error on the v1.0 board silkscreen. GPIO12/13 should be reversed.
+
 ## Purchase
 
 * [AliExpress](https://www.aliexpress.com/item/1005003145192016.html)


### PR DESCRIPTION
Putting a note on the S2 Mini page about an error on the silkscreen markings on v1.0 of the board.
GPIO12 and 13 are reversed from what they should be.