### PR TITLE
Automated website update for release 7.2.0-alpha.2

### DIFF
--- a/_data/files.json
+++ b/_data/files.json
@@ -1,6 +1,6 @@
 [
  {
-  "downloads": 0,
+  "downloads": 162,
   "id": "8086_commander",
   "versions": [
    {
@@ -119,7 +119,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 40,
   "id": "ADM_B_NRF52840_1",
   "versions": [
    {
@@ -301,7 +301,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 38,
   "id": "Seeed_XIAO_nRF52840_Sense",
   "versions": [
    {
@@ -395,7 +395,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 139,
   "id": "TG-Watch",
   "versions": [
    {
@@ -708,7 +708,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 354,
   "id": "adafruit_feather_esp32s2",
   "versions": [
    {
@@ -908,7 +908,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 183,
   "id": "adafruit_feather_esp32s2_tft",
   "versions": [
    {
@@ -1108,7 +1108,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 126,
   "id": "adafruit_feather_esp32s2_tftback_nopsram",
   "versions": [
    {
@@ -1318,7 +1318,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 1899,
   "id": "adafruit_feather_rp2040",
   "versions": [
    {
@@ -1505,7 +1505,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 749,
   "id": "adafruit_funhouse",
   "versions": [
    {
@@ -1705,7 +1705,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 430,
   "id": "adafruit_itsybitsy_rp2040",
   "versions": [
    {
@@ -1892,7 +1892,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 180,
   "id": "adafruit_kb2040",
   "versions": [
    {
@@ -2079,7 +2079,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 695,
   "id": "adafruit_led_glasses_nrf52840",
   "versions": [
    {
@@ -2262,7 +2262,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 1530,
   "id": "adafruit_macropad_rp2040",
   "versions": [
    {
@@ -2449,7 +2449,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 1615,
   "id": "adafruit_magtag_2.9_grayscale",
   "versions": [
    {
@@ -2649,7 +2649,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 569,
   "id": "adafruit_metro_esp32s2",
   "versions": [
    {
@@ -2849,7 +2849,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 436,
   "id": "adafruit_neokey_trinkey_m0",
   "versions": [
    {
@@ -2954,7 +2954,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 350,
   "id": "adafruit_proxlight_trinkey_m0",
   "versions": [
    {
@@ -3064,7 +3064,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 562,
   "id": "adafruit_qt2040_trinkey",
   "versions": [
    {
@@ -3251,7 +3251,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 309,
   "id": "adafruit_qtpy_esp32s2",
   "versions": [
    {
@@ -3557,7 +3557,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 898,
   "id": "adafruit_qtpy_rp2040",
   "versions": [
    {
@@ -3744,7 +3744,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 311,
   "id": "adafruit_rotary_trinkey_m0",
   "versions": [
    {
@@ -3851,7 +3851,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 190,
   "id": "adafruit_slide_trinkey_m0",
   "versions": [
    {
@@ -3960,7 +3960,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 145,
   "id": "ai_thinker_esp32-c3s",
   "versions": [
    {
@@ -4135,7 +4135,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 474,
   "id": "ai_thinker_esp_12k_nodemcu",
   "versions": [
    {
@@ -4335,7 +4335,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 139,
   "id": "aloriumtech_evo_m51",
   "versions": [
    {
@@ -4522,7 +4522,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 204,
   "id": "aramcon2_badge",
   "versions": [
    {
@@ -4704,7 +4704,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 209,
   "id": "aramcon_badge_2019",
   "versions": [
    {
@@ -4886,7 +4886,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 151,
   "id": "arduino_mkr1300",
   "versions": [
    {
@@ -4995,7 +4995,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 242,
   "id": "arduino_mkrzero",
   "versions": [
    {
@@ -5105,7 +5105,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 353,
   "id": "arduino_nano_33_ble",
   "versions": [
    {
@@ -5287,7 +5287,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 257,
   "id": "arduino_nano_33_iot",
   "versions": [
    {
@@ -5395,7 +5395,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 808,
   "id": "arduino_nano_rp2040_connect",
   "versions": [
    {
@@ -5582,7 +5582,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 290,
   "id": "arduino_zero",
   "versions": [
    {
@@ -5691,7 +5691,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 46,
   "id": "artisense_rd00",
   "versions": [
    {
@@ -5891,7 +5891,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 144,
   "id": "atmegazero_esp32s2",
   "versions": [
    {
@@ -6091,7 +6091,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 102,
   "id": "bast_pro_mini_m0",
   "versions": [
    {
@@ -6199,7 +6199,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 115,
   "id": "bastble",
   "versions": [
    {
@@ -6381,7 +6381,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 94,
   "id": "bdmicro_vina_d21",
   "versions": [
    {
@@ -6514,7 +6514,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 96,
   "id": "bdmicro_vina_d51",
   "versions": [
    {
@@ -6701,7 +6701,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 116,
   "id": "bdmicro_vina_d51_pcb7",
   "versions": [
    {
@@ -6888,7 +6888,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 255,
   "id": "bless_dev_board_multi_sensor",
   "versions": [
    {
@@ -7070,7 +7070,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 124,
   "id": "blm_badge",
   "versions": [
    {
@@ -7176,7 +7176,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 31,
   "id": "bluemicro833",
   "versions": [
    {
@@ -7241,7 +7241,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 148,
   "id": "bluemicro840",
   "versions": [
    {
@@ -7423,7 +7423,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 137,
   "id": "capablerobot_usbhub",
   "versions": [
    {
@@ -7568,7 +7568,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 168,
   "id": "catwan_usbstick",
   "versions": [
    {
@@ -7676,7 +7676,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 47,
   "id": "challenger_nb_rp2040_wifi",
   "versions": [
    {
@@ -7863,7 +7863,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 118,
   "id": "challenger_rp2040_lte",
   "versions": [
    {
@@ -8050,7 +8050,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 244,
   "id": "challenger_rp2040_wifi",
   "versions": [
    {
@@ -8237,7 +8237,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 141,
   "id": "circuitbrains_basic_m0",
   "versions": [
    {
@@ -8370,7 +8370,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 162,
   "id": "circuitbrains_deluxe_m4",
   "versions": [
    {
@@ -8557,7 +8557,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 1622,
   "id": "circuitplayground_bluefruit",
   "versions": [
    {
@@ -8739,7 +8739,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 2410,
   "id": "circuitplayground_express",
   "versions": [
    {
@@ -8882,7 +8882,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 171,
   "id": "circuitplayground_express_4h",
   "versions": [
    {
@@ -9025,7 +9025,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 379,
   "id": "circuitplayground_express_crickit",
   "versions": [
    {
@@ -9167,7 +9167,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 142,
   "id": "circuitplayground_express_digikey_pycon2019",
   "versions": [
    {
@@ -9310,7 +9310,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 286,
   "id": "circuitplayground_express_displayio",
   "versions": [
    {
@@ -9443,7 +9443,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 795,
   "id": "clue_nrf52840_express",
   "versions": [
    {
@@ -9625,7 +9625,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 29,
   "id": "cp32-m4",
   "versions": [
    {
@@ -9810,7 +9810,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 140,
   "id": "cp_sapling_m0",
   "versions": [
    {
@@ -9918,7 +9918,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 110,
   "id": "cp_sapling_m0_revb",
   "versions": [
    {
@@ -10026,7 +10026,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 117,
   "id": "cp_sapling_m0_spiflash",
   "versions": [
    {
@@ -10153,7 +10153,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 112,
   "id": "crumpspace_crumps2",
   "versions": [
    {
@@ -10353,7 +10353,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 115,
   "id": "cytron_maker_nano_rp2040",
   "versions": [
    {
@@ -10546,7 +10546,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 681,
   "id": "cytron_maker_pi_rp2040",
   "versions": [
    {
@@ -10741,7 +10741,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 34,
   "id": "datalore_ip_m4",
   "versions": [
    {
@@ -10928,7 +10928,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 133,
   "id": "datum_distance",
   "versions": [
    {
@@ -11036,7 +11036,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 136,
   "id": "datum_imu",
   "versions": [
    {
@@ -11144,7 +11144,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 158,
   "id": "datum_light",
   "versions": [
    {
@@ -11252,7 +11252,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 122,
   "id": "datum_weather",
   "versions": [
    {
@@ -11439,7 +11439,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 170,
   "id": "dynalora_usb",
   "versions": [
    {
@@ -11556,7 +11556,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 213,
   "id": "dynossat_edu_eps",
   "versions": [
    {
@@ -11685,7 +11685,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 210,
   "id": "dynossat_edu_obc",
   "versions": [
    {
@@ -11872,7 +11872,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 328,
   "id": "edgebadge",
   "versions": [
    {
@@ -12057,7 +12057,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 139,
   "id": "electroniccats_bastwifi",
   "versions": [
    {
@@ -12255,7 +12255,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 205,
   "id": "electronut_labs_blip",
   "versions": [
    {
@@ -12439,7 +12439,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 133,
   "id": "electronut_labs_papyr",
   "versions": [
    {
@@ -12621,7 +12621,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 108,
   "id": "escornabot_makech",
   "versions": [
    {
@@ -12922,7 +12922,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 34,
   "id": "espressif_esp32s3_box",
   "versions": [
    {
@@ -13023,7 +13023,7 @@
   ]
  },
  {
-  "downloads": 28,
+  "downloads": 39,
   "id": "espressif_esp32s3_devkitc_1",
   "versions": []
  },
@@ -13331,12 +13331,12 @@
   ]
  },
  {
-  "downloads": 29,
+  "downloads": 39,
   "id": "espressif_esp32s3_devkitc_1_nopsram",
   "versions": []
  },
  {
-  "downloads": 0,
+  "downloads": 165,
   "id": "espressif_hmi_devkit_1",
   "versions": [
    {
@@ -13536,7 +13536,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 197,
   "id": "espressif_kaluga_1",
   "versions": [
    {
@@ -13736,7 +13736,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 221,
   "id": "espressif_kaluga_1.3",
   "versions": [
    {
@@ -13936,7 +13936,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 702,
   "id": "espressif_saola_1_wroom",
   "versions": [
    {
@@ -14136,7 +14136,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 557,
   "id": "espressif_saola_1_wrover",
   "versions": [
    {
@@ -14336,7 +14336,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 62,
   "id": "espruino_pico",
   "versions": [
    {
@@ -14467,7 +14467,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 64,
   "id": "espruino_wifi",
   "versions": [
    {
@@ -14618,7 +14618,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 571,
   "id": "feather_bluefruit_sense",
   "versions": [
    {
@@ -14800,7 +14800,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 380,
   "id": "feather_m0_adalogger",
   "versions": [
    {
@@ -14909,7 +14909,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 401,
   "id": "feather_m0_basic",
   "versions": [
    {
@@ -15019,7 +15019,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 847,
   "id": "feather_m0_express",
   "versions": [
    {
@@ -15152,7 +15152,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 161,
   "id": "feather_m0_express_crickit",
   "versions": [
    {
@@ -15287,7 +15287,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 249,
   "id": "feather_m0_rfm69",
   "versions": [
    {
@@ -15393,7 +15393,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 388,
   "id": "feather_m0_rfm9x",
   "versions": [
    {
@@ -15499,7 +15499,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 146,
   "id": "feather_m0_supersized",
   "versions": [
    {
@@ -15632,7 +15632,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 293,
   "id": "feather_m4_can",
   "versions": [
    {
@@ -15819,7 +15819,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 1560,
   "id": "feather_m4_express",
   "versions": [
    {
@@ -16006,7 +16006,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 184,
   "id": "feather_m7_1011",
   "versions": [
    {
@@ -16167,7 +16167,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 208,
   "id": "feather_mimxrt1011",
   "versions": [
    {
@@ -16328,7 +16328,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 184,
   "id": "feather_mimxrt1062",
   "versions": [
    {
@@ -16483,7 +16483,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 792,
   "id": "feather_nrf52840_express",
   "versions": [
    {
@@ -16670,7 +16670,7 @@
   "versions": []
  },
  {
-  "downloads": 0,
+  "downloads": 249,
   "id": "feather_stm32f405_express",
   "versions": [
    {
@@ -16839,7 +16839,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 150,
   "id": "fluff_m0",
   "versions": [
    {
@@ -16947,7 +16947,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 191,
   "id": "fomu",
   "versions": [
    {
@@ -17064,7 +17064,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 169,
   "id": "franzininho_wifi_wroom",
   "versions": [
    {
@@ -17264,7 +17264,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 141,
   "id": "franzininho_wifi_wrover",
   "versions": [
    {
@@ -17464,7 +17464,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 612,
   "id": "gemma_m0",
   "versions": [
    {
@@ -17572,7 +17572,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 177,
   "id": "gemma_m0_pycon2018",
   "versions": [
    {
@@ -17680,7 +17680,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 471,
   "id": "grandcentral_m4_express",
   "versions": [
    {
@@ -17873,7 +17873,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 137,
   "id": "gravitech_cucumber_m",
   "versions": [
    {
@@ -18073,7 +18073,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 115,
   "id": "gravitech_cucumber_ms",
   "versions": [
    {
@@ -18273,7 +18273,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 125,
   "id": "gravitech_cucumber_r",
   "versions": [
    {
@@ -18473,7 +18473,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 136,
   "id": "gravitech_cucumber_rs",
   "versions": [
    {
@@ -18673,7 +18673,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 285,
   "id": "hallowing_m0_express",
   "versions": [
    {
@@ -18810,7 +18810,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 265,
   "id": "hallowing_m4_express",
   "versions": [
    {
@@ -18997,7 +18997,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 327,
   "id": "hiibot_bluefi",
   "versions": [
    {
@@ -19179,7 +19179,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 106,
   "id": "huntercat_nfc",
   "versions": [
    {
@@ -19312,7 +19312,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 173,
   "id": "ikigaisense_vita",
   "versions": [
    {
@@ -19494,7 +19494,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 212,
   "id": "imxrt1010_evk",
   "versions": [
    {
@@ -19655,7 +19655,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 176,
   "id": "imxrt1020_evk",
   "versions": [
    {
@@ -19810,7 +19810,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 150,
   "id": "imxrt1060_evk",
   "versions": [
    {
@@ -19965,7 +19965,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 523,
   "id": "itsybitsy_m0_express",
   "versions": [
    {
@@ -20096,7 +20096,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 724,
   "id": "itsybitsy_m4_express",
   "versions": [
    {
@@ -20281,7 +20281,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 523,
   "id": "itsybitsy_nrf52840_express",
   "versions": [
    {
@@ -20463,7 +20463,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 263,
   "id": "jpconstantineau_encoderpad_rp2040",
   "versions": [
    {
@@ -20650,7 +20650,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 24,
   "id": "jpconstantineau_pykey18",
   "versions": [
    {
@@ -20747,7 +20747,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 34,
   "id": "jpconstantineau_pykey44",
   "versions": [
    {
@@ -20844,7 +20844,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 114,
   "id": "jpconstantineau_pykey60",
   "versions": [
    {
@@ -21031,7 +21031,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 26,
   "id": "jpconstantineau_pykey87",
   "versions": [
    {
@@ -21128,7 +21128,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 136,
   "id": "kicksat-sprite",
   "versions": [
    {
@@ -21265,7 +21265,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 439,
   "id": "lilygo_ttgo_t8_s2_st7789",
   "versions": [
    {
@@ -21465,7 +21465,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 90,
   "id": "loc_ber_m4_base_board",
   "versions": [
    {
@@ -21580,7 +21580,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 438,
   "id": "lolin_s2_mini",
   "versions": [
    {
@@ -21784,7 +21784,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 66,
   "id": "lolin_s2_pico",
   "versions": [
    {
@@ -21988,7 +21988,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 212,
   "id": "makerdiary_m60_keyboard",
   "versions": [
    {
@@ -22170,7 +22170,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 154,
   "id": "makerdiary_nrf52840_m2_devkit",
   "versions": [
    {
@@ -22352,7 +22352,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 201,
   "id": "makerdiary_nrf52840_mdk",
   "versions": [
    {
@@ -22534,7 +22534,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 329,
   "id": "makerdiary_nrf52840_mdk_usb_dongle",
   "versions": [
    {
@@ -22718,7 +22718,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 1214,
   "id": "matrixportal_m4",
   "versions": [
    {
@@ -22905,7 +22905,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 61,
   "id": "melopero_shake_rp2040",
   "versions": [
    {
@@ -23092,7 +23092,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 299,
   "id": "meowbit_v121",
   "versions": [
    {
@@ -23249,7 +23249,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 122,
   "id": "meowmeow",
   "versions": [
    {
@@ -23355,7 +23355,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 619,
   "id": "metro_m0_express",
   "versions": [
    {
@@ -23488,7 +23488,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 621,
   "id": "metro_m4_airlift_lite",
   "versions": [
    {
@@ -23675,7 +23675,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 647,
   "id": "metro_m4_express",
   "versions": [
    {
@@ -23862,7 +23862,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 155,
   "id": "metro_m7_1011",
   "versions": [
    {
@@ -24023,7 +24023,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 199,
   "id": "metro_nrf52840_express",
   "versions": [
    {
@@ -24331,7 +24331,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 66,
   "id": "microdev_micro_c3",
   "versions": [
    {
@@ -24506,7 +24506,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 172,
   "id": "microdev_micro_s2",
   "versions": [
    {
@@ -24706,7 +24706,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 190,
   "id": "mini_sam_m4",
   "versions": [
    {
@@ -24895,7 +24895,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 527,
   "id": "monster_m4sk",
   "versions": [
    {
@@ -25082,7 +25082,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 119,
   "id": "morpheans_morphesp-240",
   "versions": [
    {
@@ -25282,7 +25282,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 337,
   "id": "muselab_nanoesp32_s2_wroom",
   "versions": [
    {
@@ -25482,7 +25482,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 307,
   "id": "muselab_nanoesp32_s2_wrover",
   "versions": [
    {
@@ -25682,7 +25682,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 135,
   "id": "ndgarage_ndbit6",
   "versions": [
    {
@@ -25790,7 +25790,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 48,
   "id": "ndgarage_ndbit6_v2",
   "versions": [
    {
@@ -25898,7 +25898,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 665,
   "id": "neopixel_trinkey_m0",
   "versions": [
    {
@@ -26003,7 +26003,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 225,
   "id": "nfc_copy_cat",
   "versions": [
    {
@@ -26112,7 +26112,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 233,
   "id": "nice_nano",
   "versions": [
    {
@@ -26294,7 +26294,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 66,
   "id": "nucleo_f746zg",
   "versions": [
    {
@@ -26443,7 +26443,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 92,
   "id": "nucleo_f767zi",
   "versions": [
    {
@@ -26592,7 +26592,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 85,
   "id": "nucleo_h743zi_2",
   "versions": [
    {
@@ -26737,7 +26737,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 55,
   "id": "odt_bread_2040",
   "versions": [
    {
@@ -26924,7 +26924,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 32,
   "id": "odt_cast_away_rp2040",
   "versions": [
    {
@@ -27021,7 +27021,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 114,
   "id": "odt_pixelwing_esp32_s2",
   "versions": [
    {
@@ -27221,7 +27221,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 236,
   "id": "ohs2020_badge",
   "versions": [
    {
@@ -27403,7 +27403,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 201,
   "id": "openbook_m4",
   "versions": [
    {
@@ -27592,7 +27592,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 94,
   "id": "openmv_h7",
   "versions": [
    {
@@ -27737,7 +27737,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 244,
   "id": "particle_argon",
   "versions": [
    {
@@ -27919,7 +27919,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 206,
   "id": "particle_boron",
   "versions": [
    {
@@ -28101,7 +28101,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 246,
   "id": "particle_xenon",
   "versions": [
    {
@@ -28283,7 +28283,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 252,
   "id": "pca10056",
   "versions": [
    {
@@ -28467,7 +28467,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 380,
   "id": "pca10059",
   "versions": [
    {
@@ -28651,7 +28651,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 310,
   "id": "pca10100",
   "versions": [
    {
@@ -28776,7 +28776,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 132,
   "id": "pewpew10",
   "versions": [
    {
@@ -28884,7 +28884,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 64,
   "id": "pewpew13",
   "versions": [
    {
@@ -28992,7 +28992,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 174,
   "id": "pewpew_m4",
   "versions": [
    {
@@ -29109,7 +29109,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 114,
   "id": "picoplanet",
   "versions": [
    {
@@ -29217,7 +29217,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 152,
   "id": "pimoroni_interstate75",
   "versions": [
    {
@@ -29404,7 +29404,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 502,
   "id": "pimoroni_keybow2040",
   "versions": [
    {
@@ -29591,7 +29591,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 185,
   "id": "pimoroni_pga2040",
   "versions": [
    {
@@ -29778,7 +29778,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 372,
   "id": "pimoroni_picolipo_16mb",
   "versions": [
    {
@@ -29965,7 +29965,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 289,
   "id": "pimoroni_picolipo_4mb",
   "versions": [
    {
@@ -30152,7 +30152,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 365,
   "id": "pimoroni_picosystem",
   "versions": [
    {
@@ -30345,7 +30345,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 341,
   "id": "pimoroni_plasma2040",
   "versions": [
    {
@@ -30532,7 +30532,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 626,
   "id": "pimoroni_tiny2040",
   "versions": [
    {
@@ -30719,7 +30719,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 50,
   "id": "pimoroni_tiny2040_2mb",
   "versions": [
    {
@@ -30821,7 +30821,7 @@
   "versions": []
  },
  {
-  "downloads": 0,
+  "downloads": 126,
   "id": "pitaya_go",
   "versions": [
    {
@@ -31003,7 +31003,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 86,
   "id": "pyb_nano_v2",
   "versions": [
    {
@@ -31142,7 +31142,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 648,
   "id": "pybadge",
   "versions": [
    {
@@ -31332,7 +31332,7 @@
   "versions": []
  },
  {
-  "downloads": 0,
+  "downloads": 160,
   "id": "pyboard_v11",
   "versions": [
    {
@@ -31501,7 +31501,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 268,
   "id": "pycubed",
   "versions": [
    {
@@ -31666,7 +31666,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 136,
   "id": "pycubed_mram",
   "versions": [
    {
@@ -31831,7 +31831,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 60,
   "id": "pycubed_mram_v05",
   "versions": [
    {
@@ -31996,7 +31996,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 90,
   "id": "pycubed_v05",
   "versions": [
    {
@@ -32161,7 +32161,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 584,
   "id": "pygamer",
   "versions": [
    {
@@ -32351,7 +32351,7 @@
   "versions": []
  },
  {
-  "downloads": 0,
+  "downloads": 1003,
   "id": "pyportal",
   "versions": [
    {
@@ -32538,7 +32538,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 363,
   "id": "pyportal_pynt",
   "versions": [
    {
@@ -32725,7 +32725,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 551,
   "id": "pyportal_titano",
   "versions": [
    {
@@ -32912,7 +32912,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 328,
   "id": "pyruler",
   "versions": [
    {
@@ -33020,7 +33020,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 1083,
   "id": "qtpy_m0",
   "versions": [
    {
@@ -33128,7 +33128,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 368,
   "id": "qtpy_m0_haxpress",
   "versions": [
    {
@@ -33261,7 +33261,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 8034,
   "id": "raspberry_pi_pico",
   "versions": [
    {
@@ -34078,7 +34078,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 123,
   "id": "raytac_mdbt50q-db-40",
   "versions": [
    {
@@ -34260,7 +34260,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 185,
   "id": "raytac_mdbt50q-rx",
   "versions": [
    {
@@ -34442,7 +34442,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 175,
   "id": "robohatmm1_m4",
   "versions": [
    {
@@ -34609,7 +34609,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 168,
   "id": "sam32",
   "versions": [
    {
@@ -34800,7 +34800,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 188,
   "id": "same54_xplained",
   "versions": [
    {
@@ -34983,7 +34983,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 759,
   "id": "seeeduino_wio_terminal",
   "versions": [
    {
@@ -35170,7 +35170,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 1557,
   "id": "seeeduino_xiao",
   "versions": [
    {
@@ -35278,7 +35278,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 112,
   "id": "seeeduino_xiao_kb",
   "versions": [
    {
@@ -35387,7 +35387,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 124,
   "id": "seeeduino_xiao_rp2040",
   "versions": [
    {
@@ -35484,7 +35484,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 138,
   "id": "sensebox_mcu",
   "versions": [
    {
@@ -35590,7 +35590,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 194,
   "id": "serpente",
   "versions": [
    {
@@ -35723,7 +35723,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 177,
   "id": "shirtty",
   "versions": [
    {
@@ -35831,7 +35831,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 122,
   "id": "silicognition-m4-shim",
   "versions": [
    {
@@ -36018,7 +36018,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 139,
   "id": "simmel",
   "versions": [
    {
@@ -36135,7 +36135,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 154,
   "id": "snekboard",
   "versions": [
    {
@@ -36268,7 +36268,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 134,
   "id": "solderparty_rp2040_stamp",
   "versions": [
    {
@@ -36467,7 +36467,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 194,
   "id": "sparkfun_lumidrive",
   "versions": [
    {
@@ -36598,7 +36598,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 241,
   "id": "sparkfun_micromod_rp2040",
   "versions": [
    {
@@ -36785,7 +36785,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 171,
   "id": "sparkfun_nrf52840_micromod",
   "versions": [
    {
@@ -36967,7 +36967,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 153,
   "id": "sparkfun_nrf52840_mini",
   "versions": [
    {
@@ -37149,7 +37149,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 377,
   "id": "sparkfun_pro_micro_rp2040",
   "versions": [
    {
@@ -37336,7 +37336,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 139,
   "id": "sparkfun_qwiic_micro_no_flash",
   "versions": [
    {
@@ -37444,7 +37444,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 181,
   "id": "sparkfun_qwiic_micro_with_flash",
   "versions": [
    {
@@ -37553,7 +37553,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 179,
   "id": "sparkfun_redboard_turbo",
   "versions": [
    {
@@ -37686,7 +37686,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 179,
   "id": "sparkfun_samd21_dev",
   "versions": [
    {
@@ -37794,7 +37794,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 193,
   "id": "sparkfun_samd21_mini",
   "versions": [
    {
@@ -37902,7 +37902,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 167,
   "id": "sparkfun_samd51_micromod",
   "versions": [
    {
@@ -38089,7 +38089,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 280,
   "id": "sparkfun_samd51_thing_plus",
   "versions": [
    {
@@ -38276,7 +38276,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 18,
   "id": "sparkfun_stm32_thing_plus",
   "versions": [
    {
@@ -38364,7 +38364,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 53,
   "id": "sparkfun_stm32f405_micromod",
   "versions": [
    {
@@ -38533,7 +38533,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 226,
   "id": "sparkfun_thing_plus_rp2040",
   "versions": [
    {
@@ -38720,7 +38720,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 350,
   "id": "spresense",
   "versions": [
    {
@@ -38853,7 +38853,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 89,
   "id": "stackrduino_m0_pro",
   "versions": [
    {
@@ -38986,7 +38986,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 259,
   "id": "stm32f411ce_blackpill",
   "versions": [
    {
@@ -39137,7 +39137,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 176,
   "id": "stm32f411ce_blackpill_with_flash",
   "versions": [
    {
@@ -39296,7 +39296,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 87,
   "id": "stm32f411ve_discovery",
   "versions": [
    {
@@ -39441,7 +39441,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 73,
   "id": "stm32f412zg_discovery",
   "versions": [
    {
@@ -39602,7 +39602,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 115,
   "id": "stm32f4_discovery",
   "versions": [
    {
@@ -39769,7 +39769,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 75,
   "id": "stm32f746g_discovery",
   "versions": [
    {
@@ -39918,7 +39918,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 201,
   "id": "stringcar_m0_express",
   "versions": [
    {
@@ -40049,7 +40049,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 47,
   "id": "swan_r5",
   "versions": [
    {
@@ -40184,7 +40184,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 191,
   "id": "targett_module_clip_wroom",
   "versions": [
    {
@@ -40384,7 +40384,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 143,
   "id": "targett_module_clip_wrover",
   "versions": [
    {
@@ -40584,7 +40584,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 750,
   "id": "teensy40",
   "versions": [
    {
@@ -40739,7 +40739,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 720,
   "id": "teensy41",
   "versions": [
    {
@@ -40894,7 +40894,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 216,
   "id": "teknikio_bluebird",
   "versions": [
    {
@@ -41076,7 +41076,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 41,
   "id": "thunderpack_v11",
   "versions": [
    {
@@ -41229,7 +41229,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 49,
   "id": "thunderpack_v12",
   "versions": [
    {
@@ -41386,7 +41386,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 224,
   "id": "tinkeringtech_scoutmakes_azul",
   "versions": [
    {
@@ -41568,7 +41568,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 487,
   "id": "trellis_m4_express",
   "versions": [
    {
@@ -41753,7 +41753,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 1297,
   "id": "trinket_m0",
   "versions": [
    {
@@ -41861,7 +41861,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 171,
   "id": "trinket_m0_haxpress",
   "versions": [
    {
@@ -41994,7 +41994,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 47,
   "id": "uartlogger2",
   "versions": [
    {
@@ -42181,7 +42181,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 168,
   "id": "uchip",
   "versions": [
    {
@@ -42291,7 +42291,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 135,
   "id": "ugame10",
   "versions": [
    {
@@ -42412,7 +42412,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 941,
   "id": "unexpectedmaker_feathers2",
   "versions": [
    {
@@ -42612,7 +42612,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 153,
   "id": "unexpectedmaker_feathers2_neo",
   "versions": [
    {
@@ -42816,7 +42816,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 109,
   "id": "unexpectedmaker_feathers2_prerelease",
   "versions": [
    {
@@ -43222,7 +43222,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 348,
   "id": "unexpectedmaker_tinys2",
   "versions": [
    {
@@ -43532,7 +43532,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 38,
   "id": "warmbit_bluepixel",
   "versions": [
    {
@@ -43811,7 +43811,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 149,
   "id": "winterbloom_big_honking_button",
   "versions": [
    {
@@ -43926,7 +43926,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 212,
   "id": "winterbloom_sol",
   "versions": [
    {
@@ -44069,7 +44069,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 154,
   "id": "xinabox_cc03",
   "versions": [
    {
@@ -44171,7 +44171,7 @@
   ]
  },
  {
-  "downloads": 0,
+  "downloads": 140,
   "id": "xinabox_cs11",
   "versions": [
    {

--- a/_data/files.json
+++ b/_data/files.json
@@ -1,6 +1,6 @@
 [
  {
-  "downloads": 116,
+  "downloads": 0,
   "id": "8086_commander",
   "versions": [
    {
@@ -56,8 +56,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -83,6 +83,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -112,13 +113,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 34,
+  "downloads": 0,
   "id": "ADM_B_NRF52840_1",
   "versions": [
    {
@@ -206,8 +207,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -230,6 +231,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -258,7 +260,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -294,13 +295,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 13,
+  "downloads": 0,
   "id": "Seeed_XIAO_nRF52840_Sense",
   "versions": [
    {
@@ -324,6 +325,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -352,7 +354,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -389,12 +390,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-alpha.1"
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 95,
+  "downloads": 0,
   "id": "TG-Watch",
   "versions": [
    {
@@ -496,8 +497,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -534,6 +535,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -562,7 +564,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -598,13 +599,116 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 154,
+  "downloads": 0,
+  "id": "adafruit_esp32s2_camera",
+  "versions": [
+   {
+    "extensions": [
+     "bin",
+     "uf2"
+    ],
+    "frozen_libraries": [],
+    "languages": [
+     "de_DE",
+     "en_GB",
+     "en_US",
+     "en_x_pirate",
+     "es",
+     "fil",
+     "fr",
+     "ID",
+     "it_IT",
+     "ja",
+     "nl",
+     "pl",
+     "pt_BR",
+     "ru",
+     "sv",
+     "tr",
+     "zh_Latn_pinyin"
+    ],
+    "modules": [
+     "adafruit_bus_device",
+     "adafruit_pixelbuf",
+     "aesio",
+     "alarm",
+     "analogio",
+     "atexit",
+     "audiobusio",
+     "audiocore",
+     "audiomixer",
+     "binascii",
+     "bitbangio",
+     "bitmaptools",
+     "board",
+     "busio",
+     "canio",
+     "countio",
+     "digitalio",
+     "displayio",
+     "dualbank",
+     "errno",
+     "fontio",
+     "framebufferio",
+     "frequencyio",
+     "getpass",
+     "gifio",
+     "i2cperipheral",
+     "imagecapture",
+     "ipaddress",
+     "json",
+     "keypad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "onewireio",
+     "os",
+     "paralleldisplay",
+     "ps2io",
+     "pulseio",
+     "pwmio",
+     "qrio",
+     "rainbowio",
+     "random",
+     "re",
+     "rgbmatrix",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "socketpool",
+     "ssl",
+     "storage",
+     "struct",
+     "supervisor",
+     "synthio",
+     "terminalio",
+     "time",
+     "touchio",
+     "traceback",
+     "ulab",
+     "usb_cdc",
+     "usb_hid",
+     "usb_midi",
+     "vectorio",
+     "watchdog",
+     "wifi"
+    ],
+    "stable": false,
+    "version": "7.2.0-alpha.2"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
   "id": "adafruit_feather_esp32s2",
   "versions": [
    {
@@ -701,8 +805,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -726,10 +830,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -798,13 +902,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 50,
+  "downloads": 0,
   "id": "adafruit_feather_esp32s2_tft",
   "versions": [
    {
@@ -901,8 +1005,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -926,10 +1030,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -998,13 +1102,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 93,
+  "downloads": 0,
   "id": "adafruit_feather_esp32s2_tftback_nopsram",
   "versions": [
    {
@@ -1106,8 +1210,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -1136,10 +1240,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -1208,13 +1312,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 1376,
+  "downloads": 0,
   "id": "adafruit_feather_rp2040",
   "versions": [
    {
@@ -1304,8 +1408,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -1328,6 +1432,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -1394,13 +1499,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 586,
+  "downloads": 0,
   "id": "adafruit_funhouse",
   "versions": [
    {
@@ -1497,8 +1602,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -1522,10 +1627,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -1594,13 +1699,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 286,
+  "downloads": 0,
   "id": "adafruit_itsybitsy_rp2040",
   "versions": [
    {
@@ -1690,8 +1795,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -1714,6 +1819,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -1780,13 +1886,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 43,
+  "downloads": 0,
   "id": "adafruit_kb2040",
   "versions": [
    {
@@ -1876,8 +1982,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -1900,6 +2006,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -1966,13 +2073,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 542,
+  "downloads": 0,
   "id": "adafruit_led_glasses_nrf52840",
   "versions": [
    {
@@ -2060,8 +2167,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -2084,6 +2191,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -2148,13 +2256,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 1052,
+  "downloads": 0,
   "id": "adafruit_macropad_rp2040",
   "versions": [
    {
@@ -2244,8 +2352,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -2268,6 +2376,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -2334,13 +2443,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 1229,
+  "downloads": 0,
   "id": "adafruit_magtag_2.9_grayscale",
   "versions": [
    {
@@ -2437,8 +2546,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -2462,10 +2571,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -2534,13 +2643,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 431,
+  "downloads": 0,
   "id": "adafruit_metro_esp32s2",
   "versions": [
    {
@@ -2637,8 +2746,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -2662,10 +2771,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -2734,13 +2843,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 325,
+  "downloads": 0,
   "id": "adafruit_neokey_trinkey_m0",
   "versions": [
    {
@@ -2789,8 +2898,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -2816,6 +2925,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -2838,13 +2948,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 221,
+  "downloads": 0,
   "id": "adafruit_proxlight_trinkey_m0",
   "versions": [
    {
@@ -2896,8 +3006,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -2923,6 +3033,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -2935,7 +3046,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "rainbowio",
      "random",
@@ -2948,13 +3058,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 380,
+  "downloads": 0,
   "id": "adafruit_qt2040_trinkey",
   "versions": [
    {
@@ -3044,8 +3154,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -3068,6 +3178,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -3134,13 +3245,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 91,
+  "downloads": 0,
   "id": "adafruit_qtpy_esp32s2",
   "versions": [
    {
@@ -3237,8 +3348,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -3262,10 +3373,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -3334,13 +3445,119 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 660,
+  "downloads": 0,
+  "id": "adafruit_qtpy_esp32s3_nopsram",
+  "versions": [
+   {
+    "extensions": [
+     "bin",
+     "uf2"
+    ],
+    "frozen_libraries": [
+     "Adafruit_CircuitPython_Requests",
+     "Adafruit_CircuitPython_NeoPixel",
+     "Adafruit_CircuitPython_BusDevice",
+     "Adafruit_CircuitPython_Register"
+    ],
+    "languages": [
+     "de_DE",
+     "en_GB",
+     "en_US",
+     "en_x_pirate",
+     "es",
+     "fil",
+     "fr",
+     "ID",
+     "it_IT",
+     "ja",
+     "nl",
+     "pl",
+     "pt_BR",
+     "ru",
+     "sv",
+     "tr",
+     "zh_Latn_pinyin"
+    ],
+    "modules": [
+     "_bleio",
+     "adafruit_bus_device",
+     "adafruit_pixelbuf",
+     "aesio",
+     "alarm",
+     "analogio",
+     "atexit",
+     "audiobusio",
+     "audiocore",
+     "audiomixer",
+     "binascii",
+     "bitbangio",
+     "bitmaptools",
+     "board",
+     "busio",
+     "canio",
+     "countio",
+     "digitalio",
+     "displayio",
+     "dualbank",
+     "errno",
+     "fontio",
+     "framebufferio",
+     "frequencyio",
+     "getpass",
+     "gifio",
+     "i2cperipheral",
+     "ipaddress",
+     "json",
+     "keypad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "onewireio",
+     "os",
+     "ps2io",
+     "pulseio",
+     "pwmio",
+     "rainbowio",
+     "random",
+     "re",
+     "rgbmatrix",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "socketpool",
+     "ssl",
+     "storage",
+     "struct",
+     "supervisor",
+     "synthio",
+     "terminalio",
+     "time",
+     "touchio",
+     "traceback",
+     "ulab",
+     "usb_cdc",
+     "usb_hid",
+     "usb_midi",
+     "vectorio",
+     "watchdog",
+     "wifi"
+    ],
+    "stable": false,
+    "version": "7.2.0-alpha.2"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
   "id": "adafruit_qtpy_rp2040",
   "versions": [
    {
@@ -3430,8 +3647,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -3454,6 +3671,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -3520,13 +3738,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 221,
+  "downloads": 0,
   "id": "adafruit_rotary_trinkey_m0",
   "versions": [
    {
@@ -3576,8 +3794,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -3603,6 +3821,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -3626,13 +3845,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 113,
+  "downloads": 0,
   "id": "adafruit_slide_trinkey_m0",
   "versions": [
    {
@@ -3683,8 +3902,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -3711,6 +3930,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -3734,13 +3954,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 46,
+  "downloads": 0,
   "id": "ai_thinker_esp32-c3s",
   "versions": [
    {
@@ -3771,90 +3991,6 @@
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
-     "analogio",
-     "atexit",
-     "audiocore",
-     "audiomixer",
-     "binascii",
-     "bitbangio",
-     "bitmaptools",
-     "board",
-     "busio",
-     "canio",
-     "digitalio",
-     "displayio",
-     "dualbank",
-     "errno",
-     "fontio",
-     "framebufferio",
-     "getpass",
-     "gifio",
-     "i2cperipheral",
-     "ipaddress",
-     "json",
-     "keypad",
-     "math",
-     "microcontroller",
-     "msgpack",
-     "neopixel_write",
-     "nvm",
-     "onewireio",
-     "os",
-     "ps2io",
-     "pulseio",
-     "pwmio",
-     "rainbowio",
-     "random",
-     "re",
-     "rtc",
-     "sdcardio",
-     "sharpdisplay",
-     "socketpool",
-     "ssl",
-     "storage",
-     "struct",
-     "supervisor",
-     "synthio",
-     "terminalio",
-     "time",
-     "touchio",
-     "traceback",
-     "ulab",
-     "vectorio",
-     "watchdog",
-     "wifi"
-    ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
-   },
-   {
-    "extensions": [
-     "bin"
-    ],
-    "frozen_libraries": [],
-    "languages": [
-     "de_DE",
-     "en_GB",
-     "en_US",
-     "en_x_pirate",
-     "es",
-     "fil",
-     "fr",
-     "ID",
-     "it_IT",
-     "ja",
-     "nl",
-     "pl",
-     "pt_BR",
-     "ru",
-     "sv",
-     "zh_Latn_pinyin"
-    ],
-    "modules": [
-     "_bleio",
-     "adafruit_bus_device",
-     "adafruit_pixelbuf",
-     "aesio",
      "atexit",
      "audiocore",
      "audiomixer",
@@ -3909,11 +4045,97 @@
     ],
     "stable": true,
     "version": "7.1.1"
+   },
+   {
+    "extensions": [
+     "bin"
+    ],
+    "frozen_libraries": [],
+    "languages": [
+     "de_DE",
+     "en_GB",
+     "en_US",
+     "en_x_pirate",
+     "es",
+     "fil",
+     "fr",
+     "ID",
+     "it_IT",
+     "ja",
+     "nl",
+     "pl",
+     "pt_BR",
+     "ru",
+     "sv",
+     "tr",
+     "zh_Latn_pinyin"
+    ],
+    "modules": [
+     "_bleio",
+     "adafruit_bus_device",
+     "adafruit_pixelbuf",
+     "aesio",
+     "analogio",
+     "atexit",
+     "audiocore",
+     "audiomixer",
+     "binascii",
+     "bitbangio",
+     "bitmaptools",
+     "board",
+     "busio",
+     "canio",
+     "digitalio",
+     "displayio",
+     "dualbank",
+     "errno",
+     "fontio",
+     "framebufferio",
+     "getpass",
+     "gifio",
+     "i2cperipheral",
+     "ipaddress",
+     "json",
+     "keypad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "onewireio",
+     "os",
+     "ps2io",
+     "pulseio",
+     "pwmio",
+     "rainbowio",
+     "random",
+     "re",
+     "rgbmatrix",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "socketpool",
+     "ssl",
+     "storage",
+     "struct",
+     "supervisor",
+     "synthio",
+     "terminalio",
+     "time",
+     "touchio",
+     "traceback",
+     "ulab",
+     "vectorio",
+     "watchdog",
+     "wifi"
+    ],
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 341,
+  "downloads": 0,
   "id": "ai_thinker_esp_12k_nodemcu",
   "versions": [
    {
@@ -4010,8 +4232,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -4035,10 +4257,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -4107,13 +4329,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 113,
+  "downloads": 0,
   "id": "aloriumtech_evo_m51",
   "versions": [
    {
@@ -4203,8 +4425,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -4227,6 +4449,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -4293,13 +4516,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 127,
+  "downloads": 0,
   "id": "aramcon2_badge",
   "versions": [
    {
@@ -4387,8 +4610,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -4411,6 +4634,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -4439,7 +4663,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -4475,13 +4698,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 133,
+  "downloads": 0,
   "id": "aramcon_badge_2019",
   "versions": [
    {
@@ -4569,8 +4792,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -4593,6 +4816,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -4621,7 +4845,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -4657,13 +4880,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 102,
+  "downloads": 0,
   "id": "arduino_mkr1300",
   "versions": [
    {
@@ -4714,8 +4937,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -4739,6 +4962,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -4765,13 +4989,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 181,
+  "downloads": 0,
   "id": "arduino_mkrzero",
   "versions": [
    {
@@ -4823,8 +5047,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -4848,6 +5072,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -4859,7 +5084,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -4875,13 +5099,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 246,
+  "downloads": 0,
   "id": "arduino_nano_33_ble",
   "versions": [
    {
@@ -4969,8 +5193,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -4993,6 +5217,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -5021,7 +5246,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -5057,13 +5281,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 194,
+  "downloads": 0,
   "id": "arduino_nano_33_iot",
   "versions": [
    {
@@ -5114,8 +5338,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -5139,6 +5363,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -5152,7 +5377,6 @@
      "nvm",
      "os",
      "pwmio",
-     "rainbowio",
      "random",
      "rotaryio",
      "rtc",
@@ -5165,13 +5389,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 614,
+  "downloads": 0,
   "id": "arduino_nano_rp2040_connect",
   "versions": [
    {
@@ -5261,8 +5485,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -5285,6 +5509,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -5351,13 +5576,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 221,
+  "downloads": 0,
   "id": "arduino_zero",
   "versions": [
    {
@@ -5408,8 +5633,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -5433,6 +5658,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -5459,13 +5685,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 29,
+  "downloads": 0,
   "id": "artisense_rd00",
   "versions": [
    {
@@ -5562,8 +5788,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -5587,10 +5813,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -5659,13 +5885,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 111,
+  "downloads": 0,
   "id": "atmegazero_esp32s2",
   "versions": [
    {
@@ -5762,8 +5988,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -5787,10 +6013,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -5859,13 +6085,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 82,
+  "downloads": 0,
   "id": "bast_pro_mini_m0",
   "versions": [
    {
@@ -5916,8 +6142,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -5940,6 +6166,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -5951,7 +6178,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -5967,13 +6193,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 74,
+  "downloads": 0,
   "id": "bastble",
   "versions": [
    {
@@ -6061,8 +6287,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -6085,6 +6311,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -6113,7 +6340,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -6149,13 +6375,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 74,
+  "downloads": 0,
   "id": "bdmicro_vina_d21",
   "versions": [
    {
@@ -6219,8 +6445,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -6243,12 +6469,12 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
      "adafruit_pixelbuf",
      "analogio",
-     "atexit",
      "audiobusio",
      "audiocore",
      "audioio",
@@ -6258,7 +6484,6 @@
      "displayio",
      "errno",
      "fontio",
-     "getpass",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -6283,13 +6508,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 63,
+  "downloads": 0,
   "id": "bdmicro_vina_d51",
   "versions": [
    {
@@ -6379,8 +6604,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -6403,6 +6628,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -6469,13 +6695,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 93,
+  "downloads": 0,
   "id": "bdmicro_vina_d51_pcb7",
   "versions": [
    {
@@ -6565,8 +6791,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -6589,6 +6815,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -6655,13 +6882,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 183,
+  "downloads": 0,
   "id": "bless_dev_board_multi_sensor",
   "versions": [
    {
@@ -6749,8 +6976,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -6773,6 +7000,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -6801,7 +7029,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -6837,13 +7064,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 90,
+  "downloads": 0,
   "id": "blm_badge",
   "versions": [
    {
@@ -6893,8 +7120,8 @@
      "usb_cdc",
      "usb_hid"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -6917,6 +7144,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -6931,7 +7159,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "rainbowio",
      "random",
@@ -6943,13 +7170,13 @@
      "usb_cdc",
      "usb_hid"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 10,
+  "downloads": 0,
   "id": "bluemicro833",
   "versions": [
    {
@@ -6973,6 +7200,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -7008,12 +7236,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-alpha.1"
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 113,
+  "downloads": 0,
   "id": "bluemicro840",
   "versions": [
    {
@@ -7101,8 +7329,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -7125,6 +7353,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -7153,7 +7382,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -7189,13 +7417,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 104,
+  "downloads": 0,
   "id": "capablerobot_usbhub",
   "versions": [
    {
@@ -7284,8 +7512,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -7308,78 +7536,39 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
-     "adafruit_bus_device",
-     "adafruit_pixelbuf",
-     "aesio",
      "alarm",
      "analogio",
-     "atexit",
-     "audiocore",
-     "audioio",
-     "audiomixer",
-     "audiomp3",
-     "binascii",
-     "bitbangio",
-     "bitmaptools",
      "board",
      "busio",
-     "countio",
      "digitalio",
-     "displayio",
-     "errno",
-     "fontio",
-     "framebufferio",
-     "frequencyio",
-     "getpass",
-     "gifio",
-     "i2cperipheral",
-     "json",
-     "keypad",
      "math",
      "microcontroller",
-     "msgpack",
-     "neopixel_write",
      "nvm",
      "onewireio",
      "os",
-     "paralleldisplay",
      "ps2io",
-     "pulseio",
      "pwmio",
      "rainbowio",
      "random",
-     "re",
-     "rgbmatrix",
-     "rotaryio",
      "rtc",
-     "sdcardio",
-     "sharpdisplay",
      "storage",
      "struct",
      "supervisor",
-     "synthio",
-     "terminalio",
      "time",
-     "touchio",
-     "traceback",
-     "ulab",
      "usb_cdc",
-     "usb_hid",
-     "usb_midi",
-     "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 90,
+  "downloads": 0,
   "id": "catwan_usbstick",
   "versions": [
    {
@@ -7430,8 +7619,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -7454,6 +7643,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -7465,7 +7655,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -7481,13 +7670,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 11,
+  "downloads": 0,
   "id": "challenger_nb_rp2040_wifi",
   "versions": [
    {
@@ -7577,8 +7766,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -7601,6 +7790,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -7667,13 +7857,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 21,
+  "downloads": 0,
   "id": "challenger_rp2040_lte",
   "versions": [
    {
@@ -7763,8 +7953,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -7787,6 +7977,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -7853,13 +8044,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 120,
+  "downloads": 0,
   "id": "challenger_rp2040_wifi",
   "versions": [
    {
@@ -7949,8 +8140,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -7973,6 +8164,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -8039,13 +8231,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 99,
+  "downloads": 0,
   "id": "circuitbrains_basic_m0",
   "versions": [
    {
@@ -8109,8 +8301,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -8133,12 +8325,12 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
      "adafruit_pixelbuf",
      "analogio",
-     "atexit",
      "audiobusio",
      "audiocore",
      "audioio",
@@ -8148,7 +8340,6 @@
      "displayio",
      "errno",
      "fontio",
-     "getpass",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -8173,13 +8364,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 121,
+  "downloads": 0,
   "id": "circuitbrains_deluxe_m4",
   "versions": [
    {
@@ -8269,8 +8460,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -8293,6 +8484,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -8359,13 +8551,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 1175,
+  "downloads": 0,
   "id": "circuitplayground_bluefruit",
   "versions": [
    {
@@ -8453,8 +8645,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -8477,6 +8669,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -8505,7 +8698,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -8541,13 +8733,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 1813,
+  "downloads": 0,
   "id": "circuitplayground_express",
   "versions": [
    {
@@ -8616,8 +8808,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -8646,13 +8838,13 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "analogio",
-     "atexit",
      "audiobusio",
      "audiocore",
      "audioio",
@@ -8662,7 +8854,6 @@
      "countio",
      "digitalio",
      "errno",
-     "getpass",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -8685,13 +8876,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 102,
+  "downloads": 0,
   "id": "circuitplayground_express_4h",
   "versions": [
    {
@@ -8760,8 +8951,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -8790,13 +8981,13 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "analogio",
-     "atexit",
      "audiobusio",
      "audiocore",
      "audioio",
@@ -8806,7 +8997,6 @@
      "countio",
      "digitalio",
      "errno",
-     "getpass",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -8829,13 +9019,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 253,
+  "downloads": 0,
   "id": "circuitplayground_express_crickit",
   "versions": [
    {
@@ -8903,8 +9093,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -8935,13 +9125,13 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "analogio",
-     "atexit",
      "audiobusio",
      "audiocore",
      "audioio",
@@ -8949,11 +9139,11 @@
      "busio",
      "digitalio",
      "errno",
-     "getpass",
      "math",
      "microcontroller",
      "neopixel_write",
      "nvm",
+     "onewireio",
      "os",
      "pulseio",
      "pwmio",
@@ -8971,13 +9161,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 85,
+  "downloads": 0,
   "id": "circuitplayground_express_digikey_pycon2019",
   "versions": [
    {
@@ -9046,8 +9236,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -9076,13 +9266,13 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "analogio",
-     "atexit",
      "audiobusio",
      "audiocore",
      "audioio",
@@ -9092,7 +9282,6 @@
      "countio",
      "digitalio",
      "errno",
-     "getpass",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -9115,13 +9304,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 155,
+  "downloads": 0,
   "id": "circuitplayground_express_displayio",
   "versions": [
    {
@@ -9185,8 +9374,8 @@
      "usb_cdc",
      "usb_hid"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -9214,11 +9403,11 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
      "analogio",
-     "atexit",
      "audiobusio",
      "audiocore",
      "audioio",
@@ -9228,7 +9417,6 @@
      "displayio",
      "errno",
      "fontio",
-     "getpass",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -9249,13 +9437,13 @@
      "usb_cdc",
      "usb_hid"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 601,
+  "downloads": 0,
   "id": "clue_nrf52840_express",
   "versions": [
    {
@@ -9343,8 +9531,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -9367,6 +9555,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -9395,7 +9584,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -9431,13 +9619,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 19,
+  "downloads": 0,
   "id": "cp32-m4",
   "versions": [
    {
@@ -9526,8 +9714,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -9550,6 +9738,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -9615,13 +9804,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 89,
+  "downloads": 0,
   "id": "cp_sapling_m0",
   "versions": [
    {
@@ -9672,8 +9861,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -9696,6 +9885,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -9707,7 +9897,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -9723,13 +9912,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 92,
+  "downloads": 0,
   "id": "cp_sapling_m0_revb",
   "versions": [
    {
@@ -9780,8 +9969,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -9804,6 +9993,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -9815,7 +10005,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -9831,13 +10020,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 82,
+  "downloads": 0,
   "id": "cp_sapling_m0_spiflash",
   "versions": [
    {
@@ -9898,8 +10087,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -9922,19 +10111,18 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
      "adafruit_pixelbuf",
      "analogio",
-     "atexit",
      "board",
      "busio",
      "digitalio",
      "displayio",
      "errno",
      "fontio",
-     "getpass",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -9959,13 +10147,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 90,
+  "downloads": 0,
   "id": "crumpspace_crumps2",
   "versions": [
    {
@@ -10062,8 +10250,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -10087,10 +10275,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -10159,13 +10347,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 25,
+  "downloads": 0,
   "id": "cytron_maker_nano_rp2040",
   "versions": [
    {
@@ -10258,8 +10446,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -10285,6 +10473,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -10351,13 +10540,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 485,
+  "downloads": 0,
   "id": "cytron_maker_pi_rp2040",
   "versions": [
    {
@@ -10451,8 +10640,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -10479,6 +10668,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -10545,13 +10735,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 29,
+  "downloads": 0,
   "id": "datalore_ip_m4",
   "versions": [
    {
@@ -10641,8 +10831,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -10665,6 +10855,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -10731,13 +10922,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 85,
+  "downloads": 0,
   "id": "datum_distance",
   "versions": [
    {
@@ -10788,8 +10979,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -10812,6 +11003,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -10823,7 +11015,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -10839,13 +11030,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 105,
+  "downloads": 0,
   "id": "datum_imu",
   "versions": [
    {
@@ -10896,8 +11087,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -10920,6 +11111,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -10931,7 +11123,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -10947,13 +11138,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 91,
+  "downloads": 0,
   "id": "datum_light",
   "versions": [
    {
@@ -11004,8 +11195,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -11028,6 +11219,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -11039,7 +11231,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -11055,13 +11246,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 91,
+  "downloads": 0,
   "id": "datum_weather",
   "versions": [
    {
@@ -11112,8 +11303,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -11136,6 +11327,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -11147,7 +11339,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -11163,13 +11354,92 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 107,
+  "downloads": 0,
+  "id": "diodes_delight_piunora",
+  "versions": [
+   {
+    "extensions": [
+     "disk.img.zip",
+     "kernel8.img"
+    ],
+    "frozen_libraries": [],
+    "languages": [
+     "de_DE",
+     "en_GB",
+     "en_US",
+     "en_x_pirate",
+     "es",
+     "fil",
+     "fr",
+     "ID",
+     "it_IT",
+     "ja",
+     "nl",
+     "pl",
+     "pt_BR",
+     "ru",
+     "sv",
+     "tr",
+     "zh_Latn_pinyin"
+    ],
+    "modules": [
+     "_bleio",
+     "adafruit_bus_device",
+     "adafruit_pixelbuf",
+     "aesio",
+     "atexit",
+     "binascii",
+     "bitbangio",
+     "bitmaptools",
+     "board",
+     "busio",
+     "digitalio",
+     "displayio",
+     "errno",
+     "fontio",
+     "framebufferio",
+     "getpass",
+     "gifio",
+     "json",
+     "keypad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "onewireio",
+     "os",
+     "rainbowio",
+     "random",
+     "re",
+     "sdcardio",
+     "sdioio",
+     "sharpdisplay",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "touchio",
+     "traceback",
+     "ulab",
+     "usb_cdc",
+     "usb_hid",
+     "usb_midi",
+     "vectorio"
+    ],
+    "stable": false,
+    "version": "7.2.0-alpha.2"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
   "id": "dynalora_usb",
   "versions": [
    {
@@ -11224,8 +11494,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -11251,6 +11521,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -11279,13 +11550,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 131,
+  "downloads": 0,
   "id": "dynossat_edu_eps",
   "versions": [
    {
@@ -11347,8 +11618,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -11371,12 +11642,12 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
      "adafruit_pixelbuf",
      "analogio",
-     "atexit",
      "audiobusio",
      "audiocore",
      "audioio",
@@ -11386,7 +11657,6 @@
      "displayio",
      "errno",
      "fontio",
-     "getpass",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -11409,13 +11679,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 157,
+  "downloads": 0,
   "id": "dynossat_edu_obc",
   "versions": [
    {
@@ -11505,8 +11775,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -11529,6 +11799,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -11595,13 +11866,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 209,
+  "downloads": 0,
   "id": "edgebadge",
   "versions": [
    {
@@ -11690,8 +11961,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -11716,6 +11987,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -11779,13 +12051,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 103,
+  "downloads": 0,
   "id": "electroniccats_bastwifi",
   "versions": [
    {
@@ -11881,8 +12153,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -11906,10 +12178,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -11977,13 +12249,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 112,
+  "downloads": 0,
   "id": "electronut_labs_blip",
   "versions": [
    {
@@ -12072,8 +12344,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -12096,6 +12368,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -12125,7 +12398,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -12161,13 +12433,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 105,
+  "downloads": 0,
   "id": "electronut_labs_papyr",
   "versions": [
    {
@@ -12255,8 +12527,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -12279,6 +12551,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -12307,7 +12580,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -12343,13 +12615,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 92,
+  "downloads": 0,
   "id": "escornabot_makech",
   "versions": [
    {
@@ -12399,8 +12671,8 @@
      "usb_cdc",
      "usb_hid"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -12423,6 +12695,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -12434,7 +12707,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -12449,13 +12721,208 @@
      "usb_cdc",
      "usb_hid"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 13,
+  "downloads": 0,
+  "id": "espressif_esp32c3_devkitm_1_n4",
+  "versions": [
+   {
+    "extensions": [
+     "bin"
+    ],
+    "frozen_libraries": [],
+    "languages": [
+     "de_DE",
+     "en_GB",
+     "en_US",
+     "en_x_pirate",
+     "es",
+     "fil",
+     "fr",
+     "ID",
+     "it_IT",
+     "ja",
+     "nl",
+     "pl",
+     "pt_BR",
+     "ru",
+     "sv",
+     "tr",
+     "zh_Latn_pinyin"
+    ],
+    "modules": [
+     "_bleio",
+     "adafruit_bus_device",
+     "adafruit_pixelbuf",
+     "aesio",
+     "analogio",
+     "atexit",
+     "audiocore",
+     "audiomixer",
+     "binascii",
+     "bitbangio",
+     "bitmaptools",
+     "board",
+     "busio",
+     "canio",
+     "digitalio",
+     "displayio",
+     "dualbank",
+     "errno",
+     "fontio",
+     "framebufferio",
+     "getpass",
+     "gifio",
+     "i2cperipheral",
+     "ipaddress",
+     "json",
+     "keypad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "onewireio",
+     "os",
+     "ps2io",
+     "pulseio",
+     "pwmio",
+     "rainbowio",
+     "random",
+     "re",
+     "rgbmatrix",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "socketpool",
+     "ssl",
+     "storage",
+     "struct",
+     "supervisor",
+     "synthio",
+     "terminalio",
+     "time",
+     "touchio",
+     "traceback",
+     "ulab",
+     "vectorio",
+     "watchdog",
+     "wifi"
+    ],
+    "stable": false,
+    "version": "7.2.0-alpha.2"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
+  "id": "espressif_esp32s2_devkitc_1_n4r2",
+  "versions": [
+   {
+    "extensions": [
+     "bin",
+     "uf2"
+    ],
+    "frozen_libraries": [],
+    "languages": [
+     "de_DE",
+     "en_GB",
+     "en_US",
+     "en_x_pirate",
+     "es",
+     "fil",
+     "fr",
+     "ID",
+     "it_IT",
+     "ja",
+     "nl",
+     "pl",
+     "pt_BR",
+     "ru",
+     "sv",
+     "tr",
+     "zh_Latn_pinyin"
+    ],
+    "modules": [
+     "adafruit_bus_device",
+     "adafruit_pixelbuf",
+     "aesio",
+     "alarm",
+     "analogio",
+     "atexit",
+     "audiobusio",
+     "audiocore",
+     "audiomixer",
+     "binascii",
+     "bitbangio",
+     "bitmaptools",
+     "board",
+     "busio",
+     "canio",
+     "countio",
+     "digitalio",
+     "displayio",
+     "dualbank",
+     "errno",
+     "fontio",
+     "framebufferio",
+     "frequencyio",
+     "getpass",
+     "gifio",
+     "i2cperipheral",
+     "imagecapture",
+     "ipaddress",
+     "json",
+     "keypad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "onewireio",
+     "os",
+     "paralleldisplay",
+     "ps2io",
+     "pulseio",
+     "pwmio",
+     "qrio",
+     "rainbowio",
+     "random",
+     "re",
+     "rgbmatrix",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "socketpool",
+     "ssl",
+     "storage",
+     "struct",
+     "supervisor",
+     "synthio",
+     "terminalio",
+     "time",
+     "touchio",
+     "traceback",
+     "ulab",
+     "usb_cdc",
+     "usb_hid",
+     "usb_midi",
+     "vectorio",
+     "watchdog",
+     "wifi"
+    ],
+    "stable": false,
+    "version": "7.2.0-alpha.2"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
   "id": "espressif_esp32s3_box",
   "versions": [
    {
@@ -12480,6 +12947,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -12526,6 +12994,7 @@
      "rainbowio",
      "random",
      "re",
+     "rgbmatrix",
      "rotaryio",
      "rtc",
      "sdcardio",
@@ -12549,13 +13018,18 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-alpha.1"
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
   "downloads": 28,
   "id": "espressif_esp32s3_devkitc_1",
+  "versions": []
+ },
+ {
+  "downloads": 0,
+  "id": "espressif_esp32s3_devkitc_1_n8",
   "versions": [
    {
     "extensions": [
@@ -12579,6 +13053,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -12625,6 +13100,7 @@
      "rainbowio",
      "random",
      "re",
+     "rgbmatrix",
      "rotaryio",
      "rtc",
      "sdcardio",
@@ -12648,111 +13124,219 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-alpha.1"
+    "version": "7.2.0-alpha.2"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
+  "id": "espressif_esp32s3_devkitc_1_n8r2",
+  "versions": [
+   {
+    "extensions": [
+     "bin",
+     "uf2"
+    ],
+    "frozen_libraries": [],
+    "languages": [
+     "de_DE",
+     "en_GB",
+     "en_US",
+     "en_x_pirate",
+     "es",
+     "fil",
+     "fr",
+     "ID",
+     "it_IT",
+     "ja",
+     "nl",
+     "pl",
+     "pt_BR",
+     "ru",
+     "sv",
+     "tr",
+     "zh_Latn_pinyin"
+    ],
+    "modules": [
+     "_bleio",
+     "adafruit_bus_device",
+     "adafruit_pixelbuf",
+     "aesio",
+     "alarm",
+     "analogio",
+     "atexit",
+     "audiobusio",
+     "audiocore",
+     "audiomixer",
+     "binascii",
+     "bitbangio",
+     "bitmaptools",
+     "board",
+     "busio",
+     "canio",
+     "countio",
+     "digitalio",
+     "displayio",
+     "dualbank",
+     "errno",
+     "fontio",
+     "framebufferio",
+     "frequencyio",
+     "getpass",
+     "gifio",
+     "i2cperipheral",
+     "ipaddress",
+     "json",
+     "keypad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "onewireio",
+     "os",
+     "ps2io",
+     "pulseio",
+     "pwmio",
+     "rainbowio",
+     "random",
+     "re",
+     "rgbmatrix",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "socketpool",
+     "ssl",
+     "storage",
+     "struct",
+     "supervisor",
+     "synthio",
+     "terminalio",
+     "time",
+     "touchio",
+     "traceback",
+     "ulab",
+     "usb_cdc",
+     "usb_hid",
+     "usb_midi",
+     "vectorio",
+     "watchdog",
+     "wifi"
+    ],
+    "stable": false,
+    "version": "7.2.0-alpha.2"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
+  "id": "espressif_esp32s3_devkitc_1_n8r8",
+  "versions": [
+   {
+    "extensions": [
+     "bin",
+     "uf2"
+    ],
+    "frozen_libraries": [],
+    "languages": [
+     "de_DE",
+     "en_GB",
+     "en_US",
+     "en_x_pirate",
+     "es",
+     "fil",
+     "fr",
+     "ID",
+     "it_IT",
+     "ja",
+     "nl",
+     "pl",
+     "pt_BR",
+     "ru",
+     "sv",
+     "tr",
+     "zh_Latn_pinyin"
+    ],
+    "modules": [
+     "_bleio",
+     "adafruit_bus_device",
+     "adafruit_pixelbuf",
+     "aesio",
+     "alarm",
+     "analogio",
+     "atexit",
+     "audiobusio",
+     "audiocore",
+     "audiomixer",
+     "binascii",
+     "bitbangio",
+     "bitmaptools",
+     "board",
+     "busio",
+     "canio",
+     "countio",
+     "digitalio",
+     "displayio",
+     "dualbank",
+     "errno",
+     "fontio",
+     "framebufferio",
+     "frequencyio",
+     "getpass",
+     "gifio",
+     "i2cperipheral",
+     "ipaddress",
+     "json",
+     "keypad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "onewireio",
+     "os",
+     "ps2io",
+     "pulseio",
+     "pwmio",
+     "rainbowio",
+     "random",
+     "re",
+     "rgbmatrix",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "socketpool",
+     "ssl",
+     "storage",
+     "struct",
+     "supervisor",
+     "synthio",
+     "terminalio",
+     "time",
+     "touchio",
+     "traceback",
+     "ulab",
+     "usb_cdc",
+     "usb_hid",
+     "usb_midi",
+     "vectorio",
+     "watchdog",
+     "wifi"
+    ],
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
   "downloads": 29,
   "id": "espressif_esp32s3_devkitc_1_nopsram",
-  "versions": [
-   {
-    "extensions": [
-     "bin",
-     "uf2"
-    ],
-    "frozen_libraries": [],
-    "languages": [
-     "de_DE",
-     "en_GB",
-     "en_US",
-     "en_x_pirate",
-     "es",
-     "fil",
-     "fr",
-     "ID",
-     "it_IT",
-     "ja",
-     "nl",
-     "pl",
-     "pt_BR",
-     "ru",
-     "sv",
-     "zh_Latn_pinyin"
-    ],
-    "modules": [
-     "_bleio",
-     "adafruit_bus_device",
-     "adafruit_pixelbuf",
-     "aesio",
-     "alarm",
-     "analogio",
-     "atexit",
-     "audiobusio",
-     "audiocore",
-     "audiomixer",
-     "binascii",
-     "bitbangio",
-     "bitmaptools",
-     "board",
-     "busio",
-     "canio",
-     "countio",
-     "digitalio",
-     "displayio",
-     "dualbank",
-     "errno",
-     "fontio",
-     "framebufferio",
-     "frequencyio",
-     "getpass",
-     "gifio",
-     "i2cperipheral",
-     "ipaddress",
-     "json",
-     "keypad",
-     "math",
-     "microcontroller",
-     "msgpack",
-     "neopixel_write",
-     "nvm",
-     "onewireio",
-     "os",
-     "ps2io",
-     "pulseio",
-     "pwmio",
-     "rainbowio",
-     "random",
-     "re",
-     "rotaryio",
-     "rtc",
-     "sdcardio",
-     "sharpdisplay",
-     "socketpool",
-     "ssl",
-     "storage",
-     "struct",
-     "supervisor",
-     "synthio",
-     "terminalio",
-     "time",
-     "touchio",
-     "traceback",
-     "ulab",
-     "usb_cdc",
-     "usb_hid",
-     "usb_midi",
-     "vectorio",
-     "watchdog",
-     "wifi"
-    ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
-   }
-  ]
+  "versions": []
  },
  {
-  "downloads": 127,
+  "downloads": 0,
   "id": "espressif_hmi_devkit_1",
   "versions": [
    {
@@ -12849,8 +13433,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -12874,10 +13458,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -12946,13 +13530,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 145,
+  "downloads": 0,
   "id": "espressif_kaluga_1",
   "versions": [
    {
@@ -13049,8 +13633,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -13074,10 +13658,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -13146,13 +13730,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 162,
+  "downloads": 0,
   "id": "espressif_kaluga_1.3",
   "versions": [
    {
@@ -13249,8 +13833,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -13274,10 +13858,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -13346,13 +13930,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 497,
+  "downloads": 0,
   "id": "espressif_saola_1_wroom",
   "versions": [
    {
@@ -13449,8 +14033,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -13474,10 +14058,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -13546,13 +14130,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 437,
+  "downloads": 0,
   "id": "espressif_saola_1_wrover",
   "versions": [
    {
@@ -13649,8 +14233,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -13674,10 +14258,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -13746,13 +14330,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 47,
+  "downloads": 0,
   "id": "espruino_pico",
   "versions": [
    {
@@ -13814,8 +14398,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -13838,6 +14422,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -13876,13 +14461,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 46,
+  "downloads": 0,
   "id": "espruino_wifi",
   "versions": [
    {
@@ -13954,8 +14539,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -13978,6 +14563,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -14026,13 +14612,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 408,
+  "downloads": 0,
   "id": "feather_bluefruit_sense",
   "versions": [
    {
@@ -14120,8 +14706,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -14144,6 +14730,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -14172,7 +14759,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -14208,13 +14794,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 294,
+  "downloads": 0,
   "id": "feather_m0_adalogger",
   "versions": [
    {
@@ -14265,8 +14851,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -14290,6 +14876,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -14316,13 +14903,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 294,
+  "downloads": 0,
   "id": "feather_m0_basic",
   "versions": [
    {
@@ -14374,8 +14961,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -14399,6 +14986,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -14410,7 +14998,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -14426,13 +15013,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 588,
+  "downloads": 0,
   "id": "feather_m0_express",
   "versions": [
    {
@@ -14496,8 +15083,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -14520,12 +15107,12 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
      "adafruit_pixelbuf",
      "analogio",
-     "atexit",
      "audiobusio",
      "audiocore",
      "audioio",
@@ -14535,7 +15122,6 @@
      "displayio",
      "errno",
      "fontio",
-     "getpass",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -14560,13 +15146,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 111,
+  "downloads": 0,
   "id": "feather_m0_express_crickit",
   "versions": [
    {
@@ -14631,8 +15217,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -14660,12 +15246,12 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
      "adafruit_pixelbuf",
      "analogio",
-     "atexit",
      "audiobusio",
      "audiocore",
      "audioio",
@@ -14673,7 +15259,6 @@
      "busio",
      "digitalio",
      "errno",
-     "getpass",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -14696,13 +15281,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 181,
+  "downloads": 0,
   "id": "feather_m0_rfm69",
   "versions": [
    {
@@ -14752,8 +15337,8 @@
      "time",
      "usb_cdc"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -14779,6 +15364,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -14791,7 +15377,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -14802,13 +15387,13 @@
      "time",
      "usb_cdc"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 306,
+  "downloads": 0,
   "id": "feather_m0_rfm9x",
   "versions": [
    {
@@ -14858,8 +15443,8 @@
      "time",
      "usb_cdc"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -14885,6 +15470,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -14897,7 +15483,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -14908,13 +15493,13 @@
      "time",
      "usb_cdc"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 95,
+  "downloads": 0,
   "id": "feather_m0_supersized",
   "versions": [
    {
@@ -14978,8 +15563,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -15002,12 +15587,12 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
      "adafruit_pixelbuf",
      "analogio",
-     "atexit",
      "audiobusio",
      "audiocore",
      "audioio",
@@ -15017,7 +15602,6 @@
      "displayio",
      "errno",
      "fontio",
-     "getpass",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -15042,13 +15626,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 216,
+  "downloads": 0,
   "id": "feather_m4_can",
   "versions": [
    {
@@ -15138,8 +15722,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -15162,6 +15746,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -15228,13 +15813,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 1152,
+  "downloads": 0,
   "id": "feather_m4_express",
   "versions": [
    {
@@ -15324,8 +15909,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -15348,6 +15933,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -15414,13 +16000,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 118,
+  "downloads": 0,
   "id": "feather_m7_1011",
   "versions": [
    {
@@ -15497,8 +16083,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -15525,6 +16111,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -15574,13 +16161,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 156,
+  "downloads": 0,
   "id": "feather_mimxrt1011",
   "versions": [
    {
@@ -15657,8 +16244,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -15685,6 +16272,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -15734,13 +16322,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 135,
+  "downloads": 0,
   "id": "feather_mimxrt1062",
   "versions": [
    {
@@ -15814,8 +16402,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -15839,6 +16427,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -15888,13 +16477,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 570,
+  "downloads": 0,
   "id": "feather_nrf52840_express",
   "versions": [
    {
@@ -15982,8 +16571,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -16006,6 +16595,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -16034,7 +16624,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -16070,8 +16659,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
@@ -16081,7 +16670,7 @@
   "versions": []
  },
  {
-  "downloads": 206,
+  "downloads": 0,
   "id": "feather_stm32f405_express",
   "versions": [
    {
@@ -16162,8 +16751,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -16186,6 +16775,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -16243,13 +16833,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 106,
+  "downloads": 0,
   "id": "fluff_m0",
   "versions": [
    {
@@ -16300,8 +16890,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -16324,6 +16914,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -16335,7 +16926,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -16351,13 +16941,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 119,
+  "downloads": 0,
   "id": "fomu",
   "versions": [
    {
@@ -16412,8 +17002,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -16436,6 +17026,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -16467,13 +17058,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 130,
+  "downloads": 0,
   "id": "franzininho_wifi_wroom",
   "versions": [
    {
@@ -16570,8 +17161,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -16595,10 +17186,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -16667,13 +17258,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 101,
+  "downloads": 0,
   "id": "franzininho_wifi_wrover",
   "versions": [
    {
@@ -16770,8 +17361,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -16795,10 +17386,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -16867,13 +17458,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 457,
+  "downloads": 0,
   "id": "gemma_m0",
   "versions": [
    {
@@ -16924,8 +17515,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -16948,6 +17539,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -16959,7 +17551,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -16975,13 +17566,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 98,
+  "downloads": 0,
   "id": "gemma_m0_pycon2018",
   "versions": [
    {
@@ -17032,8 +17623,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -17056,6 +17647,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -17067,7 +17659,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -17083,13 +17674,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 330,
+  "downloads": 0,
   "id": "grandcentral_m4_express",
   "versions": [
    {
@@ -17182,8 +17773,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -17206,6 +17797,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -17275,13 +17867,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 103,
+  "downloads": 0,
   "id": "gravitech_cucumber_m",
   "versions": [
    {
@@ -17378,8 +17970,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -17403,10 +17995,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -17475,13 +18067,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 87,
+  "downloads": 0,
   "id": "gravitech_cucumber_ms",
   "versions": [
    {
@@ -17578,8 +18170,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -17603,10 +18195,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -17675,13 +18267,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 97,
+  "downloads": 0,
   "id": "gravitech_cucumber_r",
   "versions": [
    {
@@ -17778,8 +18370,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -17803,10 +18395,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -17875,13 +18467,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 100,
+  "downloads": 0,
   "id": "gravitech_cucumber_rs",
   "versions": [
    {
@@ -17978,8 +18570,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -18003,10 +18595,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -18075,13 +18667,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 217,
+  "downloads": 0,
   "id": "hallowing_m0_express",
   "versions": [
    {
@@ -18147,8 +18739,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -18174,12 +18766,12 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
      "adafruit_pixelbuf",
      "analogio",
-     "atexit",
      "audiocore",
      "audioio",
      "board",
@@ -18188,7 +18780,6 @@
      "displayio",
      "errno",
      "fontio",
-     "getpass",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -18213,13 +18804,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 195,
+  "downloads": 0,
   "id": "hallowing_m4_express",
   "versions": [
    {
@@ -18309,8 +18900,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -18333,6 +18924,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -18399,13 +18991,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 219,
+  "downloads": 0,
   "id": "hiibot_bluefi",
   "versions": [
    {
@@ -18493,8 +19085,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -18517,6 +19109,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -18545,7 +19138,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -18581,13 +19173,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 79,
+  "downloads": 0,
   "id": "huntercat_nfc",
   "versions": [
    {
@@ -18651,8 +19243,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -18675,12 +19267,12 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
      "adafruit_pixelbuf",
      "analogio",
-     "atexit",
      "audiobusio",
      "audiocore",
      "audioio",
@@ -18690,7 +19282,6 @@
      "displayio",
      "errno",
      "fontio",
-     "getpass",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -18715,13 +19306,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 115,
+  "downloads": 0,
   "id": "ikigaisense_vita",
   "versions": [
    {
@@ -18809,8 +19400,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -18833,6 +19424,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -18861,7 +19453,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -18897,13 +19488,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 142,
+  "downloads": 0,
   "id": "imxrt1010_evk",
   "versions": [
    {
@@ -18980,8 +19571,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -19008,6 +19599,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -19057,13 +19649,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 124,
+  "downloads": 0,
   "id": "imxrt1020_evk",
   "versions": [
    {
@@ -19137,8 +19729,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -19162,6 +19754,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -19211,13 +19804,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 118,
+  "downloads": 0,
   "id": "imxrt1060_evk",
   "versions": [
    {
@@ -19291,8 +19884,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -19316,6 +19909,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -19365,13 +19959,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 366,
+  "downloads": 0,
   "id": "itsybitsy_m0_express",
   "versions": [
    {
@@ -19434,8 +20028,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -19458,12 +20052,12 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
      "adafruit_pixelbuf",
      "analogio",
-     "atexit",
      "audiobusio",
      "audiocore",
      "audioio",
@@ -19473,7 +20067,6 @@
      "displayio",
      "errno",
      "fontio",
-     "getpass",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -19497,13 +20090,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 560,
+  "downloads": 0,
   "id": "itsybitsy_m4_express",
   "versions": [
    {
@@ -19592,8 +20185,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -19616,6 +20209,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -19681,13 +20275,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 375,
+  "downloads": 0,
   "id": "itsybitsy_nrf52840_express",
   "versions": [
    {
@@ -19775,8 +20369,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -19799,6 +20393,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -19827,7 +20422,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -19863,13 +20457,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 140,
+  "downloads": 0,
   "id": "jpconstantineau_encoderpad_rp2040",
   "versions": [
    {
@@ -19959,8 +20553,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -19983,6 +20577,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -20049,13 +20644,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 5,
+  "downloads": 0,
   "id": "jpconstantineau_pykey18",
   "versions": [
    {
@@ -20079,6 +20674,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -20146,12 +20742,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-alpha.1"
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 11,
+  "downloads": 0,
   "id": "jpconstantineau_pykey44",
   "versions": [
    {
@@ -20175,6 +20771,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -20242,12 +20839,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-alpha.1"
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 16,
+  "downloads": 0,
   "id": "jpconstantineau_pykey60",
   "versions": [
    {
@@ -20337,8 +20934,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -20361,6 +20958,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -20427,13 +21025,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 7,
+  "downloads": 0,
   "id": "jpconstantineau_pykey87",
   "versions": [
    {
@@ -20457,6 +21055,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -20524,12 +21123,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-alpha.1"
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 92,
+  "downloads": 0,
   "id": "kicksat-sprite",
   "versions": [
    {
@@ -20594,8 +21193,8 @@
      "usb_midi",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -20618,6 +21217,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -20659,13 +21259,13 @@
      "usb_midi",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 324,
+  "downloads": 0,
   "id": "lilygo_ttgo_t8_s2_st7789",
   "versions": [
    {
@@ -20762,8 +21362,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -20787,10 +21387,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -20859,13 +21459,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 75,
+  "downloads": 0,
   "id": "loc_ber_m4_base_board",
   "versions": [
    {
@@ -20919,8 +21519,8 @@
      "usb_midi",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -20943,6 +21543,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -20973,13 +21574,13 @@
      "usb_midi",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 286,
+  "downloads": 0,
   "id": "lolin_s2_mini",
   "versions": [
    {
@@ -21078,8 +21679,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -21105,10 +21706,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -21177,13 +21778,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 23,
+  "downloads": 0,
   "id": "lolin_s2_pico",
   "versions": [
    {
@@ -21282,8 +21883,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -21309,10 +21910,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -21381,13 +21982,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 145,
+  "downloads": 0,
   "id": "makerdiary_m60_keyboard",
   "versions": [
    {
@@ -21475,8 +22076,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -21499,6 +22100,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -21527,7 +22129,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -21563,13 +22164,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 102,
+  "downloads": 0,
   "id": "makerdiary_nrf52840_m2_devkit",
   "versions": [
    {
@@ -21657,8 +22258,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -21681,6 +22282,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -21709,7 +22311,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -21745,13 +22346,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 114,
+  "downloads": 0,
   "id": "makerdiary_nrf52840_mdk",
   "versions": [
    {
@@ -21839,8 +22440,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -21863,6 +22464,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -21891,7 +22493,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -21927,13 +22528,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 229,
+  "downloads": 0,
   "id": "makerdiary_nrf52840_mdk_usb_dongle",
   "versions": [
    {
@@ -22022,8 +22623,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -22047,6 +22648,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -22075,7 +22677,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -22111,13 +22712,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 950,
+  "downloads": 0,
   "id": "matrixportal_m4",
   "versions": [
    {
@@ -22207,8 +22808,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -22231,6 +22832,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -22297,13 +22899,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 14,
+  "downloads": 0,
   "id": "melopero_shake_rp2040",
   "versions": [
    {
@@ -22393,8 +22995,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -22417,6 +23019,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -22483,13 +23086,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 218,
+  "downloads": 0,
   "id": "meowbit_v121",
   "versions": [
    {
@@ -22564,8 +23167,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -22590,6 +23193,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -22639,13 +23243,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 87,
+  "downloads": 0,
   "id": "meowmeow",
   "versions": [
    {
@@ -22695,8 +23299,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -22719,6 +23323,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -22730,7 +23335,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "rainbowio",
      "random",
@@ -22745,13 +23349,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 459,
+  "downloads": 0,
   "id": "metro_m0_express",
   "versions": [
    {
@@ -22815,8 +23419,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -22839,12 +23443,12 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
      "adafruit_pixelbuf",
      "analogio",
-     "atexit",
      "audiobusio",
      "audiocore",
      "audioio",
@@ -22854,7 +23458,6 @@
      "displayio",
      "errno",
      "fontio",
-     "getpass",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -22879,13 +23482,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 422,
+  "downloads": 0,
   "id": "metro_m4_airlift_lite",
   "versions": [
    {
@@ -22975,8 +23578,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -22999,6 +23602,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -23065,13 +23669,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 448,
+  "downloads": 0,
   "id": "metro_m4_express",
   "versions": [
    {
@@ -23161,8 +23765,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -23185,6 +23789,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -23251,13 +23856,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 108,
+  "downloads": 0,
   "id": "metro_m7_1011",
   "versions": [
    {
@@ -23334,8 +23939,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -23362,6 +23967,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -23411,13 +24017,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 133,
+  "downloads": 0,
   "id": "metro_nrf52840_express",
   "versions": [
    {
@@ -23505,8 +24111,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -23529,6 +24135,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -23557,7 +24164,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -23593,8 +24199,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
@@ -23658,8 +24264,8 @@
      "traceback",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -23682,6 +24288,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -23693,6 +24300,7 @@
      "audiocore",
      "audiomixer",
      "audiopwmio",
+     "binascii",
      "board",
      "busio",
      "digitalio",
@@ -23717,13 +24325,13 @@
      "traceback",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 3,
+  "downloads": 0,
   "id": "microdev_micro_c3",
   "versions": [
    {
@@ -23754,90 +24362,6 @@
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
-     "analogio",
-     "atexit",
-     "audiocore",
-     "audiomixer",
-     "binascii",
-     "bitbangio",
-     "bitmaptools",
-     "board",
-     "busio",
-     "canio",
-     "digitalio",
-     "displayio",
-     "dualbank",
-     "errno",
-     "fontio",
-     "framebufferio",
-     "getpass",
-     "gifio",
-     "i2cperipheral",
-     "ipaddress",
-     "json",
-     "keypad",
-     "math",
-     "microcontroller",
-     "msgpack",
-     "neopixel_write",
-     "nvm",
-     "onewireio",
-     "os",
-     "ps2io",
-     "pulseio",
-     "pwmio",
-     "rainbowio",
-     "random",
-     "re",
-     "rtc",
-     "sdcardio",
-     "sharpdisplay",
-     "socketpool",
-     "ssl",
-     "storage",
-     "struct",
-     "supervisor",
-     "synthio",
-     "terminalio",
-     "time",
-     "touchio",
-     "traceback",
-     "ulab",
-     "vectorio",
-     "watchdog",
-     "wifi"
-    ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
-   },
-   {
-    "extensions": [
-     "bin"
-    ],
-    "frozen_libraries": [],
-    "languages": [
-     "de_DE",
-     "en_GB",
-     "en_US",
-     "en_x_pirate",
-     "es",
-     "fil",
-     "fr",
-     "ID",
-     "it_IT",
-     "ja",
-     "nl",
-     "pl",
-     "pt_BR",
-     "ru",
-     "sv",
-     "zh_Latn_pinyin"
-    ],
-    "modules": [
-     "_bleio",
-     "adafruit_bus_device",
-     "adafruit_pixelbuf",
-     "aesio",
      "atexit",
      "audiocore",
      "audiomixer",
@@ -23892,11 +24416,97 @@
     ],
     "stable": true,
     "version": "7.1.1"
+   },
+   {
+    "extensions": [
+     "bin"
+    ],
+    "frozen_libraries": [],
+    "languages": [
+     "de_DE",
+     "en_GB",
+     "en_US",
+     "en_x_pirate",
+     "es",
+     "fil",
+     "fr",
+     "ID",
+     "it_IT",
+     "ja",
+     "nl",
+     "pl",
+     "pt_BR",
+     "ru",
+     "sv",
+     "tr",
+     "zh_Latn_pinyin"
+    ],
+    "modules": [
+     "_bleio",
+     "adafruit_bus_device",
+     "adafruit_pixelbuf",
+     "aesio",
+     "analogio",
+     "atexit",
+     "audiocore",
+     "audiomixer",
+     "binascii",
+     "bitbangio",
+     "bitmaptools",
+     "board",
+     "busio",
+     "canio",
+     "digitalio",
+     "displayio",
+     "dualbank",
+     "errno",
+     "fontio",
+     "framebufferio",
+     "getpass",
+     "gifio",
+     "i2cperipheral",
+     "ipaddress",
+     "json",
+     "keypad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "onewireio",
+     "os",
+     "ps2io",
+     "pulseio",
+     "pwmio",
+     "rainbowio",
+     "random",
+     "re",
+     "rgbmatrix",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "socketpool",
+     "ssl",
+     "storage",
+     "struct",
+     "supervisor",
+     "synthio",
+     "terminalio",
+     "time",
+     "touchio",
+     "traceback",
+     "ulab",
+     "vectorio",
+     "watchdog",
+     "wifi"
+    ],
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 127,
+  "downloads": 0,
   "id": "microdev_micro_s2",
   "versions": [
    {
@@ -23993,8 +24603,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -24018,10 +24628,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -24090,13 +24700,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 136,
+  "downloads": 0,
   "id": "mini_sam_m4",
   "versions": [
    {
@@ -24187,8 +24797,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -24213,6 +24823,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -24278,13 +24889,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 383,
+  "downloads": 0,
   "id": "monster_m4sk",
   "versions": [
    {
@@ -24374,8 +24985,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -24398,6 +25009,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -24464,13 +25076,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 89,
+  "downloads": 0,
   "id": "morpheans_morphesp-240",
   "versions": [
    {
@@ -24567,8 +25179,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -24592,10 +25204,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -24664,13 +25276,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 269,
+  "downloads": 0,
   "id": "muselab_nanoesp32_s2_wroom",
   "versions": [
    {
@@ -24767,8 +25379,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -24792,10 +25404,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -24864,13 +25476,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 234,
+  "downloads": 0,
   "id": "muselab_nanoesp32_s2_wrover",
   "versions": [
    {
@@ -24967,8 +25579,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -24992,10 +25604,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -25064,13 +25676,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 95,
+  "downloads": 0,
   "id": "ndgarage_ndbit6",
   "versions": [
    {
@@ -25121,8 +25733,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -25145,6 +25757,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -25156,7 +25769,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -25172,13 +25784,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 31,
+  "downloads": 0,
   "id": "ndgarage_ndbit6_v2",
   "versions": [
    {
@@ -25229,8 +25841,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -25253,6 +25865,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -25264,7 +25877,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -25280,13 +25892,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 484,
+  "downloads": 0,
   "id": "neopixel_trinkey_m0",
   "versions": [
    {
@@ -25335,8 +25947,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -25362,6 +25974,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -25384,13 +25997,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 131,
+  "downloads": 0,
   "id": "nfc_copy_cat",
   "versions": [
    {
@@ -25441,8 +26054,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -25465,6 +26078,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -25492,13 +26106,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 172,
+  "downloads": 0,
   "id": "nice_nano",
   "versions": [
    {
@@ -25586,8 +26200,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -25610,6 +26224,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -25638,7 +26253,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -25674,13 +26288,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 55,
+  "downloads": 0,
   "id": "nucleo_f746zg",
   "versions": [
    {
@@ -25751,8 +26365,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -25775,6 +26389,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -25822,13 +26437,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 66,
+  "downloads": 0,
   "id": "nucleo_f767zi",
   "versions": [
    {
@@ -25899,8 +26514,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -25923,6 +26538,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -25970,13 +26586,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 67,
+  "downloads": 0,
   "id": "nucleo_h743zi_2",
   "versions": [
    {
@@ -26045,8 +26661,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -26069,6 +26685,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -26114,13 +26731,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 9,
+  "downloads": 0,
   "id": "odt_bread_2040",
   "versions": [
    {
@@ -26210,8 +26827,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -26234,6 +26851,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -26300,13 +26918,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 11,
+  "downloads": 0,
   "id": "odt_cast_away_rp2040",
   "versions": [
    {
@@ -26330,6 +26948,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -26397,12 +27016,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-alpha.1"
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 77,
+  "downloads": 0,
   "id": "odt_pixelwing_esp32_s2",
   "versions": [
    {
@@ -26499,8 +27118,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -26524,10 +27143,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -26596,13 +27215,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 140,
+  "downloads": 0,
   "id": "ohs2020_badge",
   "versions": [
    {
@@ -26690,8 +27309,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -26714,6 +27333,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -26742,7 +27362,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -26778,13 +27397,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 131,
+  "downloads": 0,
   "id": "openbook_m4",
   "versions": [
    {
@@ -26875,8 +27494,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -26899,6 +27518,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -26966,13 +27586,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 71,
+  "downloads": 0,
   "id": "openmv_h7",
   "versions": [
    {
@@ -27041,8 +27661,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -27065,6 +27685,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -27110,13 +27731,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 145,
+  "downloads": 0,
   "id": "particle_argon",
   "versions": [
    {
@@ -27204,8 +27825,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -27228,6 +27849,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -27256,7 +27878,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -27292,13 +27913,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 144,
+  "downloads": 0,
   "id": "particle_boron",
   "versions": [
    {
@@ -27386,8 +28007,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -27410,6 +28031,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -27438,7 +28060,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -27474,13 +28095,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 179,
+  "downloads": 0,
   "id": "particle_xenon",
   "versions": [
    {
@@ -27568,8 +28189,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -27592,6 +28213,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -27620,7 +28242,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -27656,13 +28277,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 176,
+  "downloads": 0,
   "id": "pca10056",
   "versions": [
    {
@@ -27751,8 +28372,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -27776,6 +28397,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -27804,7 +28426,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -27840,13 +28461,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 281,
+  "downloads": 0,
   "id": "pca10059",
   "versions": [
    {
@@ -27935,8 +28556,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -27960,6 +28581,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -27988,7 +28610,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -28024,13 +28645,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 208,
+  "downloads": 0,
   "id": "pca10100",
   "versions": [
    {
@@ -28089,8 +28710,8 @@
      "usb_hid",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -28113,6 +28734,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -28148,13 +28770,13 @@
      "usb_hid",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 103,
+  "downloads": 0,
   "id": "pewpew10",
   "versions": [
    {
@@ -28205,8 +28827,8 @@
      "usb_cdc",
      "usb_hid"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -28231,6 +28853,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -28243,7 +28866,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -28256,13 +28878,13 @@
      "usb_cdc",
      "usb_hid"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 52,
+  "downloads": 0,
   "id": "pewpew13",
   "versions": [
    {
@@ -28313,8 +28935,8 @@
      "usb_cdc",
      "usb_hid"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -28339,6 +28961,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -28351,7 +28974,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -28364,13 +28986,13 @@
      "usb_cdc",
      "usb_hid"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 121,
+  "downloads": 0,
   "id": "pewpew_m4",
   "versions": [
    {
@@ -28425,8 +29047,8 @@
      "time",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -28451,6 +29073,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -28480,13 +29103,13 @@
      "time",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 81,
+  "downloads": 0,
   "id": "picoplanet",
   "versions": [
    {
@@ -28537,8 +29160,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -28561,6 +29184,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -28572,7 +29196,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -28588,13 +29211,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 90,
+  "downloads": 0,
   "id": "pimoroni_interstate75",
   "versions": [
    {
@@ -28684,8 +29307,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -28708,6 +29331,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -28774,13 +29398,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 337,
+  "downloads": 0,
   "id": "pimoroni_keybow2040",
   "versions": [
    {
@@ -28870,8 +29494,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -28894,6 +29518,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -28960,13 +29585,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 124,
+  "downloads": 0,
   "id": "pimoroni_pga2040",
   "versions": [
    {
@@ -29056,8 +29681,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -29080,6 +29705,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -29146,13 +29772,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 240,
+  "downloads": 0,
   "id": "pimoroni_picolipo_16mb",
   "versions": [
    {
@@ -29242,8 +29868,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -29266,6 +29892,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -29332,13 +29959,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 187,
+  "downloads": 0,
   "id": "pimoroni_picolipo_4mb",
   "versions": [
    {
@@ -29428,8 +30055,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -29452,6 +30079,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -29518,13 +30146,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 272,
+  "downloads": 0,
   "id": "pimoroni_picosystem",
   "versions": [
    {
@@ -29617,8 +30245,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -29643,6 +30271,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -29710,13 +30339,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 238,
+  "downloads": 0,
   "id": "pimoroni_plasma2040",
   "versions": [
    {
@@ -29806,8 +30435,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -29830,6 +30459,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -29896,13 +30526,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 463,
+  "downloads": 0,
   "id": "pimoroni_tiny2040",
   "versions": [
    {
@@ -29992,8 +30622,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -30016,6 +30646,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -30082,13 +30713,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 20,
+  "downloads": 0,
   "id": "pimoroni_tiny2040_2mb",
   "versions": [
    {
@@ -30112,6 +30743,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -30179,7 +30811,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-alpha.1"
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
@@ -30189,7 +30821,7 @@
   "versions": []
  },
  {
-  "downloads": 94,
+  "downloads": 0,
   "id": "pitaya_go",
   "versions": [
    {
@@ -30277,8 +30909,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -30301,6 +30933,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -30329,7 +30962,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -30365,13 +30997,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 53,
+  "downloads": 0,
   "id": "pyb_nano_v2",
   "versions": [
    {
@@ -30437,8 +31069,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -30461,6 +31093,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -30503,13 +31136,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 458,
+  "downloads": 0,
   "id": "pybadge",
   "versions": [
    {
@@ -30598,8 +31231,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -30624,6 +31257,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -30687,8 +31321,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
@@ -30698,7 +31332,7 @@
   "versions": []
  },
  {
-  "downloads": 125,
+  "downloads": 0,
   "id": "pyboard_v11",
   "versions": [
    {
@@ -30779,8 +31413,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -30803,6 +31437,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -30860,13 +31495,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 175,
+  "downloads": 0,
   "id": "pycubed",
   "versions": [
    {
@@ -30945,8 +31580,8 @@
      "usb_midi",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -30972,6 +31607,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -31024,13 +31660,13 @@
      "usb_midi",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 93,
+  "downloads": 0,
   "id": "pycubed_mram",
   "versions": [
    {
@@ -31109,8 +31745,8 @@
      "usb_midi",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -31136,6 +31772,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -31188,13 +31825,13 @@
      "usb_midi",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 11,
+  "downloads": 0,
   "id": "pycubed_mram_v05",
   "versions": [
    {
@@ -31273,8 +31910,8 @@
      "usb_midi",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -31300,6 +31937,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -31352,13 +31990,13 @@
      "usb_midi",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 23,
+  "downloads": 0,
   "id": "pycubed_v05",
   "versions": [
    {
@@ -31437,8 +32075,8 @@
      "usb_midi",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -31464,6 +32102,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -31516,13 +32155,13 @@
      "usb_midi",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 419,
+  "downloads": 0,
   "id": "pygamer",
   "versions": [
    {
@@ -31611,8 +32250,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -31637,6 +32276,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -31700,8 +32340,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
@@ -31711,7 +32351,7 @@
   "versions": []
  },
  {
-  "downloads": 743,
+  "downloads": 0,
   "id": "pyportal",
   "versions": [
    {
@@ -31801,8 +32441,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -31825,6 +32465,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -31891,13 +32532,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 226,
+  "downloads": 0,
   "id": "pyportal_pynt",
   "versions": [
    {
@@ -31987,8 +32628,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -32011,6 +32652,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -32077,13 +32719,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 408,
+  "downloads": 0,
   "id": "pyportal_titano",
   "versions": [
    {
@@ -32173,8 +32815,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -32197,6 +32839,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -32263,13 +32906,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 213,
+  "downloads": 0,
   "id": "pyruler",
   "versions": [
    {
@@ -32320,8 +32963,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -32344,6 +32987,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -32355,7 +32999,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -32371,13 +33014,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 781,
+  "downloads": 0,
   "id": "qtpy_m0",
   "versions": [
    {
@@ -32428,8 +33071,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -32452,6 +33095,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -32463,7 +33107,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -32479,13 +33122,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 274,
+  "downloads": 0,
   "id": "qtpy_m0_haxpress",
   "versions": [
    {
@@ -32549,8 +33192,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -32573,12 +33216,12 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
      "adafruit_pixelbuf",
      "analogio",
-     "atexit",
      "audiobusio",
      "audiocore",
      "audioio",
@@ -32588,7 +33231,6 @@
      "displayio",
      "errno",
      "fontio",
-     "getpass",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -32613,13 +33255,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 5828,
+  "downloads": 0,
   "id": "raspberry_pi_pico",
   "versions": [
    {
@@ -32709,8 +33351,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -32733,6 +33375,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -32799,8 +33442,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
@@ -32830,23 +33473,39 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
+     "_bleio",
+     "adafruit_bus_device",
      "adafruit_pixelbuf",
+     "aesio",
+     "atexit",
+     "binascii",
      "bitbangio",
+     "bitmaptools",
      "board",
      "busio",
      "digitalio",
      "displayio",
+     "errno",
      "fontio",
      "framebufferio",
+     "getpass",
+     "gifio",
+     "json",
+     "keypad",
      "math",
      "microcontroller",
+     "msgpack",
      "neopixel_write",
+     "onewireio",
      "os",
      "rainbowio",
      "random",
+     "re",
+     "sdcardio",
      "sdioio",
      "sharpdisplay",
      "storage",
@@ -32854,13 +33513,16 @@
      "supervisor",
      "terminalio",
      "time",
+     "touchio",
+     "traceback",
+     "ulab",
      "usb_cdc",
      "usb_hid",
      "usb_midi",
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-alpha.1"
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
@@ -32893,60 +33555,6 @@
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "adafruit_pixelbuf",
-     "bitbangio",
-     "board",
-     "busio",
-     "digitalio",
-     "displayio",
-     "fontio",
-     "framebufferio",
-     "math",
-     "microcontroller",
-     "neopixel_write",
-     "os",
-     "rainbowio",
-     "random",
-     "sdioio",
-     "sharpdisplay",
-     "storage",
-     "struct",
-     "supervisor",
-     "terminalio",
-     "time",
-     "usb_cdc",
-     "usb_hid",
-     "usb_midi",
-     "vectorio"
-    ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
-   },
-   {
-    "extensions": [
-     "disk.img.zip",
-     "kernel8.img"
-    ],
-    "frozen_libraries": [],
-    "languages": [
-     "de_DE",
-     "en_GB",
-     "en_US",
-     "en_x_pirate",
-     "es",
-     "fil",
-     "fr",
-     "ID",
-     "it_IT",
-     "ja",
-     "nl",
-     "pl",
-     "pt_BR",
-     "ru",
-     "sv",
-     "zh_Latn_pinyin"
-    ],
-    "modules": [
      "bitbangio",
      "board",
      "busio",
@@ -32973,6 +33581,79 @@
     ],
     "stable": true,
     "version": "7.1.1"
+   },
+   {
+    "extensions": [
+     "disk.img.zip",
+     "kernel8.img"
+    ],
+    "frozen_libraries": [],
+    "languages": [
+     "de_DE",
+     "en_GB",
+     "en_US",
+     "en_x_pirate",
+     "es",
+     "fil",
+     "fr",
+     "ID",
+     "it_IT",
+     "ja",
+     "nl",
+     "pl",
+     "pt_BR",
+     "ru",
+     "sv",
+     "tr",
+     "zh_Latn_pinyin"
+    ],
+    "modules": [
+     "_bleio",
+     "adafruit_bus_device",
+     "adafruit_pixelbuf",
+     "aesio",
+     "atexit",
+     "binascii",
+     "bitbangio",
+     "bitmaptools",
+     "board",
+     "busio",
+     "digitalio",
+     "displayio",
+     "errno",
+     "fontio",
+     "framebufferio",
+     "getpass",
+     "gifio",
+     "json",
+     "keypad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "onewireio",
+     "os",
+     "rainbowio",
+     "random",
+     "re",
+     "sdcardio",
+     "sdioio",
+     "sharpdisplay",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "touchio",
+     "traceback",
+     "ulab",
+     "usb_cdc",
+     "usb_hid",
+     "usb_midi",
+     "vectorio"
+    ],
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
@@ -33005,60 +33686,6 @@
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "adafruit_pixelbuf",
-     "bitbangio",
-     "board",
-     "busio",
-     "digitalio",
-     "displayio",
-     "fontio",
-     "framebufferio",
-     "math",
-     "microcontroller",
-     "neopixel_write",
-     "os",
-     "rainbowio",
-     "random",
-     "sdioio",
-     "sharpdisplay",
-     "storage",
-     "struct",
-     "supervisor",
-     "terminalio",
-     "time",
-     "usb_cdc",
-     "usb_hid",
-     "usb_midi",
-     "vectorio"
-    ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
-   },
-   {
-    "extensions": [
-     "disk.img.zip",
-     "kernel8.img"
-    ],
-    "frozen_libraries": [],
-    "languages": [
-     "de_DE",
-     "en_GB",
-     "en_US",
-     "en_x_pirate",
-     "es",
-     "fil",
-     "fr",
-     "ID",
-     "it_IT",
-     "ja",
-     "nl",
-     "pl",
-     "pt_BR",
-     "ru",
-     "sv",
-     "zh_Latn_pinyin"
-    ],
-    "modules": [
      "bitbangio",
      "board",
      "busio",
@@ -33085,6 +33712,158 @@
     ],
     "stable": true,
     "version": "7.1.1"
+   },
+   {
+    "extensions": [
+     "disk.img.zip",
+     "kernel8.img"
+    ],
+    "frozen_libraries": [],
+    "languages": [
+     "de_DE",
+     "en_GB",
+     "en_US",
+     "en_x_pirate",
+     "es",
+     "fil",
+     "fr",
+     "ID",
+     "it_IT",
+     "ja",
+     "nl",
+     "pl",
+     "pt_BR",
+     "ru",
+     "sv",
+     "tr",
+     "zh_Latn_pinyin"
+    ],
+    "modules": [
+     "_bleio",
+     "adafruit_bus_device",
+     "adafruit_pixelbuf",
+     "aesio",
+     "atexit",
+     "binascii",
+     "bitbangio",
+     "bitmaptools",
+     "board",
+     "busio",
+     "digitalio",
+     "displayio",
+     "errno",
+     "fontio",
+     "framebufferio",
+     "getpass",
+     "gifio",
+     "json",
+     "keypad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "onewireio",
+     "os",
+     "rainbowio",
+     "random",
+     "re",
+     "sdcardio",
+     "sdioio",
+     "sharpdisplay",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "touchio",
+     "traceback",
+     "ulab",
+     "usb_cdc",
+     "usb_hid",
+     "usb_midi",
+     "vectorio"
+    ],
+    "stable": false,
+    "version": "7.2.0-alpha.2"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
+  "id": "raspberrypi_zero",
+  "versions": [
+   {
+    "extensions": [
+     "disk.img.zip",
+     "kernel.img"
+    ],
+    "frozen_libraries": [],
+    "languages": [
+     "de_DE",
+     "en_GB",
+     "en_US",
+     "en_x_pirate",
+     "es",
+     "fil",
+     "fr",
+     "ID",
+     "it_IT",
+     "ja",
+     "nl",
+     "pl",
+     "pt_BR",
+     "ru",
+     "sv",
+     "tr",
+     "zh_Latn_pinyin"
+    ],
+    "modules": [
+     "_bleio",
+     "adafruit_bus_device",
+     "adafruit_pixelbuf",
+     "aesio",
+     "atexit",
+     "binascii",
+     "bitbangio",
+     "bitmaptools",
+     "board",
+     "busio",
+     "digitalio",
+     "displayio",
+     "errno",
+     "fontio",
+     "framebufferio",
+     "getpass",
+     "gifio",
+     "json",
+     "keypad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "onewireio",
+     "os",
+     "rainbowio",
+     "random",
+     "re",
+     "sdcardio",
+     "sdioio",
+     "sharpdisplay",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "touchio",
+     "traceback",
+     "ulab",
+     "usb_cdc",
+     "usb_hid",
+     "usb_midi",
+     "vectorio"
+    ],
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
@@ -33117,60 +33896,6 @@
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "adafruit_pixelbuf",
-     "bitbangio",
-     "board",
-     "busio",
-     "digitalio",
-     "displayio",
-     "fontio",
-     "framebufferio",
-     "math",
-     "microcontroller",
-     "neopixel_write",
-     "os",
-     "rainbowio",
-     "random",
-     "sdioio",
-     "sharpdisplay",
-     "storage",
-     "struct",
-     "supervisor",
-     "terminalio",
-     "time",
-     "usb_cdc",
-     "usb_hid",
-     "usb_midi",
-     "vectorio"
-    ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
-   },
-   {
-    "extensions": [
-     "disk.img.zip",
-     "kernel8.img"
-    ],
-    "frozen_libraries": [],
-    "languages": [
-     "de_DE",
-     "en_GB",
-     "en_US",
-     "en_x_pirate",
-     "es",
-     "fil",
-     "fr",
-     "ID",
-     "it_IT",
-     "ja",
-     "nl",
-     "pl",
-     "pt_BR",
-     "ru",
-     "sv",
-     "zh_Latn_pinyin"
-    ],
-    "modules": [
      "bitbangio",
      "board",
      "busio",
@@ -33197,11 +33922,163 @@
     ],
     "stable": true,
     "version": "7.1.1"
+   },
+   {
+    "extensions": [
+     "disk.img.zip",
+     "kernel8.img"
+    ],
+    "frozen_libraries": [],
+    "languages": [
+     "de_DE",
+     "en_GB",
+     "en_US",
+     "en_x_pirate",
+     "es",
+     "fil",
+     "fr",
+     "ID",
+     "it_IT",
+     "ja",
+     "nl",
+     "pl",
+     "pt_BR",
+     "ru",
+     "sv",
+     "tr",
+     "zh_Latn_pinyin"
+    ],
+    "modules": [
+     "_bleio",
+     "adafruit_bus_device",
+     "adafruit_pixelbuf",
+     "aesio",
+     "atexit",
+     "binascii",
+     "bitbangio",
+     "bitmaptools",
+     "board",
+     "busio",
+     "digitalio",
+     "displayio",
+     "errno",
+     "fontio",
+     "framebufferio",
+     "getpass",
+     "gifio",
+     "json",
+     "keypad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "onewireio",
+     "os",
+     "rainbowio",
+     "random",
+     "re",
+     "sdcardio",
+     "sdioio",
+     "sharpdisplay",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "touchio",
+     "traceback",
+     "ulab",
+     "usb_cdc",
+     "usb_hid",
+     "usb_midi",
+     "vectorio"
+    ],
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 84,
+  "downloads": 0,
+  "id": "raspberrypi_zero_w",
+  "versions": [
+   {
+    "extensions": [
+     "disk.img.zip",
+     "kernel.img"
+    ],
+    "frozen_libraries": [],
+    "languages": [
+     "de_DE",
+     "en_GB",
+     "en_US",
+     "en_x_pirate",
+     "es",
+     "fil",
+     "fr",
+     "ID",
+     "it_IT",
+     "ja",
+     "nl",
+     "pl",
+     "pt_BR",
+     "ru",
+     "sv",
+     "tr",
+     "zh_Latn_pinyin"
+    ],
+    "modules": [
+     "_bleio",
+     "adafruit_bus_device",
+     "adafruit_pixelbuf",
+     "aesio",
+     "atexit",
+     "binascii",
+     "bitbangio",
+     "bitmaptools",
+     "board",
+     "busio",
+     "digitalio",
+     "displayio",
+     "errno",
+     "fontio",
+     "framebufferio",
+     "getpass",
+     "gifio",
+     "json",
+     "keypad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "onewireio",
+     "os",
+     "rainbowio",
+     "random",
+     "re",
+     "sdcardio",
+     "sdioio",
+     "sharpdisplay",
+     "storage",
+     "struct",
+     "supervisor",
+     "terminalio",
+     "time",
+     "touchio",
+     "traceback",
+     "ulab",
+     "usb_cdc",
+     "usb_hid",
+     "usb_midi",
+     "vectorio"
+    ],
+    "stable": false,
+    "version": "7.2.0-alpha.2"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
   "id": "raytac_mdbt50q-db-40",
   "versions": [
    {
@@ -33289,8 +34166,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -33313,6 +34190,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -33341,7 +34219,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -33377,13 +34254,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 128,
+  "downloads": 0,
   "id": "raytac_mdbt50q-rx",
   "versions": [
    {
@@ -33471,8 +34348,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -33495,6 +34372,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -33523,7 +34401,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -33559,13 +34436,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 138,
+  "downloads": 0,
   "id": "robohatmm1_m4",
   "versions": [
    {
@@ -33645,8 +34522,8 @@
      "usb_midi",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -33671,6 +34548,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -33725,13 +34603,13 @@
      "usb_midi",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 110,
+  "downloads": 0,
   "id": "sam32",
   "versions": [
    {
@@ -33823,8 +34701,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -33849,6 +34727,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -33915,13 +34794,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 138,
+  "downloads": 0,
   "id": "same54_xplained",
   "versions": [
    {
@@ -34009,8 +34888,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -34033,6 +34912,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -34097,13 +34977,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 558,
+  "downloads": 0,
   "id": "seeeduino_wio_terminal",
   "versions": [
    {
@@ -34193,8 +35073,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -34217,6 +35097,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -34283,13 +35164,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 1181,
+  "downloads": 0,
   "id": "seeeduino_xiao",
   "versions": [
    {
@@ -34340,8 +35221,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -34364,6 +35245,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -34375,7 +35257,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -34391,13 +35272,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 21,
+  "downloads": 0,
   "id": "seeeduino_xiao_kb",
   "versions": [
    {
@@ -34448,8 +35329,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -34475,6 +35356,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -34499,13 +35381,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 34,
+  "downloads": 0,
   "id": "seeeduino_xiao_rp2040",
   "versions": [
    {
@@ -34529,6 +35411,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -34596,12 +35479,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-alpha.1"
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 104,
+  "downloads": 0,
   "id": "sensebox_mcu",
   "versions": [
    {
@@ -34651,8 +35534,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -34675,6 +35558,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -34688,7 +35572,6 @@
      "nvm",
      "os",
      "pwmio",
-     "rainbowio",
      "random",
      "rotaryio",
      "rtc",
@@ -34701,13 +35584,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 140,
+  "downloads": 0,
   "id": "serpente",
   "versions": [
    {
@@ -34771,8 +35654,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -34795,12 +35678,12 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
      "adafruit_pixelbuf",
      "analogio",
-     "atexit",
      "audiobusio",
      "audiocore",
      "audioio",
@@ -34810,7 +35693,6 @@
      "displayio",
      "errno",
      "fontio",
-     "getpass",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -34835,13 +35717,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 123,
+  "downloads": 0,
   "id": "shirtty",
   "versions": [
    {
@@ -34892,8 +35774,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -34916,6 +35798,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -34927,7 +35810,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -34943,13 +35825,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 90,
+  "downloads": 0,
   "id": "silicognition-m4-shim",
   "versions": [
    {
@@ -35039,8 +35921,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -35063,6 +35945,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -35129,13 +36012,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 105,
+  "downloads": 0,
   "id": "simmel",
   "versions": [
    {
@@ -35190,8 +36073,8 @@
      "usb_hid",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -35214,6 +36097,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -35245,13 +36129,13 @@
      "usb_hid",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 113,
+  "downloads": 0,
   "id": "snekboard",
   "versions": [
    {
@@ -35315,8 +36199,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -35339,12 +36223,12 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
      "adafruit_pixelbuf",
      "analogio",
-     "atexit",
      "audiobusio",
      "audiocore",
      "audioio",
@@ -35354,7 +36238,6 @@
      "displayio",
      "errno",
      "fontio",
-     "getpass",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -35379,13 +36262,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 21,
+  "downloads": 0,
   "id": "solderparty_rp2040_stamp",
   "versions": [
    {
@@ -35481,8 +36364,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -35511,6 +36394,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -35577,13 +36461,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 104,
+  "downloads": 0,
   "id": "sparkfun_lumidrive",
   "versions": [
    {
@@ -35646,8 +36530,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -35672,19 +36556,18 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
      "adafruit_pixelbuf",
      "analogio",
-     "atexit",
      "board",
      "busio",
      "digitalio",
      "displayio",
      "errno",
      "fontio",
-     "getpass",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -35709,13 +36592,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 159,
+  "downloads": 0,
   "id": "sparkfun_micromod_rp2040",
   "versions": [
    {
@@ -35805,8 +36688,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -35829,6 +36712,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -35895,13 +36779,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 134,
+  "downloads": 0,
   "id": "sparkfun_nrf52840_micromod",
   "versions": [
    {
@@ -35989,8 +36873,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -36013,6 +36897,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -36041,7 +36926,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -36077,13 +36961,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 120,
+  "downloads": 0,
   "id": "sparkfun_nrf52840_mini",
   "versions": [
    {
@@ -36171,8 +37055,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -36195,6 +37079,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -36223,7 +37108,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -36259,13 +37143,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 242,
+  "downloads": 0,
   "id": "sparkfun_pro_micro_rp2040",
   "versions": [
    {
@@ -36355,8 +37239,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -36379,6 +37263,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -36445,13 +37330,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 67,
+  "downloads": 0,
   "id": "sparkfun_qwiic_micro_no_flash",
   "versions": [
    {
@@ -36502,8 +37387,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -36526,6 +37411,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -36537,7 +37423,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -36553,13 +37438,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 98,
+  "downloads": 0,
   "id": "sparkfun_qwiic_micro_with_flash",
   "versions": [
    {
@@ -36610,8 +37495,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -36634,6 +37519,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -36661,13 +37547,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 104,
+  "downloads": 0,
   "id": "sparkfun_redboard_turbo",
   "versions": [
    {
@@ -36731,8 +37617,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -36755,12 +37641,12 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
      "adafruit_pixelbuf",
      "analogio",
-     "atexit",
      "audiobusio",
      "audiocore",
      "audioio",
@@ -36770,7 +37656,6 @@
      "displayio",
      "errno",
      "fontio",
-     "getpass",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -36795,13 +37680,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 102,
+  "downloads": 0,
   "id": "sparkfun_samd21_dev",
   "versions": [
    {
@@ -36852,8 +37737,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -36876,6 +37761,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -36887,7 +37773,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -36903,13 +37788,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 117,
+  "downloads": 0,
   "id": "sparkfun_samd21_mini",
   "versions": [
    {
@@ -36960,8 +37845,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -36984,6 +37869,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -36995,7 +37881,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -37011,13 +37896,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 108,
+  "downloads": 0,
   "id": "sparkfun_samd51_micromod",
   "versions": [
    {
@@ -37107,8 +37992,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -37131,6 +38016,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -37197,13 +38083,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 159,
+  "downloads": 0,
   "id": "sparkfun_samd51_thing_plus",
   "versions": [
    {
@@ -37293,8 +38179,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -37317,6 +38203,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -37383,13 +38270,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 4,
+  "downloads": 0,
   "id": "sparkfun_stm32_thing_plus",
   "versions": [
    {
@@ -37413,6 +38300,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -37471,12 +38359,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-alpha.1"
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 40,
+  "downloads": 0,
   "id": "sparkfun_stm32f405_micromod",
   "versions": [
    {
@@ -37557,8 +38445,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -37581,6 +38469,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -37638,13 +38527,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 164,
+  "downloads": 0,
   "id": "sparkfun_thing_plus_rp2040",
   "versions": [
    {
@@ -37734,8 +38623,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -37758,6 +38647,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -37824,13 +38714,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 251,
+  "downloads": 0,
   "id": "spresense",
   "versions": [
    {
@@ -37893,8 +38783,8 @@
      "ulab",
      "usb_cdc"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -37917,6 +38807,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -37956,13 +38847,13 @@
      "ulab",
      "usb_cdc"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 67,
+  "downloads": 0,
   "id": "stackrduino_m0_pro",
   "versions": [
    {
@@ -38026,8 +38917,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -38050,12 +38941,12 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
      "adafruit_pixelbuf",
      "analogio",
-     "atexit",
      "audiobusio",
      "audiocore",
      "audioio",
@@ -38065,7 +38956,6 @@
      "displayio",
      "errno",
      "fontio",
-     "getpass",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -38090,13 +38980,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 193,
+  "downloads": 0,
   "id": "stm32f411ce_blackpill",
   "versions": [
    {
@@ -38168,8 +39058,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -38192,6 +39082,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -38240,13 +39131,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 136,
+  "downloads": 0,
   "id": "stm32f411ce_blackpill_with_flash",
   "versions": [
    {
@@ -38322,8 +39213,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -38346,6 +39237,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -38398,13 +39290,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 65,
+  "downloads": 0,
   "id": "stm32f411ve_discovery",
   "versions": [
    {
@@ -38473,8 +39365,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -38497,6 +39389,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -38542,13 +39435,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 54,
+  "downloads": 0,
   "id": "stm32f412zg_discovery",
   "versions": [
    {
@@ -38625,8 +39518,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -38649,6 +39542,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -38702,13 +39596,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 94,
+  "downloads": 0,
   "id": "stm32f4_discovery",
   "versions": [
    {
@@ -38788,8 +39682,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -38812,6 +39706,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -38868,13 +39763,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 64,
+  "downloads": 0,
   "id": "stm32f746g_discovery",
   "versions": [
    {
@@ -38945,8 +39840,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -38969,6 +39864,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -39016,13 +39912,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 140,
+  "downloads": 0,
   "id": "stringcar_m0_express",
   "versions": [
    {
@@ -39085,8 +39981,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -39109,12 +40005,12 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
      "adafruit_pixelbuf",
      "analogio",
-     "atexit",
      "audiobusio",
      "audiocore",
      "audioio",
@@ -39124,11 +40020,11 @@
      "displayio",
      "errno",
      "fontio",
-     "getpass",
      "math",
      "microcontroller",
      "neopixel_write",
      "nvm",
+     "onewireio",
      "os",
      "paralleldisplay",
      "pulseio",
@@ -39145,16 +40041,15 @@
      "touchio",
      "traceback",
      "usb_cdc",
-     "usb_hid",
-     "usb_midi"
+     "usb_hid"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 3,
+  "downloads": 0,
   "id": "swan_r5",
   "versions": [
    {
@@ -39218,8 +40113,8 @@
      "ulab",
      "usb_cdc"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -39242,6 +40137,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -39282,13 +40178,13 @@
      "ulab",
      "usb_cdc"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 145,
+  "downloads": 0,
   "id": "targett_module_clip_wroom",
   "versions": [
    {
@@ -39385,8 +40281,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -39410,10 +40306,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -39482,13 +40378,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 103,
+  "downloads": 0,
   "id": "targett_module_clip_wrover",
   "versions": [
    {
@@ -39585,8 +40481,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -39610,10 +40506,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -39682,13 +40578,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 596,
+  "downloads": 0,
   "id": "teensy40",
   "versions": [
    {
@@ -39762,8 +40658,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -39787,6 +40683,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -39836,13 +40733,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 524,
+  "downloads": 0,
   "id": "teensy41",
   "versions": [
    {
@@ -39916,8 +40813,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -39941,6 +40838,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -39990,13 +40888,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 123,
+  "downloads": 0,
   "id": "teknikio_bluebird",
   "versions": [
    {
@@ -40084,8 +40982,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -40108,6 +41006,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -40136,7 +41035,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -40172,13 +41070,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 30,
+  "downloads": 0,
   "id": "thunderpack_v11",
   "versions": [
    {
@@ -40251,8 +41149,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -40275,6 +41173,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -40324,13 +41223,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 38,
+  "downloads": 0,
   "id": "thunderpack_v12",
   "versions": [
    {
@@ -40405,8 +41304,8 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -40429,6 +41328,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -40480,13 +41380,13 @@
      "usb_midi",
      "vectorio"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 133,
+  "downloads": 0,
   "id": "tinkeringtech_scoutmakes_azul",
   "versions": [
    {
@@ -40574,8 +41474,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -40598,6 +41498,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -40626,7 +41527,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -40662,13 +41562,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 336,
+  "downloads": 0,
   "id": "trellis_m4_express",
   "versions": [
    {
@@ -40757,8 +41657,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -40781,6 +41681,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -40846,13 +41747,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 1010,
+  "downloads": 0,
   "id": "trinket_m0",
   "versions": [
    {
@@ -40903,8 +41804,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -40927,6 +41828,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -40938,7 +41840,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -40954,13 +41855,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 107,
+  "downloads": 0,
   "id": "trinket_m0_haxpress",
   "versions": [
    {
@@ -41024,8 +41925,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -41048,12 +41949,12 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
      "adafruit_pixelbuf",
      "analogio",
-     "atexit",
      "audiobusio",
      "audiocore",
      "audioio",
@@ -41063,7 +41964,6 @@
      "displayio",
      "errno",
      "fontio",
-     "getpass",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -41088,13 +41988,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 28,
+  "downloads": 0,
   "id": "uartlogger2",
   "versions": [
    {
@@ -41184,8 +42084,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -41208,6 +42108,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -41274,13 +42175,13 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 122,
+  "downloads": 0,
   "id": "uchip",
   "versions": [
    {
@@ -41332,8 +42233,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -41357,6 +42258,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -41368,7 +42270,6 @@
      "microcontroller",
      "neopixel_write",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -41384,13 +42285,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 94,
+  "downloads": 0,
   "id": "ugame10",
   "versions": [
    {
@@ -41448,8 +42349,8 @@
      "traceback",
      "usb_cdc"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -41474,12 +42375,12 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
      "_stage",
      "analogio",
-     "atexit",
      "audiocore",
      "audioio",
      "board",
@@ -41488,7 +42389,6 @@
      "displayio",
      "errno",
      "fontio",
-     "getpass",
      "math",
      "microcontroller",
      "nvm",
@@ -41506,13 +42406,13 @@
      "traceback",
      "usb_cdc"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 729,
+  "downloads": 0,
   "id": "unexpectedmaker_feathers2",
   "versions": [
    {
@@ -41609,8 +42509,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -41634,10 +42534,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -41706,13 +42606,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 114,
+  "downloads": 0,
   "id": "unexpectedmaker_feathers2_neo",
   "versions": [
    {
@@ -41811,8 +42711,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -41838,10 +42738,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -41910,13 +42810,13 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 71,
+  "downloads": 0,
   "id": "unexpectedmaker_feathers2_prerelease",
   "versions": [
    {
@@ -42013,8 +42913,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -42038,10 +42938,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
      "aesio",
@@ -42110,13 +43010,219 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 253,
+  "downloads": 0,
+  "id": "unexpectedmaker_feathers3",
+  "versions": [
+   {
+    "extensions": [
+     "bin",
+     "uf2"
+    ],
+    "frozen_libraries": [
+     "Adafruit_CircuitPython_NeoPixel"
+    ],
+    "languages": [
+     "de_DE",
+     "en_GB",
+     "en_US",
+     "en_x_pirate",
+     "es",
+     "fil",
+     "fr",
+     "ID",
+     "it_IT",
+     "ja",
+     "nl",
+     "pl",
+     "pt_BR",
+     "ru",
+     "sv",
+     "tr",
+     "zh_Latn_pinyin"
+    ],
+    "modules": [
+     "_bleio",
+     "adafruit_bus_device",
+     "adafruit_pixelbuf",
+     "aesio",
+     "alarm",
+     "analogio",
+     "atexit",
+     "audiobusio",
+     "audiocore",
+     "audiomixer",
+     "binascii",
+     "bitbangio",
+     "bitmaptools",
+     "board",
+     "busio",
+     "canio",
+     "countio",
+     "digitalio",
+     "displayio",
+     "dualbank",
+     "errno",
+     "fontio",
+     "framebufferio",
+     "frequencyio",
+     "getpass",
+     "gifio",
+     "i2cperipheral",
+     "ipaddress",
+     "json",
+     "keypad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "onewireio",
+     "os",
+     "ps2io",
+     "pulseio",
+     "pwmio",
+     "rainbowio",
+     "random",
+     "re",
+     "rgbmatrix",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "socketpool",
+     "ssl",
+     "storage",
+     "struct",
+     "supervisor",
+     "synthio",
+     "terminalio",
+     "time",
+     "touchio",
+     "traceback",
+     "ulab",
+     "usb_cdc",
+     "usb_hid",
+     "usb_midi",
+     "vectorio",
+     "watchdog",
+     "wifi"
+    ],
+    "stable": false,
+    "version": "7.2.0-alpha.2"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
+  "id": "unexpectedmaker_pros3",
+  "versions": [
+   {
+    "extensions": [
+     "bin",
+     "uf2"
+    ],
+    "frozen_libraries": [
+     "Adafruit_CircuitPython_NeoPixel"
+    ],
+    "languages": [
+     "de_DE",
+     "en_GB",
+     "en_US",
+     "en_x_pirate",
+     "es",
+     "fil",
+     "fr",
+     "ID",
+     "it_IT",
+     "ja",
+     "nl",
+     "pl",
+     "pt_BR",
+     "ru",
+     "sv",
+     "tr",
+     "zh_Latn_pinyin"
+    ],
+    "modules": [
+     "_bleio",
+     "adafruit_bus_device",
+     "adafruit_pixelbuf",
+     "aesio",
+     "alarm",
+     "analogio",
+     "atexit",
+     "audiobusio",
+     "audiocore",
+     "audiomixer",
+     "binascii",
+     "bitbangio",
+     "bitmaptools",
+     "board",
+     "busio",
+     "canio",
+     "countio",
+     "digitalio",
+     "displayio",
+     "dualbank",
+     "errno",
+     "fontio",
+     "framebufferio",
+     "frequencyio",
+     "getpass",
+     "gifio",
+     "i2cperipheral",
+     "ipaddress",
+     "json",
+     "keypad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "onewireio",
+     "os",
+     "ps2io",
+     "pulseio",
+     "pwmio",
+     "rainbowio",
+     "random",
+     "re",
+     "rgbmatrix",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "socketpool",
+     "ssl",
+     "storage",
+     "struct",
+     "supervisor",
+     "synthio",
+     "terminalio",
+     "time",
+     "touchio",
+     "traceback",
+     "ulab",
+     "usb_cdc",
+     "usb_hid",
+     "usb_midi",
+     "vectorio",
+     "watchdog",
+     "wifi"
+    ],
+    "stable": false,
+    "version": "7.2.0-alpha.2"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
   "id": "unexpectedmaker_tinys2",
   "versions": [
    {
@@ -42216,8 +43322,8 @@
      "watchdog",
      "wifi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -42243,10 +43349,10 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
-     "_bleio",
      "_stage",
      "adafruit_bus_device",
      "adafruit_pixelbuf",
@@ -42316,13 +43422,117 @@
      "watchdog",
      "wifi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 34,
+  "downloads": 0,
+  "id": "unexpectedmaker_tinys3",
+  "versions": [
+   {
+    "extensions": [
+     "bin",
+     "uf2"
+    ],
+    "frozen_libraries": [
+     "Adafruit_CircuitPython_NeoPixel"
+    ],
+    "languages": [
+     "de_DE",
+     "en_GB",
+     "en_US",
+     "en_x_pirate",
+     "es",
+     "fil",
+     "fr",
+     "ID",
+     "it_IT",
+     "ja",
+     "nl",
+     "pl",
+     "pt_BR",
+     "ru",
+     "sv",
+     "tr",
+     "zh_Latn_pinyin"
+    ],
+    "modules": [
+     "_bleio",
+     "_stage",
+     "adafruit_bus_device",
+     "adafruit_pixelbuf",
+     "aesio",
+     "alarm",
+     "analogio",
+     "atexit",
+     "audiobusio",
+     "audiocore",
+     "audiomixer",
+     "binascii",
+     "bitbangio",
+     "bitmaptools",
+     "board",
+     "busio",
+     "canio",
+     "countio",
+     "digitalio",
+     "displayio",
+     "dualbank",
+     "errno",
+     "fontio",
+     "framebufferio",
+     "frequencyio",
+     "getpass",
+     "gifio",
+     "i2cperipheral",
+     "ipaddress",
+     "json",
+     "keypad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "onewireio",
+     "os",
+     "ps2io",
+     "pulseio",
+     "pwmio",
+     "rainbowio",
+     "random",
+     "re",
+     "rgbmatrix",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "socketpool",
+     "ssl",
+     "storage",
+     "struct",
+     "supervisor",
+     "synthio",
+     "terminalio",
+     "time",
+     "touchio",
+     "traceback",
+     "ulab",
+     "usb_cdc",
+     "usb_hid",
+     "usb_midi",
+     "vectorio",
+     "watchdog",
+     "wifi"
+    ],
+    "stable": false,
+    "version": "7.2.0-alpha.2"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
   "id": "warmbit_bluepixel",
   "versions": [
    {
@@ -42410,8 +43620,8 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -42434,6 +43644,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -42462,7 +43673,6 @@
      "framebufferio",
      "getpass",
      "gifio",
-     "is31fl3741",
      "json",
      "keypad",
      "math",
@@ -42498,13 +43708,110 @@
      "vectorio",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 115,
+  "downloads": 0,
+  "id": "waveshare_rp2040_zero",
+  "versions": [
+   {
+    "extensions": [
+     "uf2"
+    ],
+    "frozen_libraries": [],
+    "languages": [
+     "de_DE",
+     "en_GB",
+     "en_US",
+     "en_x_pirate",
+     "es",
+     "fil",
+     "fr",
+     "ID",
+     "it_IT",
+     "ja",
+     "nl",
+     "pl",
+     "pt_BR",
+     "ru",
+     "sv",
+     "tr",
+     "zh_Latn_pinyin"
+    ],
+    "modules": [
+     "_bleio",
+     "adafruit_bus_device",
+     "adafruit_pixelbuf",
+     "aesio",
+     "alarm",
+     "analogio",
+     "atexit",
+     "audiobusio",
+     "audiocore",
+     "audiomixer",
+     "audiomp3",
+     "audiopwmio",
+     "binascii",
+     "bitbangio",
+     "bitmaptools",
+     "bitops",
+     "board",
+     "busio",
+     "countio",
+     "digitalio",
+     "displayio",
+     "errno",
+     "fontio",
+     "framebufferio",
+     "getpass",
+     "gifio",
+     "imagecapture",
+     "json",
+     "keypad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "onewireio",
+     "os",
+     "paralleldisplay",
+     "pulseio",
+     "pwmio",
+     "qrio",
+     "rainbowio",
+     "random",
+     "re",
+     "rgbmatrix",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "storage",
+     "struct",
+     "supervisor",
+     "synthio",
+     "terminalio",
+     "time",
+     "touchio",
+     "traceback",
+     "ulab",
+     "usb_cdc",
+     "usb_hid",
+     "usb_midi",
+     "vectorio",
+     "watchdog"
+    ],
+    "stable": false,
+    "version": "7.2.0-alpha.2"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
   "id": "winterbloom_big_honking_button",
   "versions": [
    {
@@ -42559,8 +43866,8 @@
      "traceback",
      "usb_cdc"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -42583,19 +43890,18 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
      "adafruit_pixelbuf",
      "analogio",
-     "atexit",
      "audiocore",
      "audioio",
      "board",
      "busio",
      "digitalio",
      "errno",
-     "getpass",
      "math",
      "microcontroller",
      "neopixel_write",
@@ -42614,13 +43920,13 @@
      "traceback",
      "usb_cdc"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 133,
+  "downloads": 0,
   "id": "winterbloom_sol",
   "versions": [
    {
@@ -42688,8 +43994,8 @@
      "usb_midi",
      "watchdog"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -42712,6 +44018,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -42756,13 +44063,13 @@
      "usb_midi",
      "watchdog"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 105,
+  "downloads": 0,
   "id": "xinabox_cc03",
   "versions": [
    {
@@ -42810,8 +44117,8 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -42834,6 +44141,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -42844,7 +44152,6 @@
      "math",
      "microcontroller",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -42858,13 +44165,13 @@
      "usb_hid",
      "usb_midi"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  },
  {
-  "downloads": 100,
+  "downloads": 0,
   "id": "xinabox_cs11",
   "versions": [
    {
@@ -42911,8 +44218,8 @@
      "usb_cdc",
      "usb_hid"
     ],
-    "stable": false,
-    "version": "7.2.0-alpha.1"
+    "stable": true,
+    "version": "7.1.1"
    },
    {
     "extensions": [
@@ -42935,6 +44242,7 @@
      "pt_BR",
      "ru",
      "sv",
+     "tr",
      "zh_Latn_pinyin"
     ],
     "modules": [
@@ -42945,7 +44253,6 @@
      "math",
      "microcontroller",
      "nvm",
-     "onewireio",
      "os",
      "pwmio",
      "rainbowio",
@@ -42958,8 +44265,8 @@
      "usb_cdc",
      "usb_hid"
     ],
-    "stable": true,
-    "version": "7.1.1"
+    "stable": false,
+    "version": "7.2.0-alpha.2"
    }
   ]
  }


### PR DESCRIPTION
Automated website update for release 7.2.0-alpha.2 by Blinka.

New boards:
* diodes_delight_piunora
* raspberrypi_zero
* raspberrypi_zero_w
* espressif_esp32s2_devkitc_1_n4r2
* unexpectedmaker_pros3
* espressif_esp32c3_devkitm_1_n4
* espressif_esp32s3_devkitc_1_n8r2
* adafruit_qtpy_esp32s3_nopsram
* unexpectedmaker_tinys3
* unexpectedmaker_feathers3
* adafruit_esp32s2_camera
* espressif_esp32s3_devkitc_1_n8r8
* espressif_esp32s3_devkitc_1_n8
* waveshare_rp2040_zero

New languages:
* tr
