### PR TITLE
Automated website update for release 7.1.0-beta.1

### DIFF
--- a/_data/files.json
+++ b/_data/files.json
@@ -1,6 +1,6 @@
 [
  {
-  "downloads": 29,
+  "downloads": 0,
   "id": "8086_commander",
   "versions": [
    {
@@ -80,6 +80,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -111,12 +112,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 16,
+  "downloads": 0,
   "id": "ADM_B_NRF52840_1",
   "versions": [
    {
@@ -223,6 +224,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -252,6 +254,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -288,12 +291,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 50,
+  "downloads": 0,
   "id": "TG-Watch",
   "versions": [
    {
@@ -428,6 +431,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -457,6 +461,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -493,7 +498,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
@@ -521,6 +526,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -595,7 +601,7 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
@@ -623,6 +629,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -697,12 +704,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 49,
+  "downloads": 0,
   "id": "adafruit_feather_esp32s2_tftback_nopsram",
   "versions": [
    {
@@ -829,6 +836,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -903,12 +911,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 508,
+  "downloads": 0,
   "id": "adafruit_feather_rp2040",
   "versions": [
    {
@@ -1018,6 +1026,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -1086,12 +1095,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 253,
+  "downloads": 0,
   "id": "adafruit_funhouse",
   "versions": [
    {
@@ -1208,6 +1217,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -1282,12 +1292,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 113,
+  "downloads": 0,
   "id": "adafruit_itsybitsy_rp2040",
   "versions": [
    {
@@ -1397,6 +1407,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -1465,7 +1476,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
@@ -1492,6 +1503,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -1560,12 +1572,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 103,
+  "downloads": 0,
   "id": "adafruit_led_glasses_nrf52840",
   "versions": [
    {
@@ -1672,6 +1684,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -1701,6 +1714,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -1737,12 +1751,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 439,
+  "downloads": 0,
   "id": "adafruit_macropad_rp2040",
   "versions": [
    {
@@ -1852,6 +1866,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -1920,12 +1935,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 508,
+  "downloads": 0,
   "id": "adafruit_magtag_2.9_grayscale",
   "versions": [
    {
@@ -2042,6 +2057,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -2116,12 +2132,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 175,
+  "downloads": 0,
   "id": "adafruit_metro_esp32s2",
   "versions": [
    {
@@ -2238,6 +2254,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -2312,12 +2329,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 135,
+  "downloads": 0,
   "id": "adafruit_neokey_trinkey_m0",
   "versions": [
    {
@@ -2390,6 +2407,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -2414,12 +2432,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 68,
+  "downloads": 0,
   "id": "adafruit_proxlight_trinkey_m0",
   "versions": [
    {
@@ -2495,6 +2513,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -2522,12 +2541,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 139,
+  "downloads": 0,
   "id": "adafruit_qt2040_trinkey",
   "versions": [
    {
@@ -2637,6 +2656,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -2705,12 +2725,120 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 262,
+  "downloads": 0,
+  "id": "adafruit_qtpy_esp32s2",
+  "versions": [
+   {
+    "extensions": [
+     "bin",
+     "uf2"
+    ],
+    "frozen_libraries": [
+     "Adafruit_CircuitPython_Requests",
+     "Adafruit_CircuitPython_NeoPixel",
+     "Adafruit_CircuitPython_BusDevice",
+     "Adafruit_CircuitPython_Register"
+    ],
+    "languages": [
+     "de_DE",
+     "en_GB",
+     "en_US",
+     "en_x_pirate",
+     "es",
+     "fil",
+     "fr",
+     "ID",
+     "it_IT",
+     "ja",
+     "nl",
+     "pl",
+     "pt_BR",
+     "ru",
+     "sv",
+     "zh_Latn_pinyin"
+    ],
+    "modules": [
+     "_bleio",
+     "adafruit_bus_device",
+     "adafruit_pixelbuf",
+     "aesio",
+     "alarm",
+     "analogio",
+     "atexit",
+     "audiobusio",
+     "audiocore",
+     "audiomixer",
+     "binascii",
+     "bitbangio",
+     "bitmaptools",
+     "board",
+     "busio",
+     "canio",
+     "countio",
+     "digitalio",
+     "displayio",
+     "dualbank",
+     "errno",
+     "fontio",
+     "framebufferio",
+     "frequencyio",
+     "getpass",
+     "gifio",
+     "i2cperipheral",
+     "imagecapture",
+     "ipaddress",
+     "json",
+     "keypad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "onewireio",
+     "os",
+     "paralleldisplay",
+     "ps2io",
+     "pulseio",
+     "pwmio",
+     "qrio",
+     "rainbowio",
+     "random",
+     "re",
+     "rgbmatrix",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "socketpool",
+     "ssl",
+     "storage",
+     "struct",
+     "supervisor",
+     "synthio",
+     "terminalio",
+     "time",
+     "touchio",
+     "traceback",
+     "ulab",
+     "usb_cdc",
+     "usb_hid",
+     "usb_midi",
+     "vectorio",
+     "watchdog",
+     "wifi"
+    ],
+    "stable": false,
+    "version": "7.1.0-beta.1"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
   "id": "adafruit_qtpy_rp2040",
   "versions": [
    {
@@ -2820,6 +2948,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -2888,12 +3017,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 86,
+  "downloads": 0,
   "id": "adafruit_rotary_trinkey_m0",
   "versions": [
    {
@@ -2967,6 +3096,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -2992,12 +3122,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 38,
+  "downloads": 0,
   "id": "adafruit_slide_trinkey_m0",
   "versions": [
    {
@@ -3073,6 +3203,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -3098,7 +3229,7 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
@@ -3125,6 +3256,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -3186,12 +3318,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 125,
+  "downloads": 0,
   "id": "ai_thinker_esp_12k_nodemcu",
   "versions": [
    {
@@ -3308,6 +3440,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -3382,12 +3515,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 56,
+  "downloads": 0,
   "id": "aloriumtech_evo_m51",
   "versions": [
    {
@@ -3495,6 +3628,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -3562,12 +3696,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 52,
+  "downloads": 0,
   "id": "aramcon2_badge",
   "versions": [
    {
@@ -3674,6 +3808,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -3703,6 +3838,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -3739,12 +3875,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 57,
+  "downloads": 0,
   "id": "aramcon_badge_2019",
   "versions": [
    {
@@ -3851,6 +3987,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -3880,6 +4017,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -3916,12 +4054,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 38,
+  "downloads": 0,
   "id": "arduino_mkr1300",
   "versions": [
    {
@@ -3994,6 +4132,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -4006,9 +4145,9 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
+     "rainbowio",
      "random",
      "rotaryio",
      "rtc",
@@ -4022,12 +4161,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 76,
+  "downloads": 0,
   "id": "arduino_mkrzero",
   "versions": [
    {
@@ -4101,6 +4240,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -4130,12 +4270,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 103,
+  "downloads": 0,
   "id": "arduino_nano_33_ble",
   "versions": [
    {
@@ -4242,6 +4382,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -4271,6 +4412,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -4307,12 +4449,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 75,
+  "downloads": 0,
   "id": "arduino_nano_33_iot",
   "versions": [
    {
@@ -4385,6 +4527,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -4399,6 +4542,7 @@
      "nvm",
      "os",
      "pwmio",
+     "rainbowio",
      "random",
      "rotaryio",
      "rtc",
@@ -4412,12 +4556,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 273,
+  "downloads": 0,
   "id": "arduino_nano_rp2040_connect",
   "versions": [
    {
@@ -4527,6 +4671,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -4595,12 +4740,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 80,
+  "downloads": 0,
   "id": "arduino_zero",
   "versions": [
    {
@@ -4673,6 +4818,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -4685,9 +4831,9 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
+     "rainbowio",
      "random",
      "rotaryio",
      "rtc",
@@ -4701,12 +4847,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 11,
+  "downloads": 0,
   "id": "artisense_rd00",
   "versions": [
    {
@@ -4823,6 +4969,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -4897,12 +5044,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 47,
+  "downloads": 0,
   "id": "atmegazero_esp32s2",
   "versions": [
    {
@@ -5019,6 +5166,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -5093,12 +5241,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 33,
+  "downloads": 0,
   "id": "bast_pro_mini_m0",
   "versions": [
    {
@@ -5170,6 +5318,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -5199,12 +5348,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 33,
+  "downloads": 0,
   "id": "bastble",
   "versions": [
    {
@@ -5311,6 +5460,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -5340,6 +5490,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -5376,12 +5527,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 17,
+  "downloads": 0,
   "id": "bdmicro_vina_d21",
   "versions": [
    {
@@ -5466,6 +5617,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -5508,12 +5660,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 22,
+  "downloads": 0,
   "id": "bdmicro_vina_d51",
   "versions": [
    {
@@ -5621,6 +5773,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -5688,12 +5841,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 18,
+  "downloads": 0,
   "id": "bdmicro_vina_d51_pcb7",
   "versions": [
    {
@@ -5801,6 +5954,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -5868,12 +6022,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 86,
+  "downloads": 0,
   "id": "bless_dev_board_multi_sensor",
   "versions": [
    {
@@ -5980,6 +6134,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -6009,6 +6164,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -6045,12 +6201,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 28,
+  "downloads": 0,
   "id": "blm_badge",
   "versions": [
    {
@@ -6121,6 +6277,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -6149,12 +6306,12 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 47,
+  "downloads": 0,
   "id": "bluemicro840",
   "versions": [
    {
@@ -6261,6 +6418,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -6290,6 +6448,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -6326,12 +6485,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 41,
+  "downloads": 0,
   "id": "capablerobot_usbhub",
   "versions": [
    {
@@ -6438,6 +6597,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -6504,12 +6664,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 45,
+  "downloads": 0,
   "id": "catwan_usbstick",
   "versions": [
    {
@@ -6581,6 +6741,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -6610,7 +6771,7 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
@@ -6637,6 +6798,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -6705,7 +6867,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
@@ -6732,6 +6894,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -6800,12 +6963,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 36,
+  "downloads": 0,
   "id": "challenger_rp2040_wifi",
   "versions": [
    {
@@ -6915,6 +7078,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -6983,12 +7147,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 57,
+  "downloads": 0,
   "id": "circuitbrains_basic_m0",
   "versions": [
    {
@@ -7073,6 +7237,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -7115,12 +7280,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 53,
+  "downloads": 0,
   "id": "circuitbrains_deluxe_m4",
   "versions": [
    {
@@ -7228,6 +7393,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -7295,12 +7461,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 504,
+  "downloads": 0,
   "id": "circuitplayground_bluefruit",
   "versions": [
    {
@@ -7407,6 +7573,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -7436,6 +7603,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -7472,12 +7640,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 845,
+  "downloads": 0,
   "id": "circuitplayground_express",
   "versions": [
    {
@@ -7573,6 +7741,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -7614,12 +7783,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 46,
+  "downloads": 0,
   "id": "circuitplayground_express_4h",
   "versions": [
    {
@@ -7715,6 +7884,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -7756,12 +7926,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 104,
+  "downloads": 0,
   "id": "circuitplayground_express_crickit",
   "versions": [
    {
@@ -7859,6 +8029,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -7898,12 +8069,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 46,
+  "downloads": 0,
   "id": "circuitplayground_express_digikey_pycon2019",
   "versions": [
    {
@@ -7999,6 +8170,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -8040,12 +8212,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 72,
+  "downloads": 0,
   "id": "circuitplayground_express_displayio",
   "versions": [
    {
@@ -8135,6 +8307,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -8172,12 +8345,12 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 252,
+  "downloads": 0,
   "id": "clue_nrf52840_express",
   "versions": [
    {
@@ -8284,6 +8457,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -8313,6 +8487,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -8349,12 +8524,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 3,
+  "downloads": 0,
   "id": "cp32-m4",
   "versions": [
    {
@@ -8461,6 +8636,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -8527,12 +8703,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 44,
+  "downloads": 0,
   "id": "cp_sapling_m0",
   "versions": [
    {
@@ -8604,6 +8780,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -8633,12 +8810,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 40,
+  "downloads": 0,
   "id": "cp_sapling_m0_revb",
   "versions": [
    {
@@ -8710,6 +8887,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -8739,12 +8917,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 48,
+  "downloads": 0,
   "id": "cp_sapling_m0_spiflash",
   "versions": [
    {
@@ -8826,6 +9004,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -8865,12 +9044,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 33,
+  "downloads": 0,
   "id": "crumpspace_crumps2",
   "versions": [
    {
@@ -8987,6 +9166,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -9061,12 +9241,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 206,
+  "downloads": 0,
   "id": "cytron_maker_pi_rp2040",
   "versions": [
    {
@@ -9184,6 +9364,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -9252,12 +9433,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 4,
+  "downloads": 0,
   "id": "datalore_ip_m4",
   "versions": [
    {
@@ -9365,6 +9546,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -9432,12 +9614,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 36,
+  "downloads": 0,
   "id": "datum_distance",
   "versions": [
    {
@@ -9509,6 +9691,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -9538,12 +9721,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 44,
+  "downloads": 0,
   "id": "datum_imu",
   "versions": [
    {
@@ -9615,6 +9798,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -9644,12 +9828,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 23,
+  "downloads": 0,
   "id": "datum_light",
   "versions": [
    {
@@ -9721,6 +9905,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -9750,12 +9935,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 41,
+  "downloads": 0,
   "id": "datum_weather",
   "versions": [
    {
@@ -9827,6 +10012,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -9856,12 +10042,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 41,
+  "downloads": 0,
   "id": "dynalora_usb",
   "versions": [
    {
@@ -9941,6 +10127,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -9971,12 +10158,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 68,
+  "downloads": 0,
   "id": "dynossat_edu_eps",
   "versions": [
    {
@@ -10059,6 +10246,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -10099,12 +10287,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 70,
+  "downloads": 0,
   "id": "dynossat_edu_obc",
   "versions": [
    {
@@ -10212,6 +10400,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -10279,12 +10468,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 89,
+  "downloads": 0,
   "id": "edgebadge",
   "versions": [
    {
@@ -10397,6 +10586,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -10461,12 +10651,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 36,
+  "downloads": 0,
   "id": "electroniccats_bastwifi",
   "versions": [
    {
@@ -10582,6 +10772,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -10655,12 +10846,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 42,
+  "downloads": 0,
   "id": "electronut_labs_blip",
   "versions": [
    {
@@ -10768,6 +10959,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -10798,6 +10990,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -10834,12 +11027,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 50,
+  "downloads": 0,
   "id": "electronut_labs_papyr",
   "versions": [
    {
@@ -10946,6 +11139,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -10975,6 +11169,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -11011,12 +11206,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 32,
+  "downloads": 0,
   "id": "escornabot_makech",
   "versions": [
    {
@@ -11087,6 +11282,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -11115,12 +11311,12 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 46,
+  "downloads": 0,
   "id": "espressif_hmi_devkit_1",
   "versions": [
    {
@@ -11237,6 +11433,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -11311,12 +11508,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 55,
+  "downloads": 0,
   "id": "espressif_kaluga_1",
   "versions": [
    {
@@ -11433,6 +11630,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -11507,12 +11705,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 58,
+  "downloads": 0,
   "id": "espressif_kaluga_1.3",
   "versions": [
    {
@@ -11629,6 +11827,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -11703,12 +11902,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 197,
+  "downloads": 0,
   "id": "espressif_saola_1_wroom",
   "versions": [
    {
@@ -11825,6 +12024,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -11899,12 +12099,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 206,
+  "downloads": 0,
   "id": "espressif_saola_1_wrover",
   "versions": [
    {
@@ -12021,6 +12221,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -12095,12 +12296,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 14,
+  "downloads": 0,
   "id": "espruino_pico",
   "versions": [
    {
@@ -12184,6 +12385,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -12225,12 +12427,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 16,
+  "downloads": 0,
   "id": "espruino_wifi",
   "versions": [
    {
@@ -12322,6 +12524,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -12372,12 +12575,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 169,
+  "downloads": 0,
   "id": "feather_bluefruit_sense",
   "versions": [
    {
@@ -12484,6 +12687,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -12513,6 +12717,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -12549,12 +12754,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 124,
+  "downloads": 0,
   "id": "feather_m0_adalogger",
   "versions": [
    {
@@ -12628,6 +12833,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -12640,7 +12846,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -12657,12 +12862,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 132,
+  "downloads": 0,
   "id": "feather_m0_basic",
   "versions": [
    {
@@ -12736,6 +12941,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -12765,12 +12971,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 254,
+  "downloads": 0,
   "id": "feather_m0_express",
   "versions": [
    {
@@ -12855,6 +13061,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -12897,12 +13104,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 42,
+  "downloads": 0,
   "id": "feather_m0_express_crickit",
   "versions": [
    {
@@ -12993,6 +13200,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -13031,12 +13239,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 78,
+  "downloads": 0,
   "id": "feather_m0_rfm69",
   "versions": [
    {
@@ -13110,6 +13318,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -13135,12 +13344,12 @@
      "usb_cdc"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 129,
+  "downloads": 0,
   "id": "feather_m0_rfm9x",
   "versions": [
    {
@@ -13214,6 +13423,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -13239,12 +13449,12 @@
      "usb_cdc"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 54,
+  "downloads": 0,
   "id": "feather_m0_supersized",
   "versions": [
    {
@@ -13329,6 +13539,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -13371,12 +13582,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 88,
+  "downloads": 0,
   "id": "feather_m4_can",
   "versions": [
    {
@@ -13485,6 +13696,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -13552,12 +13764,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 493,
+  "downloads": 0,
   "id": "feather_m4_express",
   "versions": [
    {
@@ -13665,6 +13877,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -13732,12 +13945,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 39,
+  "downloads": 0,
   "id": "feather_m7_1011",
   "versions": [
    {
@@ -13838,6 +14051,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -13889,12 +14103,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 68,
+  "downloads": 0,
   "id": "feather_mimxrt1011",
   "versions": [
    {
@@ -13995,6 +14209,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -14046,12 +14261,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 62,
+  "downloads": 0,
   "id": "feather_mimxrt1062",
   "versions": [
    {
@@ -14146,6 +14361,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -14197,12 +14413,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 255,
+  "downloads": 0,
   "id": "feather_nrf52840_express",
   "versions": [
    {
@@ -14309,6 +14525,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -14338,6 +14555,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -14374,7 +14592,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
@@ -14384,7 +14602,7 @@
   "versions": []
  },
  {
-  "downloads": 104,
+  "downloads": 0,
   "id": "feather_stm32f405_express",
   "versions": [
    {
@@ -14485,6 +14703,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -14544,12 +14763,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 57,
+  "downloads": 0,
   "id": "fluff_m0",
   "versions": [
    {
@@ -14621,6 +14840,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -14650,12 +14870,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 33,
+  "downloads": 0,
   "id": "fomu",
   "versions": [
    {
@@ -14731,6 +14951,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -14764,12 +14985,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 71,
+  "downloads": 0,
   "id": "franzininho_wifi_wroom",
   "versions": [
    {
@@ -14886,6 +15107,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -14960,12 +15182,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 36,
+  "downloads": 0,
   "id": "franzininho_wifi_wrover",
   "versions": [
    {
@@ -15082,6 +15304,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -15156,12 +15379,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 230,
+  "downloads": 0,
   "id": "gemma_m0",
   "versions": [
    {
@@ -15233,6 +15456,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -15262,12 +15486,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 50,
+  "downloads": 0,
   "id": "gemma_m0_pycon2018",
   "versions": [
    {
@@ -15339,6 +15563,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -15368,12 +15593,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 133,
+  "downloads": 0,
   "id": "grandcentral_m4_express",
   "versions": [
    {
@@ -15484,6 +15709,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -15554,12 +15780,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 41,
+  "downloads": 0,
   "id": "gravitech_cucumber_m",
   "versions": [
    {
@@ -15676,6 +15902,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -15750,12 +15977,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 40,
+  "downloads": 0,
   "id": "gravitech_cucumber_ms",
   "versions": [
    {
@@ -15872,6 +16099,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -15946,12 +16174,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 28,
+  "downloads": 0,
   "id": "gravitech_cucumber_r",
   "versions": [
    {
@@ -16068,6 +16296,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -16142,12 +16371,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 41,
+  "downloads": 0,
   "id": "gravitech_cucumber_rs",
   "versions": [
    {
@@ -16264,6 +16493,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -16338,12 +16568,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 115,
+  "downloads": 0,
   "id": "hallowing_m0_express",
   "versions": [
    {
@@ -16433,6 +16663,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -16474,12 +16705,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 85,
+  "downloads": 0,
   "id": "hallowing_m4_express",
   "versions": [
    {
@@ -16587,6 +16818,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -16654,12 +16886,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 68,
+  "downloads": 0,
   "id": "hiibot_bluefi",
   "versions": [
    {
@@ -16766,6 +16998,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -16795,6 +17028,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -16831,12 +17065,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 30,
+  "downloads": 0,
   "id": "huntercat_nfc",
   "versions": [
    {
@@ -16921,6 +17155,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -16963,12 +17198,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 35,
+  "downloads": 0,
   "id": "ikigaisense_vita",
   "versions": [
    {
@@ -17075,6 +17310,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -17104,6 +17340,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -17140,12 +17377,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 58,
+  "downloads": 0,
   "id": "imxrt1010_evk",
   "versions": [
    {
@@ -17246,6 +17483,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -17297,12 +17535,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 41,
+  "downloads": 0,
   "id": "imxrt1020_evk",
   "versions": [
    {
@@ -17397,6 +17635,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -17448,12 +17687,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 51,
+  "downloads": 0,
   "id": "imxrt1060_evk",
   "versions": [
    {
@@ -17548,6 +17787,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -17599,12 +17839,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 165,
+  "downloads": 0,
   "id": "itsybitsy_m0_express",
   "versions": [
    {
@@ -17688,6 +17928,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -17729,12 +17970,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 263,
+  "downloads": 0,
   "id": "itsybitsy_m4_express",
   "versions": [
    {
@@ -17841,6 +18082,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -17907,12 +18149,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 168,
+  "downloads": 0,
   "id": "itsybitsy_nrf52840_express",
   "versions": [
    {
@@ -18019,6 +18261,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -18048,6 +18291,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -18084,12 +18328,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 35,
+  "downloads": 0,
   "id": "jpconstantineau_encoderpad_rp2040",
   "versions": [
    {
@@ -18199,6 +18443,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -18267,7 +18512,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
@@ -18294,6 +18539,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -18362,12 +18608,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 44,
+  "downloads": 0,
   "id": "kicksat-sprite",
   "versions": [
    {
@@ -18455,6 +18701,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -18497,12 +18744,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 157,
+  "downloads": 0,
   "id": "lilygo_ttgo_t8_s2_st7789",
   "versions": [
    {
@@ -18619,6 +18866,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -18693,12 +18941,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 51,
+  "downloads": 0,
   "id": "loc_ber_m4_base_board",
   "versions": [
    {
@@ -18771,6 +19019,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -18802,12 +19051,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 95,
+  "downloads": 0,
   "id": "lolin_s2_mini",
   "versions": [
    {
@@ -18928,6 +19177,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -19002,7 +19252,7 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
@@ -19032,6 +19282,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -19106,12 +19357,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 67,
+  "downloads": 0,
   "id": "makerdiary_m60_keyboard",
   "versions": [
    {
@@ -19218,6 +19469,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -19247,6 +19499,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -19283,12 +19536,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 47,
+  "downloads": 0,
   "id": "makerdiary_nrf52840_m2_devkit",
   "versions": [
    {
@@ -19395,6 +19648,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -19424,6 +19678,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -19460,12 +19715,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 51,
+  "downloads": 0,
   "id": "makerdiary_nrf52840_mdk",
   "versions": [
    {
@@ -19572,6 +19827,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -19601,6 +19857,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -19637,12 +19894,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 110,
+  "downloads": 0,
   "id": "makerdiary_nrf52840_mdk_usb_dongle",
   "versions": [
    {
@@ -19751,6 +20008,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -19780,6 +20038,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -19816,12 +20075,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 438,
+  "downloads": 0,
   "id": "matrixportal_m4",
   "versions": [
    {
@@ -19929,6 +20188,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -19996,7 +20256,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
@@ -20023,6 +20283,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -20091,12 +20352,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 100,
+  "downloads": 0,
   "id": "meowbit_v121",
   "versions": [
    {
@@ -20195,6 +20456,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -20246,12 +20508,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 38,
+  "downloads": 0,
   "id": "meowmeow",
   "versions": [
    {
@@ -20322,6 +20584,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -20350,12 +20613,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 196,
+  "downloads": 0,
   "id": "metro_m0_express",
   "versions": [
    {
@@ -20440,6 +20703,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -20482,12 +20746,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 168,
+  "downloads": 0,
   "id": "metro_m4_airlift_lite",
   "versions": [
    {
@@ -20595,6 +20859,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -20662,12 +20927,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 186,
+  "downloads": 0,
   "id": "metro_m4_express",
   "versions": [
    {
@@ -20775,6 +21040,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -20842,12 +21108,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 30,
+  "downloads": 0,
   "id": "metro_m7_1011",
   "versions": [
    {
@@ -20948,6 +21214,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -20999,12 +21266,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 32,
+  "downloads": 0,
   "id": "metro_nrf52840_express",
   "versions": [
    {
@@ -21111,6 +21378,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -21140,6 +21408,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -21176,7 +21445,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
@@ -21261,6 +21530,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -21298,7 +21568,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
@@ -21325,6 +21595,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -21386,12 +21657,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 66,
+  "downloads": 0,
   "id": "microdev_micro_s2",
   "versions": [
    {
@@ -21508,6 +21779,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -21582,12 +21854,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 65,
+  "downloads": 0,
   "id": "mini_sam_m4",
   "versions": [
    {
@@ -21698,6 +21970,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -21764,12 +22037,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 205,
+  "downloads": 0,
   "id": "monster_m4sk",
   "versions": [
    {
@@ -21877,6 +22150,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -21944,12 +22218,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 27,
+  "downloads": 0,
   "id": "morpheans_morphesp-240",
   "versions": [
    {
@@ -22066,6 +22340,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -22140,12 +22415,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 173,
+  "downloads": 0,
   "id": "muselab_nanoesp32_s2_wroom",
   "versions": [
    {
@@ -22262,6 +22537,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -22336,12 +22612,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 104,
+  "downloads": 0,
   "id": "muselab_nanoesp32_s2_wrover",
   "versions": [
    {
@@ -22458,6 +22734,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -22532,12 +22809,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 45,
+  "downloads": 0,
   "id": "ndgarage_ndbit6",
   "versions": [
    {
@@ -22609,6 +22886,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -22638,12 +22916,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 17,
+  "downloads": 0,
   "id": "ndgarage_ndbit6_v2",
   "versions": [
    {
@@ -22715,6 +22993,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -22744,12 +23023,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 208,
+  "downloads": 0,
   "id": "neopixel_trinkey_m0",
   "versions": [
    {
@@ -22822,6 +23101,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -22846,12 +23126,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 62,
+  "downloads": 0,
   "id": "nfc_copy_cat",
   "versions": [
    {
@@ -22923,6 +23203,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -22952,12 +23233,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 78,
+  "downloads": 0,
   "id": "nice_nano",
   "versions": [
    {
@@ -23064,6 +23345,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -23093,6 +23375,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -23129,12 +23412,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 24,
+  "downloads": 0,
   "id": "nucleo_f746zg",
   "versions": [
    {
@@ -23225,6 +23508,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -23274,12 +23558,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 31,
+  "downloads": 0,
   "id": "nucleo_f767zi",
   "versions": [
    {
@@ -23370,6 +23654,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -23419,12 +23704,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 33,
+  "downloads": 0,
   "id": "nucleo_h743zi_2",
   "versions": [
    {
@@ -23513,6 +23798,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -23560,7 +23846,7 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
@@ -23587,6 +23873,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -23655,12 +23942,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 27,
+  "downloads": 0,
   "id": "odt_pixelwing_esp32_s2",
   "versions": [
    {
@@ -23777,6 +24064,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -23851,12 +24139,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 60,
+  "downloads": 0,
   "id": "ohs2020_badge",
   "versions": [
    {
@@ -23963,6 +24251,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -23992,6 +24281,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -24028,12 +24318,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 41,
+  "downloads": 0,
   "id": "openbook_m4",
   "versions": [
    {
@@ -24142,6 +24432,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -24210,12 +24501,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 22,
+  "downloads": 0,
   "id": "openmv_h7",
   "versions": [
    {
@@ -24304,6 +24595,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -24351,12 +24643,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 58,
+  "downloads": 0,
   "id": "particle_argon",
   "versions": [
    {
@@ -24463,6 +24755,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -24492,6 +24785,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -24528,12 +24822,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 59,
+  "downloads": 0,
   "id": "particle_boron",
   "versions": [
    {
@@ -24640,6 +24934,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -24669,6 +24964,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -24705,12 +25001,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 62,
+  "downloads": 0,
   "id": "particle_xenon",
   "versions": [
    {
@@ -24817,6 +25113,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -24846,6 +25143,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -24882,12 +25180,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 76,
+  "downloads": 0,
   "id": "pca10056",
   "versions": [
    {
@@ -24996,6 +25294,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -25025,6 +25324,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -25061,12 +25361,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 121,
+  "downloads": 0,
   "id": "pca10059",
   "versions": [
    {
@@ -25175,6 +25475,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -25204,6 +25505,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -25240,12 +25542,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 75,
+  "downloads": 0,
   "id": "pca10100",
   "versions": [
    {
@@ -25325,6 +25627,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -25362,12 +25665,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 50,
+  "downloads": 0,
   "id": "pewpew10",
   "versions": [
    {
@@ -25441,6 +25744,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -25468,12 +25772,12 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 34,
+  "downloads": 0,
   "id": "pewpew13",
   "versions": [
    {
@@ -25547,6 +25851,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -25574,12 +25879,12 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 69,
+  "downloads": 0,
   "id": "pewpew_m4",
   "versions": [
    {
@@ -25657,6 +25962,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -25689,12 +25995,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 28,
+  "downloads": 0,
   "id": "picoplanet",
   "versions": [
    {
@@ -25766,6 +26072,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -25795,12 +26102,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 6,
+  "downloads": 0,
   "id": "pimoroni_interstate75",
   "versions": [
    {
@@ -25910,6 +26217,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -25978,12 +26286,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 130,
+  "downloads": 0,
   "id": "pimoroni_keybow2040",
   "versions": [
    {
@@ -26093,6 +26401,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -26161,12 +26470,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 55,
+  "downloads": 0,
   "id": "pimoroni_pga2040",
   "versions": [
    {
@@ -26276,6 +26585,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -26344,12 +26654,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 90,
+  "downloads": 0,
   "id": "pimoroni_picolipo_16mb",
   "versions": [
    {
@@ -26459,6 +26769,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -26527,12 +26838,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 58,
+  "downloads": 0,
   "id": "pimoroni_picolipo_4mb",
   "versions": [
    {
@@ -26642,6 +26953,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -26710,12 +27022,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 108,
+  "downloads": 0,
   "id": "pimoroni_picosystem",
   "versions": [
    {
@@ -26827,6 +27139,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -26896,12 +27209,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 88,
+  "downloads": 0,
   "id": "pimoroni_plasma2040",
   "versions": [
    {
@@ -27011,6 +27324,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -27079,12 +27393,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 167,
+  "downloads": 0,
   "id": "pimoroni_tiny2040",
   "versions": [
    {
@@ -27194,6 +27508,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -27262,7 +27577,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
@@ -27272,7 +27587,7 @@
   "versions": []
  },
  {
-  "downloads": 43,
+  "downloads": 0,
   "id": "pitaya_go",
   "versions": [
    {
@@ -27379,6 +27694,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -27408,6 +27724,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -27444,12 +27761,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 20,
+  "downloads": 0,
   "id": "pyb_nano_v2",
   "versions": [
    {
@@ -27539,6 +27856,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -27584,12 +27902,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 209,
+  "downloads": 0,
   "id": "pybadge",
   "versions": [
    {
@@ -27702,6 +28020,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -27766,7 +28085,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
@@ -27776,7 +28095,7 @@
   "versions": []
  },
  {
-  "downloads": 40,
+  "downloads": 0,
   "id": "pyboard_v11",
   "versions": [
    {
@@ -27877,6 +28196,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -27936,12 +28256,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 80,
+  "downloads": 0,
   "id": "pycubed",
   "versions": [
    {
@@ -28044,6 +28364,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -28098,12 +28419,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 53,
+  "downloads": 0,
   "id": "pycubed_mram",
   "versions": [
    {
@@ -28206,6 +28527,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -28260,7 +28582,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
@@ -28290,6 +28612,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -28344,7 +28667,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
@@ -28374,6 +28697,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -28428,12 +28752,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 173,
+  "downloads": 0,
   "id": "pygamer",
   "versions": [
    {
@@ -28546,6 +28870,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -28610,7 +28935,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
@@ -28620,7 +28945,7 @@
   "versions": []
  },
  {
-  "downloads": 278,
+  "downloads": 0,
   "id": "pyportal",
   "versions": [
    {
@@ -28728,6 +29053,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -28795,12 +29121,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 87,
+  "downloads": 0,
   "id": "pyportal_pynt",
   "versions": [
    {
@@ -28908,6 +29234,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -28975,12 +29302,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 164,
+  "downloads": 0,
   "id": "pyportal_titano",
   "versions": [
    {
@@ -29088,6 +29415,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -29155,12 +29483,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 99,
+  "downloads": 0,
   "id": "pyruler",
   "versions": [
    {
@@ -29232,6 +29560,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -29261,12 +29590,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 340,
+  "downloads": 0,
   "id": "qtpy_m0",
   "versions": [
    {
@@ -29338,6 +29667,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -29367,12 +29697,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 131,
+  "downloads": 0,
   "id": "qtpy_m0_haxpress",
   "versions": [
    {
@@ -29457,6 +29787,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -29499,12 +29830,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 2410,
+  "downloads": 0,
   "id": "raspberry_pi_pico",
   "versions": [
    {
@@ -29614,6 +29945,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -29682,12 +30014,186 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 27,
+  "downloads": 0,
+  "id": "raspberrypi_cm4io",
+  "versions": [
+   {
+    "extensions": [
+     "disk.img.zip",
+     "kernel8.img"
+    ],
+    "frozen_libraries": [],
+    "languages": [
+     "de_DE",
+     "en_GB",
+     "en_US",
+     "en_x_pirate",
+     "es",
+     "fil",
+     "fr",
+     "ID",
+     "it_IT",
+     "ja",
+     "nl",
+     "pl",
+     "pt_BR",
+     "ru",
+     "sv",
+     "zh_Latn_pinyin"
+    ],
+    "modules": [
+     "bitbangio",
+     "board",
+     "busio",
+     "digitalio",
+     "displayio",
+     "fontio",
+     "framebufferio",
+     "math",
+     "microcontroller",
+     "os",
+     "rainbowio",
+     "random",
+     "sdioio",
+     "sharpdisplay",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "usb_cdc",
+     "usb_hid",
+     "usb_midi",
+     "vectorio"
+    ],
+    "stable": false,
+    "version": "7.1.0-beta.1"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
+  "id": "raspberrypi_pi4b",
+  "versions": [
+   {
+    "extensions": [
+     "disk.img.zip",
+     "kernel8.img"
+    ],
+    "frozen_libraries": [],
+    "languages": [
+     "de_DE",
+     "en_GB",
+     "en_US",
+     "en_x_pirate",
+     "es",
+     "fil",
+     "fr",
+     "ID",
+     "it_IT",
+     "ja",
+     "nl",
+     "pl",
+     "pt_BR",
+     "ru",
+     "sv",
+     "zh_Latn_pinyin"
+    ],
+    "modules": [
+     "bitbangio",
+     "board",
+     "busio",
+     "digitalio",
+     "displayio",
+     "fontio",
+     "framebufferio",
+     "math",
+     "microcontroller",
+     "os",
+     "rainbowio",
+     "random",
+     "sdioio",
+     "sharpdisplay",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "usb_cdc",
+     "usb_hid",
+     "usb_midi",
+     "vectorio"
+    ],
+    "stable": false,
+    "version": "7.1.0-beta.1"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
+  "id": "raspberrypi_zero2w",
+  "versions": [
+   {
+    "extensions": [
+     "disk.img.zip",
+     "kernel8.img"
+    ],
+    "frozen_libraries": [],
+    "languages": [
+     "de_DE",
+     "en_GB",
+     "en_US",
+     "en_x_pirate",
+     "es",
+     "fil",
+     "fr",
+     "ID",
+     "it_IT",
+     "ja",
+     "nl",
+     "pl",
+     "pt_BR",
+     "ru",
+     "sv",
+     "zh_Latn_pinyin"
+    ],
+    "modules": [
+     "bitbangio",
+     "board",
+     "busio",
+     "digitalio",
+     "displayio",
+     "fontio",
+     "framebufferio",
+     "math",
+     "microcontroller",
+     "os",
+     "rainbowio",
+     "random",
+     "sdioio",
+     "sharpdisplay",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "usb_cdc",
+     "usb_hid",
+     "usb_midi",
+     "vectorio"
+    ],
+    "stable": false,
+    "version": "7.1.0-beta.1"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
   "id": "raytac_mdbt50q-db-40",
   "versions": [
    {
@@ -29794,6 +30300,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -29823,6 +30330,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -29859,12 +30367,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 43,
+  "downloads": 0,
   "id": "raytac_mdbt50q-rx",
   "versions": [
    {
@@ -29971,6 +30479,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -30000,6 +30509,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -30036,12 +30546,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 74,
+  "downloads": 0,
   "id": "robohatmm1_m4",
   "versions": [
    {
@@ -30142,6 +30652,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -30197,12 +30708,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 42,
+  "downloads": 0,
   "id": "sam32",
   "versions": [
    {
@@ -30314,6 +30825,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -30381,12 +30893,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 67,
+  "downloads": 0,
   "id": "same54_xplained",
   "versions": [
    {
@@ -30494,6 +31006,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -30560,12 +31073,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 244,
+  "downloads": 0,
   "id": "seeeduino_wio_terminal",
   "versions": [
    {
@@ -30673,6 +31186,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -30740,12 +31254,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 501,
+  "downloads": 0,
   "id": "seeeduino_xiao",
   "versions": [
    {
@@ -30817,6 +31331,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -30846,7 +31361,7 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
@@ -30876,6 +31391,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -30902,12 +31418,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 34,
+  "downloads": 0,
   "id": "sensebox_mcu",
   "versions": [
    {
@@ -30977,6 +31493,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -31005,12 +31522,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 74,
+  "downloads": 0,
   "id": "serpente",
   "versions": [
    {
@@ -31095,6 +31612,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -31137,12 +31655,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 57,
+  "downloads": 0,
   "id": "shirtty",
   "versions": [
    {
@@ -31214,6 +31732,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -31243,12 +31762,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 29,
+  "downloads": 0,
   "id": "silicognition-m4-shim",
   "versions": [
    {
@@ -31356,6 +31875,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -31423,12 +31943,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 30,
+  "downloads": 0,
   "id": "simmel",
   "versions": [
    {
@@ -31506,6 +32026,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -31539,12 +32060,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 35,
+  "downloads": 0,
   "id": "snekboard",
   "versions": [
    {
@@ -31629,6 +32150,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -31671,7 +32193,7 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
@@ -31704,6 +32226,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -31772,12 +32295,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 59,
+  "downloads": 0,
   "id": "sparkfun_lumidrive",
   "versions": [
    {
@@ -31863,6 +32386,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -31902,12 +32426,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 73,
+  "downloads": 0,
   "id": "sparkfun_micromod_rp2040",
   "versions": [
    {
@@ -32017,6 +32541,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -32085,12 +32610,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 53,
+  "downloads": 0,
   "id": "sparkfun_nrf52840_micromod",
   "versions": [
    {
@@ -32197,6 +32722,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -32226,6 +32752,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -32262,12 +32789,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 61,
+  "downloads": 0,
   "id": "sparkfun_nrf52840_mini",
   "versions": [
    {
@@ -32374,6 +32901,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -32403,6 +32931,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -32439,12 +32968,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 102,
+  "downloads": 0,
   "id": "sparkfun_pro_micro_rp2040",
   "versions": [
    {
@@ -32554,6 +33083,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -32622,12 +33152,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 29,
+  "downloads": 0,
   "id": "sparkfun_qwiic_micro_no_flash",
   "versions": [
    {
@@ -32699,6 +33229,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -32728,12 +33259,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 27,
+  "downloads": 0,
   "id": "sparkfun_qwiic_micro_with_flash",
   "versions": [
    {
@@ -32805,6 +33336,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -32834,12 +33366,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 50,
+  "downloads": 0,
   "id": "sparkfun_redboard_turbo",
   "versions": [
    {
@@ -32924,6 +33456,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -32966,12 +33499,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 50,
+  "downloads": 0,
   "id": "sparkfun_samd21_dev",
   "versions": [
    {
@@ -33043,6 +33576,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -33072,12 +33606,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 53,
+  "downloads": 0,
   "id": "sparkfun_samd21_mini",
   "versions": [
    {
@@ -33149,6 +33683,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -33178,12 +33713,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 33,
+  "downloads": 0,
   "id": "sparkfun_samd51_micromod",
   "versions": [
    {
@@ -33291,6 +33826,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -33358,12 +33894,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 61,
+  "downloads": 0,
   "id": "sparkfun_samd51_thing_plus",
   "versions": [
    {
@@ -33471,6 +34007,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -33538,12 +34075,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 16,
+  "downloads": 0,
   "id": "sparkfun_stm32f405_micromod",
   "versions": [
    {
@@ -33644,6 +34181,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -33703,12 +34241,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 75,
+  "downloads": 0,
   "id": "sparkfun_thing_plus_rp2040",
   "versions": [
    {
@@ -33818,6 +34356,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -33886,12 +34425,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 109,
+  "downloads": 0,
   "id": "spresense",
   "versions": [
    {
@@ -33975,6 +34514,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -34016,12 +34556,12 @@
      "usb_cdc"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 22,
+  "downloads": 0,
   "id": "stackrduino_m0_pro",
   "versions": [
    {
@@ -34106,6 +34646,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -34148,12 +34689,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 81,
+  "downloads": 0,
   "id": "stm32f411ce_blackpill",
   "versions": [
    {
@@ -34245,6 +34786,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -34295,12 +34837,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 44,
+  "downloads": 0,
   "id": "stm32f411ce_blackpill_with_flash",
   "versions": [
    {
@@ -34396,6 +34938,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -34450,12 +34993,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 30,
+  "downloads": 0,
   "id": "stm32f411ve_discovery",
   "versions": [
    {
@@ -34544,6 +35087,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -34591,12 +35135,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 26,
+  "downloads": 0,
   "id": "stm32f412zg_discovery",
   "versions": [
    {
@@ -34693,6 +35237,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -34748,12 +35293,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 39,
+  "downloads": 0,
   "id": "stm32f4_discovery",
   "versions": [
    {
@@ -34853,6 +35398,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -34911,12 +35457,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 26,
+  "downloads": 0,
   "id": "stm32f746g_discovery",
   "versions": [
    {
@@ -35007,6 +35553,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -35056,12 +35603,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 52,
+  "downloads": 0,
   "id": "stringcar_m0_express",
   "versions": [
    {
@@ -35146,6 +35693,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -35167,7 +35715,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "paralleldisplay",
      "pulseio",
@@ -35188,7 +35735,7 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
@@ -35215,6 +35762,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -35257,12 +35805,12 @@
      "usb_cdc"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 75,
+  "downloads": 0,
   "id": "targett_module_clip_wroom",
   "versions": [
    {
@@ -35379,6 +35927,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -35453,12 +36002,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 54,
+  "downloads": 0,
   "id": "targett_module_clip_wrover",
   "versions": [
    {
@@ -35575,6 +36124,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -35649,12 +36199,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 285,
+  "downloads": 0,
   "id": "teensy40",
   "versions": [
    {
@@ -35749,6 +36299,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -35800,12 +36351,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 226,
+  "downloads": 0,
   "id": "teensy41",
   "versions": [
    {
@@ -35900,6 +36451,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -35951,12 +36503,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 57,
+  "downloads": 0,
   "id": "teknikio_bluebird",
   "versions": [
    {
@@ -36063,6 +36615,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -36092,6 +36645,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -36128,12 +36682,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 8,
+  "downloads": 0,
   "id": "thunderpack_v11",
   "versions": [
    {
@@ -36227,6 +36781,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -36278,12 +36833,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 12,
+  "downloads": 0,
   "id": "thunderpack_v12",
   "versions": [
    {
@@ -36379,6 +36934,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -36432,12 +36988,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 44,
+  "downloads": 0,
   "id": "tinkeringtech_scoutmakes_azul",
   "versions": [
    {
@@ -36544,6 +37100,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -36573,6 +37130,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -36609,12 +37167,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 141,
+  "downloads": 0,
   "id": "trellis_m4_express",
   "versions": [
    {
@@ -36721,6 +37279,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -36787,12 +37346,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 442,
+  "downloads": 0,
   "id": "trinket_m0",
   "versions": [
    {
@@ -36864,6 +37423,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -36893,12 +37453,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 55,
+  "downloads": 0,
   "id": "trinket_m0_haxpress",
   "versions": [
    {
@@ -36983,6 +37543,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -37025,12 +37586,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 10,
+  "downloads": 0,
   "id": "uartlogger2",
   "versions": [
    {
@@ -37138,6 +37699,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -37205,12 +37767,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 44,
+  "downloads": 0,
   "id": "uchip",
   "versions": [
    {
@@ -37284,6 +37846,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -37313,12 +37876,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 37,
+  "downloads": 0,
   "id": "ugame10",
   "versions": [
    {
@@ -37399,6 +37962,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -37433,12 +37997,12 @@
      "usb_cdc"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 348,
+  "downloads": 0,
   "id": "unexpectedmaker_feathers2",
   "versions": [
    {
@@ -37555,6 +38119,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -37629,12 +38194,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 48,
+  "downloads": 0,
   "id": "unexpectedmaker_feathers2_neo",
   "versions": [
    {
@@ -37755,6 +38320,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -37829,12 +38395,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 23,
+  "downloads": 0,
   "id": "unexpectedmaker_feathers2_prerelease",
   "versions": [
    {
@@ -37951,6 +38517,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -38025,12 +38592,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 91,
+  "downloads": 0,
   "id": "unexpectedmaker_tinys2",
   "versions": [
    {
@@ -38152,6 +38719,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -38227,12 +38795,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 23,
+  "downloads": 0,
   "id": "warmbit_bluepixel",
   "versions": [
    {
@@ -38339,6 +38907,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -38368,6 +38937,7 @@
      "framebufferio",
      "getpass",
      "gifio",
+     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -38404,12 +38974,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 69,
+  "downloads": 0,
   "id": "winterbloom_big_honking_button",
   "versions": [
    {
@@ -38485,6 +39055,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -38518,12 +39089,12 @@
      "usb_cdc"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 60,
+  "downloads": 0,
   "id": "winterbloom_sol",
   "versions": [
    {
@@ -38610,6 +39181,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -38655,12 +39227,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 43,
+  "downloads": 0,
   "id": "xinabox_cc03",
   "versions": [
    {
@@ -38729,6 +39301,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -38755,12 +39328,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  },
  {
-  "downloads": 41,
+  "downloads": 0,
   "id": "xinabox_cs11",
   "versions": [
    {
@@ -38830,6 +39403,7 @@
      "nl",
      "pl",
      "pt_BR",
+     "ru",
      "sv",
      "zh_Latn_pinyin"
     ],
@@ -38855,7 +39429,7 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "7.1.0-beta.0"
+    "version": "7.1.0-beta.1"
    }
   ]
  }

--- a/_data/files.json
+++ b/_data/files.json
@@ -1,6 +1,6 @@
 [
  {
-  "downloads": 0,
+  "downloads": 53,
   "id": "8086_commander",
   "versions": [
    {
@@ -117,7 +117,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 31,
   "id": "ADM_B_NRF52840_1",
   "versions": [
    {
@@ -296,7 +296,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 66,
   "id": "TG-Watch",
   "versions": [
    {
@@ -503,7 +503,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 86,
   "id": "adafruit_feather_esp32s2",
   "versions": [
    {
@@ -606,7 +606,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 11,
   "id": "adafruit_feather_esp32s2_tft",
   "versions": [
    {
@@ -709,7 +709,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 67,
   "id": "adafruit_feather_esp32s2_tftback_nopsram",
   "versions": [
    {
@@ -916,7 +916,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 714,
   "id": "adafruit_feather_rp2040",
   "versions": [
    {
@@ -1100,7 +1100,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 362,
   "id": "adafruit_funhouse",
   "versions": [
    {
@@ -1297,7 +1297,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 165,
   "id": "adafruit_itsybitsy_rp2040",
   "versions": [
    {
@@ -1481,7 +1481,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 26,
   "id": "adafruit_kb2040",
   "versions": [
    {
@@ -1577,7 +1577,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 321,
   "id": "adafruit_led_glasses_nrf52840",
   "versions": [
    {
@@ -1756,7 +1756,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 553,
   "id": "adafruit_macropad_rp2040",
   "versions": [
    {
@@ -1940,7 +1940,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 690,
   "id": "adafruit_magtag_2.9_grayscale",
   "versions": [
    {
@@ -2137,7 +2137,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 245,
   "id": "adafruit_metro_esp32s2",
   "versions": [
    {
@@ -2334,7 +2334,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 185,
   "id": "adafruit_neokey_trinkey_m0",
   "versions": [
    {
@@ -2437,7 +2437,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 105,
   "id": "adafruit_proxlight_trinkey_m0",
   "versions": [
    {
@@ -2546,7 +2546,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 189,
   "id": "adafruit_qt2040_trinkey",
   "versions": [
    {
@@ -2838,7 +2838,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 378,
   "id": "adafruit_qtpy_rp2040",
   "versions": [
    {
@@ -3022,7 +3022,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 129,
   "id": "adafruit_rotary_trinkey_m0",
   "versions": [
    {
@@ -3127,7 +3127,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 58,
   "id": "adafruit_slide_trinkey_m0",
   "versions": [
    {
@@ -3234,7 +3234,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 28,
   "id": "ai_thinker_esp32-c3s",
   "versions": [
    {
@@ -3323,7 +3323,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 245,
   "id": "ai_thinker_esp_12k_nodemcu",
   "versions": [
    {
@@ -3520,7 +3520,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 80,
   "id": "aloriumtech_evo_m51",
   "versions": [
    {
@@ -3701,7 +3701,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 73,
   "id": "aramcon2_badge",
   "versions": [
    {
@@ -3880,7 +3880,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 95,
   "id": "aramcon_badge_2019",
   "versions": [
    {
@@ -4059,7 +4059,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 62,
   "id": "arduino_mkr1300",
   "versions": [
    {
@@ -4166,7 +4166,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 99,
   "id": "arduino_mkrzero",
   "versions": [
    {
@@ -4275,7 +4275,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 137,
   "id": "arduino_nano_33_ble",
   "versions": [
    {
@@ -4454,7 +4454,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 102,
   "id": "arduino_nano_33_iot",
   "versions": [
    {
@@ -4561,7 +4561,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 383,
   "id": "arduino_nano_rp2040_connect",
   "versions": [
    {
@@ -4745,7 +4745,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 124,
   "id": "arduino_zero",
   "versions": [
    {
@@ -4852,7 +4852,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 19,
   "id": "artisense_rd00",
   "versions": [
    {
@@ -5049,7 +5049,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 64,
   "id": "atmegazero_esp32s2",
   "versions": [
    {
@@ -5246,7 +5246,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 56,
   "id": "bast_pro_mini_m0",
   "versions": [
    {
@@ -5353,7 +5353,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 37,
   "id": "bastble",
   "versions": [
    {
@@ -5532,7 +5532,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 40,
   "id": "bdmicro_vina_d21",
   "versions": [
    {
@@ -5665,7 +5665,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 41,
   "id": "bdmicro_vina_d51",
   "versions": [
    {
@@ -5846,7 +5846,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 38,
   "id": "bdmicro_vina_d51_pcb7",
   "versions": [
    {
@@ -6027,7 +6027,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 113,
   "id": "bless_dev_board_multi_sensor",
   "versions": [
    {
@@ -6206,7 +6206,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 59,
   "id": "blm_badge",
   "versions": [
    {
@@ -6311,7 +6311,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 68,
   "id": "bluemicro840",
   "versions": [
    {
@@ -6490,7 +6490,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 57,
   "id": "capablerobot_usbhub",
   "versions": [
    {
@@ -6669,7 +6669,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 72,
   "id": "catwan_usbstick",
   "versions": [
    {
@@ -6776,7 +6776,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 12,
   "id": "challenger_nb_rp2040_wifi",
   "versions": [
    {
@@ -6872,7 +6872,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 90,
   "id": "challenger_rp2040_lte",
   "versions": [
    {
@@ -6968,7 +6968,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 63,
   "id": "challenger_rp2040_wifi",
   "versions": [
    {
@@ -7152,7 +7152,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 78,
   "id": "circuitbrains_basic_m0",
   "versions": [
    {
@@ -7285,7 +7285,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 79,
   "id": "circuitbrains_deluxe_m4",
   "versions": [
    {
@@ -7466,7 +7466,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 695,
   "id": "circuitplayground_bluefruit",
   "versions": [
    {
@@ -7645,7 +7645,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 1133,
   "id": "circuitplayground_express",
   "versions": [
    {
@@ -7788,7 +7788,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 54,
   "id": "circuitplayground_express_4h",
   "versions": [
    {
@@ -7931,7 +7931,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 148,
   "id": "circuitplayground_express_crickit",
   "versions": [
    {
@@ -8074,7 +8074,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 62,
   "id": "circuitplayground_express_digikey_pycon2019",
   "versions": [
    {
@@ -8217,7 +8217,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 111,
   "id": "circuitplayground_express_displayio",
   "versions": [
    {
@@ -8350,7 +8350,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 362,
   "id": "clue_nrf52840_express",
   "versions": [
    {
@@ -8529,7 +8529,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 4,
   "id": "cp32-m4",
   "versions": [
    {
@@ -8708,7 +8708,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 59,
   "id": "cp_sapling_m0",
   "versions": [
    {
@@ -8815,7 +8815,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 58,
   "id": "cp_sapling_m0_revb",
   "versions": [
    {
@@ -8922,7 +8922,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 65,
   "id": "cp_sapling_m0_spiflash",
   "versions": [
    {
@@ -9049,7 +9049,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 50,
   "id": "crumpspace_crumps2",
   "versions": [
    {
@@ -9246,7 +9246,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 299,
   "id": "cytron_maker_pi_rp2040",
   "versions": [
    {
@@ -9438,7 +9438,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 8,
   "id": "datalore_ip_m4",
   "versions": [
    {
@@ -9619,7 +9619,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 51,
   "id": "datum_distance",
   "versions": [
    {
@@ -9726,7 +9726,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 67,
   "id": "datum_imu",
   "versions": [
    {
@@ -9833,7 +9833,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 59,
   "id": "datum_light",
   "versions": [
    {
@@ -9940,7 +9940,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 54,
   "id": "datum_weather",
   "versions": [
    {
@@ -10047,7 +10047,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 67,
   "id": "dynalora_usb",
   "versions": [
    {
@@ -10163,7 +10163,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 90,
   "id": "dynossat_edu_eps",
   "versions": [
    {
@@ -10292,7 +10292,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 89,
   "id": "dynossat_edu_obc",
   "versions": [
    {
@@ -10473,7 +10473,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 128,
   "id": "edgebadge",
   "versions": [
    {
@@ -10656,7 +10656,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 52,
   "id": "electroniccats_bastwifi",
   "versions": [
    {
@@ -10851,7 +10851,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 64,
   "id": "electronut_labs_blip",
   "versions": [
    {
@@ -11032,7 +11032,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 69,
   "id": "electronut_labs_papyr",
   "versions": [
    {
@@ -11211,7 +11211,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 54,
   "id": "escornabot_makech",
   "versions": [
    {
@@ -11316,7 +11316,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 70,
   "id": "espressif_hmi_devkit_1",
   "versions": [
    {
@@ -11513,7 +11513,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 86,
   "id": "espressif_kaluga_1",
   "versions": [
    {
@@ -11710,7 +11710,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 87,
   "id": "espressif_kaluga_1.3",
   "versions": [
    {
@@ -11907,7 +11907,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 284,
   "id": "espressif_saola_1_wroom",
   "versions": [
    {
@@ -12104,7 +12104,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 295,
   "id": "espressif_saola_1_wrover",
   "versions": [
    {
@@ -12301,7 +12301,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 20,
   "id": "espruino_pico",
   "versions": [
    {
@@ -12432,7 +12432,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 23,
   "id": "espruino_wifi",
   "versions": [
    {
@@ -12580,7 +12580,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 234,
   "id": "feather_bluefruit_sense",
   "versions": [
    {
@@ -12759,7 +12759,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 175,
   "id": "feather_m0_adalogger",
   "versions": [
    {
@@ -12867,7 +12867,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 173,
   "id": "feather_m0_basic",
   "versions": [
    {
@@ -12976,7 +12976,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 347,
   "id": "feather_m0_express",
   "versions": [
    {
@@ -13109,7 +13109,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 70,
   "id": "feather_m0_express_crickit",
   "versions": [
    {
@@ -13244,7 +13244,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 114,
   "id": "feather_m0_rfm69",
   "versions": [
    {
@@ -13349,7 +13349,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 204,
   "id": "feather_m0_rfm9x",
   "versions": [
    {
@@ -13454,7 +13454,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 62,
   "id": "feather_m0_supersized",
   "versions": [
    {
@@ -13587,7 +13587,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 139,
   "id": "feather_m4_can",
   "versions": [
    {
@@ -13769,7 +13769,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 699,
   "id": "feather_m4_express",
   "versions": [
    {
@@ -13950,7 +13950,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 62,
   "id": "feather_m7_1011",
   "versions": [
    {
@@ -14108,7 +14108,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 91,
   "id": "feather_mimxrt1011",
   "versions": [
    {
@@ -14266,7 +14266,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 89,
   "id": "feather_mimxrt1062",
   "versions": [
    {
@@ -14418,7 +14418,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 348,
   "id": "feather_nrf52840_express",
   "versions": [
    {
@@ -14602,7 +14602,7 @@
   "versions": []
  },
  {
-  "downloads": 0,
+  "downloads": 137,
   "id": "feather_stm32f405_express",
   "versions": [
    {
@@ -14768,7 +14768,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 75,
   "id": "fluff_m0",
   "versions": [
    {
@@ -14875,7 +14875,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 59,
   "id": "fomu",
   "versions": [
    {
@@ -14990,7 +14990,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 87,
   "id": "franzininho_wifi_wroom",
   "versions": [
    {
@@ -15187,7 +15187,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 60,
   "id": "franzininho_wifi_wrover",
   "versions": [
    {
@@ -15384,7 +15384,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 308,
   "id": "gemma_m0",
   "versions": [
    {
@@ -15491,7 +15491,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 78,
   "id": "gemma_m0_pycon2018",
   "versions": [
    {
@@ -15598,7 +15598,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 186,
   "id": "grandcentral_m4_express",
   "versions": [
    {
@@ -15785,7 +15785,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 61,
   "id": "gravitech_cucumber_m",
   "versions": [
    {
@@ -15982,7 +15982,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 52,
   "id": "gravitech_cucumber_ms",
   "versions": [
    {
@@ -16179,7 +16179,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 45,
   "id": "gravitech_cucumber_r",
   "versions": [
    {
@@ -16376,7 +16376,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 57,
   "id": "gravitech_cucumber_rs",
   "versions": [
    {
@@ -16573,7 +16573,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 165,
   "id": "hallowing_m0_express",
   "versions": [
    {
@@ -16710,7 +16710,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 123,
   "id": "hallowing_m4_express",
   "versions": [
    {
@@ -16891,7 +16891,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 139,
   "id": "hiibot_bluefi",
   "versions": [
    {
@@ -17070,7 +17070,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 49,
   "id": "huntercat_nfc",
   "versions": [
    {
@@ -17203,7 +17203,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 62,
   "id": "ikigaisense_vita",
   "versions": [
    {
@@ -17382,7 +17382,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 87,
   "id": "imxrt1010_evk",
   "versions": [
    {
@@ -17540,7 +17540,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 71,
   "id": "imxrt1020_evk",
   "versions": [
    {
@@ -17692,7 +17692,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 73,
   "id": "imxrt1060_evk",
   "versions": [
    {
@@ -17844,7 +17844,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 232,
   "id": "itsybitsy_m0_express",
   "versions": [
    {
@@ -17975,7 +17975,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 353,
   "id": "itsybitsy_m4_express",
   "versions": [
    {
@@ -18154,7 +18154,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 237,
   "id": "itsybitsy_nrf52840_express",
   "versions": [
    {
@@ -18333,7 +18333,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 64,
   "id": "jpconstantineau_encoderpad_rp2040",
   "versions": [
    {
@@ -18517,7 +18517,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 11,
   "id": "jpconstantineau_pykey60",
   "versions": [
    {
@@ -18613,7 +18613,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 65,
   "id": "kicksat-sprite",
   "versions": [
    {
@@ -18749,7 +18749,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 216,
   "id": "lilygo_ttgo_t8_s2_st7789",
   "versions": [
    {
@@ -18946,7 +18946,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 65,
   "id": "loc_ber_m4_base_board",
   "versions": [
    {
@@ -19056,7 +19056,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 136,
   "id": "lolin_s2_mini",
   "versions": [
    {
@@ -19257,7 +19257,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 14,
   "id": "lolin_s2_pico",
   "versions": [
    {
@@ -19362,7 +19362,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 96,
   "id": "makerdiary_m60_keyboard",
   "versions": [
    {
@@ -19541,7 +19541,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 72,
   "id": "makerdiary_nrf52840_m2_devkit",
   "versions": [
    {
@@ -19720,7 +19720,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 74,
   "id": "makerdiary_nrf52840_mdk",
   "versions": [
    {
@@ -19899,7 +19899,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 144,
   "id": "makerdiary_nrf52840_mdk_usb_dongle",
   "versions": [
    {
@@ -20080,7 +20080,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 583,
   "id": "matrixportal_m4",
   "versions": [
    {
@@ -20261,7 +20261,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 12,
   "id": "melopero_shake_rp2040",
   "versions": [
    {
@@ -20357,7 +20357,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 141,
   "id": "meowbit_v121",
   "versions": [
    {
@@ -20513,7 +20513,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 59,
   "id": "meowmeow",
   "versions": [
    {
@@ -20618,7 +20618,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 305,
   "id": "metro_m0_express",
   "versions": [
    {
@@ -20751,7 +20751,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 263,
   "id": "metro_m4_airlift_lite",
   "versions": [
    {
@@ -20932,7 +20932,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 257,
   "id": "metro_m4_express",
   "versions": [
    {
@@ -21113,7 +21113,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 53,
   "id": "metro_m7_1011",
   "versions": [
    {
@@ -21271,7 +21271,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 71,
   "id": "metro_nrf52840_express",
   "versions": [
    {
@@ -21662,7 +21662,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 88,
   "id": "microdev_micro_s2",
   "versions": [
    {
@@ -21859,7 +21859,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 89,
   "id": "mini_sam_m4",
   "versions": [
    {
@@ -22042,7 +22042,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 251,
   "id": "monster_m4sk",
   "versions": [
    {
@@ -22223,7 +22223,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 46,
   "id": "morpheans_morphesp-240",
   "versions": [
    {
@@ -22420,7 +22420,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 196,
   "id": "muselab_nanoesp32_s2_wroom",
   "versions": [
    {
@@ -22617,7 +22617,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 132,
   "id": "muselab_nanoesp32_s2_wrover",
   "versions": [
    {
@@ -22814,7 +22814,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 58,
   "id": "ndgarage_ndbit6",
   "versions": [
    {
@@ -22921,7 +22921,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 25,
   "id": "ndgarage_ndbit6_v2",
   "versions": [
    {
@@ -23028,7 +23028,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 288,
   "id": "neopixel_trinkey_m0",
   "versions": [
    {
@@ -23131,7 +23131,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 96,
   "id": "nfc_copy_cat",
   "versions": [
    {
@@ -23238,7 +23238,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 107,
   "id": "nice_nano",
   "versions": [
    {
@@ -23417,7 +23417,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 29,
   "id": "nucleo_f746zg",
   "versions": [
    {
@@ -23563,7 +23563,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 38,
   "id": "nucleo_f767zi",
   "versions": [
    {
@@ -23709,7 +23709,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 42,
   "id": "nucleo_h743zi_2",
   "versions": [
    {
@@ -23851,7 +23851,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 5,
   "id": "odt_bread_2040",
   "versions": [
    {
@@ -23947,7 +23947,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 44,
   "id": "odt_pixelwing_esp32_s2",
   "versions": [
    {
@@ -24144,7 +24144,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 77,
   "id": "ohs2020_badge",
   "versions": [
    {
@@ -24323,7 +24323,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 78,
   "id": "openbook_m4",
   "versions": [
    {
@@ -24506,7 +24506,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 45,
   "id": "openmv_h7",
   "versions": [
    {
@@ -24648,7 +24648,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 84,
   "id": "particle_argon",
   "versions": [
    {
@@ -24827,7 +24827,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 84,
   "id": "particle_boron",
   "versions": [
    {
@@ -25006,7 +25006,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 108,
   "id": "particle_xenon",
   "versions": [
    {
@@ -25185,7 +25185,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 105,
   "id": "pca10056",
   "versions": [
    {
@@ -25366,7 +25366,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 157,
   "id": "pca10059",
   "versions": [
    {
@@ -25547,7 +25547,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 128,
   "id": "pca10100",
   "versions": [
    {
@@ -25670,7 +25670,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 69,
   "id": "pewpew10",
   "versions": [
    {
@@ -25777,7 +25777,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 46,
   "id": "pewpew13",
   "versions": [
    {
@@ -25884,7 +25884,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 88,
   "id": "pewpew_m4",
   "versions": [
    {
@@ -26000,7 +26000,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 57,
   "id": "picoplanet",
   "versions": [
    {
@@ -26107,7 +26107,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 11,
   "id": "pimoroni_interstate75",
   "versions": [
    {
@@ -26291,7 +26291,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 191,
   "id": "pimoroni_keybow2040",
   "versions": [
    {
@@ -26475,7 +26475,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 75,
   "id": "pimoroni_pga2040",
   "versions": [
    {
@@ -26659,7 +26659,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 134,
   "id": "pimoroni_picolipo_16mb",
   "versions": [
    {
@@ -26843,7 +26843,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 95,
   "id": "pimoroni_picolipo_4mb",
   "versions": [
    {
@@ -27027,7 +27027,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 153,
   "id": "pimoroni_picosystem",
   "versions": [
    {
@@ -27214,7 +27214,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 129,
   "id": "pimoroni_plasma2040",
   "versions": [
    {
@@ -27398,7 +27398,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 263,
   "id": "pimoroni_tiny2040",
   "versions": [
    {
@@ -27587,7 +27587,7 @@
   "versions": []
  },
  {
-  "downloads": 0,
+  "downloads": 69,
   "id": "pitaya_go",
   "versions": [
    {
@@ -27766,7 +27766,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 26,
   "id": "pyb_nano_v2",
   "versions": [
    {
@@ -27907,7 +27907,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 286,
   "id": "pybadge",
   "versions": [
    {
@@ -28095,7 +28095,7 @@
   "versions": []
  },
  {
-  "downloads": 0,
+  "downloads": 66,
   "id": "pyboard_v11",
   "versions": [
    {
@@ -28261,7 +28261,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 105,
   "id": "pycubed",
   "versions": [
    {
@@ -28424,7 +28424,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 70,
   "id": "pycubed_mram",
   "versions": [
    {
@@ -28587,7 +28587,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 6,
   "id": "pycubed_mram_v05",
   "versions": [
    {
@@ -28672,7 +28672,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 6,
   "id": "pycubed_v05",
   "versions": [
    {
@@ -28757,7 +28757,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 223,
   "id": "pygamer",
   "versions": [
    {
@@ -28945,7 +28945,7 @@
   "versions": []
  },
  {
-  "downloads": 0,
+  "downloads": 410,
   "id": "pyportal",
   "versions": [
    {
@@ -29126,7 +29126,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 123,
   "id": "pyportal_pynt",
   "versions": [
    {
@@ -29307,7 +29307,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 233,
   "id": "pyportal_titano",
   "versions": [
    {
@@ -29488,7 +29488,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 143,
   "id": "pyruler",
   "versions": [
    {
@@ -29595,7 +29595,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 467,
   "id": "qtpy_m0",
   "versions": [
    {
@@ -29702,7 +29702,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 191,
   "id": "qtpy_m0_haxpress",
   "versions": [
    {
@@ -29835,7 +29835,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 3426,
   "id": "raspberry_pi_pico",
   "versions": [
    {
@@ -30193,7 +30193,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 46,
   "id": "raytac_mdbt50q-db-40",
   "versions": [
    {
@@ -30372,7 +30372,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 61,
   "id": "raytac_mdbt50q-rx",
   "versions": [
    {
@@ -30551,7 +30551,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 97,
   "id": "robohatmm1_m4",
   "versions": [
    {
@@ -30713,7 +30713,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 72,
   "id": "sam32",
   "versions": [
    {
@@ -30898,7 +30898,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 90,
   "id": "same54_xplained",
   "versions": [
    {
@@ -31078,7 +31078,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 347,
   "id": "seeeduino_wio_terminal",
   "versions": [
    {
@@ -31259,7 +31259,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 707,
   "id": "seeeduino_xiao",
   "versions": [
    {
@@ -31366,7 +31366,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 21,
   "id": "seeeduino_xiao_kb",
   "versions": [
    {
@@ -31423,7 +31423,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 61,
   "id": "sensebox_mcu",
   "versions": [
    {
@@ -31527,7 +31527,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 96,
   "id": "serpente",
   "versions": [
    {
@@ -31660,7 +31660,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 82,
   "id": "shirtty",
   "versions": [
    {
@@ -31767,7 +31767,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 53,
   "id": "silicognition-m4-shim",
   "versions": [
    {
@@ -31948,7 +31948,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 58,
   "id": "simmel",
   "versions": [
    {
@@ -32065,7 +32065,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 63,
   "id": "snekboard",
   "versions": [
    {
@@ -32198,7 +32198,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 82,
   "id": "solderparty_rp2040_stamp",
   "versions": [
    {
@@ -32300,7 +32300,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 76,
   "id": "sparkfun_lumidrive",
   "versions": [
    {
@@ -32431,7 +32431,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 97,
   "id": "sparkfun_micromod_rp2040",
   "versions": [
    {
@@ -32615,7 +32615,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 77,
   "id": "sparkfun_nrf52840_micromod",
   "versions": [
    {
@@ -32794,7 +32794,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 74,
   "id": "sparkfun_nrf52840_mini",
   "versions": [
    {
@@ -32973,7 +32973,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 151,
   "id": "sparkfun_pro_micro_rp2040",
   "versions": [
    {
@@ -33157,7 +33157,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 51,
   "id": "sparkfun_qwiic_micro_no_flash",
   "versions": [
    {
@@ -33264,7 +33264,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 40,
   "id": "sparkfun_qwiic_micro_with_flash",
   "versions": [
    {
@@ -33371,7 +33371,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 87,
   "id": "sparkfun_redboard_turbo",
   "versions": [
    {
@@ -33504,7 +33504,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 65,
   "id": "sparkfun_samd21_dev",
   "versions": [
    {
@@ -33611,7 +33611,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 80,
   "id": "sparkfun_samd21_mini",
   "versions": [
    {
@@ -33718,7 +33718,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 51,
   "id": "sparkfun_samd51_micromod",
   "versions": [
    {
@@ -33899,7 +33899,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 91,
   "id": "sparkfun_samd51_thing_plus",
   "versions": [
    {
@@ -34080,7 +34080,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 25,
   "id": "sparkfun_stm32f405_micromod",
   "versions": [
    {
@@ -34246,7 +34246,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 107,
   "id": "sparkfun_thing_plus_rp2040",
   "versions": [
    {
@@ -34430,7 +34430,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 173,
   "id": "spresense",
   "versions": [
    {
@@ -34561,7 +34561,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 48,
   "id": "stackrduino_m0_pro",
   "versions": [
    {
@@ -34694,7 +34694,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 115,
   "id": "stm32f411ce_blackpill",
   "versions": [
    {
@@ -34842,7 +34842,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 62,
   "id": "stm32f411ce_blackpill_with_flash",
   "versions": [
    {
@@ -34998,7 +34998,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 39,
   "id": "stm32f411ve_discovery",
   "versions": [
    {
@@ -35140,7 +35140,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 37,
   "id": "stm32f412zg_discovery",
   "versions": [
    {
@@ -35298,7 +35298,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 55,
   "id": "stm32f4_discovery",
   "versions": [
    {
@@ -35462,7 +35462,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 32,
   "id": "stm32f746g_discovery",
   "versions": [
    {
@@ -35608,7 +35608,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 80,
   "id": "stringcar_m0_express",
   "versions": [
    {
@@ -35740,7 +35740,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 7,
   "id": "swan_r5",
   "versions": [
    {
@@ -35810,7 +35810,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 106,
   "id": "targett_module_clip_wroom",
   "versions": [
    {
@@ -36007,7 +36007,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 73,
   "id": "targett_module_clip_wrover",
   "versions": [
    {
@@ -36204,7 +36204,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 483,
   "id": "teensy40",
   "versions": [
    {
@@ -36356,7 +36356,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 330,
   "id": "teensy41",
   "versions": [
    {
@@ -36508,7 +36508,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 72,
   "id": "teknikio_bluebird",
   "versions": [
    {
@@ -36687,7 +36687,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 12,
   "id": "thunderpack_v11",
   "versions": [
    {
@@ -36838,7 +36838,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 19,
   "id": "thunderpack_v12",
   "versions": [
    {
@@ -36993,7 +36993,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 79,
   "id": "tinkeringtech_scoutmakes_azul",
   "versions": [
    {
@@ -37172,7 +37172,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 195,
   "id": "trellis_m4_express",
   "versions": [
    {
@@ -37351,7 +37351,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 613,
   "id": "trinket_m0",
   "versions": [
    {
@@ -37458,7 +37458,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 72,
   "id": "trinket_m0_haxpress",
   "versions": [
    {
@@ -37591,7 +37591,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 14,
   "id": "uartlogger2",
   "versions": [
    {
@@ -37772,7 +37772,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 65,
   "id": "uchip",
   "versions": [
    {
@@ -37881,7 +37881,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 55,
   "id": "ugame10",
   "versions": [
    {
@@ -38002,7 +38002,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 462,
   "id": "unexpectedmaker_feathers2",
   "versions": [
    {
@@ -38199,7 +38199,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 73,
   "id": "unexpectedmaker_feathers2_neo",
   "versions": [
    {
@@ -38400,7 +38400,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 43,
   "id": "unexpectedmaker_feathers2_prerelease",
   "versions": [
    {
@@ -38597,7 +38597,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 142,
   "id": "unexpectedmaker_tinys2",
   "versions": [
    {
@@ -38800,7 +38800,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 29,
   "id": "warmbit_bluepixel",
   "versions": [
    {
@@ -38979,7 +38979,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 88,
   "id": "winterbloom_big_honking_button",
   "versions": [
    {
@@ -39094,7 +39094,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 83,
   "id": "winterbloom_sol",
   "versions": [
    {
@@ -39232,7 +39232,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 69,
   "id": "xinabox_cc03",
   "versions": [
    {
@@ -39333,7 +39333,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 62,
   "id": "xinabox_cs11",
   "versions": [
    {


### PR DESCRIPTION
Automated website update for release 7.1.0-beta.1 by Blinka.

New boards:
* raspberrypi_pi4b
* raspberrypi_zero2w
* raspberrypi_cm4io
* adafruit_qtpy_esp32s2

New languages:
* ru
