### PR TITLE
Change .unstable and .unrecommended links to purple

### DIFF
--- a/assets/sass/pages/_download.scss
+++ b/assets/sass/pages/_download.scss
@@ -116,30 +116,30 @@
 
       .unstable {
         .language-select {
-            border-color: $gray;
+            border-color: $purple;
         }
           .language-select:after {
-              color: $gray;
+              color: $purple;
           }
 
         a.download-button, a.download-button-unrecommended {
-          background-color: $gray;
+          background-color: $purple;
         }
         a.download-button:hover, a.download-button-unrecommended:hover {
-          background-color: $pink;
+          background-color: $purple;
         }
         .download-modules {
-            color: $gray;
+            color: $purple;
         }
       }
 
       .unrecommended {
           .language-select:after {
-              color: $gray;
+              color: $purple;
           }
 
         a.download-button, a.download-button-unrecommended {
-          background-color: $gray;
+          background-color: $purple;
         }
       }
 


### PR DESCRIPTION
- Fixes #764.

Change unstable and unrecommended download links to purple, to avoid confusion that the links are not functional.

I left the markers in, in case we want to change the link colors again, in the future. Also, I did not change the language dropdown away from gray.

![purple-downloads](https://user-images.githubusercontent.com/2847802/134263639-7c45a9e2-5fcc-4da3-a3b7-619d1764dd74.png)
