### PR TITLE
Update bootloader versions to latest

### DIFF
--- a/_data/bootloaders.json
+++ b/_data/bootloaders.json
@@ -1,13 +1,13 @@
 {
     "bootloaders": {
         "nrf52840": {
-            "version": "0.3.2"
+            "version": "0.6.3"
         },
         "atmel-samd": {
             "version": "v3.13.0"
         },
         "esp32s2": {
-            "version": "0.5.2"
+            "version": "0.7.0"
         },
         "stm": {},
         "cxd56": {},


### PR DESCRIPTION
TinyUF2 is now at 0.7.0, and Adafruit_nRF52_Bootloader is now at 0.6.3.