### PR TITLE
Rename manufacturer to remove single quote

### DIFF
--- a/_board/fomu.md
+++ b/_board/fomu.md
@@ -3,7 +3,7 @@ layout: download
 board_id: "fomu"
 title: "Fomu Download"
 name: "Fomu"
-manufacturer: "Sean 'xobs' Cross"
+manufacturer: Sean Cross (xobs)
 board_url: "https://tomu.im/fomu.html"
 board_image: "fomu.jpg"
 date_added: 2020-4-16


### PR DESCRIPTION
The quote causes issue with sorting. This was the quick fix.

Should be able to close out: https://github.com/adafruit/circuitpython-org/issues/524