### PR TITLE
Renamed Nordic to Nordic Semiconductor for 2 boards

### DIFF
--- a/_board/pca10059.md
+++ b/_board/pca10059.md
@@ -3,7 +3,7 @@ layout: download
 board_id: "pca10059"
 title: "nRF52840 Dongle (PCA10059) Download"
 name: "nRF52840 Dongle (PCA10059)"
-manufacturer: "Nordic"
+manufacturer: "Nordic Semiconductor"
 board_url: "https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-Dongle"
 board_image: "nRF52840_dongle.jpg"
 date_added: 2019-3-9

--- a/_board/pca10100.md
+++ b/_board/pca10100.md
@@ -3,7 +3,7 @@ layout: download
 board_id: "pca10100"
 title: "nRF52833 DK (PCA10100) Download"
 name: "nRF52833 DK (PCA10100)"
-manufacturer: "Nordic"
+manufacturer: "Nordic Semiconductor"
 board_url: "https://www.nordicsemi.com/Software-and-tools/Development-Kits/nRF52833-DK"
 board_image: "pca10100.jpg"
 date_added: 2019-05-04


### PR DESCRIPTION
Renamed the "Manufacturer" for 2 boards to match the actual name of the manufacturer.
Both the PCA10059 and PCA10100 had only "Nordic" as manufacturer while the PCA10056 had "Nordic Semiconductor"

This caused the 3 boards to show up as 2 different manufacturers in the list of filters, which obviously is redundant and incorrect. 