### PR TITLE
change <p> with video URL to <video> element on awesome page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -61,3 +61,4 @@ exclude:
   - icon.png
   - template.md
   - Rakefile
+  - .idea

--- a/awesome.html
+++ b/awesome.html
@@ -4,9 +4,37 @@ title: Awesome
 permalink: /awesome
 ---
 
+<style>
+  .video_player{
+      width: 720px;
+      margin: 0 auto;
+      display: block;
+
+  }
+</style>
+
 <div id="awesome-page" class="common-layout">
   <div class="content">
     {% capture awesome_include %}{% include_relative awesome-circuitpython/README.md %}{% endcapture %}
     {{ awesome_include | markdownify }}
-  <div>
+  </div>
 </div>
+<script>
+    const video_url = "https://user-images.githubusercontent.com/1685947/115119719-d6e21f00-9f77-11eb-84bf-3f7af59948a3.mov";
+    [...document.querySelectorAll("p")]
+        .filter(p => p.textContent.includes(video_url))
+        .forEach(p => change_to_video(p.textContent, p));
+
+    function insertAfter(newNode, existingNode) {
+        existingNode.parentNode.insertBefore(newNode, existingNode.nextSibling);
+    }
+
+    function change_to_video(url, p) {
+        let video = document.createElement('video');
+        video.controls = true;
+        video.classList.add("video_player")
+        video.src = url;
+        insertAfter(video, p)
+        p.remove();
+    }
+</script>

--- a/awesome.html
+++ b/awesome.html
@@ -9,7 +9,6 @@ permalink: /awesome
       width: 720px;
       margin: 0 auto;
       display: block;
-
   }
 </style>
 
@@ -25,16 +24,12 @@ permalink: /awesome
         .filter(p => p.textContent.includes(video_url))
         .forEach(p => change_to_video(p.textContent, p));
 
-    function insertAfter(newNode, existingNode) {
-        existingNode.parentNode.insertBefore(newNode, existingNode.nextSibling);
-    }
-
     function change_to_video(url, p) {
         let video = document.createElement('video');
         video.controls = true;
         video.classList.add("video_player")
         video.src = url;
-        insertAfter(video, p)
+        p.parentNode.insertBefore(video, p);
         p.remove();
     }
 </script>


### PR DESCRIPTION
This is meant to resolve: https://github.com/adafruit/awesome-circuitpython/issues/33

I looked into it a bit and `markdownify` is a template filter provided by the Jekyll project. The templating language used is called Liquid, but Jekyll adds some functionality that isn't in the upstream Liquid project. Markdownify is documented on this page: https://jekyllrb.com/docs/liquid/filters/

I couldn't find a way to instruct it to render video elements. Theoretically that functionality could be added inside of Jekyll and then it would take effect here in our usage. But making that change within Jekyll is a bit beyond me at this stage.

To solve for this page I've used Javscript to find the `<p>` element with the video URL in it and build a `<video>` element to swap in to that spot on the page. This is probably not an ideal solution because the URL for the video is hardcoded, but in this case It seems unlikely that the video URL will be changing frequently. It could maybe be made a bit more generic by searching for any `<p>` whose content ends with `.mov` or `.mp4`. I don't think there are currently any other instances of videos embedded into the awesome circuitpython md file though so this would not really change anything in the current usage. If there are likely to be more embedded videos in the future let me know and I can work on this, it's probably worthwhile to do it if we do anticipate more embedded videos.

There are two other small changes that are also included in this PR:

- close the inner `<div>` element in the awesome.html template file. It seems like this was mistakenly having an open `<div>` tag where it should have been a closing `</div>` tag. Luckily modern browsers are somewhat forgiving so this does not seem to be breaking the page even though it is invalid HTML.
- Added `.idea` to the Jekyll exclude list in `_config.yml` I noticed that as my IDE saved changes to the files in `.idea` directory Jekyll server was noticing the changes and triggering a re-build of the HTML pages. This should not have any effect in the live instance of the site and it's pages, but allows quicker development by not triggering those extra builds anytime something unrelated changes in the IDEs folder. 

Tested running locally the page from the branch for this PR looks like this:
![awesome_with_vid](https://user-images.githubusercontent.com/2406189/143304882-be57e7a4-dd09-4d86-b98f-90d4abf57170.png)
