### PR TITLE
Update SAMD UF2 bootloader to v3.14.0

### DIFF
--- a/_data/bootloaders.json
+++ b/_data/bootloaders.json
@@ -4,7 +4,7 @@
             "version": "0.6.3"
         },
         "atmel-samd": {
-            "version": "v3.13.0"
+            "version": "v3.14.0"
         },
         "esp32s2": {
             "version": "0.7.0"


### PR DESCRIPTION
Updated to reflect https://github.com/adafruit/uf2-samdx1/releases/tag/v3.14.0. This new release just supports more boards: no bootloader update is needed or desirable for existing boards.