### PR TITLE
Automated website update for release 7.2.0-rc.1

### DIFF
--- a/_data/files.json
+++ b/_data/files.json
@@ -1,6 +1,6 @@
 [
  {
-  "downloads": 61,
+  "downloads": 0,
   "id": "8086_commander",
   "versions": [
    {
@@ -114,12 +114,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 14,
+  "downloads": 0,
   "id": "ADM_B_NRF52840_1",
   "versions": [
    {
@@ -296,12 +296,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 55,
+  "downloads": 0,
   "id": "Seeed_XIAO_nRF52840_Sense",
   "versions": [
    {
@@ -390,12 +390,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 54,
+  "downloads": 0,
   "id": "TG-Watch",
   "versions": [
    {
@@ -600,12 +600,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 6,
+  "downloads": 0,
   "id": "adafruit_esp32s2_camera",
   "versions": [
    {
@@ -703,12 +703,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 253,
+  "downloads": 0,
   "id": "adafruit_feather_esp32s2",
   "versions": [
    {
@@ -903,12 +903,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 191,
+  "downloads": 0,
   "id": "adafruit_feather_esp32s2_tft",
   "versions": [
    {
@@ -1103,12 +1103,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 47,
+  "downloads": 0,
   "id": "adafruit_feather_esp32s2_tftback_nopsram",
   "versions": [
    {
@@ -1313,12 +1313,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 569,
+  "downloads": 0,
   "id": "adafruit_feather_rp2040",
   "versions": [
    {
@@ -1500,12 +1500,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 204,
+  "downloads": 0,
   "id": "adafruit_funhouse",
   "versions": [
    {
@@ -1706,12 +1706,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 158,
+  "downloads": 0,
   "id": "adafruit_itsybitsy_rp2040",
   "versions": [
    {
@@ -1893,12 +1893,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 183,
+  "downloads": 0,
   "id": "adafruit_kb2040",
   "versions": [
    {
@@ -2080,12 +2080,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 138,
+  "downloads": 0,
   "id": "adafruit_led_glasses_nrf52840",
   "versions": [
    {
@@ -2263,12 +2263,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 554,
+  "downloads": 0,
   "id": "adafruit_macropad_rp2040",
   "versions": [
    {
@@ -2450,12 +2450,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 488,
+  "downloads": 0,
   "id": "adafruit_magtag_2.9_grayscale",
   "versions": [
    {
@@ -2657,12 +2657,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 179,
+  "downloads": 0,
   "id": "adafruit_metro_esp32s2",
   "versions": [
    {
@@ -2857,12 +2857,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 108,
+  "downloads": 0,
   "id": "adafruit_neokey_trinkey_m0",
   "versions": [
    {
@@ -2962,12 +2962,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 148,
+  "downloads": 0,
   "id": "adafruit_proxlight_trinkey_m0",
   "versions": [
    {
@@ -3072,12 +3072,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 195,
+  "downloads": 0,
   "id": "adafruit_qt2040_trinkey",
   "versions": [
    {
@@ -3259,12 +3259,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 277,
+  "downloads": 0,
   "id": "adafruit_qtpy_esp32s2",
   "versions": [
    {
@@ -3459,12 +3459,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 5,
+  "downloads": 0,
   "id": "adafruit_qtpy_esp32s3_nopsram",
   "versions": [
    {
@@ -3565,12 +3565,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 270,
+  "downloads": 0,
   "id": "adafruit_qtpy_rp2040",
   "versions": [
    {
@@ -3752,12 +3752,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 85,
+  "downloads": 0,
   "id": "adafruit_rotary_trinkey_m0",
   "versions": [
    {
@@ -3859,12 +3859,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 90,
+  "downloads": 0,
   "id": "adafruit_slide_trinkey_m0",
   "versions": [
    {
@@ -3968,12 +3968,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 128,
+  "downloads": 0,
   "id": "ai_thinker_esp32-c3s",
   "versions": [
    {
@@ -4143,7 +4143,7 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
@@ -4235,12 +4235,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 143,
+  "downloads": 0,
   "id": "ai_thinker_esp_12k_nodemcu",
   "versions": [
    {
@@ -4435,12 +4435,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 43,
+  "downloads": 0,
   "id": "aloriumtech_evo_m51",
   "versions": [
    {
@@ -4622,12 +4622,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 58,
+  "downloads": 0,
   "id": "aramcon2_badge",
   "versions": [
    {
@@ -4804,12 +4804,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 88,
+  "downloads": 0,
   "id": "aramcon_badge_2019",
   "versions": [
    {
@@ -4986,12 +4986,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 59,
+  "downloads": 0,
   "id": "arduino_mkr1300",
   "versions": [
    {
@@ -5095,12 +5095,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 77,
+  "downloads": 0,
   "id": "arduino_mkrzero",
   "versions": [
    {
@@ -5205,12 +5205,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 89,
+  "downloads": 0,
   "id": "arduino_nano_33_ble",
   "versions": [
    {
@@ -5387,12 +5387,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 79,
+  "downloads": 0,
   "id": "arduino_nano_33_iot",
   "versions": [
    {
@@ -5495,12 +5495,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 228,
+  "downloads": 0,
   "id": "arduino_nano_rp2040_connect",
   "versions": [
    {
@@ -5682,12 +5682,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 84,
+  "downloads": 0,
   "id": "arduino_zero",
   "versions": [
    {
@@ -5791,12 +5791,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 18,
+  "downloads": 0,
   "id": "artisense_rd00",
   "versions": [
    {
@@ -5991,12 +5991,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 40,
+  "downloads": 0,
   "id": "atmegazero_esp32s2",
   "versions": [
    {
@@ -6191,12 +6191,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 32,
+  "downloads": 0,
   "id": "bast_pro_mini_m0",
   "versions": [
    {
@@ -6299,12 +6299,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 46,
+  "downloads": 0,
   "id": "bastble",
   "versions": [
    {
@@ -6481,12 +6481,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 30,
+  "downloads": 0,
   "id": "bdmicro_vina_d21",
   "versions": [
    {
@@ -6614,12 +6614,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 34,
+  "downloads": 0,
   "id": "bdmicro_vina_d51",
   "versions": [
    {
@@ -6801,12 +6801,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 19,
+  "downloads": 0,
   "id": "bdmicro_vina_d51_pcb7",
   "versions": [
    {
@@ -6988,12 +6988,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 89,
+  "downloads": 0,
   "id": "bless_dev_board_multi_sensor",
   "versions": [
    {
@@ -7170,12 +7170,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 47,
+  "downloads": 0,
   "id": "blm_badge",
   "versions": [
    {
@@ -7276,12 +7276,12 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 34,
+  "downloads": 0,
   "id": "bluemicro833",
   "versions": [
    {
@@ -7341,12 +7341,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 46,
+  "downloads": 0,
   "id": "bluemicro840",
   "versions": [
    {
@@ -7523,12 +7523,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 56,
+  "downloads": 0,
   "id": "capablerobot_usbhub",
   "versions": [
    {
@@ -7668,12 +7668,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 72,
+  "downloads": 0,
   "id": "catwan_usbstick",
   "versions": [
    {
@@ -7776,12 +7776,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 46,
+  "downloads": 0,
   "id": "challenger_nb_rp2040_wifi",
   "versions": [
    {
@@ -7963,12 +7963,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 104,
+  "downloads": 0,
   "id": "challenger_rp2040_lte",
   "versions": [
    {
@@ -8150,12 +8150,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 116,
+  "downloads": 0,
   "id": "challenger_rp2040_wifi",
   "versions": [
    {
@@ -8337,12 +8337,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 62,
+  "downloads": 0,
   "id": "circuitbrains_basic_m0",
   "versions": [
    {
@@ -8470,12 +8470,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 82,
+  "downloads": 0,
   "id": "circuitbrains_deluxe_m4",
   "versions": [
    {
@@ -8657,12 +8657,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 488,
+  "downloads": 0,
   "id": "circuitplayground_bluefruit",
   "versions": [
    {
@@ -8839,12 +8839,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 672,
+  "downloads": 0,
   "id": "circuitplayground_express",
   "versions": [
    {
@@ -8982,12 +8982,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 72,
+  "downloads": 0,
   "id": "circuitplayground_express_4h",
   "versions": [
    {
@@ -9125,12 +9125,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 131,
+  "downloads": 0,
   "id": "circuitplayground_express_crickit",
   "versions": [
    {
@@ -9267,12 +9267,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 69,
+  "downloads": 0,
   "id": "circuitplayground_express_digikey_pycon2019",
   "versions": [
    {
@@ -9410,12 +9410,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 122,
+  "downloads": 0,
   "id": "circuitplayground_express_displayio",
   "versions": [
    {
@@ -9543,12 +9543,12 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 223,
+  "downloads": 0,
   "id": "clue_nrf52840_express",
   "versions": [
    {
@@ -9725,12 +9725,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 7,
+  "downloads": 0,
   "id": "cp32-m4",
   "versions": [
    {
@@ -9910,12 +9910,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 53,
+  "downloads": 0,
   "id": "cp_sapling_m0",
   "versions": [
    {
@@ -10018,12 +10018,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 26,
+  "downloads": 0,
   "id": "cp_sapling_m0_revb",
   "versions": [
    {
@@ -10126,12 +10126,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 60,
+  "downloads": 0,
   "id": "cp_sapling_m0_spiflash",
   "versions": [
    {
@@ -10253,12 +10253,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 30,
+  "downloads": 0,
   "id": "crumpspace_crumps2",
   "versions": [
    {
@@ -10453,12 +10453,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 93,
+  "downloads": 0,
   "id": "cytron_maker_nano_rp2040",
   "versions": [
    {
@@ -10646,12 +10646,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 212,
+  "downloads": 0,
   "id": "cytron_maker_pi_rp2040",
   "versions": [
    {
@@ -10841,12 +10841,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 6,
+  "downloads": 0,
   "id": "datalore_ip_m4",
   "versions": [
    {
@@ -11028,12 +11028,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 60,
+  "downloads": 0,
   "id": "datum_distance",
   "versions": [
    {
@@ -11136,12 +11136,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 40,
+  "downloads": 0,
   "id": "datum_imu",
   "versions": [
    {
@@ -11244,12 +11244,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 78,
+  "downloads": 0,
   "id": "datum_light",
   "versions": [
    {
@@ -11352,12 +11352,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 44,
+  "downloads": 0,
   "id": "datum_weather",
   "versions": [
    {
@@ -11460,7 +11460,7 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
@@ -11539,12 +11539,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 71,
+  "downloads": 0,
   "id": "dynalora_usb",
   "versions": [
    {
@@ -11656,12 +11656,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 66,
+  "downloads": 0,
   "id": "dynossat_edu_eps",
   "versions": [
    {
@@ -11785,12 +11785,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 58,
+  "downloads": 0,
   "id": "dynossat_edu_obc",
   "versions": [
    {
@@ -11972,12 +11972,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 118,
+  "downloads": 0,
   "id": "edgebadge",
   "versions": [
    {
@@ -12157,12 +12157,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 46,
+  "downloads": 0,
   "id": "electroniccats_bastwifi",
   "versions": [
    {
@@ -12355,12 +12355,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 80,
+  "downloads": 0,
   "id": "electronut_labs_blip",
   "versions": [
    {
@@ -12539,12 +12539,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 63,
+  "downloads": 0,
   "id": "electronut_labs_papyr",
   "versions": [
    {
@@ -12721,12 +12721,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 24,
+  "downloads": 0,
   "id": "escornabot_makech",
   "versions": [
    {
@@ -12827,12 +12827,12 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 6,
+  "downloads": 0,
   "id": "espressif_esp32c3_devkitm_1_n4",
   "versions": [
    {
@@ -12919,12 +12919,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 11,
+  "downloads": 0,
   "id": "espressif_esp32s2_devkitc_1_n4r2",
   "versions": [
    {
@@ -13022,12 +13022,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 47,
+  "downloads": 0,
   "id": "espressif_esp32s3_box",
   "versions": [
    {
@@ -13123,12 +13123,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 10,
+  "downloads": 0,
   "id": "espressif_esp32s3_devkitc_1_n8",
   "versions": [
    {
@@ -13224,12 +13224,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 6,
+  "downloads": 0,
   "id": "espressif_esp32s3_devkitc_1_n8r2",
   "versions": [
    {
@@ -13325,12 +13325,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 29,
+  "downloads": 0,
   "id": "espressif_esp32s3_devkitc_1_n8r8",
   "versions": [
    {
@@ -13426,12 +13426,113 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 49,
+  "downloads": 0,
+  "id": "espressif_esp32s3_devkitm_1_n8",
+  "versions": [
+   {
+    "extensions": [
+     "bin",
+     "uf2"
+    ],
+    "frozen_libraries": [],
+    "languages": [
+     "de_DE",
+     "en_GB",
+     "en_US",
+     "en_x_pirate",
+     "es",
+     "fil",
+     "fr",
+     "ID",
+     "it_IT",
+     "ja",
+     "nl",
+     "pl",
+     "pt_BR",
+     "ru",
+     "sv",
+     "tr",
+     "zh_Latn_pinyin"
+    ],
+    "modules": [
+     "_bleio",
+     "adafruit_bus_device",
+     "adafruit_pixelbuf",
+     "aesio",
+     "alarm",
+     "analogio",
+     "atexit",
+     "audiobusio",
+     "audiocore",
+     "audiomixer",
+     "binascii",
+     "bitbangio",
+     "bitmaptools",
+     "board",
+     "busio",
+     "canio",
+     "countio",
+     "digitalio",
+     "displayio",
+     "dualbank",
+     "errno",
+     "fontio",
+     "framebufferio",
+     "frequencyio",
+     "getpass",
+     "gifio",
+     "i2cperipheral",
+     "ipaddress",
+     "json",
+     "keypad",
+     "math",
+     "microcontroller",
+     "msgpack",
+     "neopixel_write",
+     "nvm",
+     "onewireio",
+     "os",
+     "ps2io",
+     "pulseio",
+     "pwmio",
+     "rainbowio",
+     "random",
+     "re",
+     "rgbmatrix",
+     "rotaryio",
+     "rtc",
+     "sdcardio",
+     "sharpdisplay",
+     "socketpool",
+     "ssl",
+     "storage",
+     "struct",
+     "supervisor",
+     "synthio",
+     "terminalio",
+     "time",
+     "touchio",
+     "traceback",
+     "ulab",
+     "usb_cdc",
+     "usb_hid",
+     "usb_midi",
+     "vectorio",
+     "watchdog",
+     "wifi"
+    ],
+    "stable": false,
+    "version": "7.2.0-rc.1"
+   }
+  ]
+ },
+ {
+  "downloads": 0,
   "id": "espressif_hmi_devkit_1",
   "versions": [
    {
@@ -13626,12 +13727,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 60,
+  "downloads": 0,
   "id": "espressif_kaluga_1",
   "versions": [
    {
@@ -13826,12 +13927,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 65,
+  "downloads": 0,
   "id": "espressif_kaluga_1.3",
   "versions": [
    {
@@ -14026,12 +14127,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 269,
+  "downloads": 0,
   "id": "espressif_saola_1_wroom",
   "versions": [
    {
@@ -14226,12 +14327,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 155,
+  "downloads": 0,
   "id": "espressif_saola_1_wrover",
   "versions": [
    {
@@ -14426,12 +14527,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 20,
+  "downloads": 0,
   "id": "espruino_pico",
   "versions": [
    {
@@ -14557,12 +14658,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 24,
+  "downloads": 0,
   "id": "espruino_wifi",
   "versions": [
    {
@@ -14708,12 +14809,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 190,
+  "downloads": 0,
   "id": "feather_bluefruit_sense",
   "versions": [
    {
@@ -14890,12 +14991,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 105,
+  "downloads": 0,
   "id": "feather_m0_adalogger",
   "versions": [
    {
@@ -14999,12 +15100,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 118,
+  "downloads": 0,
   "id": "feather_m0_basic",
   "versions": [
    {
@@ -15109,12 +15210,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 241,
+  "downloads": 0,
   "id": "feather_m0_express",
   "versions": [
    {
@@ -15242,12 +15343,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 90,
+  "downloads": 0,
   "id": "feather_m0_express_crickit",
   "versions": [
    {
@@ -15377,12 +15478,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 81,
+  "downloads": 0,
   "id": "feather_m0_rfm69",
   "versions": [
    {
@@ -15483,12 +15584,12 @@
      "usb_cdc"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 92,
+  "downloads": 0,
   "id": "feather_m0_rfm9x",
   "versions": [
    {
@@ -15589,12 +15690,12 @@
      "usb_cdc"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 64,
+  "downloads": 0,
   "id": "feather_m0_supersized",
   "versions": [
    {
@@ -15722,12 +15823,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 116,
+  "downloads": 0,
   "id": "feather_m4_can",
   "versions": [
    {
@@ -15909,12 +16010,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 447,
+  "downloads": 0,
   "id": "feather_m4_express",
   "versions": [
    {
@@ -16096,12 +16197,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 70,
+  "downloads": 0,
   "id": "feather_m7_1011",
   "versions": [
    {
@@ -16257,12 +16358,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 70,
+  "downloads": 0,
   "id": "feather_mimxrt1011",
   "versions": [
    {
@@ -16418,12 +16519,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 55,
+  "downloads": 0,
   "id": "feather_mimxrt1062",
   "versions": [
    {
@@ -16573,12 +16674,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 240,
+  "downloads": 0,
   "id": "feather_nrf52840_express",
   "versions": [
    {
@@ -16755,7 +16856,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
@@ -16765,7 +16866,7 @@
   "versions": []
  },
  {
-  "downloads": 65,
+  "downloads": 0,
   "id": "feather_stm32f405_express",
   "versions": [
    {
@@ -16929,12 +17030,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 48,
+  "downloads": 0,
   "id": "fluff_m0",
   "versions": [
    {
@@ -17037,12 +17138,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 71,
+  "downloads": 0,
   "id": "fomu",
   "versions": [
    {
@@ -17154,12 +17255,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 56,
+  "downloads": 0,
   "id": "franzininho_wifi_wroom",
   "versions": [
    {
@@ -17354,12 +17455,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 45,
+  "downloads": 0,
   "id": "franzininho_wifi_wrover",
   "versions": [
    {
@@ -17554,12 +17655,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 161,
+  "downloads": 0,
   "id": "gemma_m0",
   "versions": [
    {
@@ -17662,12 +17763,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 89,
+  "downloads": 0,
   "id": "gemma_m0_pycon2018",
   "versions": [
    {
@@ -17770,12 +17871,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 139,
+  "downloads": 0,
   "id": "grandcentral_m4_express",
   "versions": [
    {
@@ -17963,12 +18064,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 35,
+  "downloads": 0,
   "id": "gravitech_cucumber_m",
   "versions": [
    {
@@ -18163,12 +18264,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 31,
+  "downloads": 0,
   "id": "gravitech_cucumber_ms",
   "versions": [
    {
@@ -18363,12 +18464,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 36,
+  "downloads": 0,
   "id": "gravitech_cucumber_r",
   "versions": [
    {
@@ -18563,12 +18664,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 35,
+  "downloads": 0,
   "id": "gravitech_cucumber_rs",
   "versions": [
    {
@@ -18763,12 +18864,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 82,
+  "downloads": 0,
   "id": "hallowing_m0_express",
   "versions": [
    {
@@ -18900,12 +19001,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 75,
+  "downloads": 0,
   "id": "hallowing_m4_express",
   "versions": [
    {
@@ -19087,12 +19188,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 87,
+  "downloads": 0,
   "id": "hiibot_bluefi",
   "versions": [
    {
@@ -19269,7 +19370,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
@@ -19372,12 +19473,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 53,
+  "downloads": 0,
   "id": "huntercat_nfc",
   "versions": [
    {
@@ -19505,12 +19606,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 34,
+  "downloads": 0,
   "id": "ikigaisense_vita",
   "versions": [
    {
@@ -19687,12 +19788,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 82,
+  "downloads": 0,
   "id": "imxrt1010_evk",
   "versions": [
    {
@@ -19848,12 +19949,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 75,
+  "downloads": 0,
   "id": "imxrt1020_evk",
   "versions": [
    {
@@ -20003,12 +20104,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 50,
+  "downloads": 0,
   "id": "imxrt1060_evk",
   "versions": [
    {
@@ -20158,12 +20259,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 151,
+  "downloads": 0,
   "id": "itsybitsy_m0_express",
   "versions": [
    {
@@ -20289,12 +20390,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 208,
+  "downloads": 0,
   "id": "itsybitsy_m4_express",
   "versions": [
    {
@@ -20474,12 +20575,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 161,
+  "downloads": 0,
   "id": "itsybitsy_nrf52840_express",
   "versions": [
    {
@@ -20656,12 +20757,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 111,
+  "downloads": 0,
   "id": "jpconstantineau_encoderpad_rp2040",
   "versions": [
    {
@@ -20843,12 +20944,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 31,
+  "downloads": 0,
   "id": "jpconstantineau_pykey18",
   "versions": [
    {
@@ -20940,12 +21041,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 42,
+  "downloads": 0,
   "id": "jpconstantineau_pykey44",
   "versions": [
    {
@@ -21037,12 +21138,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 98,
+  "downloads": 0,
   "id": "jpconstantineau_pykey60",
   "versions": [
    {
@@ -21224,12 +21325,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 30,
+  "downloads": 0,
   "id": "jpconstantineau_pykey87",
   "versions": [
    {
@@ -21321,12 +21422,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 48,
+  "downloads": 0,
   "id": "kicksat-sprite",
   "versions": [
    {
@@ -21458,12 +21559,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 159,
+  "downloads": 0,
   "id": "lilygo_ttgo_t8_s2_st7789",
   "versions": [
    {
@@ -21658,12 +21759,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 42,
+  "downloads": 0,
   "id": "loc_ber_m4_base_board",
   "versions": [
    {
@@ -21773,12 +21874,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 195,
+  "downloads": 0,
   "id": "lolin_s2_mini",
   "versions": [
    {
@@ -21977,12 +22078,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 63,
+  "downloads": 0,
   "id": "lolin_s2_pico",
   "versions": [
    {
@@ -22181,12 +22282,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 76,
+  "downloads": 0,
   "id": "makerdiary_m60_keyboard",
   "versions": [
    {
@@ -22363,12 +22464,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 73,
+  "downloads": 0,
   "id": "makerdiary_nrf52840_m2_devkit",
   "versions": [
    {
@@ -22545,12 +22646,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 101,
+  "downloads": 0,
   "id": "makerdiary_nrf52840_mdk",
   "versions": [
    {
@@ -22727,12 +22828,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 117,
+  "downloads": 0,
   "id": "makerdiary_nrf52840_mdk_usb_dongle",
   "versions": [
    {
@@ -22911,12 +23012,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 307,
+  "downloads": 0,
   "id": "matrixportal_m4",
   "versions": [
    {
@@ -23100,12 +23201,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 57,
+  "downloads": 0,
   "id": "melopero_shake_rp2040",
   "versions": [
    {
@@ -23287,12 +23388,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 86,
+  "downloads": 0,
   "id": "meowbit_v121",
   "versions": [
    {
@@ -23444,12 +23545,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 47,
+  "downloads": 0,
   "id": "meowmeow",
   "versions": [
    {
@@ -23550,12 +23651,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 158,
+  "downloads": 0,
   "id": "metro_m0_express",
   "versions": [
    {
@@ -23683,12 +23784,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 168,
+  "downloads": 0,
   "id": "metro_m4_airlift_lite",
   "versions": [
    {
@@ -23870,12 +23971,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 201,
+  "downloads": 0,
   "id": "metro_m4_express",
   "versions": [
    {
@@ -24057,12 +24158,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 58,
+  "downloads": 0,
   "id": "metro_m7_1011",
   "versions": [
    {
@@ -24218,12 +24319,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 46,
+  "downloads": 0,
   "id": "metro_nrf52840_express",
   "versions": [
    {
@@ -24400,7 +24501,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
@@ -24526,12 +24627,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 68,
+  "downloads": 0,
   "id": "microdev_micro_c3",
   "versions": [
    {
@@ -24701,12 +24802,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 49,
+  "downloads": 0,
   "id": "microdev_micro_s2",
   "versions": [
    {
@@ -24901,12 +25002,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 57,
+  "downloads": 0,
   "id": "mini_sam_m4",
   "versions": [
    {
@@ -25090,12 +25191,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 123,
+  "downloads": 0,
   "id": "monster_m4sk",
   "versions": [
    {
@@ -25277,12 +25378,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 48,
+  "downloads": 0,
   "id": "morpheans_morphesp-240",
   "versions": [
    {
@@ -25477,12 +25578,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 79,
+  "downloads": 0,
   "id": "muselab_nanoesp32_s2_wroom",
   "versions": [
    {
@@ -25677,12 +25778,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 95,
+  "downloads": 0,
   "id": "muselab_nanoesp32_s2_wrover",
   "versions": [
    {
@@ -25877,12 +25978,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 44,
+  "downloads": 0,
   "id": "ndgarage_ndbit6",
   "versions": [
    {
@@ -25985,12 +26086,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 14,
+  "downloads": 0,
   "id": "ndgarage_ndbit6_v2",
   "versions": [
    {
@@ -26093,12 +26194,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 182,
+  "downloads": 0,
   "id": "neopixel_trinkey_m0",
   "versions": [
    {
@@ -26198,12 +26299,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 86,
+  "downloads": 0,
   "id": "nfc_copy_cat",
   "versions": [
    {
@@ -26307,12 +26408,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 73,
+  "downloads": 0,
   "id": "nice_nano",
   "versions": [
    {
@@ -26489,12 +26590,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 16,
+  "downloads": 0,
   "id": "nucleo_f746zg",
   "versions": [
    {
@@ -26638,12 +26739,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 31,
+  "downloads": 0,
   "id": "nucleo_f767zi",
   "versions": [
    {
@@ -26787,12 +26888,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 19,
+  "downloads": 0,
   "id": "nucleo_h743zi_2",
   "versions": [
    {
@@ -26932,12 +27033,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 56,
+  "downloads": 0,
   "id": "odt_bread_2040",
   "versions": [
    {
@@ -27119,12 +27220,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 52,
+  "downloads": 0,
   "id": "odt_cast_away_rp2040",
   "versions": [
    {
@@ -27216,12 +27317,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 44,
+  "downloads": 0,
   "id": "odt_pixelwing_esp32_s2",
   "versions": [
    {
@@ -27416,12 +27517,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 84,
+  "downloads": 0,
   "id": "ohs2020_badge",
   "versions": [
    {
@@ -27598,12 +27699,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 45,
+  "downloads": 0,
   "id": "openbook_m4",
   "versions": [
    {
@@ -27787,12 +27888,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 17,
+  "downloads": 0,
   "id": "openmv_h7",
   "versions": [
    {
@@ -27932,12 +28033,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 73,
+  "downloads": 0,
   "id": "particle_argon",
   "versions": [
    {
@@ -28114,12 +28215,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 65,
+  "downloads": 0,
   "id": "particle_boron",
   "versions": [
    {
@@ -28296,12 +28397,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 54,
+  "downloads": 0,
   "id": "particle_xenon",
   "versions": [
    {
@@ -28478,12 +28579,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 106,
+  "downloads": 0,
   "id": "pca10056",
   "versions": [
    {
@@ -28662,12 +28763,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 129,
+  "downloads": 0,
   "id": "pca10059",
   "versions": [
    {
@@ -28846,12 +28947,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 82,
+  "downloads": 0,
   "id": "pca10100",
   "versions": [
    {
@@ -28971,12 +29072,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 42,
+  "downloads": 0,
   "id": "pewpew10",
   "versions": [
    {
@@ -29079,12 +29180,12 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 19,
+  "downloads": 0,
   "id": "pewpew13",
   "versions": [
    {
@@ -29187,12 +29288,12 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 51,
+  "downloads": 0,
   "id": "pewpew_m4",
   "versions": [
    {
@@ -29304,12 +29405,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 41,
+  "downloads": 0,
   "id": "picoplanet",
   "versions": [
    {
@@ -29412,12 +29513,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 78,
+  "downloads": 0,
   "id": "pimoroni_interstate75",
   "versions": [
    {
@@ -29599,12 +29700,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 159,
+  "downloads": 0,
   "id": "pimoroni_keybow2040",
   "versions": [
    {
@@ -29786,12 +29887,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 58,
+  "downloads": 0,
   "id": "pimoroni_pga2040",
   "versions": [
    {
@@ -29973,12 +30074,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 126,
+  "downloads": 0,
   "id": "pimoroni_picolipo_16mb",
   "versions": [
    {
@@ -30160,12 +30261,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 88,
+  "downloads": 0,
   "id": "pimoroni_picolipo_4mb",
   "versions": [
    {
@@ -30347,12 +30448,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 86,
+  "downloads": 0,
   "id": "pimoroni_picosystem",
   "versions": [
    {
@@ -30540,12 +30641,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 121,
+  "downloads": 0,
   "id": "pimoroni_plasma2040",
   "versions": [
    {
@@ -30727,12 +30828,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 164,
+  "downloads": 0,
   "id": "pimoroni_tiny2040",
   "versions": [
    {
@@ -30914,12 +31015,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 72,
+  "downloads": 0,
   "id": "pimoroni_tiny2040_2mb",
   "versions": [
    {
@@ -31011,7 +31112,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
@@ -31021,7 +31122,7 @@
   "versions": []
  },
  {
-  "downloads": 37,
+  "downloads": 0,
   "id": "pitaya_go",
   "versions": [
    {
@@ -31198,12 +31299,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 21,
+  "downloads": 0,
   "id": "pyb_nano_v2",
   "versions": [
    {
@@ -31337,12 +31438,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 182,
+  "downloads": 0,
   "id": "pybadge",
   "versions": [
    {
@@ -31522,7 +31623,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
@@ -31532,7 +31633,7 @@
   "versions": []
  },
  {
-  "downloads": 43,
+  "downloads": 0,
   "id": "pyboard_v11",
   "versions": [
    {
@@ -31696,12 +31797,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 80,
+  "downloads": 0,
   "id": "pycubed",
   "versions": [
    {
@@ -31861,12 +31962,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 48,
+  "downloads": 0,
   "id": "pycubed_mram",
   "versions": [
    {
@@ -32026,12 +32127,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 55,
+  "downloads": 0,
   "id": "pycubed_mram_v05",
   "versions": [
    {
@@ -32191,12 +32292,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 81,
+  "downloads": 0,
   "id": "pycubed_v05",
   "versions": [
    {
@@ -32356,12 +32457,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 155,
+  "downloads": 0,
   "id": "pygamer",
   "versions": [
    {
@@ -32541,7 +32642,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
@@ -32551,7 +32652,7 @@
   "versions": []
  },
  {
-  "downloads": 284,
+  "downloads": 0,
   "id": "pyportal",
   "versions": [
    {
@@ -32740,12 +32841,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 116,
+  "downloads": 0,
   "id": "pyportal_pynt",
   "versions": [
    {
@@ -32934,12 +33035,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 163,
+  "downloads": 0,
   "id": "pyportal_titano",
   "versions": [
    {
@@ -33128,12 +33229,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 115,
+  "downloads": 0,
   "id": "pyruler",
   "versions": [
    {
@@ -33236,12 +33337,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 319,
+  "downloads": 0,
   "id": "qtpy_m0",
   "versions": [
    {
@@ -33344,12 +33445,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 124,
+  "downloads": 0,
   "id": "qtpy_m0_haxpress",
   "versions": [
    {
@@ -33477,12 +33578,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 2635,
+  "downloads": 0,
   "id": "raspberry_pi_pico",
   "versions": [
    {
@@ -33664,7 +33765,7 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
@@ -33743,7 +33844,7 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
@@ -33874,7 +33975,7 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
@@ -34005,7 +34106,7 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
@@ -34084,7 +34185,7 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
@@ -34215,7 +34316,7 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
@@ -34294,12 +34395,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 55,
+  "downloads": 0,
   "id": "raytac_mdbt50q-db-40",
   "versions": [
    {
@@ -34476,12 +34577,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 55,
+  "downloads": 0,
   "id": "raytac_mdbt50q-rx",
   "versions": [
    {
@@ -34658,12 +34759,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 50,
+  "downloads": 0,
   "id": "robohatmm1_m4",
   "versions": [
    {
@@ -34825,12 +34926,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 71,
+  "downloads": 0,
   "id": "sam32",
   "versions": [
    {
@@ -35016,12 +35117,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 60,
+  "downloads": 0,
   "id": "same54_xplained",
   "versions": [
    {
@@ -35199,12 +35300,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 199,
+  "downloads": 0,
   "id": "seeeduino_wio_terminal",
   "versions": [
    {
@@ -35386,12 +35487,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 404,
+  "downloads": 0,
   "id": "seeeduino_xiao",
   "versions": [
    {
@@ -35494,12 +35595,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 111,
+  "downloads": 0,
   "id": "seeeduino_xiao_kb",
   "versions": [
    {
@@ -35603,12 +35704,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 154,
+  "downloads": 0,
   "id": "seeeduino_xiao_rp2040",
   "versions": [
    {
@@ -35700,12 +35801,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 41,
+  "downloads": 0,
   "id": "sensebox_mcu",
   "versions": [
    {
@@ -35806,12 +35907,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 58,
+  "downloads": 0,
   "id": "serpente",
   "versions": [
    {
@@ -35939,12 +36040,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 60,
+  "downloads": 0,
   "id": "shirtty",
   "versions": [
    {
@@ -36047,12 +36148,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 68,
+  "downloads": 0,
   "id": "silicognition-m4-shim",
   "versions": [
    {
@@ -36234,12 +36335,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 60,
+  "downloads": 0,
   "id": "simmel",
   "versions": [
    {
@@ -36351,12 +36452,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 56,
+  "downloads": 0,
   "id": "snekboard",
   "versions": [
    {
@@ -36484,12 +36585,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 113,
+  "downloads": 0,
   "id": "solderparty_rp2040_stamp",
   "versions": [
    {
@@ -36683,12 +36784,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 97,
+  "downloads": 0,
   "id": "sparkfun_lumidrive",
   "versions": [
    {
@@ -36814,12 +36915,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 84,
+  "downloads": 0,
   "id": "sparkfun_micromod_rp2040",
   "versions": [
    {
@@ -37001,12 +37102,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 41,
+  "downloads": 0,
   "id": "sparkfun_nrf52840_micromod",
   "versions": [
    {
@@ -37183,12 +37284,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 51,
+  "downloads": 0,
   "id": "sparkfun_nrf52840_mini",
   "versions": [
    {
@@ -37365,12 +37466,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 116,
+  "downloads": 0,
   "id": "sparkfun_pro_micro_rp2040",
   "versions": [
    {
@@ -37552,12 +37653,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 71,
+  "downloads": 0,
   "id": "sparkfun_qwiic_micro_no_flash",
   "versions": [
    {
@@ -37660,12 +37761,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 82,
+  "downloads": 0,
   "id": "sparkfun_qwiic_micro_with_flash",
   "versions": [
    {
@@ -37769,12 +37870,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 73,
+  "downloads": 0,
   "id": "sparkfun_redboard_turbo",
   "versions": [
    {
@@ -37902,12 +38003,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 77,
+  "downloads": 0,
   "id": "sparkfun_samd21_dev",
   "versions": [
    {
@@ -38010,12 +38111,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 87,
+  "downloads": 0,
   "id": "sparkfun_samd21_mini",
   "versions": [
    {
@@ -38118,12 +38219,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 79,
+  "downloads": 0,
   "id": "sparkfun_samd51_micromod",
   "versions": [
    {
@@ -38305,12 +38406,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 94,
+  "downloads": 0,
   "id": "sparkfun_samd51_thing_plus",
   "versions": [
    {
@@ -38492,12 +38593,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 21,
+  "downloads": 0,
   "id": "sparkfun_stm32_thing_plus",
   "versions": [
    {
@@ -38580,12 +38681,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 23,
+  "downloads": 0,
   "id": "sparkfun_stm32f405_micromod",
   "versions": [
    {
@@ -38749,12 +38850,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 53,
+  "downloads": 0,
   "id": "sparkfun_thing_plus_rp2040",
   "versions": [
    {
@@ -38936,12 +39037,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 100,
+  "downloads": 0,
   "id": "spresense",
   "versions": [
    {
@@ -39069,12 +39170,12 @@
      "usb_cdc"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 41,
+  "downloads": 0,
   "id": "stackrduino_m0_pro",
   "versions": [
    {
@@ -39202,12 +39303,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 88,
+  "downloads": 0,
   "id": "stm32f411ce_blackpill",
   "versions": [
    {
@@ -39353,12 +39454,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 72,
+  "downloads": 0,
   "id": "stm32f411ce_blackpill_with_flash",
   "versions": [
    {
@@ -39512,12 +39613,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 21,
+  "downloads": 0,
   "id": "stm32f411ve_discovery",
   "versions": [
    {
@@ -39657,12 +39758,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 18,
+  "downloads": 0,
   "id": "stm32f412zg_discovery",
   "versions": [
    {
@@ -39818,12 +39919,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 32,
+  "downloads": 0,
   "id": "stm32f4_discovery",
   "versions": [
    {
@@ -39985,12 +40086,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 19,
+  "downloads": 0,
   "id": "stm32f746g_discovery",
   "versions": [
    {
@@ -40134,12 +40235,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 53,
+  "downloads": 0,
   "id": "stringcar_m0_express",
   "versions": [
    {
@@ -40265,12 +40366,12 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 51,
+  "downloads": 0,
   "id": "swan_r5",
   "versions": [
    {
@@ -40400,12 +40501,12 @@
      "usb_cdc"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 49,
+  "downloads": 0,
   "id": "targett_module_clip_wroom",
   "versions": [
    {
@@ -40600,12 +40701,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 45,
+  "downloads": 0,
   "id": "targett_module_clip_wrover",
   "versions": [
    {
@@ -40800,12 +40901,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 188,
+  "downloads": 0,
   "id": "teensy40",
   "versions": [
    {
@@ -40955,12 +41056,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 244,
+  "downloads": 0,
   "id": "teensy41",
   "versions": [
    {
@@ -41110,12 +41211,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 92,
+  "downloads": 0,
   "id": "teknikio_bluebird",
   "versions": [
    {
@@ -41292,12 +41393,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 21,
+  "downloads": 0,
   "id": "thunderpack_v11",
   "versions": [
    {
@@ -41445,12 +41546,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 21,
+  "downloads": 0,
   "id": "thunderpack_v12",
   "versions": [
    {
@@ -41602,12 +41703,12 @@
      "vectorio"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 76,
+  "downloads": 0,
   "id": "tinkeringtech_scoutmakes_azul",
   "versions": [
    {
@@ -41784,12 +41885,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 124,
+  "downloads": 0,
   "id": "trellis_m4_express",
   "versions": [
    {
@@ -41969,12 +42070,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 317,
+  "downloads": 0,
   "id": "trinket_m0",
   "versions": [
    {
@@ -42077,12 +42178,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 71,
+  "downloads": 0,
   "id": "trinket_m0_haxpress",
   "versions": [
    {
@@ -42210,12 +42311,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 20,
+  "downloads": 0,
   "id": "uartlogger2",
   "versions": [
    {
@@ -42397,12 +42498,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 59,
+  "downloads": 0,
   "id": "uchip",
   "versions": [
    {
@@ -42507,12 +42608,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 48,
+  "downloads": 0,
   "id": "ugame10",
   "versions": [
    {
@@ -42628,12 +42729,12 @@
      "usb_cdc"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 291,
+  "downloads": 0,
   "id": "unexpectedmaker_feathers2",
   "versions": [
    {
@@ -42828,12 +42929,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 63,
+  "downloads": 0,
   "id": "unexpectedmaker_feathers2_neo",
   "versions": [
    {
@@ -43032,12 +43133,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 51,
+  "downloads": 0,
   "id": "unexpectedmaker_feathers2_prerelease",
   "versions": [
    {
@@ -43232,12 +43333,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 9,
+  "downloads": 0,
   "id": "unexpectedmaker_feathers3",
   "versions": [
    {
@@ -43335,12 +43436,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 9,
+  "downloads": 0,
   "id": "unexpectedmaker_pros3",
   "versions": [
    {
@@ -43438,12 +43539,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 129,
+  "downloads": 0,
   "id": "unexpectedmaker_tinys2",
   "versions": [
    {
@@ -43644,12 +43745,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 7,
+  "downloads": 0,
   "id": "unexpectedmaker_tinys3",
   "versions": [
    {
@@ -43748,12 +43849,12 @@
      "wifi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 5,
+  "downloads": 0,
   "id": "warmbit_bluepixel",
   "versions": [
    {
@@ -43930,12 +44031,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 15,
+  "downloads": 0,
   "id": "waveshare_rp2040_zero",
   "versions": [
    {
@@ -44027,12 +44128,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 59,
+  "downloads": 0,
   "id": "winterbloom_big_honking_button",
   "versions": [
    {
@@ -44142,12 +44243,12 @@
      "usb_cdc"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 70,
+  "downloads": 0,
   "id": "winterbloom_sol",
   "versions": [
    {
@@ -44285,12 +44386,12 @@
      "watchdog"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 55,
+  "downloads": 0,
   "id": "xinabox_cc03",
   "versions": [
    {
@@ -44387,12 +44488,12 @@
      "usb_midi"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  },
  {
-  "downloads": 41,
+  "downloads": 0,
   "id": "xinabox_cs11",
   "versions": [
    {
@@ -44487,7 +44588,7 @@
      "usb_hid"
     ],
     "stable": false,
-    "version": "7.2.0-rc.0"
+    "version": "7.2.0-rc.1"
    }
   ]
  }


### PR DESCRIPTION
Automated website update for release 7.2.0-rc.1 by Blinka.

New boards:
* espressif_esp32s3_devkitm_1_n8


