### PR TITLE
Correct esptool.py write_flash example

### DIFF
--- a/_board/muselab_nanoesp32_s2_wroom.md
+++ b/_board/muselab_nanoesp32_s2_wroom.md
@@ -20,7 +20,9 @@ This is the nanoESP32-S2 board with a WROOM ESP32-S2 module.
 
 This image can be flashed with the [TinyUF2 bootloader](https://github.com/adafruit/tinyuf2/releases) or with esptool using this command:
 
-esptool.py -p (COMPORT)-b 460800 write_flash --flash_mode dio --flash_size detect --flash_freq 40m 0x00000 adafruit-circuitpython-muselab_nanoesp32_s2_wroom-ll_LL-X.Y.Z.bin
+```sh
+esptool.py -p (COMPORT) -b 460800 write_flash --flash_mode dio --flash_size detect --flash_freq 40m 0x00000 adafruit-circuitpython-muselab_nanoesp32_s2_wroom-ll_LL-X.Y.Z.bin
+```
 
 **NOTE:** This board has 2 USB-C connector, one for Serial (ch340) and one for Native USB (esp32).
 


### PR DESCRIPTION
The sample was missing a space before `-b` and the double hyphens were being rendered as an emdash instead of two hyphens (`--`).