### PR TITLE
Fix community bundle link

### DIFF
--- a/libraries/index.html
+++ b/libraries/index.html
@@ -106,7 +106,7 @@ permalink: /libraries
       <p>
       The libraries in the bundles above are officially supported.
       Additional libraries written and supported by community members are available in the
-      <a href="https://github.com/circuitpython/CircuitPython_Org_Bundle">Community Bundle</a>.
+      <a href="https://github.com/adafruit/CircuitPython_Community_Bundle">Community Bundle</a>.
       </p>
     </section>
     <section>


### PR DESCRIPTION
The link for the Community Bundle pointed to the Circuitpython Organisation Bundle (which should probably get a link too some day).