### PR TITLE
Get some straggling 'contribute' headers removed

### DIFF
--- a/_board/microbit_v2.md
+++ b/_board/microbit_v2.md
@@ -31,6 +31,3 @@ Some new features of the board:
 
 ### Purchase
 - [Adafruit](https://www.adafruit.com/product/4781)
-
-### Contribute
-Have some info to add for this board? Edit the source for this page [here](https://github.com/adafruit/circuitpython-org/edit/main/_board/{{page.board_id}}.md).

--- a/_board/microdev_micro_c3.md
+++ b/_board/microdev_micro_c3.md
@@ -15,6 +15,3 @@ features:
 ---
 
 Oops! Looks like we don't know anything about this board. This means it's likely very new.
-
-### Contribute
-Have some info to add for this board? Edit the source for this page [here](https://github.com/adafruit/circuitpython-org/edit/main/_board/{{page.board_id}}.md).

--- a/_board/microdev_micro_s2.md
+++ b/_board/microdev_micro_s2.md
@@ -30,6 +30,3 @@ With Wi-Fi, native USB and a load of Flash & PSRAM the microS2 is perfect for us
 
 ### Learn More
 - [GitHub](https://github.com/microDev1/microS2/wiki)
-
-### Contribute
-Have some info to add for this board? Edit the source for this page [here](https://github.com/adafruit/circuitpython-org/edit/main/_board/{{page.board_id}}.md).


### PR DESCRIPTION
These had three hash marks before "Contribute". Other headings in these files may also have had "###" where "##" is usual, further review wouldn't hurt.