### PR TITLE
Remove 6.x bundle links; add pointer to obsolete bundles list

### DIFF
--- a/libraries/index.html
+++ b/libraries/index.html
@@ -33,7 +33,7 @@ permalink: /libraries
       versions of Python source code.
       <strong>Make sure to download the bundle that matches the major version
       of your CircuitPython</strong>, because the <b>.mpy</b> files can change between versions.
-      For example, if you are running 6.3.0 you should download the 6.x bundle.
+      For example, if you are running 7.0.0 you should download the 7.x bundle.
     </p>
     <p>
       The precompiled <b>.mpy</b> files take up less space on your CIRCUITPY drive than the <b>.py</b> files.
@@ -66,13 +66,6 @@ permalink: /libraries
   <section>
     <h2>Bundles</h2>
     <div class="release-section">
-      <div id="adafruit-circuitpython-bundle-6.x-mpy">
-        <h3>Bundle for Version 6.x</h3>
-        <p>
-          This bundle is built for use with CircuitPython 6.x.x. If you are using
-          CircuitPython 6, please download this bundle.
-        </p>
-      </div>
       <div id="adafruit-circuitpython-bundle-7.x-mpy">
           <h3>Bundle for Version 7.x</h3>
           <p>
@@ -81,10 +74,17 @@ permalink: /libraries
               changed for CircuitPython 7; 6.x .mpy files are not compatible.
           </p>
       </div>
+      <div>
+        <h3>Bundles for Older Versions</h3>
+        <p>
+          If you need a bundle for an older version of CircuitPython,
+          see <a href="https://learn.adafruit.com/welcome-to-circuitpython/frequently-asked-questions#faq-3105289">this list</a>.
+        </p>
+      </div>
       <div id="adafruit-circuitpython-bundle-py">
         <h3>Python Source Bundle</h3>
         <p>
-          This bundle is the uncompiled Python source code for every library. It is not
+          This bundle is the latest uncompiled Python source code for every library. It is not
           intended for general use! It is only recommended if you need to edit
           a library file. This bundle works with all supported versions of CircuitPython.
         </p>
@@ -116,6 +116,13 @@ permalink: /libraries
         <p>
           This bundle is built for use with CircuitPython 7.x.x. If you are using
           CircuitPython 7, please download this bundle.
+        </p>
+      </div>
+      <div>
+        <h3>Bundle for Older Versions</h3>
+        <p>
+          If you are looking for Community Bundles for older versions of CircuitPython, you can find them on
+          <a href="https://github.com/adafruit/CircuitPython_Community_Bundle/releases/">GitHub</a>.
         </p>
       </div>
       <div id="circuitpython-community-bundle-py">


### PR DESCRIPTION
6.x bundle building was stopped by https://github.com/adafruit/circuitpython-build-tools/pull/83. This removes explicit listing of the 6.x bundles, and adds links to the last bundle built for a particular version.