### PR TITLE
Fixed Processor Family for STM32F405

### DIFF
--- a/_board/feather_stm32f405_express.md
+++ b/_board/feather_stm32f405_express.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url: "https://www.adafruit.com/product/4382"
 board_image: "feather_stm32f405_express.jpg"
 date_added: 2019-9-26
-family: atmel-samd
+family: stm
 features:
   - Feather-Compatible
   - Battery Charging


### PR DESCRIPTION
Adjusted the processor family for the Feather STM32F405 Express from samd to STM.

Fixes #779