### PR TITLE
Compress features list and add links to details

### DIFF
--- a/_board/lolin_s2_pico.md
+++ b/_board/lolin_s2_pico.md
@@ -17,51 +17,34 @@ features:
 
 ---
 
-### Features
+A development boards with an OLED and a small form factor.
+
+## Features
 
 - ESP32-S2FN4R2 WiFi SoC
-    - Xtensa® single-core 32-bit LX7 microprocessor, up to 240 MHz
-    - Integrated 802.11 b/g/n WiFi 2.4GHz Transceiver, up to 150Mbps
-    - Integrated RISC-V ULP Coprocessor
-    - Integrated Temperature Sensor (-20°C to 110°C)
-    - Operating Voltage: 3.0 to 3.6V
-        - WiFi: 310mA (peak)
-        - Modem-sleep: 12-19mA
-        - Light-Sleep: 450µA
-        - Deep-Sleep: 20-190µA
-    - 320 KB SRAM
-    - 4 MB Flash (embedded)
-    - 2 MB PSRAM (embedded)
-    - 16 KB SRAM in RTC (accessable by main CPU, 8 KB accessable by ULP coprocessor)
-    - 4 Kbit eFuse (1792 bits reserved for user data)
-    - 2 × 13-bit SAR ADCs, up to 20 channels (2 channels not available on ADC2 due to USB D+/D-)
-    - 2 × 8-bit DAC
-    - 14 × touch sensing IOs
-    - 4 × SPI (2 usable due to embedded flash & PSRAM)
-    - 1 × I2S
-    - 2 × I2C
-    - 2 × UART
-    - 1 × DVP 8/16 camera interface, implemented using the hardware resources of I2S
-    - 1 × LCD interface (8-bit serial RGB/8080/6800), implemented using the hardware resources of SPI2
-    - 1 × LCD interface (8/16/24-bit parallel), implemented using the hardware resources of I2S
-    - 1 × TWAI® controller compatible with ISO 11898-1 (CAN Specification 2.0)
-    - LED PWM controller, up to 8 channels
-    - USB OTG 1.1 controller and PHY, with host and device support
-    - Cryptographic Hardware Accelerators: AES, ECB/CBC/OFB/CFB/CTR, GCM, SHA, RSA, ECC (Digital Signature)
-- USB Type-C connector, for built-in ROM USB bootloader, serial port debugging, and USB device mode
-- 3.3V regulator ME6211C33
-    - Maximum Output Current: 500mA （V<sub>IN</sub>＝4.3V, V<sub>OUT</sub>＝3.3V）
-    - Dropout Voltage: 100mV@ I<sub>OUT</sub>＝100 mA
-    - Operating Voltage Range: 2V～6.0V
-    - Low Power Consumption: 40µA（typ.）
-    - Standby Current: 0.1µA（typ.）
-- 27 × GPIO pins, plus `VBUS`, `3V3`, `GND`
-    - 21 × pins broken out to breadboard-friendly headers
-    - `EN` RESET button
-    - `GPIO0` BOOT button
-    - `GPIO10` LED (blue status LED)
-    - Lolin I2C JST SH 4-pin port (not QWIIC/Stemma-Qt pinout) using GPIO8 (SDA)/GPIO9 (SCL)
-    - 128 x 32 SSD1306 OLED display internally connected to the same I2C bus as the external port, reset pin connected to GPIO18
+  - Xtensa® single-core 32-bit LX7 microprocessor, up to 240 MHz
+  - Integrated 802.11 b/g/n WiFi 2.4 GHz Transceiver, up to 150 Mbps
+  - Integrated RISC-V ULP Coprocessor
+  - Integrated Temperature Sensor (-20 °C to 110 °C)
+  - Operating Voltage: 3.0 to 3.6 V (WiFi: 310 mA (peak), Modem sleep: 12-19 mA, Light sleep: 450 µA, Deep sleep: 20-190 µA)
+  - 320 KB SRAM, 4 MB Flash (embedded), 2 MB PSRAM (embedded), 16 KB SRAM in RTC (accessable by main CPU, 8 KB accessable by ULP coprocessor), 4 Kbit eFuse (1792 bits reserved for user data)
+  - 2 x 13-bit SAR ADCs, up to 20 channels (2 channels not available on ADC2 due to USB D+/D-)
+  - 2 x 8-bit DAC, 14 x touch sensing IOs
+  - 4 x SPI (2 usable due to embedded flash & PSRAM), 1 x I2S, 2 x I2C, 2 x UART
+  - 1 x DVP 8/16 camera interface, implemented using the hardware resources of I2S
+  - 1 x LCD interface SPI2 (8-bit serial RGB/8080/6800), 1 x LCD interface I2S (8/16/24-bit parallel)
+  - 1 x TWAI® controller compatible with ISO 11898-1 (CAN Specification 2.0)
+  - LED PWM controller, up to 8 channels
+  - USB OTG 1.1 controller and PHY, with host and device support
+  - Cryptographic Hardware Accelerators: AES, ECB/CBC/OFB/CFB/CTR, GCM, SHA, RSA, ECC (Digital Signature)
+- USB-C connector, for built-in ROM USB bootloader, serial port debugging, and USB device mode
+- 27 x GPIO pins, plus `VBUS`, `3V3`, `GND`
+  - 21 x pins broken out to breadboard-friendly headers
+  - `EN` RESET button
+  - `GPIO0` BOOT button
+  - `GPIO10` LED (blue status LED)
+  - Lolin I2C JST SH 4-pin port (not QWIIC/Stemma-Qt pinout) using `GPIO8` (SDA) and `GPIO9` (SCL)
+  - 128 x 32 SSD1306 OLED display internally connected to the same I2C bus as the external port, reset pin connected to `GPIO18`, I2C address `0x3C`
 - Compatible with CircuitPython, MicroPython (default firmware), Arduino and ESP-IDF
 
 ## Purchase
@@ -71,3 +54,6 @@ features:
 ## Learn More
 
 * [Manufacturer Specifications](https://www.wemos.cc/en/latest/s2/s2_pico.html)
+* [Schematic](https://www.wemos.cc/en/latest/_static/files/sch_s2_pico_v1.0.0.pdf)
+* [Dimension](https://www.wemos.cc/en/latest/_static/files/dim_s2_pico_v1.0.0.pdf)
+* [Factory MicroPython firmware](https://www.wemos.cc/en/latest/tutorials/s2/get_started_with_micropython_s2.html)


### PR DESCRIPTION
The feature list is now a bit shorter. The details were a bit extensive from my point of view and mostly covering the ESP32-S2FN4R2 and not so much the S2 Pico itself.