### PR TITLE
Minor Pykey Updates (Links and enabling visibility)

### DIFF
--- a/_board/jpconstantineau_encoderpad_rp2040.md
+++ b/_board/jpconstantineau_encoderpad_rp2040.md
@@ -35,5 +35,5 @@ It's not just a macropad with a big encoder but also a USB drive containing the 
 * [Board Documentation](https://github.com/jpconstantineau/EncoderPad_RP2040)
 
 ## Purchase
-The EncoderPad RP2040 is currently being tested.  Keep an eye on the Tindie store if you are interested in getting one.
-* [Tindie](https://www.tindie.com/stores/jpconstantineau/)
+The EncoderPad RP2040 is now on the Tindie store if you are interested in getting one.
+* [Tindie](https://www.tindie.com/products/jpconstantineau/rgb-video-editing-macropad-with-a-rp2040/)

--- a/_board/jpconstantineau_pykey18.md
+++ b/_board/jpconstantineau_pykey18.md
@@ -6,7 +6,7 @@ name: "PyKey18 Numpad"
 manufacturer: "JPConstantineau"
 board_url: "https://github.com/jpconstantineau/PyKey60"
 board_image: "jpconstantineau_pykey18.jpg"
-downloads_display: false
+downloads_display: true
 date_added: 2021-12-15
 family: raspberrypi
 
@@ -20,6 +20,8 @@ features:
 The PyKey18 is a custom programmable mechanical keyboard with a standard Numpad layout, a rotary encoder and a small OLED display. The PyKey18 uses mechanical switches (Cherry MX type). The keys are hot-swap socketed and have an individual underglow RGB LED which can be turned on.  The PCB was designed for use with PCB-mount stabilizers.
 
 Since this is a Hot Swappable Switches keyboard, you can choose the MX switches as well as the keycaps you prefer.  You can even mix and match switches for the ultimate customization.
+
+The PyKey18 also has a small 0.91" OLED display and has a location for an optional Stemma QT/QWIIC connector.
 
 
 ## Features

--- a/_board/jpconstantineau_pykey87.md
+++ b/_board/jpconstantineau_pykey87.md
@@ -6,7 +6,7 @@ name: "PyKey87 Ten Key Less (TKL) Keyboard"
 manufacturer: "JPConstantineau"
 board_url: "https://github.com/jpconstantineau/PyKey60"
 board_image: "jpconstantineau_pykey87.jpg"
-downloads_display: false
+downloads_display: true
 date_added: 2021-12-15
 family: raspberrypi
 
@@ -16,11 +16,13 @@ features:
   - STEMMA QT/QWIIC
 ---
 
-The PyKey87 is a custom programmable mechanical keyboard with a standard TKL layout. The PyKey18 uses mechanical switches (Cherry MX type). The keys are hot-swap socketed and have an individual underglow RGB LED which can be turned on.  The PCB was designed for use with PCB-mount stabilizers. The PCB was designed for use with PCB-mount stabilizers.
+The PyKey87 is a custom programmable mechanical keyboard with a standard TKL layout. The PyKey87 uses mechanical switches (Cherry MX type). The keys are hot-swap socketed and have an individual underglow RGB LED which can be turned on.  The PCB was designed for use with PCB-mount stabilizers. 
 
 Since this is a Hot Swappable Switches keyboard, you can choose the MX switches as well as the keycaps you prefer.  You can even mix and match switches for the ultimate customization.
 
 Just like CircuitPython, this keyboard is targeted for beginners.  The design keeps the matrix definition simple to 17 columns and 6 rows instead of using a GPIO-optimized matrix of 8 columns and 8 rows.  Neopixel order is also in line with key numbers.  This keeps the complexity of coding a keyboard firmware to a minimum.
+
+The PCB also has a location for an optional Stemma QT/QWIIC connector.
 
 ## Features
 * Powered by RP2040

--- a/_board/jpconstantineau_pykey87.md
+++ b/_board/jpconstantineau_pykey87.md
@@ -43,4 +43,4 @@ It's not just a keyboard but also a USB drive containing the firmware as Circuit
 
 ## Purchase
 The PyKey87 is available on the Tindie store if you are interested in getting one.
-* [Tindie](https://www.tindie.com/products/edit/pykey87-rgb-tkl-keyboard-with-a-rp2040/)
+* [Tindie](https://www.tindie.com/products/jpconstantineau/pykey87-rgb-tkl-keyboard-with-a-rp2040/)


### PR DESCRIPTION
This PR makes PyKey18 and PyKey87 visible on the download page as well as updates the product link for the CNC Encoder Pad RP2040 as it didn't point to the product itself.