### PR TITLE
Various updates

### DIFF
--- a/_blinka/adafruit_feather_rp2040.md
+++ b/_blinka/adafruit_feather_rp2040.md
@@ -9,52 +9,52 @@ board_image: "adafruit_feather_rp2040.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-libraries-on-any-computer-with-raspberry-pi-pico"
 date_added: 2021-12-6
 features:
+  - USB-C
   - Feather-Compatible
   - STEMMA QT/QWIIC
 ---
 
-A new chip means a new Feather, and the Raspberry Pi RP2040 is no exception. When we saw this chip we thought "this chip is going to be awesome when we give it the Feather Treatment" and so we did! This Feather features the **RP2040**, and all niceties you know and love about Feather
-* Measures 2.0" x 0.9" x 0.28" (50.8mm x 22.8mm x 7mm) without headers soldered in
+A new chip means a new Feather, and the Raspberry Pi RP2040 is no exception. When we saw this chip we thought "this chip is going to be awesome when we give it the Feather Treatment" and so we did! This Feather features the **RP2040**, and all niceties you know and love about Feather.
+
+## Technical details
+
+* Measures 2.0" x 0.9" x 0.28" (50.8 mm x 22.8 mm x 7 mm) without headers soldered in
 * Light as a (large?) feather - 5 grams
-* RP2040 32-bit Cortex M0+ dual core running at ~125 MHz @ 3.3V logic and power
+* RP2040 32-bit Cortex M0+ dual core running at ~125 MHz @ 3.3 V logic and power
 * 264 KB RAM
 * **8 MB SPI FLASH** chip for storing files and CircuitPython/MicroPython code storage. No EEPROM
-* **Tons of GPIO! 21 x GPIO pins with following capabilities:**
+* **21 GPIO pins with following capabilities:**
   * **Four** 12 bit ADCs (one more than Pico)
   * Two I2C, Two SPI and two UART peripherals, we label one for the 'main' interface in standard Feather locations
-  * 16 x PWM outputs - for servos, LEDs, etc
+  * 16 PWM outputs - for servos, LEDs, etc
   * The 8 digital 'non-ADC/non-peripheral' GPIO are consecutive for maximum PIO compatibility
-* **Built in 200mA lipoly charger** with charging status indicator LED
+* **Built in 200 mA lipoly charger** with charging status indicator LED
 * **Pin #13 red LED** for general purpose blinking
 * **RGB NeoPixel** with power pin on GPIO so you can depower it for low power usages.
 * On-board **STEMMA QT connector** that lets you quickly connect any Qwiic, STEMMA QT or Grove I2C devices with no soldering!
 * **Both Reset button and Bootloader select button for quick restarts (no unplugging-replugging to relaunch code)**
-* 3.3V Power/enable pin
+* 3.3 V Power/enable pin
 * [Optional SWD debug port can be soldered in for debug access](https://www.adafruit.com/product/752)
 * 4 mounting holes
 * 24 MHz crystal for perfect timing.
-* 3.3V regulator with 500mA peak current output
-* **USB Type C connector** lets you access built-in ROM USB bootloader and serial port debugging
-
+* 3.3 V regulator with 500 mA peak current output
+* **USB-C connector** lets you access built-in ROM USB bootloader and serial port debugging
 
 **Inside the RP2040 is a 'permanent ROM' USB UF2 bootloader.** What that means is when you want to program new firmware, you can hold down the BOOTSEL button while plugging it into USB (or pulling down the RUN/Reset pin to ground) and it will appear as a USB disk drive you can drag the firmware onto. Folks who have been using Adafruit products will find this very familiar - we use the technique on all our native-USB boards. Just note you don't double-click reset, instead hold down BOOTSEL during boot to enter the bootloader!
 
-
 The RP2040 is a powerful chip, which has the clock speed of our M4 (SAMD51), and two cores that are equivalent to our M0 (SAMD1). Since it is an M0 chip, it does not have a floating point unit, or DSP hardware support - so if you're doing something with heavy floating-point math, it will be done in software and thus not as fast as an M4. For many other computational tasks, you'll get close-to-M4 speeds!
 
-
 For peripherals, there are two I2C controllers, two SPI controllers, and two UARTs that are multiplexed across the GPIO - check the pinout for what pins can be set to which. There are 16 PWM channels, each pin has a channel it can be set to (ditto on the pinout).
-
 
 You'll note there's no I2S peripheral, or SDIO, or camera, what's up with that? Well instead of having specific hardware support for serial-data-like peripherals like these, the RP2040 comes with the PIO state machine system which is a unique and powerful way to create custom hardware logic and data processing blocks that run on their own without taking up a CPU. For example, NeoPixels - often we bitbang the timing-specific protocol for these LEDs. For the RP2040, we instead use PIO object that reads in the data buffer and clocks out the right bitstream with perfect accuracy. Same with I2S audio in or out, LED matrix displays, 8-bit or SPI based TFTs, even VGA! In MicroPython and CircuitPython you can create PIO control commands to script the peripheral and load it in at runtime. There are 2 PIO peripherals with 4 state machines each.
 
 **At the time of launch, there is no Arduino core support for this board. There is great [C/C++ support](https://github.com/raspberrypi/pico-sdk), an official [MicroPython port](https://github.com/raspberrypi/micropython), and a [CircuitPython port](/downloads)!** We of course [recommend CircuitPython because we think it's the easiest way to get started](https://learn.adafruit.com/welcome-to-circuitpython) and it has support with most of our drivers, displays, sensors, and more, supported out of the box so you can follow along with our CircuitPython projects and tutorials.
 
-While the RP2040 has lots of onboard RAM (264KB), it does not have built-in FLASH memory. Instead, that is provided by the external QSPI flash chip. **On this board there is 8 MB**, which is shared between the program it's running and any file storage used by MicroPython or CircuitPython. When using C/C++ you get the whole flash memory, if using Python you will have about 7 MB remaining for code, files, images, fonts, etc.
+While the RP2040 has lots of onboard RAM (264 KB), it does not have built-in FLASH memory. Instead, that is provided by the external QSPI flash chip. **On this board there is 8 MB**, which is shared between the program it's running and any file storage used by MicroPython or CircuitPython. When using C/C++ you get the whole flash memory, if using Python you will have about 7 MB remaining for code, files, images, fonts, etc.
 
 **RP2040 Chip features:**
-* Dual ARM Cortex-M0+ @ 133MHz
-* 264kB on-chip SRAM in six independent banks
+* Dual ARM Cortex-M0+ @ 133 MHz
+* 264 kB on-chip SRAM in six independent banks
 * Support for up to 16MB of off-chip Flash memory via dedicated QSPI bus
 * DMA controller
 * Fully-connected AHB crossbar

--- a/_blinka/adafruit_itsybitsy_rp2040.md
+++ b/_blinka/adafruit_itsybitsy_rp2040.md
@@ -12,27 +12,29 @@ features:
 
 ---
 
-A new chip means a new ItsyBitsy, and the Raspberry Pi RP2040 is no exception. When we saw this chip we thought "this chip is going to be awesome when we give it the ItsyBitsy teensy-weensy Treatment" and so we did! This Itsy' features the RP2040, [and all niceties you know and love about the ItsyBitsy family](https://www.adafruit.com/category/1008)
+A new chip means a new ItsyBitsy, and the Raspberry Pi RP2040 is no exception. When we saw this chip we thought "this chip is going to be awesome when we give it the ItsyBitsy teensy-weensy Treatment" and so we did! This Itsy' features the RP2040, and all niceties you know and love about the [ItsyBitsy family](https://www.adafruit.com/category/1008).
 
-What's smaller than a Feather but larger than a Trinket? It's an Adafruit ItsyBitsy RP2040 featuring the Raspberry Pi RP2040! Small, powerful, with a ultra fast duel Cortex M0+ processor running at 125 MHz - this microcontroller board is perfect when you want something very compact, with lots of horsepower and a bunch of pins. This Itsy has sports car speed, but SUV roominess with 4 MB of FLASH and 264KB of SRAM.
+What's smaller than a Feather but larger than a Trinket? It's an Adafruit ItsyBitsy RP2040 featuring the Raspberry Pi RP2040! Small, powerful, with a ultra fast duel Cortex M0+ processor running at 125 MHz - this microcontroller board is perfect when you want something very compact, with lots of horsepower and a bunch of pins. This Itsy has sports car speed, but SUV roominess with 4 MB of FLASH and 264 KB of SRAM.
 
 ItsyBitsy RP2040 is only 1.4" long by 0.7" wide, but has 6 power pins, 23 digital GPIO pins (4 of which can be analog in and 16 x PWM out). It's the same chip as the [Feather RP2040](https://www.adafruit.com/products/4884) and [Raspberry Pi Pico](https://www.adafruit.com/products/4883) *but really really small*. So it's great once you've finished up a prototype, and want to make the project much smaller. It even comes with 4MB of SPI Flash built in, for data logging, file storage, or CircuitPython/MicroPython code
 
-- [Same size and form-factor as the rest of the ItsyBitsy family](https://www.adafruit.com/category/1008) and nearly-identical pinout
-- Measures 1.4" x 0.7" x 0.2" (36mm x 18mm x 4mm) without headers soldered in
+## Technical details
+
+- Same size and form-factor as the rest of the [ItsyBitsy family](https://www.adafruit.com/category/1008) and nearly-identical pinout
+- Measures 1.4" x 0.7" x 0.2" (36 mm x 18 mm x 4 mm) without headers soldered in
 - RP2040 32-bit Cortex M0+ dual core running at ~125 MHz @ 3.3V logic and power
 - 264 KB RAM
 - **4 MB SPI FLASH** chip for storing files and CircuitPython/MicroPython code storage. No EEPROM
-- Tons of GPIO! 23 x GPIO pins with following capabilities:
-  - **Four** 12 bit ADCs (one more than Pico)
-  - Two I2C, Two SPI and two UART peripherals, we label one for the 'main' interface in standard ItsyBitsy locations
-  - 16 x PWM outputs - for servos, LEDs, etc
+- 23 GPIO pins with following capabilities:
+  - 4 12-bit ADCs (one more than Pico)
+  - 2 I2C, 2 SPI and 2 UART peripherals, we label one for the 'main' interface in standard ItsyBitsy locations
+  - 16 PWM outputs - for servos, LEDs, etc
   - The 10 digital 'non-ADC/non-peripheral' GPIO are consecutive for maximum PIO compatibility
 - **Pin #13 red LED** for general purpose blinking
 - **RGB NeoPixel** with power pin on GPIO so you can depower it for low power usages.
 - **Both Reset button and Bootloader select button for quick restarts (no unplugging-replugging to relaunch code)**
-- 3.3V regulator with 500mA peak current output
-- 3.3V Power/enable pin
+- 3.3 V regulator with 500mA peak current output
+- 3.3 V Power/enable pin
 - Power with either USB or external output (such as a battery) - it'll automatically switch over
 - Broken-out SWD pins for debug access
 - 24 MHz crystal for perfect timing.

--- a/_blinka/adafruit_macropad_rp2040.md
+++ b/_blinka/adafruit_macropad_rp2040.md
@@ -24,7 +24,7 @@ Want to add more hardware? No worries - [a STEMMA QT port on the side lets you c
 
  **Please note, the RP2040 chip does not currently have QMK support** - this macropad is designed to be programmed in Arduino or CircuitPython! If QMK eventually does add RP2040 as a supported chipset (no ETA and no plans that we know of), we'll update this page.
 
- TL;DR?
+## Technical details
 
 - **Raspberry Pi RP2040 Chip + 8MB Flash memory** - Dual core Cortex M0+ at ~130MHz with 264KB or RAM. Runs CircuitPython, Arduino or MicroPython with ease and lots of space for development code and files
 - **USB C Connector for Power/Data** - of course this can act as an HID device but also can be MIDI, UART, etc.

--- a/_blinka/adafruit_qt2040_trinkey.md
+++ b/_blinka/adafruit_qt2040_trinkey.md
@@ -9,6 +9,7 @@ board_image: "adafruit_qt2040_trinkey.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-libraries-on-any-computer-with-raspberry-pi-pico"
 date_added: 2021-12-6
 features:
+  - STEMMA QT/QWIIC
 
 ---
 
@@ -19,6 +20,21 @@ The PCB is designed to slip into any USB A port on a computer or laptop. There's
 With the body of the board being 1.0" x 0.7" and four mounting holes, you can attach just about any of our QT boards right on (some are a little larger so just check that has the holes in the same locations). [Use M2.5 sized standoffs and screws](https://www.adafruit.com/product/3658) to do so, you could use 2 diagonal at a minimum. Then use a [shorty QT cable](https://www.adafruit.com/product/4399) and you've got a custom sensor Trinkey for any sensor purpose.
 
 The board comes with 8 MB of QSPI flash memory so you can put *all* of our CircuitPython drivers on the disk!
+
+## Technical details
+
+* Main body is same size/mounting holes as most of our Stemma QT boards (1.0" x 0.7" with M2.5 holes)
+* USB Type A connector with extra-thick PCB to fit into a USB host port
+* RP2040 32-bit Cortex M0+ dual-core running at ~125 MHz @ 3.3 V logic and power
+* 264 KB RAM
+* 8 MB SPI FLASH chip for storing files and CircuitPython/MicroPython code storage. No EEPROM
+* Native USB supported by every OS - can be used as USB serial console, MIDI, Keyboard/Mouse HID, even a little disk drive for storing Python scripts.
+* Built-in RGB NeoPixel LED
+* STEMMA QT/Qwiic port for I2C connectivity
+* 3.3 V regulator with 600 mA peak output
+* 12 MHz crystal
+* Both Reset button and Bootloader select buttons for quick restarts (no unplugging-replugging to relaunch code)
+* Bootloader button can also be safely used in 'user' code
 
 ## Purchase
 

--- a/_blinka/adafruit_qtpy_rp2040.md
+++ b/_blinka/adafruit_qtpy_rp2040.md
@@ -10,6 +10,7 @@ download_instructions: "https://learn.adafruit.com/circuitpython-libraries-on-an
 date_added: 2021-12-6
 features:
   - STEMMA QT/QWIIC
+  - USB-C
 ---
 
 What a cutie pie! Or is it... a QT Py? This diminutive dev board comes with one of our new favorite chip, the RP2040. It's been made famous in the new [Raspberry Pi Pico](https://www.adafruit.com/pico) *and* our [Feather RP2040](http://www.adafruit.com/product/4884) and [ItsyBitsy RP2040](http://www.adafruit.com/product/4888), but what if we wanted something really *smol?*
@@ -24,13 +25,13 @@ Use any [SparkFun Qwiic](http://www.sparkfun.com/qwiic) boards! [Seeed Grove I2C
 
 **At the time of launch, there is no Arduino core support for the chip on this board. There is great [C/C++ support](https://github.com/raspberrypi/pico-sdk), an official [MicroPython port](https://github.com/raspberrypi/micropython), and a [CircuitPython port](https://circuitpython.org/downloads)!** We of course [recommend CircuitPython because we think it's the easiest way to get started](https://learn.adafruit.com/welcome-to-circuitpython) and it has support with most of our drivers, displays, sensors, and more, supported out of the box so you can follow along with our CircuitPython projects and tutorials.
 
-Pinout and shape is [Seeed Xiao](https://wiki.seeedstudio.com/Seeeduino-XIAO/) compatible, with castellated pads so you can solder it to a PCB with a cut out to allow the bottom components some breathing room. In addition to the QT connector, we also added an **RGB NeoPixel** (with a controllable power pin to allow for ultra-low-power usage), **and both boot-mode and reset buttons** (great for restarting your program or entering the bootloader). This QT Py comes with loose 0.1" headers you can solder in for breadboard use
+Pinout and shape is [Seeed Xiao](https://wiki.seeedstudio.com/Seeeduino-XIAO/) compatible, with castellated pads so you can solder it to a PCB with a cut out to allow the bottom components some breathing room. In addition to the QT connector, we also added an **RGB NeoPixel** (with a controllable power pin to allow for ultra-low-power usage), **and both boot-mode and reset buttons** (great for restarting your program or entering the bootloader). This QT Py comes with loose 0.1" headers you can solder in for breadboard use.
 
-While the RP2040 has lots of onboard RAM (264KB), it does not have built-in FLASH memory. Instead, that is provided by the external QSPI flash chip. On this board there is 4MB, which is shared between the program it's running and any file storage used by MicroPython or CircuitPython. When using C/C++ you get the whole flash memory, if using Python you will have about 3 MB remaining for code, files, images, fonts, etc.
+While the RP2040 has lots of onboard RAM (264 KB), it does not have built-in FLASH memory. Instead, that is provided by the external QSPI flash chip. On this board there is 4MB, which is shared between the program it's running and any file storage used by MicroPython or CircuitPython. When using C/C++ you get the whole flash memory, if using Python you will have about 3 MB remaining for code, files, images, fonts, etc.
 
 - Same size, form-factor, and pin-out as [our SAMD-based QT Py](https://www.adafruit.com/product/4600)
-- **USB Type C connector** - [If you have only Micro B cables, this adapter will come in handy](https://www.adafruit.com/product/4299)!
-- **RP2040 32-bit Cortex M0+** dual-core running at ~125 MHz @ 3.3V logic and power
+- **USB-C connector** - [If you have only Micro B cables, this adapter will come in handy](https://www.adafruit.com/product/4299)!
+- **RP2040 32-bit Cortex M0+** dual-core running at ~125 MHz @ 3.3 V logic and power
 - 264 KB RAM
 - **8 MB SPI FLASH** chip for storing files and CircuitPython/MicroPython code storage. No EEPROM
 - Native USB supported by every OS - can be used in Arduino or CircuitPython as USB serial console, MIDI, Keyboard/Mouse HID, even a little disk drive for storing Python scripts.
@@ -42,7 +43,7 @@ While the RP2040 has lots of onboard RAM (264KB), it does not have built-in FLAS
   - SPI and UART peripherals, in standard QT Py locations,
   - PWM outputs on every IO pin - for servos, LEDs, etc
   - There are 6 GPIO in consecutive order for PIO compatibility
-- 3.3V regulator with [**600mA peak output**](https://www.diodes.com/assets/Datasheets/AP2112.pdf)
+- 3.3 V regulator with [**600 mA peak output**](https://www.diodes.com/assets/Datasheets/AP2112.pdf)
 - **Both Reset button and Bootloader select buttons** for quick restarts (no unplugging-replugging to relaunch code)
 - **Really really small**
 

--- a/_blinka/google_coral.md
+++ b/_blinka/google_coral.md
@@ -20,24 +20,27 @@ features:
 
 A development board to quickly prototype on-device ML products. Scale from prototype to production with a removable system-on-module (SOM).
 
-Edge TPU Module
-- CPU	NXP i.MX 8M SOC (quad Cortex-A53, Cortex-M4F)
-- GPU	Integrated GC7000 Lite Graphics
-- ML accelerator	Google Edge TPU coprocessor
-- RAM	1 GB LPDDR4
-- Flash memory	8 GB eMMC
-- Wireless	Wi-Fi 2x2 MIMO (802.11b/g/n/ac 2.4/5GHz) Bluetooth 4.1
-- Dimensions	48mm x 40mm x 5mm
+### Edge TPU Module
 
-Baseboard
-- Flash memory	MicroSD slot
-- USB	Type-C OTG Type-C power Type-A 3.0 host Micro-B serial console
-- LAN	Gigabit Ethernet port
-- Audio	3.5mm audio jack (CTIA compliant) Digital PDM microphone (x2) 2.54mm 4-pin terminal for stereo speakers
-- Video	HDMI 2.0a (full size) 39-pin FFC connector for MIPI-DSI display (4-lane) 24-pin FFC connector for MIPI-CSI2 camera (4-lane)
-- GPIO	3.3V power rail 40 - 255 ohms programmable impedance ~82 mA max current
-- Power	5V DC (USB Type-C)
-- Dimensions	88 mm x 60 mm x 24mm
+- CPU: NXP i.MX 8M SOC (quad Cortex-A53, Cortex-M4F)
+- GPU: Integrated GC7000 Lite Graphics
+- ML accelerator: Google Edge TPU coprocessor
+- RAM: 1 GB LPDDR4
+- Flash memory: 8 GB eMMC
+- Wireless: Wi-Fi 2x2 MIMO (802.11b/g/n/ac 2.4/5 GHz) Bluetooth 4.1
+- Dimensions: 48 mm x 40 mm x 5 mm
+
+### Baseboard
+
+- Flash memory MicroSD slot
+- USB: USB-C OTG, USB-C power, Type-A 3.0 host,  Micro-B serial console
+- LAN: Gigabit Ethernet port
+- Audio: 3.5 mm audio jack (CTIA compliant) Digital PDM microphone (x2) 2.54 mm 4-pin terminal for stereo speakers
+- Video: HDMI 2.0a (full size) 39-pin FFC connector for MIPI-DSI display (4-lane) 24-pin FFC connector for MIPI-CSI2 camera (4-lane)
+- GPIO: 3.3 V power rail 40 - 255 ohm programmable impedance ~82 mA max current
+- Power: 5 V DC (USB-C)
+- Dimensions:	88 mm x 60 mm x 24mm
 
 ## Purchase
+
 * [Google](https://coral.withgoogle.com/products/dev-board)

--- a/_blinka/orange_pi_zero2.md
+++ b/_blinka/orange_pi_zero2.md
@@ -22,22 +22,22 @@ Orange Pi Zero2 is for anyone who wants to start creating with technology – no
 - Allwinner H616 64-bit high-performance Quad-core Cortex-A53 processor
 - Mali G31 MP2
 - Supports OpenGL ES 1.0/2.0/3.2, OpenCL 2.0
-- 512MB/1GB DDR3 (Shared with GPU)
+- 512 MB/1 GB DDR3 (Shared with GPU)
 - TF card slot
-- 2MB SPI Flash
+- 2 MB SPI Flash
 - Support 1000M/100M/10M Ethernet
 - Onboard Wifi + Bluetooth
 - AW859A Chip
 - Support IEEE 802.11 a/b/g/n/ac
 - Support BT5.0
-- Type-C interface 5V2A input
+- USB-C interface 5 V/2 A input
 - 3*USB 2.0 HOST (Two of them are via 13pin interface board)
 - UART-TX, UART-RX and GND
 - Power Button(SW602)
 - 26pin header with I2C, SPI, UART and multiple GPIO ports
 - 13pin header with 2*USB Host, IR pin, Tv-out, AUDIO (no MIC) and 3 GPIO ports
 - Power led & Status led
-- Android4.4, Lubuntu, Debian, Armbian Image
+- Android 4.4, Lubuntu, Debian, Armbian Image
 
 ## Purchase
 * [Amazon](https://www.amazon.com/dp/B08M9MWZCQ)

--- a/_blinka/stm32mp157c_dk2.md
+++ b/_blinka/stm32mp157c_dk2.md
@@ -20,11 +20,13 @@ features:
 
 The STM32MP157A-DK1 and STM32MP157C-DK2 Discovery kits leverage the capabilities of STM32MP1 Series microprocessors to allow users easily develop applications using STM32 MPU OpenSTLinux Distribution software for the main processor and STM32CubeMP1 software for the co-processor.
 
-They include an ST-LINK embedded debug tool, LEDs, push-buttons, one Ethernet 1-Gbps connector, one USB Type-CTM OTG connector, four USB Type-A Host connectors, one HDMI® transceiver, one stereo headset jack with analog microphone, and one microSDTM connector.
+They include an ST-LINK embedded debug tool, LEDs, push-buttons, one Ethernet 1-Gbps connector, one USB-C OTG connector, four USB Type-A Host connectors, one HDMI transceiver, one stereo headset jack with analog microphone, and one microSD connector.
 
-To expand the functionality of the STM32MP157A-DK1 and STM32MP157C-DK2 Discovery kits, two GPIO expansion connectors are also available for ARDUINO® and Raspberry Pi® shields.
+To expand the functionality of the STM32MP157A-DK1 and STM32MP157C-DK2 Discovery kits, two GPIO expansion connectors are also available for ARDUINO® and Raspberry Pi shields.
 
-Additionally, the STM32MP157C-DK2 Discovery kit features an LCD display with a touch panel, and Wi-Fi® and Bluetooth® Low Energy capability.
+Additionally, the STM32MP157C-DK2 Discovery kit features an LCD display with a touch panel, and Wi-Fi and Bluetooth Low Energy capability.
+
+## Technical details
 
 - STM32MP157 Arm®-based dual Cortex®-A7 32 bits + Cortex®-M4 32 bits MPU in TFBGA361 package
 - ST PMIC STPMIC1
@@ -34,14 +36,19 @@ Additionally, the STM32MP157C-DK2 Discovery kit features an LCD display with a t
 - Audio codec
 - 4 user LEDs
 - 2 user and reset push-buttons, 1 wake-up button
-- 5 V / 3 A USB Type-CTM power supply input (not provided)
-- Board connectors:Ethernet RJ454 × USB Host Type-AUSB Type-CTM DRPMIPI DSISMHDMI®Stereo headset jack including analog microphone inputmicroSDTM cardGPIO expansion connector (Raspberry Pi® shields capability)ARDUINO® Uno V3 expansion connectors
+- 5 V / 3 A USB-C power supply input (not provided)
+- Board connectors: 
+  - Ethernet RJ45
+  - 4x USB Host Type-A and USB-C
+  - HDMI Stereo headset jack including analog microphone input
+  - microSD card
+  - GPIO expansion connector (Raspberry Pi shields capability) and Arduino Uno V3 expansion connectors
 - On-board ST-LINK/V2-1 debugger/programmer with USB re-enumeration capability: Virtual COM port and debug port
-- STM32CubeMP1 and full mainline open-source Linux® STM32 MPU OpenSTLinux Distribution (such as STM32MP1Starter) software and examples
-- Support of a wide choice of Integrated Development Environments (IDEs) including IARTM, Keil®, GCC-based IDEs
+- STM32 CubeMP1 and full mainline open-source Linux STM32 MPU OpenSTLinux Distribution (such as STM32MP1Starter) software and examples
+- Support of a wide choice of Integrated Development Environments (IDEs) including IARTM, Keil, GCC-based IDEs
 - 4" TFT 480×800 pixels with LED backlight, MIPI DSISM interface, and capacitive touch panel
-- Wi-Fi® 802.11b/g/n
-- Bluetooth® Low Energy 4.1
+- Wi-Fi 802.11b/g/n
+- Bluetooth Low Energy 4.1
 
 ## Purchase
 * [STMicroelectronics](https://estore.st.com/en/products/evaluation-tools/product-evaluation-tools/mcu-mpu-eval-tools/stm32-mcu-mpu-eval-tools/stm32-discovery-kits/stm32mp157c-dk2.html)

--- a/_board/TG-Watch.md
+++ b/_board/TG-Watch.md
@@ -15,15 +15,17 @@ features:
   - USB-C
 ---
 
-Why buy an apple watch when you can spend your weekends building a microcontroller based "smart" watch instead? the TG-Watch is an open source, not-dumb watch meant for makers who want to hack on their watch, people who want to bring python with them everywhere, or as a great starting point to learn about programming.
+Why buy an Apple watch when you can spend your weekends building a microcontroller based "smart" watch instead? The TG-Watch is an open source, not-dumb watch meant for makers who want to hack on their watch, people who want to bring Python with them everywhere, or as a great starting point to learn about programming.
 
-Some of its features include:
- * a 240x240, 1.54" lcd
- * capacitive touchscreen
- * USB Type-C port (2.0)
- * Step counter and pedometer
- * vibration motor and haptic motor driver
- * Bluetooth 5, Bluetooth mesh, Thread, ZigBee
+## Technical details
+
+* 240x240, 1.54" LCD
+* capacitive touchscreen
+* USB-C port (2.0)
+* Step counter and pedometer
+* Vibration motor and haptic motor driver
+* Bluetooth 5, Bluetooth mesh, Thread, ZigBee
 
 ## Learn More
+
 * [Download PCB Files on Github](https://github.com/TG-Techie/TG-Watch02-PCB)

--- a/_board/adafruit_feather_esp32s2.md
+++ b/_board/adafruit_feather_esp32s2.md
@@ -26,20 +26,20 @@ The ESP32-S2 is a highly-integrated, low-power, 2.4 GHz Wi-Fi System-on-Chip (So
 
 **Please note** the Feather ESP32-S2 has a single-core 240 MHz chip, so it won't be as fast as ESP32's with dual-core. Also, there is no Bluetooth support. However, we are super excited about the ESP32-S2's native USB which unlocks a lot of capabilities for advanced interfacing! This ESP32-S2 mini-module we are using on the Feather comes with 4 MB flash and 2 MB PSRAM so you can buffer massive JSON files for parsing!
 
-**Features:**
+## Technical details
 
-- **ESP32-S2 240MHz Tensilica processor** - the next generation of ESP32, now with native USB so it can act like a keyboard/mouse, MIDI device, disk drive, etc!
-- **Mini module** has FCC/CE certification and comes with 4 MByte of Flash and 2 MByte of PSRAM - you can have huge data buffers
-- **Power options** - USB type C **or** Lipoly battery
+- **ESP32-S2 240 MHz Tensilica processor** - the next generation of ESP32, now with native USB so it can act like a keyboard/mouse, MIDI device, disk drive, etc!
+- **Mini module** has FCC/CE certification and comes with 4 MB of Flash and 2 M of PSRAM - you can have huge data buffers
+- **Power options** - USB-C **or** Lipoly battery
 - **Built-in battery charging** when powered over USB-C
-- **BME280 temperature / humidity / barometric pressures sensor** connected over I2C on address 0x77 for immediate ambient weather sensing (**on BME280 version only!**)
+- **BME280** temperature / humidity / barometric pressure sensor connected over I2C on address `0x77` for immediate ambient weather sensing (**on BME280 version only!**)
 - **LiPoly battery monitor** - LC709203 chip actively monitors your battery for voltage and state of charge / percentage reporting over I2C
 - **Reset and DFU** (BOOT0) buttons to get into the ROM bootloader (which is a USB serial port so you don't need a separate cable!)
 - **Serial debug output pin** (optional, for checking the hardware serial debug console)
-- **STEMMA QT** connector for I2C devices, with switchable power, so you can go into low power mode.
-- **On/Charge/User** LEDs + status **NeoPixel** with pin-controlled power for low power usage
-- **Low Power friendly**! In deep sleep mode we can get down to 30uA of current draw from the Lipoly connection. Quiescent current is from the power regulator, ESP32-S2 chip, and Lipoly monitor. Turn off the NeoPixel and external I2C power for the lowest quiescent current draw.
-- **Works with Arduino or CircuitPython**
+- **STEMMA QT** connector for I2C devices, with switchable power, so you can go into low power mode
+- **On/Charge/User** LEDs and status **NeoPixel** with pin-controlled power for low power usage
+- **Low Power friendly**! In deep sleep mode we can get down to 30 uA of current draw from the Lipoly connection. Quiescent current is from the power regulator, ESP32-S2 chip, and Lipoly monitor. Turn off the NeoPixel and external I2C power for the lowest quiescent current draw.
+- Works with Arduino or CircuitPython
 
 ## Purchase
 

--- a/_board/adafruit_feather_esp32s2_bme280.md
+++ b/_board/adafruit_feather_esp32s2_bme280.md
@@ -22,26 +22,26 @@ features:
 
 What's Feather-shaped and has an ESP32-S2 WiFi module? What has a STEMMA QT connector for I2C devices and a built in ambient sensor? What has your favorite Espressif WiFi microcontroller and lots of Flash and RAM memory for your next IoT project? What will make your next IoT project sensor project flyyyyy?
 
-That's right - it's the new **Adafruit ESP32-S2 Feather with BME280** temperature/humidity/pressure sensor built right in! With native USB and 4 MB flash + 2 MB of PSRAM, this board is perfect for use with CircuitPython or Arduino with low-cost WiFi. Native USB means it can act like a keyboard or a disk drive. WiFi means its awesome for IoT projects. And Feather means it works with the large community of Feather Wings for expandability.
+That's right - it's the new **Adafruit ESP32-S2 Feather with BME280** temperature/humidity/pressure sensor built right in! With native USB and 4 MB flash and 2 MB of PSRAM, this board is perfect for use with CircuitPython or Arduino with low-cost WiFi. Native USB means it can act like a keyboard or a disk drive. WiFi means its awesome for IoT projects. And Feather means it works with the large community of Feather Wings for expandability.
   
 The ESP32-S2 is a highly-integrated, low-power, 2.4 GHz Wi-Fi System-on-Chip (SoC) solution that now has **built-in native USB** as well as some other interesting new technologies like Time of Flight distance measurements. With its state-of-the-art power and RF performance, this SoC is an ideal choice for a wide variety of application scenarios relating to the [Internet of Things (IoT)](https://www.adafruit.com/category/342), [wearable electronics](https://www.adafruit.com/category/65), and smart homes.
   
 **Please note** the Feather ESP32-S2 has a single-core 240 MHz chip, so it won't be as fast as ESP32's with dual-core. Also, there is no Bluetooth support. However, we are super excited about the ESP32-S2's native USB which unlocks a lot of capabilities for advanced interfacing! This ESP32-S2 mini-module we are using on the Feather comes with 4 MB flash and 2 MB PSRAM so you can buffer massive JSON files for parsing!
   
-**Features:**
+## Technical details
   
-  - **ESP32-S2 240MHz Tensilica processor** - the next generation of ESP32, now with native USB so it can act like a keyboard/mouse, MIDI device, disk drive, etc!
-  - **Mini module** has FCC/CE certification and comes with 4 MByte of Flash and 2 MByte of PSRAM - you can have huge data buffers
-  - **Power options** - USB type C **or** Lipoly battery
+  - **ESP32-S2 240 MHz Tensilica processor** - the next generation of ESP32, now with native USB so it can act like a keyboard/mouse, MIDI device, disk drive, etc!
+  - **Mini module** has FCC/CE certification and comes with 4 MB of Flash and 2 MB of PSRAM - you can have huge data buffers
+  - **Power options** - USB-C **or** Lipoly battery
   - **Built-in battery charging** when powered over USB-C
-  - **BME280 temperature / humidity / barometric pressures sensor** connected over I2C on address 0x77 for immediate ambient weather sensing.
+  - **BME280** temperature/humidity/barometric pressure sensor connected over I2C on address `0x77` for immediate ambient weather sensing
   - **LiPoly battery monitor** - LC709203 chip actively monitors your battery for voltage and state of charge / percentage reporting over I2C
   - **Reset and DFU** (BOOT0) buttons to get into the ROM bootloader (which is a USB serial port so you don't need a separate cable!)
   - **Serial debug output pin** (optional, for checking the hardware serial debug console)
-  - **STEMMA QT** connector for I2C devices, with switchable power, so you can go into low power mode.
-  - **On/Charge/User** LEDs + status **NeoPixel** with pin-controlled power for low power usage
-  - **Low Power friendly**! In deep sleep mode we can get down to 80~100uA of current draw from the Lipoly connection. Quiescent current is from the power regulator, ESP32-S2 chip, and Lipoly monitor. Turn off the NeoPixel and external I2C power for the lowest quiescent current draw.
-  - **Works with Arduino or CircuitPython**
+  - **STEMMA QT** connector for I2C devices, with switchable power, so you can go into low power mode
+  - **On/Charge/User** LEDs and status **NeoPixel** with pin-controlled power for low power usage
+  - **Low Power friendly**! In deep sleep mode we can get down to 80~100 uA of current draw from the Lipoly connection. Quiescent current is from the power regulator, ESP32-S2 chip, and Lipoly monitor. Turn off the NeoPixel and external I2C power for the lowest quiescent current draw.
+  - Works with Arduino or CircuitPython
 
 ## Purchase
 

--- a/_board/adafruit_feather_esp32s2_tft.md
+++ b/_board/adafruit_feather_esp32s2_tft.md
@@ -31,20 +31,20 @@ The color TFT is connected to the SPI pins, and uses additional pins for control
 
 For low power usages, the Feather has a *second* AP2112 regulator. The regulator is controlled with a GPIO pin on the enable line and can shut off power to the Stemma QT port and TFT. There is also a separate power pin for the NeoPixel that can be used to disable it for even lower quiescent power. With everything off and in deep sleep mode, the TFT feather uses about 100uA of current.
 
-**Features:**
+## Technical details
 
-- **ESP32-S2 240MHz Tensilica processor** - the next generation of ESP32, now with native USB so it can act like a keyboard/mouse, MIDI device, disk drive, etc!
-- **Mini module** has FCC/CE certification and comes with 4 MByte of Flash and 2 MByte of PSRAM - you can have huge data buffers
+- **ESP32-S2 240 MHz Tensilica processor** - the next generation of ESP32, now with native USB so it can act like a keyboard/mouse, MIDI device, disk drive, etc!
+- **Mini module** has FCC/CE certification and comes with 4 MB of Flash and 2 MB of PSRAM - you can have huge data buffers
 - **[Color 1.14" IPS TFT with 240x135 pixels](https://www.adafruit.com/product/4383)** - bright and colorful display with ST7789 chipset that can be viewed at any angle angle.
-- **Power options** - USB type C **or** Lipoly battery
+- **Power options** - USB-C **or** Lipoly battery
 - **Built-in battery charging** when powered over USB-C
 - **LiPoly battery monitor** - LC709203 chip actively monitors your battery for voltage and state of charge / percentage reporting over I2C
 - **Reset and DFU** (BOOT0) buttons to get into the ROM bootloader (which is a USB serial port so you don't need a separate cable!)
 - **Serial debug output pin** (optional, for checking the hardware serial debug console)
-- **STEMMA QT** connector for I2C devices, with switchable power, so you can go into low power mode.
+- **STEMMA QT** connector for I2C devices, with switchable power, so you can go into low power mode
 - **On/Charge/User** LEDs + status **NeoPixel** with pin-controlled power for low power usage
-- **Low Power friendly**! In deep sleep mode we can get down to 80~100uA of current draw from the Lipoly connection. Quiescent current is from the power regulator, ESP32-S2 chip, and Lipoly monitor. Turn off the NeoPixel and external I2C/TFT power for the lowest quiescent current draw.
-- **Works with Arduino or CircuitPython**
+- **Low Power friendly**! In deep sleep mode we can get down to 80~100 uA of current draw from the Lipoly connection. Quiescent current is from the power regulator, ESP32-S2 chip, and Lipoly monitor. Turn off the NeoPixel and external I2C/TFT power for the lowest quiescent current draw.
+- Works with Arduino or CircuitPython
 
 ## Purchase
 

--- a/_board/adafruit_feather_rp2040.md
+++ b/_board/adafruit_feather_rp2040.md
@@ -16,38 +16,37 @@ features:
   - Breadboard-Friendly
 ---
 
-A new chip means a new Feather, and the Raspberry Pi RP2040 is no exception. When we saw this chip we thought "this chip is going to be awesome when we give it the Feather Treatment" and so we did! This Feather features the **RP2040**, and all niceties you know and love about Feather
-* Measures 2.0" x 0.9" x 0.28" (50.8mm x 22.8mm x 7mm) without headers soldered in
+A new chip means a new Feather, and the Raspberry Pi RP2040 is no exception. When we saw this chip we thought "this chip is going to be awesome when we give it the Feather Treatment" and so we did! This Feather features the **RP2040**, and all niceties you know and love about Feather.
+
+## Technical details
+
+* Measures 2.0" x 0.9" x 0.28" (50.8 mm x 22.8 mm x 7 mm) without headers soldered in
 * Light as a (large?) feather - 5 grams
-* RP2040 32-bit Cortex M0+ dual core running at ~125 MHz @ 3.3V logic and power
+* RP2040 32-bit Cortex M0+ dual core running at ~125 MHz @ 3.3 V logic and power
 * 264 KB RAM
 * **8 MB SPI FLASH** chip for storing files and CircuitPython/MicroPython code storage. No EEPROM
-* **Tons of GPIO! 21 x GPIO pins with following capabilities:**
-  * **Four** 12 bit ADCs (one more than Pico)
-  * Two I2C, Two SPI and two UART peripherals, we label one for the 'main' interface in standard Feather locations
-  * 16 x PWM outputs - for servos, LEDs, etc
+* 21 GPIO pins with following capabilities:**
+  * 4 12-bit ADCs (one more than Pico)
+  * 2 I2C, 2 SPI and 2 UART peripherals, we label one for the 'main' interface in standard Feather locations
+  * 16 PWM outputs - for servos, LEDs, etc
   * The 8 digital 'non-ADC/non-peripheral' GPIO are consecutive for maximum PIO compatibility
-* **Built in 200mA lipoly charger** with charging status indicator LED
+* **Built in 200 mA lipoly charger** with charging status indicator LED
 * **Pin #13 red LED** for general purpose blinking
 * **RGB NeoPixel** with power pin on GPIO so you can depower it for low power usages.
 * On-board **STEMMA QT connector** that lets you quickly connect any Qwiic, STEMMA QT or Grove I2C devices with no soldering!
 * **Both Reset button and Bootloader select button for quick restarts (no unplugging-replugging to relaunch code)**
-* 3.3V Power/enable pin
+* 3.3 V Power/enable pin
 * [Optional SWD debug port can be soldered in for debug access](https://www.adafruit.com/product/752)
 * 4 mounting holes
-* 24 MHz crystal for perfect timing.
-* 3.3V regulator with 500mA peak current output
-* **USB Type C connector** lets you access built-in ROM USB bootloader and serial port debugging
-
+* 24 MHz crystal for perfect timing
+* 3.3 V regulator with 500 mA peak current output
+* **USB-C connector** lets you access built-in ROM USB bootloader and serial port debugging
 
 **Inside the RP2040 is a 'permanent ROM' USB UF2 bootloader.** What that means is when you want to program new firmware, you can hold down the BOOTSEL button while plugging it into USB (or pulling down the RUN/Reset pin to ground) and it will appear as a USB disk drive you can drag the firmware onto. Folks who have been using Adafruit products will find this very familiar - we use the technique on all our native-USB boards. Just note you don't double-click reset, instead hold down BOOTSEL during boot to enter the bootloader!
 
-
 The RP2040 is a powerful chip, which has the clock speed of our M4 (SAMD51), and two cores that are equivalent to our M0 (SAMD1). Since it is an M0 chip, it does not have a floating point unit, or DSP hardware support - so if you're doing something with heavy floating-point math, it will be done in software and thus not as fast as an M4. For many other computational tasks, you'll get close-to-M4 speeds!
 
-
 For peripherals, there are two I2C controllers, two SPI controllers, and two UARTs that are multiplexed across the GPIO - check the pinout for what pins can be set to which. There are 16 PWM channels, each pin has a channel it can be set to (ditto on the pinout).
-
 
 You'll note there's no I2S peripheral, or SDIO, or camera, what's up with that? Well instead of having specific hardware support for serial-data-like peripherals like these, the RP2040 comes with the PIO state machine system which is a unique and powerful way to create custom hardware logic and data processing blocks that run on their own without taking up a CPU. For example, NeoPixels - often we bitbang the timing-specific protocol for these LEDs. For the RP2040, we instead use PIO object that reads in the data buffer and clocks out the right bitstream with perfect accuracy. Same with I2S audio in or out, LED matrix displays, 8-bit or SPI based TFTs, even VGA! In MicroPython and CircuitPython you can create PIO control commands to script the peripheral and load it in at runtime. There are 2 PIO peripherals with 4 state machines each.
 
@@ -56,9 +55,9 @@ There is great [C/C++ support](https://github.com/raspberrypi/pico-sdk), unoffic
 While the RP2040 has lots of onboard RAM (264KB), it does not have built-in FLASH memory. Instead, that is provided by the external QSPI flash chip. **On this board there is 8 MB**, which is shared between the program it's running and any file storage used by MicroPython or CircuitPython. When using C/C++ you get the whole flash memory, if using Python you will have about 7 MB remaining for code, files, images, fonts, etc.
 
 **RP2040 Chip features:**
-* Dual ARM Cortex-M0+ @ 133MHz
-* 264kB on-chip SRAM in six independent banks
-* Support for up to 16MB of off-chip Flash memory via dedicated QSPI bus
+* Dual ARM Cortex-M0+ @ 133 MHz
+* 264 kB on-chip SRAM in six independent banks
+* Support for up to 16 MB of off-chip Flash memory via dedicated QSPI bus
 * DMA controller
 * Fully-connected AHB crossbar
 * Interpolator and integer divider peripherals

--- a/_board/adafruit_funhouse.md
+++ b/_board/adafruit_funhouse.md
@@ -23,21 +23,22 @@ The main processor is the ESP32-S2, which has the advantage of the low cost and 
 
 The board is designed to make it easy to wire up sensors with little or no soldering. There are built in sensors for light, pressure, humidity and temperature sensors. [Three JST PH plugs allow for quick connection of STEMMA boards](https://www.adafruit.com/category/1019) that use digital or analog I/O, and there's a [STEMMA QT port for any I2C devices](https://www.adafruit.com/category/620).
 
-Here's what we included on this development board:
- * **ESP32-S2 240MHz Tensilica processor** - the next generation of ESP32, now with native USB so it can act like a keyboard/mouse, MIDI device, disk drive, etc!
- * **WROVER module** has FCC/CE certification and comes with 4 MByte of Flash and 2 MByte of PSRAM - you can have huge data buffers
+## Technical details
+
+ * **ESP32-S2 240 MHz Tensilica processor** - the next generation of ESP32, now with native USB so it can act like a keyboard/mouse, MIDI device, disk drive, etc!
+ * **WROVER module** has FCC/CE certification and comes with 4 MB of Flash and 2 MB of PSRAM - you can have huge data buffers
  * **[1.54" Color TFT display with 240x240 pixels](https://www.adafruit.com/product/4421)**. This petite display is one of our favorites, with SPI interface and a controllable backlight.
  * **USB C** power and data connector
  * **Five mini RGB DotStar LEDs** on the top, for animations or easily-visible notification
- * **Three buttons** can be used to wake up the ESP32 from deep-sleep, or select different modes
+ * 3 **buttons** can be used to wake up the ESP32 from deep-sleep, or select different modes
  * **[DPS310](https://www.adafruit.com/product/4494) barometric pressure and temperature sensor**
  * **[AHT20](https://www.adafruit.com/product/4566) relative humidity and temperature sensor**
  * Plug in socket for [Mini PIR sensor](https://www.adafruit.com/product/4871) (not included)
  * Front facing **light sensor**
  * **Speaker/Buzzer** can play tones and beeps for audible notification.
  * **STEMMA QT** port for [attaching all sorts of I2C devices](https://www.adafruit.com/stemma)
- * Three **STEMMA 3 pin JST** connectors for attaching [NeoPixels](https://www.adafruit.com/product/3919), [speakers](https://www.adafruit.com/product/3885), [servos](https://www.adafruit.com/product/4326) or [relays](https://www.adafruit.com/product/4409).
- * Three **capacitive touch pads** and one **capacitive touch slider** with 5 elements.
+ * 3 **STEMMA 3 pin JST** connectors for attaching [NeoPixels](https://www.adafruit.com/product/3919), [speakers](https://www.adafruit.com/product/3885), [servos](https://www.adafruit.com/product/4326) or [relays](https://www.adafruit.com/product/4409).
+ * 3 **capacitive touch pads** and one **capacitive touch slider** with 5 elements.
  * **On/Off switch**
  * **Boot** and **Reset buttons** for re-programming
 

--- a/_board/adafruit_itsybitsy_rp2040.md
+++ b/_board/adafruit_itsybitsy_rp2040.md
@@ -12,27 +12,29 @@ features:
   - Breadboard-Friendly
 ---
 
-A new chip means a new ItsyBitsy, and the Raspberry Pi RP2040 is no exception. When we saw this chip we thought "this chip is going to be awesome when we give it the ItsyBitsy teensy-weensy Treatment" and so we did! This Itsy' features the RP2040, [and all niceties you know and love about the ItsyBitsy family](https://www.adafruit.com/category/1008)
+A new chip means a new ItsyBitsy, and the Raspberry Pi RP2040 is no exception. When we saw this chip we thought "this chip is going to be awesome when we give it the ItsyBitsy teensy-weensy Treatment" and so we did! This Itsy' features the RP2040, and all niceties you know and love about the [ItsyBitsy family](https://www.adafruit.com/category/1008).
 
-What's smaller than a Feather but larger than a Trinket? It's an Adafruit ItsyBitsy RP2040 featuring the Raspberry Pi RP2040! Small, powerful, with a ultra fast duel Cortex M0+ processor running at 125 MHz - this microcontroller board is perfect when you want something very compact, with lots of horsepower and a bunch of pins. This Itsy has sports car speed, but SUV roominess with 4 MB of FLASH and 264KB of SRAM.
+What's smaller than a Feather but larger than a Trinket? It's an Adafruit ItsyBitsy RP2040 featuring the Raspberry Pi RP2040! Small, powerful, with a ultra fast duel Cortex M0+ processor running at 125 MHz - this microcontroller board is perfect when you want something very compact, with lots of horsepower and a bunch of pins. This Itsy has sports car speed, but SUV roominess with 4 MB of FLASH and 264 KB of SRAM.
 
-ItsyBitsy RP2040 is only 1.4" long by 0.7" wide, but has 6 power pins, 23 digital GPIO pins (4 of which can be analog in and 16 x PWM out). It's the same chip as the [Feather RP2040](https://www.adafruit.com/products/4884) and [Raspberry Pi Pico](https://www.adafruit.com/products/4883) *but really really small*. So it's great once you've finished up a prototype, and want to make the project much smaller. It even comes with 4MB of SPI Flash built in, for data logging, file storage, or CircuitPython/MicroPython code
+ItsyBitsy RP2040 is only 1.4" long by 0.7" wide, but has 6 power pins, 23 digital GPIO pins (4 of which can be analog in and 16x PWM out). It's the same chip as the [Feather RP2040](https://www.adafruit.com/products/4884) and [Raspberry Pi Pico](https://www.adafruit.com/products/4883) *but really really small*. So it's great once you've finished up a prototype, and want to make the project much smaller. It even comes with 4MB of SPI Flash built in, for data logging, file storage, or CircuitPython/MicroPython code.
+
+## Technical details
 
 - [Same size and form-factor as the rest of the ItsyBitsy family](https://www.adafruit.com/category/1008) and nearly-identical pinout
-- Measures 1.4" x 0.7" x 0.2" (36mm x 18mm x 4mm) without headers soldered in
-- RP2040 32-bit Cortex M0+ dual core running at ~125 MHz @ 3.3V logic and power
+- Measures 1.4" x 0.7" x 0.2" (36 mm x 18 mm x 4 mm) without headers soldered in
+- RP2040 32-bit Cortex M0+ dual core running at ~125 MHz @ 3.3 V logic and power
 - 264 KB RAM
 - **4 MB SPI FLASH** chip for storing files and CircuitPython/MicroPython code storage. No EEPROM
-- Tons of GPIO! 23 x GPIO pins with following capabilities:
-  - **Four** 12 bit ADCs (one more than Pico)
-  - Two I2C, Two SPI and two UART peripherals, we label one for the 'main' interface in standard ItsyBitsy locations
-  - 16 x PWM outputs - for servos, LEDs, etc
+- 23 GPIO pins with following capabilities:
+  - 4 12 bit ADCs (one more than Pico)
+  - 2 I2C, 2 SPI and 2 UART peripherals, we label one for the 'main' interface in standard ItsyBitsy locations
+  - 16 PWM outputs - for servos, LEDs, etc
   - The 10 digital 'non-ADC/non-peripheral' GPIO are consecutive for maximum PIO compatibility
 - **Pin #13 red LED** for general purpose blinking
 - **RGB NeoPixel** with power pin on GPIO so you can depower it for low power usages.
 - **Both Reset button and Bootloader select button for quick restarts (no unplugging-replugging to relaunch code)**
-- 3.3V regulator with 500mA peak current output
-- 3.3V Power/enable pin
+- 3.3 V regulator with 500mA peak current output
+- 3.3 V Power/enable pin
 - Power with either USB or external output (such as a battery) - it'll automatically switch over
 - Broken-out SWD pins for debug access
 - 24 MHz crystal for perfect timing.
@@ -51,12 +53,12 @@ You'll note there's no I2S peripheral, or SDIO, or camera, what's up with that? 
 
 This Itsy comes with loose 0.1" headers you can solder in for breadboard use!
 
-While the RP2040 has lots of onboard RAM (264KB), it does not have built-in FLASH memory. Instead, that is provided by the external QSPI flash chip. On this board there is 2MB, which is shared between the program it's running and any file storage used by MicroPython or CircuitPython. When using C/C++ you get the whole flash memory, if using Python you will have about 1 MB remaining for code, files, images, fonts, etc.
+While the RP2040 has lots of onboard RAM (264 KB), it does not have built-in FLASH memory. Instead, that is provided by the external QSPI flash chip. On this board there is 2 MB, which is shared between the program it's running and any file storage used by MicroPython or CircuitPython. When using C/C++ you get the whole flash memory, if using Python you will have about 1 MB remaining for code, files, images, fonts, etc.
 
 **RP2040 Chip features:**
 
-- Dual ARM Cortex-M0+ @ 133MHz
-- 264kB on-chip SRAM in six independent banks
+- Dual ARM Cortex-M0+ @ 133 MHz
+- 264 kB on-chip SRAM in six independent banks
 - Support for up to 16MB of off-chip Flash memory via dedicated QSPI bus
 - DMA controller
 - Fully-connected AHB crossbar

--- a/_board/adafruit_kb2040.md
+++ b/_board/adafruit_kb2040.md
@@ -22,25 +22,25 @@ We mixed together what we liked most about the SparkFun Pro Micro RP2040 (**Qwii
 
 With 20 GPIO available (18 on castellated pins, 2 on STEMMA QT port) you can easily make up to 100-keys matrices, or common 65% 5x15 layouts. [Use a plug-and-play QT cable to connect to the last two pins](https://www.adafruit.com/product/4209) without having to do any desoldering/rework.
 
-Board features:
+## Technical details
 
 - [Same size and form-factor as a Pro Micro breakout](https://www.sparkfun.com/products/12640) and nearly-identical pinout (this board has fewer analog pins, for example)
 - Measures 1.3" x 0.7" without headers soldered in
-- RP2040 32-bit Cortex M0+ dual core running at ~125 MHz @ 3.3V logic and power. 264 KB RAM, No EEPROM. 12 MHz crystal for perfect timing.
+- RP2040 32-bit Cortex M0+ dual core running at ~125 MHz @ 3.3 V logic and power. 264 KB RAM, No EEPROM. 12 MHz crystal for perfect timing.
 - **8 MB SPI FLASH** chip for storing files and CircuitPython/MicroPython code storage.
-- 20 x GPIO pins with following capabilities:
+- 20 GPIO pins with following capabilities:
   - 18 GPIO on castellated/pin breakout pads. 2 GPIO on QT port that can be easily accessed for 5x15 keyboard layouts.
-  - Four 12 bit ADCs
-  - Two I2C, Two SPI and two UART peripherals, we label one of for the 'main' interface in standard Pro Micro locations
-  - 16 x PWM outputs - for servos, LEDs, etc
+  - 4 12 bit ADCs
+  - 2 I2C, 2 SPI and 2 UART peripherals, we label one of for the 'main' interface in standard Pro Micro locations
+  - 16 PWM outputs - for servos, LEDs, etc
   - The 10 digital non-ADC GPIO are consecutive for maximum PIO compatibility
 - **RGB NeoPixel** for colorful status indiction
 - Classic **green power LED**
 - Both Reset button and Bootloader select button for quick restarts. Bootloader button is also available as a generic GPIO input button.
 - [STEMMA QT connector](https://learn.adafruit.com/introducing-adafruit-stemma-qt/what-is-stemma-qt) on the end is compatible with the [SparkFun Qwiic](https://www.sparkfun.com/qwiic) I2C connector, and can be used to plug and play I2C devices, or just as 2 extra GPIO pins.
-- 3.3V regulator with 500mA peak current output
-- **RAW** output, for powering NeoPixels or other 5V devices. Jumper on bottom lets you skip over the 500mA fuse, for up to 2A from USB ports.
-- **USB Type C connector** lets you access built-in ROM USB bootloader and serial port debugging
+- 3.3 V regulator with 500 mA peak current output
+- **RAW** output, for powering NeoPixels or other 5 V devices. Jumper on bottom lets you skip over the 500 mA fuse, for up to 2 A from USB ports.
+- **USB-C connector** lets you access built-in ROM USB bootloader and serial port debugging
 - **Extra D- and D+ breakouts** for alternative USB connection options.
 
 ## Purchase

--- a/_board/adafruit_led_glasses_nrf52840.md
+++ b/_board/adafruit_led_glasses_nrf52840.md
@@ -22,17 +22,17 @@ The driver *looks* a little like a Feather but it does not have any breakout pin
 
 In exchange for GPIO outputs, we added some sensors on instead: each board [comes with a LIS3DH triple-axis accelerometer](https://www.adafruit.com/product/2809) that can be used for motion and orientation sensing, [and a PDM digital microphone](https://www.adafruit.com/product/3492) for audio sensing. To add more sensors or connect to the LED Glasses front panel, there's a [STEMMA QT connector for plug-and-play I2C support](https://www.adafruit.com/category/1018).
 
-Unlike our Itsy/Feather boards, this driver also comes with a proper on/off switch which will cut power to the microcontroller and external sensors. There's optional LiPo charge support because we think that many folks will want to power this board with AAA or coin cell batteries. If you'd like to enable LiPo charging, short the jumper on the back and then make sure to only use 4.2V/3.7V rechargeable batteries in the battery port.
+Unlike our Itsy/Feather boards, this driver also comes with a proper on/off switch which will cut power to the microcontroller and external sensors. There's optional LiPo charge support because we think that many folks will want to power this board with AAA or coin cell batteries. If you'd like to enable LiPo charging, short the jumper on the back and then make sure to only use 4.2 V/3.7 V rechargeable batteries in the battery port.
 
-The nRF52840 is a lovely Bluetooth LE microcontroller, with good support in both Arduino and CircuitPython. It feathers a Cortex M4 processor with 1 MB of FLASH and 256KB of SRAM. Best of all, it's got that native USB! Finally, no need for a separate USB serial chip like CP2104 or FT232. Serial is handled as a USB CDC descriptor, and the chip can act like a keyboard, mouse, MIDI device or even disk drive. [This chip has TinyUSB support](https://github.com/adafruit/Adafruit_TinyUSB_Arduino) - that means you can use it with Arduino as a native USB device and act as UART (CDC), HID, Mass Storage, MIDI and more!
+The nRF52840 is a lovely Bluetooth LE microcontroller, with good support in both Arduino and CircuitPython. It feathers a Cortex M4 processor with 1 MB of FLASH and 256 KB of SRAM. Best of all, it's got that native USB! Finally, no need for a separate USB serial chip like CP2104 or FT232. Serial is handled as a USB CDC descriptor, and the chip can act like a keyboard, mouse, MIDI device or even disk drive. [This chip has TinyUSB support](https://github.com/adafruit/Adafruit_TinyUSB_Arduino) - that means you can use it with Arduino as a native USB device and act as UART (CDC), HID, Mass Storage, MIDI and more!
 
-**Board Features:**
+## Technical details
 
-- ARM Cortex M4F (with HW floating point acceleration) running at 64MHz
-- 1MB flash and 256KB SRAM
+- ARM Cortex M4F (with HW floating point acceleration) running at 64 MHz
+- 1 MB flash and 256 KB SRAM
 - Bluetooth Low Energy compatible 2.4GHz radio (Details available in the [nRF52840](https://www.nordicsemi.com/Products/Low-power-short-range-wireless/nRF52840) product specification)
-- FCC / IC / TELEC certified module with up to +8dBm output power
-- 2MB external QSPI flash for CircuitPython file storage
+- FCC/IC/TELEC certified module with up to +8 dBm output power
+- 2 MB external QSPI flash for CircuitPython file storage
 - Built in LIS3DH accelerometer and PDM microphone
 - Red LED for general purpose blinking, plus a tiny NeoPixel for colorful feedback
 - [STEMMA QT connector for plug-and-play I2C support](https://www.adafruit.com/category/1018).
@@ -40,7 +40,7 @@ The nRF52840 is a lovely Bluetooth LE microcontroller, with good support in both
 - 4 mounting holes/slots
 - Reset button and User button
 - Native USB supported by every OS - can be used in Arduino or CircuitPython as USB serial console, Keyboard/Mouse HID, even a little disk drive for storing Python scripts.
-- **Can be used with Arduino IDE or CircuitPython**
+- Can be used with Arduino IDE or CircuitPython
 - Comes pre-loaded with the [UF2 bootloader](https://learn.adafruit.com/adafruit-metro-m0-express-designed-for-circuitpython/uf2-bootloader), which looks like a USB storage key. Simply drag firmware on to program, no special tools or drivers needed! It can be used to load up CircuitPython or Arduino IDE
 
 For developers, we pre-programed the chip with our UF2 bootloader, which can use either command line UART programming with nrfutil (we use this for Arduino) or drag-n-drop mass storage, for CircuitPython installation and also because mass-storage-drive bootloaders make updating firmware so easy. Want to program the chip directly? You can use our command line tools with your favorite editor and toolchain. If you want to use an SWD programmer/debugger (for even more advanced usage), we have broken out the SWD pads for easy soldering.

--- a/_board/adafruit_macropad_rp2040.md
+++ b/_board/adafruit_macropad_rp2040.md
@@ -25,15 +25,15 @@ Want to add more hardware? No worries - [a STEMMA QT port on the side lets you c
 
  **Please note, the RP2040 chip does not currently have QMK support** - this macropad is designed to be programmed in Arduino or CircuitPython! If QMK eventually does add RP2040 as a supported chipset (no ETA and no plans that we know of), we'll update this page.
 
- TL;DR?
+## Technical details
 
-- **Raspberry Pi RP2040 Chip + 8MB Flash memory** - Dual core Cortex M0+ at ~130MHz with 264KB or RAM. Runs CircuitPython, Arduino or MicroPython with ease and lots of space for development code and files
+- **Raspberry Pi RP2040 Chip + 8MB Flash memory** - Dual core Cortex M0+ at ~130MHz with 264 KB or RAM. Runs CircuitPython, Arduino or MicroPython with ease and lots of space for development code and files
 - **USB C Connector for Power/Data** - of course this can act as an HID device but also can be MIDI, UART, etc.
 - **3x4 Mechanical key switch sockets** - accepts any Cherry MX-compatible switches. Individually tied to GPIO pins (not matrix wired)
 - **One NeoPixel RGB LED per switch**, on north side
 - **Rotary encoder**, 20 detents per rotation, with push-switch on GPIO pin. Push switch is also used for entering bootloader mode when held down on power-up or reset.
 - **128x64 SH1106 Monochrome OLED display** - On high speed hardware SPI port for quick updates
-- **8mm Speaker/Buzzer** - With Class D amplifier and RC filter, can be used to make simple beeps and sounds effects.
+- **8 mm Speaker/Buzzer** - With Class D amplifier and RC filter, can be used to make simple beeps and sounds effects.
 - **STEMMA QT Connector** - Allows adding any I2C sensors/displays/devices with plug-and-play cables.
 - **Reset button -** On the side, for quick restarting of code
 - **Four M3 mounting bosses** - Make custom enclosures easily

--- a/_board/adafruit_magtag_2.9_grayscale.md
+++ b/_board/adafruit_magtag_2.9_grayscale.md
@@ -24,20 +24,19 @@ We designed this board to be low-power friendly - with a spot for a 350 or 420 m
 
 And of course, the Mag in MagTag stands for _magnetic_. [We have four M3 standoffs that will work perfectly with these mini magnet feet](https://www.adafruit.com/product/4631). (Originally they're designed for RGB Matrices but they'll do an excellent job here as well). Screw on the feet and you can attach this display to a metallic shelf, fridge, or bench.
 
-Here's the cool hardware we put together:
+## Technical details
 
-**Features:**
- * **ESP32-S2 240MHz Tensilica processor** - the next generation of ESP32, now with native USB so it can act like a keyboard/mouse, MIDI device, disk drive, etc!
- * **WROVER module** has FCC/CE certification and comes with 4 MByte of Flash and 2 MByte of PSRAM - you can have huge data buffers
+ * **ESP32-S2 240 MHz Tensilica processor** - the next generation of ESP32, now with native USB so it can act like a keyboard/mouse, MIDI device, disk drive, etc!
+ * **WROVER module** has FCC/CE certification and comes with 4 MB of Flash and 2 MB of PSRAM - you can have huge data buffers
  * **2.9" grayscale display with 296x128 pixels**. Each pixel can be white, light gray, dark gray or black. Compared to 'tri-color' displays with a red pigment, this display takes a lot less time to update, only about a second instead of 15 seconds!
  * **USB C** power and data connector
- * **Four RGB side-emitting NeoPixels** so you can light up the display with any color or pattern
- * **Four buttons** can be used to wake up the ESP32 from deep-sleep, or select different modes
+ * 4 **RGB side-emitting NeoPixels** so you can light up the display with any color or pattern
+ * 4 **buttons** can be used to wake up the ESP32 from deep-sleep, or select different modes
  * **Triple-axis accelerometer** (LIS3DH) can be used to detect orientation of the display
  * **Speaker/Buzzer** with mini class D amplifier on DAC output A0 can play tones or lo-fi audio clips.
  * Front facing **light sensor**
  * **STEMMA QT** port for [attaching all sorts of I2C devices](https://www.adafruit.com/stemma)
- * Two **STEMMA 3 pin JST** connectors for attaching [NeoPixels](https://www.adafruit.com/product/3919), [speakers](https://www.adafruit.com/product/3885), [servos](https://www.adafruit.com/product/4326) or [relays](https://www.adafruit.com/product/4409).
+ * 2 **STEMMA 3 pin JST** connectors for attaching [NeoPixels](https://www.adafruit.com/product/3919), [speakers](https://www.adafruit.com/product/3885), [servos](https://www.adafruit.com/product/4326) or [relays](https://www.adafruit.com/product/4409).
  * **On/Off switch**
  * **Boot** and **Reset buttons** for re-programming
 

--- a/_board/adafruit_metro_esp32s2.md
+++ b/_board/adafruit_metro_esp32s2.md
@@ -17,12 +17,13 @@ features:
   - Arduino Shield Compatible
 ---
 
-What's Metro shaped and has an ESP32-S2 WiFi module? What has a STEMMA QT connector for I2C devices, and a Lipoly charger circuit? What's finishing up testing and nearly ready for fabrication? That's right - its the new Adafruit Metro ESP32-S2! With native USB and a load of PSRAM this board is perfect for use with CircuitPython or Arduino, to add low-cost WiFi while keeping shield-compatibility
+What's Metro shaped and has an ESP32-S2 WiFi module? What has a STEMMA QT connector for I2C devices, and a Lipoly charger circuit? What's finishing up testing and nearly ready for fabrication? That's right - its the new Adafruit Metro ESP32-S2! With native USB and a load of PSRAM this board is perfect for use with CircuitPython or Arduino, to add low-cost WiFi while keeping shield-compatibility.
 
-**Features:**
- * **ESP32-S2 240MHz Tensilica processor** - the next generation of ESP32, now with native USB so it can act like a keyboard/mouse, MIDI device, disk drive, etc!
- * **WROVER module** has FCC/CE certification and comes with 4 MByte of Flash and 2 MByte of PSRAM - you can have huge data buffers
- * **Lotsa power options** - 6-12VDC barrel jack or USB type C or Lipoly battery
+## Technical details
+
+ * **ESP32-S2 240 MHz Tensilica processor** - the next generation of ESP32, now with native USB so it can act like a keyboard/mouse, MIDI device, disk drive, etc!
+ * **WROVER module** has FCC/CE certification and comes with 4 MB of Flash and 2 MB of PSRAM - you can have huge data buffers
+ * **Lotsa power options** - 6-12 VDC barrel jack or USB-C or Lipoly battery
  * **Built in battery charging** when powered over DC or USB
  * UNO-shape so shields can plug in
  * **Reset and DFU** (BOOT0) buttons to get into the ROM bootloader (which is a USB serial port so you don't need a separate cable!)
@@ -31,7 +32,7 @@ What's Metro shaped and has an ESP32-S2 WiFi module? What has a STEMMA QT connec
  * **On/Off switch**
  * **STEMMA QT** connector for I2C devices
  * **On/Charge/User** LEDs + status **NeoPixel**
- * **Works with Arduino or CircuitPython**
+ * Works with Arduino or CircuitPython
 
 ## Purchase:
 

--- a/_board/adafruit_neokey_trinkey_m0.md
+++ b/_board/adafruit_neokey_trinkey_m0.md
@@ -22,11 +22,13 @@ The SAMD21 can run CircuitPython or Arduino very nicely - with existing NeoPixel
 
 We think it's just an adorable little board, small and durable and inexpensive enough that it could be a first microcontroller board, or inspiration for advanced developers to make something simple and fun.
 
+## Technical details
+
 - ATSAMD21E18 32-bit Cortex M0+ - 48 MHz 32 bit processor with 256KB Flash and 32 KB RAM
 - Native USB supported by every OS - can be used in **Arduino or CircuitPython** as USB serial console, MIDI, Keyboard/Mouse HID, even a little disk drive for storing Python scripts.
 - Can be used with Arduino IDE or CircuitPython
 - Single reverse-mount RGB NeoPixel LED
-- One Capacitive Touch pad
+- 1 Capacitive Touch pad
 - Cherry-MX compatible footprint can be used by nearly any mechanical switch. Note we only have a center-nub hole. If your switch has two mini side-nubs they need to be clipped off.
 - Reset switch for starting your project code over or entering bootloader mode
 - Cute & keychain-friendly!

--- a/_board/adafruit_proxlight_trinkey_m0.md
+++ b/_board/adafruit_proxlight_trinkey_m0.md
@@ -28,11 +28,13 @@ The star of this Trinkey is the APDS9960 from Avago Technologies, which has a fe
 
 We think it's just an adorable little board, small and durable and inexpensive enough that it could be a first microcontroller board or inspiration for advanced developers to make something simple and fun.
 
-- ATSAMD21E18 32-bit Cortex M0+ - 48 MHz 32 bit processor with 256KB Flash and 32 KB RAM
+## Technical details
+
+- ATSAMD21E18 32-bit Cortex M0+ - 48 MHz 32 bit processor with 256 KB Flash and 32 KB RAM
 - Native USB supported by every OS - can be used in Arduino or CircuitPython as USB serial console, MIDI, Keyboard/Mouse HID, even a little disk drive for storing Python scripts.
 - Can be used with Arduino IDE or CircuitPython
-- Two RGB NeoPixel LEDs
-- Two Capacitive Touchpads
+- 2 RGB NeoPixel LEDs
+- 2 Capacitive Touchpads
 - APDS9960 Light/Color/Proximity/Gesture sensor
 - Reset switch for starting your project code over or entering bootloader mode
 - Slim and cute, keychain-friendly!

--- a/_board/adafruit_qtpy_esp32s2.md
+++ b/_board/adafruit_qtpy_esp32s2.md
@@ -23,12 +23,14 @@ The ESP32-S2 is a highly-integrated, low-power, 2.4 GHz Wi-Fi System-on-Chip (So
 
 [OLEDs](https://www.adafruit.com/?q=qt+oled&main_page=category&cPath=1005&sort=BestMatch)! [Inertial Measurement Units](https://www.adafruit.com/?q=qt+imu&main_page=category&cPath=1005&sort=BestMatch)! [Sensors a-plenty](https://www.adafruit.com/?q=qt+sensor&main_page=category&cPath=1005&sort=BestMatch). All plug-and-play thanks to the innovative chainable design: [SparkFun Qwiic](https://www.sparkfun.com/qwiic)-compatible [STEMMA QT](https://learn.adafruit.com/introducing-adafruit-stemma-qt) connectors for the I2C bus so you don't even need to solder! Just plug in a compatible cable and attach it to your MCU of choice, and you’re ready to load up some software and measure some light. [Seeed Grove I2C boards](https://www.adafruit.com/product/4528) will also work with this adapter cable.
 
-Pinout and shape are [Seeed Xiao](https://wiki.seeedstudio.com/Seeeduino-XIAO/) compatible, with castellated pads so you can solder it flat to a PCB. In addition to the QT connector, we also added an **RGB NeoPixel** (with controllable power pin to allow for ultra-low-power usage), **a reset button** (great for restarting your program or entering the bootloader) and a button on GPIO 0 for entering the ROM bootloader or for user input
+Pinout and shape are [Seeed Xiao](https://wiki.seeedstudio.com/Seeeduino-XIAO/) compatible, with castellated pads so you can solder it flat to a PCB. In addition to the QT connector, we also added an **RGB NeoPixel** (with controllable power pin to allow for ultra-low-power usage), **a reset button** (great for restarting your program or entering the bootloader) and a button on GPIO 0 for entering the ROM bootloader or for user input.
 
 Runs Arduino like a dream, and CircuitPython projects are fantastically fun.
 
+## Technical details
+
 - Same size, form-factor, and pin-out as Seeed Xiao
-- **USB Type C connector** - [If you have only Micro B cables, this adapter will come in handy](https://www.adafruit.com/product/4299)!
+- **USB-C connector** - [If you have only Micro B cables, this adapter will come in handy](https://www.adafruit.com/product/4299)!
 - **ESP32-S2 240MHz Tensilica processor** - the next generation of ESP32, now with native USB so it can act like a keyboard/mouse, MIDI device, disk drive, etc!
 - **4 MB Flash & 2 MB PSRAM**
 - Native USB supported by every OS - can be used in Arduino or CircuitPython as USB serial console, MIDI, Keyboard/Mouse HID, even a little disk drive for storing Python scripts.
@@ -37,16 +39,16 @@ Runs Arduino like a dream, and CircuitPython projects are fantastically fun.
 - Battery input pads on underside with diode protection for external battery packs up to 6V input
 - 13 GPIO pins:
   - 11 on breakout pads, 2 more on QT connector
-  - 10 x 12-bit analog inputs (SPI high speed pads do not have analog inputs)
+  - 10 12-bit analog inputs (SPI high speed pads do not have analog inputs)
   - 8-bit analog output DAC
   - PWM outputs on any pin
-  - Two I2C ports, one on the breakout pads, and another with STEMMA QT plug-n-play connector
+  - 2 I2C ports, one on the breakout pads, and another with STEMMA QT plug-n-play connector
   - Hardware UART
   - Hardware SPI on the high speed SPI peripheral pins
   - Hardware I2S on any pins
-  - 5 x Capacitive Touch with no additional components required
-- 3.3V regulator with [**600mA peak output**](https://www.diodes.com/assets/Datasheets/AP2112.pdf)
-- Deep sleep at 100uA
+  - 5 Capacitive Touch with no additional components required
+- 3.3 V regulator with [**600 mA peak output**](https://www.diodes.com/assets/Datasheets/AP2112.pdf)
+- Deep sleep at 100 uA
 - **Reset switch** for starting your project code over, boot 0 button for entering bootloader mode
 - **Really really small**
 

--- a/_board/adafruit_qtpy_rp2040.md
+++ b/_board/adafruit_qtpy_rp2040.md
@@ -16,7 +16,7 @@ features:
 
 What a cutie pie! Or is it... a QT Py? This diminutive dev board comes with one of our new favorite chip, the RP2040. It's been made famous in the new [Raspberry Pi Pico](https://www.adafruit.com/pico) *and* our [Feather RP2040](http://www.adafruit.com/product/4884) and [ItsyBitsy RP2040](http://www.adafruit.com/product/4888), but what if we wanted something really *smol?*
 
-A new chip means a new QT Py, and the Raspberry Pi RP2040 is no exception. When we saw this chip we thought "this chip is going to be awesome when we give it the cuuutie QT Py Treatment", and so we did! This QT Py features the RP2040, [and all niceties you know and love about the original QT Py](https://www.adafruit.com/category/4600)
+A new chip means a new QT Py, and the Raspberry Pi RP2040 is no exception. When we saw this chip we thought "this chip is going to be awesome when we give it the cuuutie QT Py Treatment", and so we did! This QT Py features the RP2040, [and all niceties you know and love about the original QT Py](https://www.adafruit.com/category/4600).
 
 The star of the QT Py is [our favorite connector - the STEMMA QT](http://adafruit.com/stemma), a chainable I2C port that can be used with [any of our STEMMA QT sensors and accessories](https://www.adafruit.com/category/620). Having this connector means you don't need to do any soldering to get started.
 
@@ -26,25 +26,27 @@ Use any [SparkFun Qwiic](http://www.sparkfun.com/qwiic) boards! [Seeed Grove I2C
 
 There is great [C/C++ support](https://github.com/raspberrypi/pico-sdk), unofficial (but really good) [Arduino support](https://github.com/earlephilhower/arduino-pico), an official [MicroPython port](https://github.com/raspberrypi/micropython), and a [CircuitPython port](/downloads). We of course [recommend CircuitPython because we think it's the easiest way to get started](https://learn.adafruit.com/welcome-to-circuitpython) and it has support with most of our drivers, displays, sensors, and more, supported out of the box so you can follow along with our CircuitPython projects and tutorials.
 
-Pinout and shape is [Seeed Xiao](https://wiki.seeedstudio.com/Seeeduino-XIAO/) compatible, with castellated pads so you can solder it to a PCB with a cut out to allow the bottom components some breathing room. In addition to the QT connector, we also added an **RGB NeoPixel** (with a controllable power pin to allow for ultra-low-power usage), **and both boot-mode and reset buttons** (great for restarting your program or entering the bootloader). This QT Py comes with loose 0.1" headers you can solder in for breadboard use
+Pinout and shape is [Seeed Xiao](https://wiki.seeedstudio.com/Seeeduino-XIAO/) compatible, with castellated pads so you can solder it to a PCB with a cut out to allow the bottom components some breathing room. In addition to the QT connector, we also added an **RGB NeoPixel** (with a controllable power pin to allow for ultra-low-power usage), **and both boot-mode and reset buttons** (great for restarting your program or entering the bootloader). This QT Py comes with loose 0.1" headers you can solder in for breadboard use.
 
 While the RP2040 has lots of onboard RAM (264KB), it does not have built-in FLASH memory. Instead, that is provided by the external QSPI flash chip. On this board there is 4MB, which is shared between the program it's running and any file storage used by MicroPython or CircuitPython. When using C/C++ you get the whole flash memory, if using Python you will have about 3 MB remaining for code, files, images, fonts, etc.
 
+## Technical details
+
 - Same size, form-factor, and pin-out as [our SAMD-based QT Py](https://www.adafruit.com/product/4600)
-- **USB Type C connector** - [If you have only Micro B cables, this adapter will come in handy](https://www.adafruit.com/product/4299)!
-- **RP2040 32-bit Cortex M0+** dual-core running at ~125 MHz @ 3.3V logic and power
+- **USB-C connector** - [If you have only Micro B cables, this adapter will come in handy](https://www.adafruit.com/product/4299)!
+- **RP2040 32-bit Cortex M0+** dual-core running at ~125 MHz @ 3.3 V logic and power
 - 264 KB RAM
 - **8 MB SPI FLASH** chip for storing files and CircuitPython/MicroPython code storage. No EEPROM
 - Native USB supported by every OS - can be used in Arduino or CircuitPython as USB serial console, MIDI, Keyboard/Mouse HID, even a little disk drive for storing Python scripts.
 - Can be used with **Arduino IDE** or **CircuitPython**
 - **Built-in RGB NeoPixel LED**
 - 13 GPIO pins (11 breakout pads and two QT pads):
-  - **Four** 12 bit ADCs (one more than Pico)
-  - Two I2C ports (one on the QT connector, one on the breakout pads)
+  - 4 12-bit ADCs (one more than Pico)
+  - 2 I2C ports (one on the QT connector, one on the breakout pads)
   - SPI and UART peripherals, in standard QT Py locations,
   - PWM outputs on every IO pin - for servos, LEDs, etc
   - There are 6 GPIO in consecutive order for PIO compatibility
-- 3.3V regulator with [**600mA peak output**](https://www.diodes.com/assets/Datasheets/AP2112.pdf)
+- 3.3 V regulator with [**600 mA peak output**](https://www.diodes.com/assets/Datasheets/AP2112.pdf)
 - **Both Reset button and Bootloader select buttons** for quick restarts (no unplugging-replugging to relaunch code)
 - **Really really small**
 

--- a/_board/ai_thinker_esp32-c3s-2m.md
+++ b/_board/ai_thinker_esp32-c3s-2m.md
@@ -26,20 +26,20 @@ This is an entry-level development board based on Espressif ESP32-C3 SoC, which 
 
 ### Specifications
 
-- Complete Wi-Fi 802.11b/g/n, 1T1R mode data rate up to 150Mbps
-- Support BLE5.0 and rate support: 125Kbps, 500Kbps, 1Mbps,2Mbps
+- Complete Wi-Fi 802.11b/g/n, 1T1R mode data rate up to 150 Mbps
+- Support BLE5.0 and rate support: 125 Kbps, 500 Kbps, 1 Mbps, 2 Mbps
 - Onboard ESP32-C3 chip, 32-bit RISC-V single-core processor, supports a clock frequency of up to 160 MHz, with 400 KB SRAM, 384 KB ROM, 8KB RTC SRAM
 - Support UART/PWM/GPIO/ADC/I2C/I2S interface, temperature sensor, pulse counter
 - SMD-38 package
 - Integrated Wi-Fi MAC/ BB/RF/PA/LNA/BLE
-- Support multiple sleep modes, deep sleep electric current is less than 5uA
-- UART rate up to 5Mbps
+- Support multiple sleep modes, deep sleep electric current is less than 5 uA
+- UART rate up to 5 Mbps
 - Support STA/AP/STA+AP mode and mix mode
 - Support Smart Config (APP)/AirKiss (WeChat) of Android and IOS One-click network configuration
 - Support UART port local upgrade and remote firmware upgrade (FOTA)
 - General AT commands can be better understand
 - Support secondary development, integrated Linux development environment
-- ESP-C3-32S module acquiesce in using the built-in 2MByte Flash, meanwhile support external Flash version
+- ESP-C3-32S module acquiesce in using the built-in 2 MByte Flash, meanwhile support external Flash version
 
 ## Purchase
 

--- a/_board/ai_thinker_esp32-c3s.md
+++ b/_board/ai_thinker_esp32-c3s.md
@@ -13,6 +13,7 @@ features:
   - Wi-Fi
   - Bluetooth/BTLE
 ---
+
 This is an entry-level development board based on Espressif ESP32-C3 SoC, which is equipped with a RISC-V 32-bit single-core processor, operating frequency up to 160 MHz, supports secondary development without using other microcontrollers or processors. The ESP32-C3 is an highly integrated low power Wi-Fi and Bluetooth system-level chip (SoC), designed for various applications such as internet of things (IoT), mobile devices, wearable electronics, smart home, etc.
 
 ### Features
@@ -21,25 +22,25 @@ This is an entry-level development board based on Espressif ESP32-C3 SoC, which 
 - Onboard CH340, USB to UART converter
 - RGB 3-in-1 LED, convenient for secondary development
 - USB port for power input, firmware programming, or UART debugging
-- 2x15pin extension headers, breakout all the I/O pins of the module
+- 2x15 pin extension headers, breakout all the I/O pins of the module
 - 2x keys, used as reset or user-defined
 
 ### Specifications
 
-- Complete Wi-Fi 802.11b/g/n, 1T1R mode data rate up to 150Mbps
-- Support BLE5.0 and rate support: 125Kbps, 500Kbps, 1Mbps,2Mbps
+- Complete Wi-Fi 802.11b/g/n, 1T1R mode data rate up to 150 Mbps
+- Support BLE5.0 and rate support: 125 Kbps, 500 Kbps, 1 Mbps, 2 Mbps
 - Onboard ESP32-C3 chip, 32-bit RISC-V single-core processor, supports a clock frequency of up to 160 MHz, with 400 KB SRAM, 384 KB ROM, 8KB RTC SRAM
 - Support UART/PWM/GPIO/ADC/I2C/I2S interface, temperature sensor, pulse counter
 - SMD-38 package
 - Integrated Wi-Fi MAC/ BB/RF/PA/LNA/BLE
-- Support multiple sleep modes, deep sleep electric current is less than 5uA
-- UART rate up to 5Mbps
+- Support multiple sleep modes, deep sleep electric current is less than 5 uA
+- UART rate up to 5 Mbps
 - Support STA/AP/STA+AP mode and mix mode
 - Support Smart Config (APP)/AirKiss (WeChat) of Android and IOS One-click network configuration
 - Support UART port local upgrade and remote firmware upgrade (FOTA)
 - General AT commands can be better understand
 - Support secondary development, integrated Linux development environment
-- ESP-C3-32S module acquiesce in using the built-in 2MByte Flash, meanwhile support external Flash version
+- ESP-C3-32S module acquiesce in using the built-in 2 MByte Flash, meanwhile support external Flash version
 
 ## Purchase
 

--- a/_board/ai_thinker_esp_12k_nodemcu.md
+++ b/_board/ai_thinker_esp_12k_nodemcu.md
@@ -12,23 +12,24 @@ features:
   - Breadboard-Friendly
   - Wi-Fi
 ---
+
 This board is a version of the NodeMCU board with an ESP-12K (ESP32-S2) module on it. The board has a micro USB connection with which it can be programmed and/or powered.
 
-Specifications:
+### Specifications
+
 - Supply voltage:
-  - Micro USB: 5V DC
-  - 5V pin: 5V DC
-  - 3V3 pin: 3.3V DC
-- GPIO voltage: 3.3V
+  - Micro USB: 5 V DC
+  - 5V pin: 5 V DC
+  - 3V3 pin: 3.3 V DC
+- GPIO voltage: 3.3 V
 - Chip: ESP32-S2 ESP-12K
-  - Flash memory: 4MB
-  - PSRAM: 8MB
-  - SRAM: 320KB
+  - Flash memory: 4 MB
+  - PSRAM: 8 MB
+  - SRAM: 320 KB
   - Built-in Wi-Fi
 - USB to serial converter: CH340C
 
-
-The micro USB connector on this board is wired through a CH430C USB to serial converter chip for debugging and programming. The native USB is not available on a USB connector - instead you'll want to pick up a [Micro B USB](https://www.adafruit.com/product/1833) connector breakout, [Type C USB](https://www.adafruit.com/product/4090) connector breakout or [USB data cable](https://www.adafruit.com/product/4448) and hand-wire IO19/IO20 to D- and D+ pads.
+The micro USB connector on this board is wired through a CH430C USB to serial converter chip for debugging and programming. The native USB is not available on a USB connector - instead you'll want to pick up a [Micro B USB](https://www.adafruit.com/product/1833) connector breakout, [USB-C](https://www.adafruit.com/product/4090) connector breakout or [USB data cable](https://www.adafruit.com/product/4448) and hand-wire IO19/IO20 to D- and D+ pads.
 
 ## Purchase
 

--- a/_board/aramcon2_badge.md
+++ b/_board/aramcon2_badge.md
@@ -11,8 +11,6 @@ family: nrf52840
 downloads_display: true
 blinka: false
 download_instructions: ""
-# Features are tags; they should be limited to the items in this list and spelled exactly the same.
-# Include only the features your board supports, and remove these comment lines before committing.
 features:
   - Display
   - Bluetooth/BTLE
@@ -20,21 +18,24 @@ features:
 
 nRF52840-Based Smart Badge with Bluetooth, 2.9" ePaper Display, Neopixels, SAO support, and more!
 
-**Features:**
-* Nordic nRF52840 Cortex M4 Module(E73-2G4M08S1C)
-* 2.9 inch e-paper glass display(GDEW029T5)
-* I²C Accelerometer(LIS2DH12)
-* 128MBit Serial Flash(W25Q128JV)
-* SAO V1.69BIS Connector
+## Features
+
+* Nordic nRF52840 Cortex M4 Module (E73-2G4M08S1C)
+* 2.9" e-paper glass display (GDEW029T5)
+* I2C accelerometer (LIS2DH12)
+* 128 MBit Serial Flash (W25Q128JV)
+* SAO V1.69BIS connector
 * 8-Pin extension slot (on the back)
-* 5 x 6mm Push Buttons
-* 2 x WS2812B "NeoPixel" Addressable RGB LEDs
+* 5 x 6 mm Push buttons
+* 2 x WS2812B "NeoPixel" addressable RGB LEDs
 * 1 x Green Indication LED
-* Reset Button
+* Reset button
 * Vibration motor
 
 ## Purchase
+
 Not available for direct purchase. The badge was given to all attendees of the ARAMCON2 conference.
 
 ## Learn More
+
 * [Github](https://github.com/aramcon-badge/)

--- a/_board/blm_badge.md
+++ b/_board/blm_badge.md
@@ -19,10 +19,12 @@ The kit is a snapshot in time, a time capsule of what we did together, and what 
 
 The kits will never be for sale from Adafruit, they will be donated to learning-to-code organizations, social justice groups, and events.
 
-This education and workshop kit features a Cortex M0+ processor that can run Arduino or CircuitPython.
+This education and workshop kit is build around a Cortex M0+ processor that can run Arduino or CircuitPython.
 
- * **USB Type C connector** - If you have only Micro B cables, [this adapter will come in handy](https://www.adafruit.com/product/4299).
- * **ATSAMD21E18 32-bit Cortex M0+** - 48 MHz 32 bit processor with 256KB Flash and 32 KB RAM
+## Features
+
+ * **USB-C connector** - If you have only Micro B cables, [this adapter will come in handy](https://www.adafruit.com/product/4299).
+ * **ATSAMD21E18 32-bit Cortex M0+** - 48 MHz 32-bit processor with 256KB Flash and 32 KB RAM
  * **Native USB supported by every OS** - can be used in Arduino or CircuitPython as USB serial console, MIDI, Keyboard/Mouse HID, even a little disk drive for storing Python scripts.
  * Can be used with **Arduino IDE** or **CircuitPython**
  * Power with **2 x AAA** batteries, rechargeable or alkaline
@@ -30,7 +32,7 @@ This education and workshop kit features a Cortex M0+ processor that can run Ard
  * **Four Capacitive Touch pads** - they can also be used as digital/analog pins
  * **Light Sensor**
  * **Sound Sensor** (microphone)
- * Red 'pin 13' LED
+ * Red LED (`GPIO13`)
  * **On / Off switch**
  * **Reset switch** for starting your project code over or entering bootloader mode
  * Lanyard hole

--- a/_board/bluemicro833.md
+++ b/_board/bluemicro833.md
@@ -16,14 +16,15 @@ features:
   - Battery Charging
 ---
 
-The BlueMicro833 is a nRF52833 controller with the footprint of an Arduino Pro Micro and a USB-C Connector.  It uses the EByte E73-2GM08S1E nRF52833 module, has a neopixel and software controller 3.3V regulator that can turn on/off power to external devices.  It's based on the BlueMicro840 design but uses the internal voltage regulator to run.  Just like other Bluemicros, there is a LiPo battery charger on board.
+The BlueMicro833 is a nRF52833 controller with the footprint of an Arduino Pro Micro and a USB-C connector. It uses the EByte E73-2GM08S1E nRF52833 module, has a Neopixel and software controller 3.3 V regulator that can turn on/off power to external devices. It's based on the BlueMicro840 design but uses the internal voltage regulator to run. Just like other Bluemicros, there is a LiPo battery charger on board.
 
 Many DIY keyboards use the Arduino Pro Micro or the Arduino Micro as their microcontroller. These don't support BLE communications natively. Because the nRF52 chips have a 32-bit ARM Cortex-M4F processor, they have plenty of processing power compared to the traditional AVR chips. The BlueMicro boards were inspired from the Adafruit nrf52 feathers but made to be used directly in DIY keyboards as a replacement for the atmega32u4 based controllers.
 
-
 ## Learn More
+
 * [Board Documentation](http://nrf52.jpconstantineau.com/docs/bluemicro833)
 * [Board Hardware Repo](https://github.com/jpconstantineau/BlueMicro833_hardware)
 
 ## Purchase
+
 * [Tindie](https://www.tindie.com/products/jpconstantineau/ebyte-e73-2g4m08s1e-breakout-bluemicro833-pcba/)

--- a/_board/bluemicro840.md
+++ b/_board/bluemicro840.md
@@ -16,13 +16,15 @@ features:
   - Battery Charging
 ---
 
-The BlueMicro840 is a nRF52840 controller inspired on the Adafruit nRF52840 feather but with the footprint of an Arduino Pro Micro and a USB-C Connector.
+The BlueMicro840 is a nRF52840 controller inspired on the Adafruit nRF52840 feather but with the footprint of an Arduino Pro Micro and a USB-C connector.
 
 Many DIY keyboards use the Arduino Pro Micro or the Arduino Micro as their microcontroller. These don't support BLE communications natively. Because the nRF52 chips have a 32-bit ARM Cortex-M4F processor, they have plenty of processing power compared to the traditional AVR chips. The BlueMicro boards were inspired from the Adafruit nrf52 feathers but made to be used directly in DIY keyboards as a replacement for the atmega32u4 based controllers.
 
 
 ## Learn More
+
 * [Board Documentation](http://nrf52.jpconstantineau.com/docs/bluemicro840_v1)
 
 ## Purchase
+
 * [Tindie](https://www.tindie.com/products/jpconstantineau/bluemicro840/)

--- a/_board/challenger_nb_rp2040_wifi.md
+++ b/_board/challenger_nb_rp2040_wifi.md
@@ -23,23 +23,23 @@ The ESP8285 chip comes pre-flashed with Espressif’s AT command interpreter sto
 
 ### Technical details
 
-- Raspberry Pi Pico Dual Core Cortex-M0 @ 133MHz
-- 8 MByte FLASH Memory.
-- 264 KByte SRAM Memory.
-- 1 Hardware I2C channel.
-- 1 Hardware SPI channel.
-- 1 Hardware UART for the user (Serial1).
-- 1 Hardware UART connected to the network processor (Serial2 @ 1Mbit/s)
+- Raspberry Pi Pico Dual Core Cortex-M0 @ 133 MHz
+- 8 MByte FLASH Memory
+- 264 KByte SRAM Memory
+- 1 Hardware I2C channel
+- 1 Hardware SPI channel
+- 1 Hardware UART for the user (Serial1)
+- 1 Hardware UART connected to the network processor (Serial2 @ 1 Mbit/s)
 - 12 Bit ADC.
 - ESP8285 with internal 1MByte FLASH Memory
-- WiFi (2.4GHz)
+- WiFi (2.4 GHz)
 - Espressif AT interpreter
 - Communicates at 921600 bits/s
 - Neopixel LED
 - New fancy schmancy I2C connector =)
-- USB Type C connector
-
+- USB-C connector
 
 ## Purchase
+
 * [Tindie](https://www.tindie.com/products/invector/challenger-nb-rp2040-wifi/)
 

--- a/_board/challenger_rp2040_lte.md
+++ b/_board/challenger_rp2040_lte.md
@@ -17,29 +17,29 @@ features:
 
 The Challenger RP2040 LTE is an Arduino/CircuitPython compatible Adafruit Feather format micro controller board based on the Raspberry Pico chip.
 
-This board has been designed with portable applications in mind. By using the powerful dual core RP2040 combined with 8Mbyte of flash memory you get a device that can handle pretty much anything you can trow at it. For instance if you let one core handle the LTE modem and the second core do all the UI stuff you get an extremely responsive system. Not to mention that the 8MByte of FLASH memory will let you install any (or all) circuitpython support libraries that you will every need.
+This board has been designed with portable applications in mind. By using the powerful dual core RP2040 combined with 8Mbyte of flash memory you get a device that can handle pretty much anything you can trow at it. For instance if you let one core handle the LTE modem and the second core do all the UI stuff you get an extremely responsive system. Not to mention that the 8 MByte of FLASH memory will let you install any (or all) CircuitPython support libraries that you will every need.
 
 ### Technical details
 
-- Raspberry Pi Pico Dual Core Cortex-M0 @ 133MHz
-- 8 MByte FLASH Memory.
-- 264 KByte SRAM Memory.
-- 1 Hardware I2C channel.
-- 1 Hardware SPI channel.
-- 1 Hardware UART for the user (Serial1).
-- 1 Hardware UART connected to the network processor (Serial2 @ 1Mbit/s)
+- Raspberry Pi Pico Dual Core Cortex-M0 @ 133 MHz
+- 8 MByte FLASH Memory
+- 264 KByte SRAM Memory
+- 1 Hardware I2C channel
+- 1 Hardware SPI channel
+- 1 Hardware UART for the user (Serial1)
+- 1 Hardware UART connected to the network processor (Serial2 @ 1 Mbit/s)
 - 12 Bit ADC.
 - SARA-R410M-02B
 - LTE Category M1/NB1
 - Multiregion
 - Data rate M1: up to 375 kb/s UL, 300 kb/s DL
 - Data rate NB1: up to 62.5 kb/s UL, 27.2 kb/s DL
-- LiPo charger circuit with 250mA charging current
+- LiPo charger circuit with 250 mA charging current
 - Standard LiPo battery connector
-- USB Type C connector
+- USB-C connector
 - Bi2C
 
-
 ## Purchase
+
 * [Tindie](https://www.tindie.com/products/invector/challenger-rp2040-lte/)
 

--- a/_board/challenger_rp2040_wifi.md
+++ b/_board/challenger_rp2040_wifi.md
@@ -18,30 +18,30 @@ features:
 
 The Challenger RP2040 WiFi is an Arduino/Micropython compatible Adafruit Feather format micro controller board based on the Raspberry Pico chip.
 
-When we designed this board we took our existing Challenger M0 WiFi board and replaced the SAMD21 micro controller with the much more powerful dual core RP2040 Cortex-M0 device. The RP2040 have two Cortex-M0 CPU cores clocked at 133Mhz and 264Kbyte SRAM integrated. On our board we decided to put a 8MByte flash memory for your programs and file storage.
+When we designed this board we took our existing Challenger M0 WiFi board and replaced the SAMD21 micro controller with the much more powerful dual core RP2040 Cortex-M0 device. The RP2040 have two Cortex-M0 CPU cores clocked at 133 Mhz and 264 Kbyte SRAM integrated. On our board we decided to put a 8 MByte flash memory for your programs and file storage.
 
-Just like the Challenger M0 WiFi it has a ESP8285 WiFi chip. For those of you that is unfamiliar with this device, it is basically an ESP8266 device with an integrated 1MByte of flash memory. This allows us to have an AT command interpreter inside this chip that the main controller can talk to and connect to you local WiFi network. The communications channel between the two devices is an unused UART on the main controller and the standard UART on the ESP8285. As simple as it can be.
+Just like the Challenger M0 WiFi it has a ESP8285 WiFi chip. For those of you that is unfamiliar with this device, it is basically an ESP8266 device with an integrated 1 MByte of flash memory. This allows us to have an AT command interpreter inside this chip that the main controller can talk to and connect to you local WiFi network. The communications channel between the two devices is an unused UART on the main controller and the standard UART on the ESP8285. As simple as it can be.
 
 ### Technical details
 
-- Raspberry Pi Pico Dual Core Cortex-M0 @ 133MHz
-- 8 MByte FLASH Memory.
-- 264 KByte SRAM Memory.
-- 1 Hardware I2C channel.
-- 1 Hardware SPI channel.
-- 1 Hardware UART for the user (Serial1).
+- Raspberry Pi Pico Dual Core Cortex-M0 @ 133 MHz
+- 8 MByte FLASH Memory
+- 264 KByte SRAM Memory
+- 1 Hardware I2C channel
+- 1 Hardware SPI channel
+- 1 Hardware UART for the user (Serial1)
 - 1 Hardware UART connected to the network processor (Serial2 @ 1Mbit/s)
 - 12 Bit ADC.
 - ESP8285 with internal 1MByte FLASH Memory
-- WiFi (2.4GHz)
+- WiFi (2.4 GHz)
 - Espressif AT interpreter
 - Communicates at 921600 bits/s
 - Neopixel LED
-- LiPo charger circuit with 250mA charging current
+- LiPo charger circuit with 250 mA charging current
 - Standard LiPo battery connector
-- USB Type C connector
-
+- USB-C connector
 
 ## Purchase
+
 * [Tindie](https://www.tindie.com/products/invector/challenger-rp2040-wifi/)
 

--- a/_board/circuitbrains_basic_m0.md
+++ b/_board/circuitbrains_basic_m0.md
@@ -32,6 +32,10 @@ CircuitPython on an ARM Cortex M0 in 1 square inch! This "Just Add Solder" caste
 - Breakouts for 4 Analog and 8 Digital Inputs/Outputs
 
 ## Purchase
-Coming soon. Follow the below links for manufacturing updates:
+
 * [CircuitBrains Basic Project Page](https://kevinneubauer.com/portfolio/circuitbrains-basic/)
 * [Kevin Neubauer Twitter](https://twitter.com/kevinneubauer)
+
+## Learn more
+
+* [GitHub](https://github.com/neubauek/CircuitBrains)

--- a/_board/circuitbrains_deluxe_m4.md
+++ b/_board/circuitbrains_deluxe_m4.md
@@ -18,9 +18,9 @@ CircuitPython on an ARM Cortex M4 in almost 1 square inch! This "Just Add Solder
 
 **NOTE:** This board does not have a USB connector for the native USB. Native USB is broken out on the header/castellations and therefore requires a non-standard USB connection such as mounting to a motherboard PCB.
 
-## Technical Specs
+## Technical details
 
-- Dimensions: 29 x 29 x 3.5 millimeters / 1.15 x 1.15 x 0.15 inches
+- Dimensions: 29 x 29 x 3.5 mm / 1.15 x 1.15 x 0.15 inches
 - Atmel ATSAMD51J19A Microcontroller (32-bit ARM Cortex M4)
 - 120 MHz
 - 192 KB SRAM
@@ -32,6 +32,10 @@ CircuitPython on an ARM Cortex M4 in almost 1 square inch! This "Just Add Solder
 - Breakouts for 14 Analog and 19 Digital Inputs/Outputs
 
 ## Purchase
-Coming soon. Follow the below links for manufacturing updates:
+
 * [CircuitBrains Deluxe Project Page](https://kevinneubauer.com/portfolio/circuitbrains-deluxe/)
 * [Kevin Neubauer Twitter](https://twitter.com/kevinneubauer)
+
+## Learn more
+
+* [GitHub](https://github.com/neubauek/CircuitBrains)

--- a/_board/circuitplayground_bluefruit.md
+++ b/_board/circuitplayground_bluefruit.md
@@ -15,31 +15,24 @@ features:
   - Bluetooth/BTLE
 ---
 
-**Circuit Playground Bluefruit** is our third board in the Circuit Playground series,
-  another step towards a perfect introduction to electronics and programming. We've
-  taken the popular Circuit Playground Express and made it even better! Now the main
-  chip is an nRF52840 microcontroller which is not only more powerful, but also comes
-  with Bluetooth Low Energy support for wireless connectivity.
+**Circuit Playground Bluefruit** is our third board in the Circuit Playground series, another step towards a perfect introduction to electronics and programming. We've taken the popular Circuit Playground Express and made it even better! Now the main   chip is an nRF52840 microcontroller which is not only more powerful, but also comes with Bluetooth Low Energy support for wireless connectivity.
 
-The board is round and has alligator-clip pads around it so you don't have to solder
-or sew to make it work. You can power it from USB, a AAA battery pack, or with a
-Lipoly battery (for advanced users). Circuit Playground Bluefruit has built-in USB
-support. Built in USB means you plug it in to program it and it just shows up, no
-special cable or adapter required. Just program your code into the board then take it
-on the go!
+The board is round and has alligator-clip pads around it so you don't have to solder or sew to make it work. You can power it from USB, a AAA battery pack, or with a Lipoly battery (for advanced users). Circuit Playground Bluefruit has built-in USB support.
 
-**Features:**
+Built in USB means you plug it in to program it and it just shows up, no special cable or adapter required. Just program your code into the board then take it on the go!
 
-* 1 x nRF52840 Cortex M4 processor with Bluetooth Low Energy support
-* 10 x mini NeoPixels, each one can display any color
-* 1 x Motion sensor (LIS3DH triple-axis accelerometer with tap detection, free-fall detection)
-* 1 x Temperature sensor (thermistor)
-* 1 x Light sensor (phototransistor). Can also act as a color sensor and pulse sensor.
-* 1 x Sound sensor (MEMS microphone)
-* 1 x Mini speaker with class D amplifier (7.5mm magnetic speaker/buzzer)
-* 2 x Push buttons, labeled A and B
-* 1 x Slide switch
-* 8 x alligator-clip friendly input/output pins
+## Technical details
+
+* 1x nRF52840 Cortex M4 processor with Bluetooth Low Energy support
+* 10x mini NeoPixels, each one can display any color
+* 1x Motion sensor (LIS3DH triple-axis accelerometer with tap detection, free-fall detection)
+* 1x Temperature sensor (thermistor)
+* 1x Light sensor (phototransistor). Can also act as a color sensor and pulse sensor.
+* 1x Sound sensor (MEMS microphone)
+* 1x Mini speaker with class D amplifier (7.5 mm magnetic speaker/buzzer)
+* 2x Push buttons, labeled A and B
+* 1x Slide switch
+* 8x alligator-clip friendly input/output pins
 * Includes I2C, UART, 6 pins that can do analog inputs, multiple PWM outputs
 * Green "ON" LED so you know its powered
 * Red "#13" LED for basic blinking

--- a/_board/circuitplayground_express.md
+++ b/_board/circuitplayground_express.md
@@ -19,33 +19,35 @@ It brings the "batteries included" approach of Python to hardware by including a
 functionality built-in. It is one of the best beginner boards available. If you are new to hardware,
 then this is a great board to start with.
 
-Here's some of the great goodies baked in to each Circuit Playground Express:
+## Technical details
 
-* 10 x mini NeoPixels, each one can display any color
-* 1 x Motion sensor (LIS3DH triple-axis accelerometer with tap detection, free-fall detection)
-* 1 x Temperature sensor (thermistor)
-* 1 x Light sensor (phototransistor). Can also act as a color sensor and pulse sensor.
-* 1 x Sound sensor (MEMS microphone)
-* 1 x Mini speaker with class D amplifier (7.5mm magnetic speaker/buzzer)
-* 2 x Push buttons, labeled A and B
-* 1 x Slide switch
+* 10x mini NeoPixels, each one can display any color
+* 1x Motion sensor (LIS3DH triple-axis accelerometer with tap detection, free-fall detection)
+* 1x Temperature sensor (thermistor)
+* 1x Light sensor (phototransistor). Can also act as a color sensor and pulse sensor.
+* 1x Sound sensor (MEMS microphone)
+* 1x Mini speaker with class D amplifier (7.5 mm magnetic speaker/buzzer)
+* 2x Push buttons, labeled A and B
+* 1x Slide switch
 * Infrared receiver and transmitter - can receive and transmit any remote control codes, as well as send messages between Circuit Playground Expresses. Can also act as a proximity sensor.
-* 8 x alligator-clip friendly input/output pins
+* 8x alligator-clip friendly input/output pins
 * Includes I2C, UART, 8 pins that can do analog inputs, multiple PWM output
 * 7 pads can act as capacitive touch inputs and the 1 remaining is a true analog output
 * Green "ON" LED so you know its powered
 * Red `board.D13` LED for basic blinking
 * Reset button
-* ATSAMD21 ARM Cortex M0 Processor, running at 3.3V and 48MHz
+* ATSAMD21 ARM Cortex M0 Processor, running at 3.3 V and 48 MHz
 * 2 MB of SPI Flash storage, used  to store code and libraries.
 * MicroUSB port for programming and debugging
 * USB port can act like serial port, keyboard, mouse, joystick or MIDI!
 
 ## Tutorials
+
 * [Circuit Playground Express Overview](https://learn.adafruit.com/adafruit-circuit-playground-express)
 * [Projects and Guides](https://learn.adafruit.com/products/3333/guides)
 
 ## Purchase
+
 * [Adafruit](https://www.adafruit.com/product/3333)
 * [Digi-Key](https://www.digikey.com/short/p88cfj)
 * [Pimoroni](https://shop.pimoroni.com/products/circuit-playground-express-developer-edition)

--- a/_board/circuitplayground_express_4h.md
+++ b/_board/circuitplayground_express_4h.md
@@ -15,34 +15,34 @@ features:
 ---
 
 The Circuit Playground Express is Adafruit's flagship educational board designed for CircuitPython.
-It brings the "batteries included" approach includes an assortment of
-functionality built-in. It is one of the best beginner boards available. If you are new to hardware,
-then this is a great board to start with. This version includes 4-H branding [approved by the USDA](https://blog.adafruit.com/2019/03/18/adafruit-circuit-playground-express-4-h-edition-approved-adafruit-4h-4h-4hgrowshere/).
 
-Here's some of the great goodies baked in to each Circuit Playground Express:
+It brings the "batteries included" approach includes an assortment of functionality built-in. It is one of the best beginner boards available. If you are new to hardware, then this is a great board to start with. This version includes 4-H branding [approved by the USDA](https://blog.adafruit.com/2019/03/18/adafruit-circuit-playground-express-4-h-edition-approved-adafruit-4h-4h-4hgrowshere/).
 
-* 10 x mini NeoPixels, each one can display any color
-* 1 x Motion sensor (LIS3DH triple-axis accelerometer with tap detection, free-fall detection)
-* 1 x Temperature sensor (thermistor)
-* 1 x Light sensor (phototransistor). Can also act as a color sensor and pulse sensor.
-* 1 x Sound sensor (MEMS microphone)
-* 1 x Mini speaker with class D amplifier (7.5mm magnetic speaker/buzzer)
-* 2 x Push buttons, labeled A and B
-* 1 x Slide switch
+## Technical details
+
+* 10x mini NeoPixels, each one can display any color
+* 1x Motion sensor (LIS3DH triple-axis accelerometer with tap detection, free-fall detection)
+* 1x Temperature sensor (thermistor)
+* 1x Light sensor (phototransistor). Can also act as a color sensor and pulse sensor.
+* 1x Sound sensor (MEMS microphone)
+* 1x Mini speaker with class D amplifier (7.5 mm magnetic speaker/buzzer)
+* 2x Push buttons, labeled A and B
+* 1x Slide switch
 * Infrared receiver and transmitter - can receive and transmit any remote control codes, as well as send messages between Circuit Playground Expresses. Can also act as a proximity sensor.
-* 8 x alligator-clip friendly input/output pins
+* 8x alligator-clip friendly input/output pins
 * Includes I2C, UART, 8 pins that can do analog inputs, multiple PWM output
 * 7 pads can act as capacitive touch inputs and the 1 remaining is a true analog output
 * Green "ON" LED so you know its powered
 * Red `board.D13` LED for basic blinking
 * Reset button
-* ATSAMD21 ARM Cortex M0 Processor, running at 3.3V and 48MHz
+* ATSAMD21 ARM Cortex M0 Processor, running at 3.3 V and 48 MHz
 * 2 MB of SPI Flash storage, used  to store code and libraries.
 * MicroUSB port for programming and debugging
 * USB port can act like serial port, keyboard, mouse, joystick or MIDI!
 * Programmable in multiple environments including Microsoft [MakeCode](https://www.microsoft.com/en-us/makecode), [CircuitPython](https://learn.adafruit.com/welcome-to-circuitpython), [Code.org CSD](https://learn.adafruit.com/adafruit-circuit-playground-express/code-org-csd), and the [Arduino IDE](https://learn.adafruit.com/adafruit-circuit-playground-express/arduino)
 
 ## Tutorials
+
 * [Circuit Playground Express Overview](https://learn.adafruit.com/adafruit-circuit-playground-express)
 * 4-H STEMLab Curriculum: [Circuit Playground Express Soil Moisture Sensor](https://docs.google.com/document/d/1GVcTo_lZIsQleITaE80sy2t4RPOU4SKW9SzHaNbtnh8/edit#heading=h.gd2jfvbzhwp9)
 * Soil Moisture Sensor Tutorial: [YouTube Introduction](https://youtu.be/fsg1iP75kck) and [Adafruit Online Tutorial](https://learn.adafruit.com/soil-moisture-sensor-with-circuit-playground-express)
@@ -50,12 +50,14 @@ Here's some of the great goodies baked in to each Circuit Playground Express:
 * [Microsoft Tutorials and Projects with MakeCode](https://makecode.adafruit.com/)
 
 ## Purchase
+
 * [Adafruit Circuit Playground Express board (4-H Green with logo)](https://www.adafruit.com/product/4180)
 * [Circuit Playground Express board (black)](https://www.adafruit.com/product/3333)
 * [Adafruit Circuit Playground Express base kit (black)](https://www.adafruit.com/product/3517)
 * [Shop4-H.org base kit](https://shop4-h.org/products/circuit-playground-express-base-kit)
 
 ## Other 4-H Links
+
 * [Adafruit attends the 2018 National 4-H Youth Maker Summit in Chevy Chase, Maryland](https://blog.adafruit.com/2018/11/07/national-4-h-youth-maker-summit-uses-adafruit-circuit-playground-express-4h-4hsummits-4hmaker-adafruit-circuitplaygroundexpress-msmakecode/)
 * [Microsoft teams with Brown County 4-H](https://youtu.be/bdXGku9DO3Q) - WBAY video (YouTube)
 * The Adafruit Connection to 4-H: [4-H, electronics, makers, holland lops, silkie chickens & more](https://blog.adafruit.com/2017/11/04/4-h-electronics-makers-holland-lops-silkie-chickens-more-4h-nationofmakers/)

--- a/_board/circuitplayground_express_crickit.md
+++ b/_board/circuitplayground_express_crickit.md
@@ -21,17 +21,17 @@ Bolt on a Circuit Playground using the included stand-off bolts and start contro
 
 The Crickit is powered by seesaw, a I2C-to-whatever bridge firmware. So you only need to use two data pins to control the huge number of inputs and outputs on the Crickit. All those timers, PWMs, sensors are offloaded to the co-processor.
 
-Includes:
+## Technical details
 
-*   4 x Analog or Digital Servo control, with precision 16-bit timers
-*   2 x Bi-directional brushed DC motor control, 1 Amp current limited each, with 8-bit PWM speed control (or one stepper)
-*   4 x High current "Darlington" 500mA drive outputs with kick-back diode protection. For solenoids, relays, large LEDs, or one uni-polar stepper
-*   4 x Capacitive touch sensors with alligator-pads
-*   8 x Signal pins, digital in/out or analog inputs
-*   1 x NeoPixel driver with 5V level shifter
-*   1 x Class D, 4-8 ohm speaker, 3W-max audio amplifier
+* 4x Analog or Digital Servo control, with precision 16-bit timers
+* 2x Bi-directional brushed DC motor control, 1 A current limited each, with 8-bit PWM speed control (or one stepper)
+* 4x High current "Darlington" 500mA drive outputs with kick-back diode protection. For solenoids, relays, large LEDs, or one uni-polar stepper
+* 4x Capacitive touch sensors with alligator-pads
+* 8x Signal pins, digital in/out or analog inputs
+* 1x NeoPixel driver with 5 V level shifter
+* 1x Class D, 4-8 ohm speaker, 3 W-max audio amplifier
 
-All are powered via 5V DC, so you can use any 5V-powered servos, DC motors, steppers, solenoids, relays etc. To keep things simple and safe, CRIKIT does not support mixing voltages, use only 5V - not for use with 9V or 12V robotic components.
+All are powered via 5 V DC, so you can use any 5V-powered servos, DC motors, steppers, solenoids, relays etc. To keep things simple and safe, CRIKIT does not support mixing voltages, use only 5 V - not for use with 9 V or 12 V robotic components.
 
 ## Tutorial
 

--- a/_board/circuitplayground_express_digikey_pycon2019.md
+++ b/_board/circuitplayground_express_digikey_pycon2019.md
@@ -15,41 +15,43 @@ features:
 ---
 
 The Circuit Playground Express is Adafruit's flagship educational board designed for CircuitPython.
-It brings the "batteries included" approach of Python to hardware by including an assortment of
-functionality built-in. It is one of the best beginner boards available. If you are new to hardware,
-then this is a great board to start with.
 
-Here's some of the great goodies baked in to each Circuit Playground Express:
+It brings the "batteries included" approach of Python to hardware by including an assortment of functionality built-in. It is one of the best beginner boards available. If you are new to hardware, then this is a great board to start with.
 
-* 10 x mini NeoPixels, each one can display any color
-* 1 x Motion sensor (LIS3DH triple-axis accelerometer with tap detection, free-fall detection)
-* 1 x Temperature sensor (thermistor)
-* 1 x Light sensor (phototransistor). Can also act as a color sensor and pulse sensor.
-* 1 x Sound sensor (MEMS microphone)
-* 1 x Mini speaker with class D amplifier (7.5mm magnetic speaker/buzzer)
-* 2 x Push buttons, labeled A and B
-* 1 x Slide switch
+## Technical details
+
+* 10x mini NeoPixels, each one can display any color
+* 1x Motion sensor (LIS3DH triple-axis accelerometer with tap detection, free-fall detection)
+* 1x Temperature sensor (thermistor)
+* 1x Light sensor (phototransistor). Can also act as a color sensor and pulse sensor.
+* 1x Sound sensor (MEMS microphone)
+* 1x Mini speaker with class D amplifier (7.5 mm magnetic speaker/buzzer)
+* 2x Push buttons, labeled A and B
+* 1x Slide switch
 * Infrared receiver and transmitter - can receive and transmit any remote control codes, as well as send messages between Circuit Playground Expresses. Can also act as a proximity sensor.
-* 8 x alligator-clip friendly input/output pins
+* 8x alligator-clip friendly input/output pins
 * Includes I2C, UART, 8 pins that can do analog inputs, multiple PWM output
 * 7 pads can act as capacitive touch inputs and the 1 remaining is a true analog output
 * Green "ON" LED so you know its powered
 * Red `board.D13` LED for basic blinking
 * Reset button
-* ATSAMD21 ARM Cortex M0 Processor, running at 3.3V and 48MHz
+* ATSAMD21 ARM Cortex M0 Processor, running at 3.3 V and 48 MHz
 * 2 MB of SPI Flash storage, used  to store code and libraries.
 * MicroUSB port for programming and debugging
 * USB port can act like serial port, keyboard, mouse, joystick or MIDI!
 
 ## Tutorials
+
 * [Circuit Playground Express Overview](https://learn.adafruit.com/adafruit-circuit-playground-express)
 * [CircuitPython Made Easy on Circuit Playground Express](https://learn.adafruit.com/circuitpython-made-easy-on-circuit-playground-express/)
 
 ## Downloads
+
 * [PyCon 2019 Circuit Playground Express Default Files](https://github.com/adafruit/PyCon2019/tree/master/Default_Files)
 * [PyCon 2019 Open Spaces Example Content](https://github.com/adafruit/PyCon2019/)
 * [Pycon 2019 Circuit Playground Express Quickstart Worksheet](https://github.com/adafruit/PyCon2019/blob/master/PyCon%202019%20Circuit%20Playground%20Express%20Quickstart.pdf)
 
 ## More Information
+
 * [CircuitPython Open Spaces Planned for PyCon 2019](https://blog.adafruit.com/2019/04/01/circuitpython-open-spaces-planned-for-pycon-2019-pycon-circuitplaygroundexpress-adafruit-adafruit-circuitpython/)
 * [Digi-Key and Adafruit at PyCon - All attendees will receive a Circuit Playground Express!](https://blog.adafruit.com/2019/02/23/digi-key-and-adafruit-at-pycon-all-attendees-will-receive-a-circuit-playground-express-digikey-adafruit-pycon-pycon2019/)

--- a/_board/circuitplayground_express_displayio.md
+++ b/_board/circuitplayground_express_displayio.md
@@ -24,6 +24,7 @@ This is a great companion for our Circuit Playground Express or Bluefruit boards
 Comes with a PCB that has pre-soldered standoffs attached, and 12x M3 screws for attachment. Fits all Circuit Playgrounds but like we mentioned earlier, the Express and Bluefruit are recommended.
 
 ## Tutorials
+
 * [Circuit Playground Express Overview](https://learn.adafruit.com/adafruit-circuit-playground-express)
 * [Adafruit Circuit Playground TFT Gizmo](https://learn.adafruit.com/adafruit-tft-gizmo)
 

--- a/_board/clue_nrf52840_express.md
+++ b/_board/clue_nrf52840_express.md
@@ -15,17 +15,31 @@ features:
   - Solder-Free Alligator Clip
   - STEMMA QT/QWIIC
 ---
-We wanted to build some projects that have a small screen and a lot of sensors. This board has a 1.3″ 240×240 IPS TFT display, two buttons, and a ton of sensors:
+We wanted to build some projects that have a small screen and a lot of sensors. This board has a 1.3″ 240×240 IPS TFT display, two buttons, and sensors.
 
-LSM series 9-DoF motion - LSM6DS33 Accel/Gyro + LIS3MDL magnetometer
-APDS9960 Proximity, Light, RGB, and Gesture Sensor
-PDM Microphone sound sensor
-Humidity, temperature and barometric environmental sensing
-There’s a Qwiic / STEMMA QT connector for adding more sensors, like PM2.5 air quality and others that were too big to fit on the board.
+Available sensors:
 
-We’ll be primarily using CircuitPython for programming it, but it will also work in Arduino. And of course, we’d love to see MakeCode on it!
+* LSM series 9-DoF motion - LSM6DS33 Accel/Gyro + LIS3MDL magnetometer
+* APDS9960 Proximity, Light, RGB, and Gesture Sensor
+* PDM Microphone sound sensor
+* Humidity, temperature and barometric environmental sensing
+
+There’s a Qwiic/STEMMA QT connector for adding more sensors, like PM2.5 air quality and others that were too big to fit on the board.
+
+We’ll be primarily using CircuitPython for programming it, but it will also work in Arduino.
 
 After designing it, the board was close enough to micro:bit-shape-size that we moved a few parts to make it fit in micro:bit robots and some projects – the nrf52840 is a big upgrade chip and can do stuff like Tensorflow Lite for Microcontrollers, BLE central and peripheral, and more.
+
+## Technical details
+
+* Nordic nRF52840 Bluetooth LE processor - 1 MB of Flash, 256 KB RAM, 64 MHz Cortex M4 processor
+* 1.3″ 240x240 Color IPS TFT display for high resolution text and graphics
+* Power it from any 3-6V battery source (internal regulator and protection diodes)
+* Two A/B user buttons and one reset button
+* RGB NeoPixel indicator LED
+* 2 MB internal flash storage for datalogging, images, fonts or CircuitPython code
+* Buzzer/speaker for playing tones and beeps
+* Two bright white LEDs in front for illumination/color sensing.
 
 ## Tutorials
 
@@ -33,4 +47,5 @@ After designing it, the board was close enough to micro:bit-shape-size that we m
 * [Projects and Guides](https://learn.adafruit.com/products/4500/guides)
 
 ## Purchase
+
 * [Adafruit CLUE](https://www.adafruit.com/product/4500)

--- a/_board/espressif_kaluga_1.3.md
+++ b/_board/espressif_kaluga_1.3.md
@@ -12,27 +12,28 @@ features:
   - Wi-Fi
 ---
 
-The **ESP32-S2-Kaluga-1** version 1.3 kit is a full featured development kit by Espressif for the ESP32-S2 that comes with everything but the kitchen sink! From TFTs to touch panels, this dev board has it all. Espressif designed this kit to demonstrate the ESP32-S2’s human-computer interaction functionalities and provide the users with the tools for development of human-computer interaction applications based on their new WiFi modules with the ESP32-S2 chip
+The **ESP32-S2-Kaluga-1** version 1.3 kit is a full featured development kit by Espressif for the ESP32-S2. From TFTs to touch panels, this dev board has it all. Espressif designed this kit to demonstrate the ESP32-S2's human-computer interaction functionalities and provide the users with the tools for development of human-computer interaction applications based on their new WiFi modules with the ESP32-S2 chip.
 
-Version 1.3 was released starting in Summer 2020.  The original version, 1.2, [also has a CircuitPython port](/board/espressif_kaluga_1/).  The pinouts are slightly different between the two versions.  You can tell which version you have by the silkscreen on the bottom of the main board.
+Version 1.3 was released starting in Summer 2020. The original version, 1.2, [also has a CircuitPython port](/board/espressif_kaluga_1/). The pinouts are slightly different between the two versions. You can tell which version you have by the silkscreen on the bottom of the main board.
 
 The Kaluga comes with a WROVER module, which has 2 MB (16 Mbit) PSRAM mounted for a roomy development environment!
 
-The micro USB connector on the Kaluga is wired through a CP210x USB to serial converter chip for debugging and programming. The native USB is not available on a USB connector - instead you'll want to pick up a [Micro B USB](https://www.adafruit.com/product/1833) connector breakout, [Type C USB](https://www.adafruit.com/product/4090) connector breakout or [USB data cable](https://www.adafruit.com/product/4448) and hand-wire D19/D20 to D- and D+ pads.
+The micro USB connector on the Kaluga is wired through a CP210x USB to serial converter chip for debugging and programming. The native USB is not available on a USB connector - instead you'll want to pick up a [Micro B USB](https://www.adafruit.com/product/1833) connector breakout, [USB-C](https://www.adafruit.com/product/4090) connector breakout or [USB data cable](https://www.adafruit.com/product/4448) and hand-wire D19/D20 to D- and D+ pads.
 
-There are many ways of how the ESP32-S2’s abundant functionalities can be used. For starters, the possible use cases may include:
+There are many ways of how the ESP32-S2's abundant functionalities can be used. For starters, the possible use cases may include:
 
- - **Smart home**: From simplest smart lighting, smart door locks, smart sockets, to video streaming devices, security cameras, OTT devices, and home appliances
- - **Battery-powered equipment**: Wi-Fi mesh sensor networks, Wi-Fi-networked toys, wearable devices, health management equipment
- - **Industrial automation equipment**: Wireless control and robot technology, intelligent lighting, HVAC control equipment, etc.
- - **Retail and catering industry**: POS machines and service robots
+- **Smart home**: From simplest smart lighting, smart door locks, smart sockets, to video streaming devices, security cameras, OTT devices, and home appliances
+- **Battery-powered equipment**: Wi-Fi mesh sensor networks, Wi-Fi-networked toys, wearable devices, health management equipment
+- **Industrial automation equipment**: Wireless control and robot technology, intelligent lighting, HVAC control equipment, etc.
+- **Retail and catering industry**: POS machines and service robots
 
 Each order comes with a nice boxed kit containing:
- - Main board: ESP32-S2-Kaluga-1
- - [ESP-LyraT-8311A](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-esp-lyrat-8311a_v1.2.html) audio player extension board
- - [ESP-LyraP-TouchA](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-esp-lyrap-toucha-v1.1.html) touch panel extension board
- - [ESP-LyraP-LCD32](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-esp-lyrap-lcd32-v1.1.html) 3.2” LCD screen extension board
- - [ESP-LyraP-CAM](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-esp-lyrap-cam-v1.0.html) camera board extension board
+
+- Main board: ESP32-S2-Kaluga-1
+- [ESP-LyraT-8311A](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-esp-lyrat-8311a_v1.2.html) audio player extension board
+- [ESP-LyraP-TouchA](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-esp-lyrap-toucha-v1.1.html) touch panel extension board
+- [ESP-LyraP-LCD32](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-esp-lyrap-lcd32-v1.1.html) 3.2” LCD screen extension board
+- [ESP-LyraP-CAM](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-esp-lyrap-cam-v1.0.html) camera board extension board
 
 ## Purchase
 

--- a/_board/espressif_kaluga_1.md
+++ b/_board/espressif_kaluga_1.md
@@ -13,27 +13,28 @@ features:
   - Wi-Fi
 ---
 
-The **ESP32-S2-Kaluga-1** version 1.2 kit is a full featured development kit by Espressif for the ESP32-S2 that comes with everything but the kitchen sink! From TFTs to touch panels, this dev board has it all. Espressif designed this kit to demonstrate the ESP32-S2’s human-computer interaction functionalities and provide the users with the tools for development of human-computer interaction applications based on their new WiFi modules with the ESP32-S2 chip
+The **ESP32-S2-Kaluga-1** version 1.2 kit is a full featured development kit by Espressif for the ESP32-S2. From TFTs to touch panels, this dev board has it all. Espressif designed this kit to demonstrate the ESP32-S2's human-computer interaction functionalities and provide the users with the tools for development of human-computer interaction applications based on their new WiFi modules with the ESP32-S2 chip.
 
-A newer version, 1.3, was released starting in Summer 2020, and [also has a CircuitPython port](/board/espressif_kaluga_1.3/).  The pinouts are slightly different between the two versions.  You can tell which version you have by the silkscreen on the bottom of the main board.
+A newer version, 1.3, was released starting in Summer 2020, and [also has a CircuitPython port](/board/espressif_kaluga_1.3/). The pinouts are slightly different between the two versions. You can tell which version you have by the silkscreen on the bottom of the main board.
 
 The Kaluga comes with a WROVER module, which has 2 MB (16 Mbit) PSRAM mounted for a roomy development environment!
 
-The micro USB connector on the Kaluga is wired through a CP210x USB to serial converter chip for debugging and programming. The native USB is not available on a USB connector - instead you'll want to pick up a [Micro B USB](https://www.adafruit.com/product/1833) connector breakout, [Type C USB](https://www.adafruit.com/product/4090) connector breakout or [USB data cable](https://www.adafruit.com/product/4448) and hand-wire D19/D20 to D- and D+ pads.
+The micro USB connector on the Kaluga is wired through a CP210x USB to serial converter chip for debugging and programming. The native USB is not available on a USB connector - instead you'll want to pick up a [Micro B USB](https://www.adafruit.com/product/1833) connector breakout, [USB-C](https://www.adafruit.com/product/4090) connector breakout or [USB data cable](https://www.adafruit.com/product/4448) and hand-wire D19/D20 to D- and D+ pads.
 
-There are many ways of how the ESP32-S2’s abundant functionalities can be used. For starters, the possible use cases may include:
+There are many ways of how the ESP32-S2's abundant functionalities can be used. For starters, the possible use cases may include:
 
- - **Smart home**: From simplest smart lighting, smart door locks, smart sockets, to video streaming devices, security cameras, OTT devices, and home appliances
- - **Battery-powered equipment**: Wi-Fi mesh sensor networks, Wi-Fi-networked toys, wearable devices, health management equipment
- - **Industrial automation equipment**: Wireless control and robot technology, intelligent lighting, HVAC control equipment, etc.
- - **Retail and catering industry**: POS machines and service robots
+- **Smart home**: From simplest smart lighting, smart door locks, smart sockets, to video streaming devices, security cameras, OTT devices, and home appliances
+- **Battery-powered equipment**: Wi-Fi mesh sensor networks, Wi-Fi-networked toys, wearable devices, health management equipment
+- **Industrial automation equipment**: Wireless control and robot technology, intelligent lighting, HVAC control equipment, etc.
+- **Retail and catering industry**: POS machines and service robots
 
 Each order comes with a nice boxed kit containing:
- - Main board: ESP32-S2-Kaluga-1
- - [ESP-LyraT-8311A](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-esp-lyrat-8311a_v1.2.html) audio player extension board
- - [ESP-LyraP-TouchA](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-esp-lyrap-toucha-v1.1.html) touch panel extension board
- - [ESP-LyraP-LCD32](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-esp-lyrap-lcd32-v1.1.html) 3.2” LCD screen extension board
- - [ESP-LyraP-CAM](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-esp-lyrap-cam-v1.0.html) camera board extension board
+
+- Main board: ESP32-S2-Kaluga-1
+- [ESP-LyraT-8311A](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-esp-lyrat-8311a_v1.2.html) audio player extension board
+- [ESP-LyraP-TouchA](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-esp-lyrap-toucha-v1.1.html) touch panel extension board
+- [ESP-LyraP-LCD32](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-esp-lyrap-lcd32-v1.1.html) 3.2” LCD screen extension board
+- [ESP-LyraP-CAM](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-esp-lyrap-cam-v1.0.html) camera board extension board
 
 ## Purchase
 

--- a/_board/espressif_saola_1_wroom.md
+++ b/_board/espressif_saola_1_wroom.md
@@ -14,9 +14,10 @@ features:
   - Breadboard-Friendly
 ---
 
-This is the Saola dev board with a WROOM ESP32-S2 module.
+This is the Saola development board with a WROOM ESP32-S2 module.
 
-**NOTE:** This board does not have a USB connector for the native USB. Native USB is broken out on the header and therefore requires a non-standard USB connection such as [a breakout cable](https://www.adafruit.com/product/4448).
+The micro USB connector on the Saola is wired through a CP210x USB to serial converter chip for debugging and programming. The native USB is not available on a USB connector - instead you'll want to pick up a [Micro B USB](https://www.adafruit.com/product/1833) connector breakout, [USB-C](https://www.adafruit.com/product/4090) connector breakout or [USB data cable](https://www.adafruit.com/product/4448) and hand-wire D19/D20 to D- and D+ pads.
 
 ## Learn More
+
 * [User Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-saola-1-v1.2.html)

--- a/_board/espressif_saola_1_wrover.md
+++ b/_board/espressif_saola_1_wrover.md
@@ -18,7 +18,7 @@ features:
 
 This particular Saola comes with a WROVER module, which has 2 MB (8 Mbit) PSRAM mounted for a roomy development environment!
 
-The micro USB connector on the Saola is wired through a CP210x USB to serial converter chip for debugging and programming. The native USB is not available on a USB connector - instead you'll want to pick up a [Micro B USB](https://www.adafruit.com/product/1833) connector breakout, [Type C USB](https://www.adafruit.com/product/4090) connector breakout or [USB data cable](https://www.adafruit.com/product/4448) and hand-wire D19/D20 to D- and D+ pads.
+The micro USB connector on the Saola is wired through a CP210x USB to serial converter chip for debugging and programming. The native USB is not available on a USB connector - instead you'll want to pick up a [Micro B USB](https://www.adafruit.com/product/1833) connector breakout, [USB-C](https://www.adafruit.com/product/4090) connector breakout or [USB data cable](https://www.adafruit.com/product/4448) and hand-wire D19/D20 to D- and D+ pads.
 
 ## Purchase
 

--- a/_board/feather_bluefruit_sense.md
+++ b/_board/feather_bluefruit_sense.md
@@ -30,17 +30,18 @@ A chorus of supporting sensors surround the module so you can do all sorts of **
  * [SHT Humidity](https://www.adafruit.com/product/4099)
  * [BMP280 temperature and barometric pressure/altitude](https://www.adafruit.com/product/2651)
 
-Features:
+## Technical details
+
  * ARM Cortex M4F (with HW floating point acceleration) running at 64MHz
  * 1MB flash and 256KB SRAM
  * **Native Open Source USB stack** - pre-programmed with UF2 bootloader
  * Bluetooth Low Energy compatible 2.4GHz radio (Details available in the [nRF52840](https://www.nordicsemi.com/Products/Low-power-short-range-wireless/nRF52840) product specification)
  * **FCC / IC / TELEC certified module**
- * Up to +8dBm output power
+ * Up to +8 dBm output power
  * 21 GPIO, 6 x 12-bit ADC pins, up to 12 PWM outputs (3 PWM modules with 4 outputs each)
  * Pin #13 red LED for general purpose blinking, Blue LED for general purpose connection status, NeoPixel for colorful feedback
  * Power/enable pin
- * Measures 2.0" x 0.9" x 0.28" (51mm x 23mm x 7.2mm) without headers soldered in
+ * Measures 2.0" x 0.9" x 0.28" (51 mm x 23 mm x 7.2 mm) without headers soldered in
  * Light as a (large?) feather - 6 grams
  * 4 mounting holes
  * Reset button
@@ -48,4 +49,5 @@ Features:
  * [Works out of the box with all of our Adafruit FeatherWings!](https://www.adafruit.com/categories/814) (Even the UART-using ones like the GPS FeatherWing)
 
 ## Purchase
+
 * [Adafruit](https://www.adafruit.com/product/4516)

--- a/_board/feather_m0_adalogger.md
+++ b/_board/feather_m0_adalogger.md
@@ -17,35 +17,35 @@ features:
 
 Feather is a development board from Adafruit, and like its namesake it is thin, light, and lets you fly! Adafruit designed Feather to be a new open standard for portable microcontroller cores.
 
-This is the **Adafruit Feather M0 Adalogger** - Adafruit's take on an 'all-in-one' Cortex M0 datalogger (or data-reader) with built in USB and battery charging. It is an Adafruit Feather M0 with a microSD holder ready to rock! [Adafruit has other boards in the Feather family here](https://www.adafruit.com/feather)
+This is the **Adafruit Feather M0 Adalogger** - Adafruit's take on an 'all-in-one' Cortex M0 datalogger (or data-reader) with built in USB and battery charging. It is an Adafruit Feather M0 with a microSD holder.  Check out the other boards in the [Feather family](https://www.adafruit.com/feather).
 
-At the Feather M0's heart is an ATSAMD21G18 ARM Cortex M0 processor, clocked at 48 MHz and at 3.3V logic, the same one used in the new [Arduino Zero](https://www.adafruit.com/products/2843). This chip has a whopping 256K of FLASH (8x more than the Atmega328 or 32u4) and 32K of RAM (16x as much)! This chip comes with built in USB so it has USB-to-Serial program & debug capability built in with no need for an FTDI-like chip.
+At the Feather M0's heart is an ATSAMD21G18 ARM Cortex M0 processor, clocked at 48 MHz and at 3.3 V logic, the same one used in the new [Arduino Zero](https://www.adafruit.com/products/2843). This chip has a whopping 256 KB of FLASH (8x more than the Atmega328 or 32u4) and 32 KB of RAM (16x as much)! This chip comes with built in USB so it has USB-to-Serial program & debug capability built in with no need for an FTDI-like chip.
 
-To make it easy to use for portable projects, Adafruit added a connector for 3.7V Lithium polymer batteries and built in battery charging. You don't need a battery, it will run just fine straight from the micro USB connector. But, if you do have a battery, you can take it on the go, then plug in the USB to recharge. The Feather will automatically switch over to USB power when its available. The battery is tied thru a divider to an analog pin, so you can measure and monitor the battery voltage to detect when you need a recharge.
+To make it easy to use for portable projects, Adafruit added a connector for 3.7 V Lithium polymer batteries and built in battery charging. You don't need a battery, it will run just fine straight from the micro USB connector. But, if you do have a battery, you can take it on the go, then plug in the USB to recharge. The Feather will automatically switch over to USB power when its available. The battery is tied thru a divider to an analog pin, so you can measure and monitor the battery voltage to detect when you need a recharge.
 
-Here's some handy specs! Like all other Feather M0's you get:
+## ## Technical details
 
-*   Measures 2.0" x 0.9" x 0.28" (51mm x 23mm x 8mm) without headers soldered in
-*   Light as a (large?) feather - 5.3 grams
-*   ATSAMD21G18 @ 48MHz with 3.3V logic/power
-*   256KB of FLASH + 32KB of RAM
-*   No EEPROM
-*   3.3V regulator with 500mA peak current output
-*   USB native support, comes with USB bootloader and serial port debugging
-*   You also get tons of pins - 20 GPIO pins
-*   Hardware Serial, hardware I2C, hardware SPI support
-*   8 x PWM pins
-*   10 x analog inputs
-*   Built in 100mA lipoly charger with charging status indicator LED
-*   Pin #13 red LED for general purpose blinking
-*   Power/enable pin
-*   4 mounting holes
-*   Reset button
+* Measures 2.0" x 0.9" x 0.28" (51 mm x 23 mm x 8 mm) without headers soldered in
+* Light as a (large?) feather - 5.3 grams
+* ATSAMD21G18 @ 48MHz with 3.3V logic/power
+* 256 KB of FLASH + 32 KB of RAM
+* No EEPROM
+* 3.3 V regulator with 500 mA peak current output
+* USB native support, comes with USB bootloader and serial port debugging
+* 20x GPIO pins
+  * Hardware Serial, hardware I2C, hardware SPI support
+  * 8x PWM pins
+  * 10x analog inputs
+* Built in 100 mA lipoly charger with charging status indicator LED
+* Pin #13 red LED for general purpose blinking
+* Power/enable pin
+* 4 mounting holes
+* Reset button
 
 The **Feather M0 Adalogger** uses the extra space left over to add MicroSD + a green LED:
 
-*   Pin #8 green LED for your blinking pleasure
-*   MicroSD card holder for adding as much storage as you could possibly want, for reading or writing.
+* Pin #8 green LED for your blinking pleasure
+* MicroSD card holder for adding as much storage as you could possibly want, for reading or writing.
 
 Comes fully assembled and tested, with a USB bootloader. Includes some header so you can solder it in and plug into a solderless breadboard.
 

--- a/_board/feather_m0_basic.md
+++ b/_board/feather_m0_basic.md
@@ -16,32 +16,32 @@ features:
 ---
 Feather is thin, light, and lets you fly! Adafruit designed Feather to be a new open standard for portable microcontroller cores.
 
-This is the **Feather M0 Basic Proto**, it has a bunch of prototyping space built right in. [There are other boards in the Feather family as well](https://www.adafruit.com/feather).
+This is the **Feather M0 Basic Proto**, it has a bunch of prototyping space built right in. Check out the other boards in the [Feather family](https://www.adafruit.com/feather).
 
-At the Feather M0's heart is an ATSAMD21G18 ARM Cortex M0 processor, clocked at 48 MHz and at 3.3V logic, the same one used in the new [Arduino Zero](https://www.adafruit.com/products/2843). This chip has a whopping 256K of FLASH (8x more than the Atmega328 or 32u4) and 32K of RAM (16x as much)! This chip comes with built in USB so it has USB-to-Serial program & debug capability built in with no need for an FTDI-like chip.
+At the Feather M0's heart is an ATSAMD21G18 ARM Cortex M0 processor, clocked at 48 MHz and at 3.3 V logic, the same one used in the new [Arduino Zero](https://www.adafruit.com/products/2843). This chip has a whopping 256 KB of FLASH (8x more than the Atmega328 or 32u4) and 32 KB of RAM (16x as much)! This chip comes with built in USB so it has USB-to-Serial program & debug capability built in with no need for an FTDI-like chip.
 
 To make it easy to use for portable projects, there is a connector for 3.7V Lithium polymer batteries and built in battery charging. You don't need a battery, it will run just fine straight from the micro USB connector. But, if you do have a battery, you can take it on the go, then plug in the USB to recharge. The Feather will automatically switch over to USB power when it is available. The battery is tied thru a divider to an analog pin, so you can measure and monitor the battery voltage to detect when you need a recharge.
 
-**Here are some handy specs!**
+## Technical details
 
-*   Measures 2.0" x 0.9" x 0.28" (51mm x 23mm x 8mm) without headers soldered in
-*   Light as a (large?) feather - 4.6 grams
-*   ATSAMD21G18 @ 48MHz with 3.3V logic/power
-*   256KB of FLASH + 32KB of RAM
-*   No EEPROM
-*   32.768 KHz crystal for clock generation & RTC
-*   3.3V regulator with 500mA peak current output
-*   USB native support, comes with USB bootloader and serial port debugging
-*   You also get tons of pins - 20 GPIO pins
-*   Hardware Serial, hardware I2C, hardware SPI support
-*   PWM outputs on all pins
-*   6 x 12-bit analog inputs
-*   1 x 10-bit analog ouput (DAC)
-*   Built in 100mA lipoly charger with charging status indicator LED
-*   Pin #13 red LED for general purpose blinking
-*   Power/enable pin
-*   4 mounting holes
-*   Reset button
+* Measures 2.0" x 0.9" x 0.28" (51 mm x 23 mm x 8 mm) without headers soldered in
+* Light as a (large?) feather - 4.6 grams
+* ATSAMD21G18 @ 48 MHz with 3.3V logic/power
+* 256KB of FLASH + 32KB of RAM
+* No EEPROM
+* 32.768 KHz crystal for clock generation & RTC
+* 3.3 V regulator with 500 mA peak current output
+* USB native support, comes with USB bootloader and serial port debugging
+* You also get tons of pins - 20 GPIO pins
+* Hardware Serial, hardware I2C, hardware SPI support
+* PWM outputs on all pins
+* 6 x 12-bit analog inputs
+* 1 x 10-bit analog ouput (DAC)
+* Built in 100 mA lipoly charger with charging status indicator LED
+* Pin #13 red LED for general purpose blinking
+* Power/enable pin
+* 4 mounting holes
+* Reset button
 
 The **Feather M0 Basic Proto** has some extra space left over, so we give you a tiny little prototyping area. If you just need to attach a button or sensor, you may be able to skip out on a breadboard and wire it directly on there.
 

--- a/_board/feather_m0_express.md
+++ b/_board/feather_m0_express.md
@@ -15,13 +15,35 @@ features:
   - Breadboard-Friendly
 ---
 
-The Adafruit Feather M0 Express was one of the first development boards designed for CircuitPython by Adafruit. Unlike the original Feather M0 Basic, it added a NeoPixel status LED and external 2MB SPI Flash for storing CircuitPython code.
+The Adafruit Feather M0 Express was one of the first development boards designed for CircuitPython by Adafruit. Unlike the original Feather M0 Basic, it added a NeoPixel status LED and external 2 MB SPI Flash for storing CircuitPython code.
 
-It is a great entry into the Feather ecosystem with CircuitPython. However, it is now out performed by the [Feather M4 Express]({{ "/board/feather_m4_express/" | relative_url }}) which has a faster microcontroller with more RAM. The additional RAM allows CircuitPython to load more code all at once than this Feather M0 Express can.
+It is a great entry into the Feather ecosystem with CircuitPython. However, it is now out performed by the [Feather M4 Express]({{ "/board/feather_m4_express/" | relative_url }}) which has a faster microcontroller with more RAM. The additional RAM allows CircuitPython to load more code all at once than this Feather M0 Express can. Check out the other boards in the [Feather family](https://www.adafruit.com/feather).
+
+## Technical details
+
+* Measures 2.0" x 0.9" x 0.28" (51 mm x 23 mm x 8 mm) without headers soldered in
+* Light as a (large?) feather - 5 grams
+* TSAMD21G18 @ 48 MHz with 3.3V logic/power
+* 256 KB of FLASH + 32 KB of RAM
+* No EEPROM
+* 32.768 kHz crystal for clock generation & RTC
+* 3.3 V regulator with 500 mA peak current output
+* USB native support, comes with USB bootloader and serial port debugging
+* 20x GPIO pins (PWM outputs on all pins)
+  * Hardware Serial, hardware I2C, hardware SPI support
+  * 6 x 12-bit analog inputs
+  * 1 x 10-bit analog ouput (DAC)
+* Built in 100 mA lipoly charger with charging status indicator LED
+* Pin #13 red LED for general purpose blinking
+* Power/enable pin
+* 4 mounting holes
+* Reset button
 
 ## Tutorials
+
 * [Feather M0 Express Overview](https://learn.adafruit.com/adafruit-feather-m0-express-designed-for-circuit-python-circuitpython)
 
 ## Purchase
+
 * [Adafruit](https://www.adafruit.com/product/3403)
 * [Digi-Key](https://www.digikey.com/short/p87w83)

--- a/_board/feather_m0_express_crickit.md
+++ b/_board/feather_m0_express_crickit.md
@@ -18,20 +18,21 @@ features:
 
 **Crickit** is Adafruit's **C**reative **R**obotics & **I**nteractive **C**onstruction **Kit**. It's an add-on to popular Feather ecosystem boards that lets you **#MakeRobotFriend **using CircuitPython.
 
-Plug in _any_ Feather mainboard you want into the center, and you're good to go! **The Crickit is powered by seesaw, an I2C-to-whatever bridge firmware. So you only need to use two I2C data pins to control the huge number of inputs and outputs on the Crickit. All those timers, PWMs, sensors are offloaded to the co-processor.**
+Plug in _any_ Feather mainboard you want into the center, and you're good to go! The Crickit is powered by seesaw, an I2C-to-whatever bridge firmware. So you only need to use two I2C data pins to control the huge number of inputs and outputs on the Crickit. All those timers, PWMs, sensors are offloaded to the co-processor.
 
 The only thing that is _not_ managed by seesaw is the audio output. Provided is a small jumper you can solder to connect the audio amplifier to the first analog pin. On Feather M0's this is a true analog output (DAC) and you can play audio clips with CircuitPython. Other Feathers _may not have a DAC!_ In that case, you can solder a wire to jumper the audio amp to a PWM pin.
 
 You get to use all the non-I2C signal pins on your feather and get a boat-load of extra in/out pins, motor controllers, capacitive touch sensors, a NeoPixel driver and amplified speaker output. It complements & extends your Feather so you can still use all the goodies, including stacking FeatherWings on top. But now you have a robotics playground as well.
 
-Features:
-*   4 x Analog or Digital Servo control, with precision 16-bit timers
-*   2 x Bi-directional brushed DC motor control, 1 Amp current limited each, with 8-bit PWM speed control (or one stepper)
-*   4 x High current "Darlington" 500mA drive outputs with kick-back diode protection. For solenoids, relays, large LEDs, or one uni-polar stepper
-*   4 x Capacitive touch sensors with alligator-pads
-*   8 x Signal pins, digital in/out or analog inputs
-*   1 x NeoPixel driver with 5V level shifter - The NeoPixels are buffered and controlled by the seesaw chip
-*   1 x Class D, 4-8 ohm speaker, 3W-max audio amplifier - the audio input pin is available as a solder-able pad for your configuration, you can connect it to your Feather's DAC or PWM output as you desire.
+## Technical details
+
+* 4 x Analog or Digital Servo control, with precision 16-bit timers
+* 2 x Bi-directional brushed DC motor control, 1 A current limited each, with 8-bit PWM speed control (or one stepper)
+* 4 x High current "Darlington" 500 mA drive outputs with kick-back diode protection. For solenoids, relays, large LEDs, or one uni-polar stepper
+* 4 x Capacitive touch sensors with alligator-pads
+* 8 x Signal pins, digital in/out or analog inputs
+* 1 x NeoPixel driver with 5V level shifter - The NeoPixels are buffered and controlled by the seesaw chip
+* 1 x Class D, 4-8 ohm speaker, 3 W-max audio amplifier - the audio input pin is available as a solder-able pad for your configuration, you can connect it to your Feather's DAC or PWM output as you desire.
 
 All are powered via 5V DC, so you can use any 5V-powered servos, DC motors, steppers, solenoids, relays etc. To keep things simple and safe, we don't support mixing voltages, so only 5V, not for use with 9V or 12V robotic components.
 

--- a/_board/feather_m0_rfm69.md
+++ b/_board/feather_m0_rfm69.md
@@ -18,44 +18,44 @@ features:
 
 This is the** Adafruit Feather M0 RFM69 Packet Radio (433, 868, or 915 MHz)****.** Also called _RadioFruits**,**_ Adafruit's take on an microcontroller with a RFM69HCW packet radio transceiver plus built in USB and battery charging. Its an Adafruit Feather M0 with a VHF radio module cooked in!
 
-Feather is the development platform from Adafruit, and like its namesake it is thin, light, and lets you fly! Adafruit designed Feather to be an open standard for portable microcontroller cores. [Adafruit has other boards in the Feather family here.](https://www.adafruit.com/feather)
+Feather is the development platform from Adafruit, and like its namesake it is thin, light, and lets you fly! Adafruit designed Feather to be an open standard for portable microcontroller cores. Check out the other boards in the [Feather family](https://www.adafruit.com/feather).
 
-**There are two versions: 433 MHz and 900 MHz. The 900 MHz version can be used for either 868MHz or 915MHz transmission/reception** - the exact radio frequency is determined when you load the software since it can be tuned around dynamically.
+**There are two versions: 433 MHz and 900 MHz. The 900 MHz version can be used for either 868 MHz or 915MHz transmission/reception** - the exact radio frequency is determined when you load the software since it can be tuned around dynamically.
 
-At the Feather M0's heart is an ATSAMD21G18 ARM Cortex M0 processor, clocked at 48 MHz and at 3.3V logic, the same one used in the new [Arduino Zero](https://www.adafruit.com/products/2843). This chip has a whopping 256K of FLASH (8x more than the Atmega328 or 32u4) and 32K of RAM (16x as much)! This chip comes with built in USB so it has USB-to-Serial program & debug capability built in with no need for an FTDI-like chip.
+At the Feather M0's heart is an ATSAMD21G18 ARM Cortex M0 processor, clocked at 48 MHz and at 3.3 V logic, the same one used in the new [Arduino Zero](https://www.adafruit.com/products/2843). This chip has a whopping 256 KB of FLASH (8x more than the Atmega328 or 32u4) and 32 KB of RAM (16x as much)! This chip comes with built in USB so it has USB-to-Serial program & debug capability built in with no need for an FTDI-like chip.
 
-To make it easy to use for portable projects, Adafruit added a connector for 3.7V Lithium polymer batteries and built in battery charging. You don't need a battery, it will run just fine straight from the micro USB connector. But, if you do have a battery, you can take it on the go, then plug in the USB to recharge. The Feather will automatically switch over to USB power when its available. The battery is tied thru a divider to an analog pin, so you can measure and monitor the battery voltage to detect when you need a recharge.
+To make it easy to use for portable projects, Adafruit added a connector for 3.7 V Lithium polymer batteries and built in battery charging. You don't need a battery, it will run just fine straight from the micro USB connector. But, if you do have a battery, you can take it on the go, then plug in the USB to recharge. The Feather will automatically switch over to USB power when its available. The battery is tied thru a divider to an analog pin, so you can measure and monitor the battery voltage to detect when you need a recharge.
 
-**Here's some handy specs! Like all Feather M0's you get:**
+## Technical details
 
-*   Measures 2.0" x 0.9" x 0.3" (51mm x 23mm x 8mm) without headers soldered in
-*   Light as a (large?) feather - 5.8 grams
-*   ATSAMD21G18 @ 48MHz with 3.3V logic/power
-*   No EEPROM
-*   3.3V regulator with 500mA peak current outpu0t
-*   USB native support, comes with USB bootloader and serial port debugging
-*   You also get tons of pins - 20 GPIO pins
-*   Hardware Serial, hardware I2C, hardware SPI support
-*   8 x PWM pins
-*   10 x analog inputs
-*   1 x analog output
-*   Built in 100mA lipoly charger with charging status indicator LED
-*   Pin #13 red LED for general purpose blinking
-*   Power/enable pin
-*   4 mounting holes
-*   Reset button
+* Measures 2.0" x 0.9" x 0.3" (51 mm x 23 mm x 8 mm) without headers soldered in
+* Light as a (large?) feather - 5.8 grams
+* ATSAMD21G18 @ 48 MHz with 3.3 V logic/power
+* No EEPROM
+* 3.3 V regulator with 500 mA peak current outpu0t
+* USB native support, comes with USB bootloader and serial port debugging
+* You also get tons of pins - 20 GPIO pins
+* Hardware Serial, hardware I2C, hardware SPI support
+* 8 x PWM pins
+* 10 x analog inputs
+* 1 x analog output
+* Built in 100 mA lipoly charger with charging status indicator LED
+* Pin #13 red LED for general purpose blinking
+* Power/enable pin
+* 4 mounting holes
+* Reset button
 
-The **Feather M0 Radio** uses the extra space left over to add an RFM69HCW 433 or 900MHz radio module. These radios are not good for transmitting audio or video, but they do work quite well for small data packet transmission when you need more range than 2.4 GHz (BT, BLE, WiFi, ZigBee)
+The **Feather M0 Radio** uses the extra space left over to add an RFM69HCW 433 or 900 MHz radio module. These radios are not good for transmitting audio or video, but they do work quite well for small data packet transmission when you need more range than 2.4 GHz (BT, BLE, WiFi, ZigBee).
 
-*   SX1231 based module with SPI interface
-*   433 MHz version: Uses the amateur or license-free ISM band (ITU "Europe" license-free ISM or ITU "American" amateur with limitations)
-*   900 MHz version: Uses the license-free ISM band ("European ISM" @ 868MHz or "American ISM" @ 915MHz)
-*   +13 to +20 dBm up to 100 mW Power Output Capability (power output selectable in software)
-*   50mA (+13 dBm) to 150mA (+20dBm) current draw for transmissions
-*   Range of approx. 350 meters, depending on obstructions, frequency, antenna and power output
-*   Create multipoint networks with individual node addresses
-*   Encrypted packet engine with AES-128
-*   Simple wire antenna or spot for uFL connector
+* SX1231 based module with SPI interface
+* 433 MHz version: Uses the amateur or license-free ISM band (ITU "Europe" license-free ISM or ITU "American" amateur with limitations)
+* 900 MHz version: Uses the license-free ISM band ("European ISM" @ 868MHz or "American ISM" @ 915 MHz)
+* +13 to +20 dBm up to 100 mW Power Output Capability (power output selectable in software)
+* 50 mA (+13 dBm) to 150mA (+20 dBm) current draw for transmissions
+* Range of approx. 350 meters, depending on obstructions, frequency, antenna and power output
+* Create multipoint networks with individual node addresses
+* Encrypted packet engine with AES-128
+* Simple wire antenna or spot for uFL connector
 
 Comes fully assembled and tested, with a USB bootloader. Includes some headers so you can solder it in and plug into a solderless breadboard. You will need to cut and solder on a small piece of wire (any solid or stranded core is fine) in order to create your antenna.
 

--- a/_board/feather_m0_rfm9x.md
+++ b/_board/feather_m0_rfm9x.md
@@ -18,43 +18,43 @@ features:
 
 This is the **Adafruit Feather M0 RFM96 LoRa Radio (433 MHz).** Also called _RadioFruits**,**_ Adafruit's take on an microcontroller with a "[Long Range (LoRa)](https://www.lora-alliance.org/)" packet radio transceiver with built in USB and battery charging. It is an Adafruit Feather M0 with a 433MHz radio module cooked in! Great for making wireless networks that are more flexible than Bluetooth LE and without the high power requirements of WiFi.
 
-Feather is the development board platform from Adafruit, and like its namesake it is thin, light, and lets you fly! Adafruit designed Feather to be an open standard for portable microcontroller cores.[Adafruit has other boards in the Feather family here](https://www.adafruit.com/feather).
+Feather is the development board platform from Adafruit, and like its namesake it is thin, light, and lets you fly! Adafruit designed Feather to be an open standard for portable microcontroller cores. Check out the other boards in the [Feather family](https://www.adafruit.com/feather).
 
 **There are 433 MHz and 898/915 MHz radio versions.**
 
-At the Feather M0's heart is an ATSAMD21G18 ARM Cortex M0 processor, clocked at 48 MHz and at 3.3V logic, the same one used in the new [Arduino Zero](https://www.adafruit.com/products/2843). This chip has a whopping 256K of FLASH (8x more than the Atmega328 or 32u4) and 32K of RAM (16x as much)! This chip comes with built in USB so it has USB-to-Serial program & debug capability built in with no need for an FTDI-like chip.
+At the Feather M0's heart is an ATSAMD21G18 ARM Cortex M0 processor, clocked at 48 MHz and at 3.3 V logic, the same one used in the new [Arduino Zero](https://www.adafruit.com/products/2843). This chip has a whopping 256 K of FLASH (8x more than the Atmega328 or 32u4) and 32 K of RAM (16x as much)! This chip comes with built in USB so it has USB-to-Serial program & debug capability built in with no need for an FTDI-like chip.
 
-To make it easy to use for portable projects, Adafruit added a connector for 3.7V Lithium polymer batteries and built in battery charging. You don't need a battery, it will run just fine straight from the micro USB connector. But, if you do have a battery, you can take it on the go, then plug in the USB to recharge. The Feather will automatically switch over to USB power when its available. The battery is tied thru a divider to an analog pin, so you can measure and monitor the battery voltage to detect when you need a recharge.
+To make it easy to use for portable projects, Adafruit added a connector for 3.7 V Lithium polymer batteries and built in battery charging. You don't need a battery, it will run just fine straight from the micro USB connector. But, if you do have a battery, you can take it on the go, then plug in the USB to recharge. The Feather will automatically switch over to USB power when its available. The battery is tied thru a divider to an analog pin, so you can measure and monitor the battery voltage to detect when you need a recharge.
 
-**Here's some handy specs! Like all Feather M0's you get:**
+## Technical details
 
-*   Measures 2.0" x 0.9" x 0.3" (51mm x 23mm x 8mm) without headers soldered in
-*   Light as a (large?) feather - 5.8 grams
-*   ATSAMD21G18 @ 48MHz with 3.3V logic/power
-*   No EEPROM
-*   3.3V regulator with 500mA peak current output
-*   USB native support, comes with USB bootloader and serial port debugging
-*   You also get tons of pins - 20 GPIO pins
-*   Hardware Serial, hardware I2C, hardware SPI support
-*   8 x PWM pins
-*   10 x analog inputs
-*   1 x analog output
-*   Built in 100mA lipoly charger with charging status indicator LED
-*   Pin #13 red LED for general purpose blinking
-*   Power/enable pin
-*   4 mounting holes
-*   Reset button
+* Measures 2.0" x 0.9" x 0.3" (51 mm x 23 mm x 8 mm) without headers soldered in
+* Light as a (large?) feather - 5.8 grams
+* ATSAMD21G18 @ 48MHz with 3.3 V logic/power
+* No EEPROM
+* 3.3 V regulator with 500mA peak current output
+* USB native support, comes with USB bootloader and serial port debugging
+* You also get tons of pins - 20 GPIO pins
+* Hardware Serial, hardware I2C, hardware SPI support
+* 8 x PWM pins
+* 10 x analog inputs
+* 1 x analog output
+* Built in 100 mA lipoly charger with charging status indicator LED
+* Pin #13 red LED for general purpose blinking
+* Power/enable pin
+* 4 mounting holes
+* Reset button
 
 This **Feather M0 LoRa Radio** uses the extra space left over to add an RFM9x LoRa 868/915 MHz radio module. These radios are not good for transmitting audio or video, but they do work quite well for small data packet transmission when you need more range than 2.4 GHz (BT, BLE, WiFi, ZigBee).
 
-*   SX127x LoRa® based module with SPI interface
-*   Packet radio with ready-to-go Arduino libraries
-*   Uses the license-free ISM bands (ITU "Europe" @ 433MHz and ITU "Americas" @ 900MHz)
-*   +5 to +20 dBm up to 100 mW Power Output Capability (power output selectable in software)
-*   ~300uA during full sleep, ~120mA peak during +20dBm transmit, ~40mA during active radio listening.
-*   Simple wire antenna or spot for uFL connector
+* SX127x LoRa® based module with SPI interface
+* Packet radio with ready-to-go Arduino libraries
+* Uses the license-free ISM bands (ITU "Europe" @ 433 MHz and ITU "Americas" @ 900 MHz)
+* +5 to +20 dBm up to 100 mW Power Output Capability (power output selectable in software)
+* ~300 uA during full sleep, ~120 mA peak during +20 dBm transmit, ~40 mA during active radio listening.
+* Simple wire antenna or spot for uFL connector
 
-The initial tests with default library settings: over 1.2mi/2Km line-of-sight with wire quarter-wave antennas. ([With setting tweaking and directional antennas, 20Km is possible](http://forum.anarduino.com/posts/list/46.page#2854)).
+The initial tests with default library settings: over 1.2mi/2Km line-of-sight with wire quarter-wave antennas. ([With setting tweaking and directional antennas, 20 km is possible](http://forum.anarduino.com/posts/list/46.page#2854)).
 
 Comes fully assembled and tested, with a USB bootloader. Also includes some headers so you can solder it in and plug into a solderless breadboard. You will need to cut and solder on a small piece of wire (any solid or stranded core is fine) in order to create your antenna.
 

--- a/_board/feather_m0_supersized.md
+++ b/_board/feather_m0_supersized.md
@@ -16,7 +16,7 @@ features:
 ---
 
 This is a [Feather M0 Express]({{ "/board/feather_m0_express/" | relative_url }}) that has been
-supersized by Dave Astels to fit a larger SPI flash chip than the default 2MB chip. It is not
+supersized by Dave Astels to fit a larger SPI flash chip than the default 2 MB chip. It is not
 available for purchase.
 
 It was documented as a DIY project [here](http://daveastels.com/feather-m0-express-supersizing.html).

--- a/_board/feather_m4_can.md
+++ b/_board/feather_m4_can.md
@@ -17,7 +17,7 @@ features:
  
 One of our favorite Feathers, the Feather M4 Express, gets a glow-up here with an upgrade to the SAME51 chipset which has built-in CAN bus support! Like its SAMD51 cousin, the ATSAME51J19 comes with a 120 MHz Cortex M4 with floating point support and 512 KB Flash and 192 KB RAM. Your code will zig and zag and zoom, and with a bunch of extra peripherals for support, this will for sure be your favorite new chipset for CAN interfacing projects.
 
-At the end of the board we have placed a CAN transceiver chip as well as a 5 V converter to generate 5 V power to the transceiver even when running on battery. The two CAN signal lines and ground reference signal are available on a 3-pin 3.5 mm terminal block. The chip and booster can be put to sleep for power saving. The built in CAN can read or write packets and has support in both Arduino and CircuitPython.
+At the end of the board we have placed a CAN transceiver chip as well as a 5 V converter to generate 5 V power to the transceiver even when running on battery. The two CAN signal lines and ground reference signal are available on a 3-pin 3.5 mm terminal block. The chip and booster can be put to sleep for power saving. The built-in CAN can read or write packets and has support in both Arduino and CircuitPython.
 
 Like the original Feather M4 Express, you'll find a Mini NeoPixel and 2 MB SPI Flash. When used in CircuitPython, the 2 MB flash acts as storage for all your scripts, libraries and files.
 
@@ -29,7 +29,7 @@ Comes fully assembled and tested, with the UF2 USB bootloader. We also toss in s
 
 ## Technical details
 
-* Measures 2.0" x 0.9" x 0.28" (50. mm x 22.8 mm x 7 mm) without headers soldered in
+* Measures 2.0" x 0.9" x 0.28" (50.8 mm x 22.8 mm x 7 mm) without headers soldered in
 * Light as a (large?) feather - 5 grams
 * ATSAME51 32-bit Cortex M4 core running at 120 MHz, 32-bit, 3.3 V logic and power
 * Hardware CAN bus support with built-in transceiver, 5V booster and terminal connection.
@@ -38,14 +38,14 @@ Comes fully assembled and tested, with the UF2 USB bootloader. We also toss in s
 * 2 MB SPI FLASH chip for storing files and CircuitPython code storage.
 * No EEPROM
 * 32.768 kHz crystal for clock generation & RTC
-* 3.3V regulator with 500mA peak current output
-* USB Type C connector for USB native support, comes with USB bootloader and serial port debugging
+* 3.3 V regulator with 500 mA peak current output
+* USB-C connector for USB native support, comes with USB bootloader and serial port debugging
 * Built in crypto engines with AES (256 bit), true RNG, Pubkey controller
-* 21 x GPIO pins with following capabilities:
+* 21 GPIO pins with following capabilities:
   * Dual 1 MSPS 12 bit true analog DAC (A0 and A1) - can be used to play 12-bit stereo audio clips
   * Dual 1 MSPS 12 bit ADC (6 analog pins some on ADC1 and some on ADC2)
-  * 6x hardware SERCOM - Native hardware SPI, I2C and Serial all available
-  * 16x PWM outputs - for servos, LEDs, etc
+  * 6 hardware SERCOM - Native hardware SPI, I2C and Serial all available
+  * 16 PWM outputs - for servos, LEDs, etc
   * I2S input and output
   * 8-bit Parallel capture controller (for camera/video in)
 * Built in 100 mA lipoly charger with charging status indicator LED
@@ -53,6 +53,7 @@ Comes fully assembled and tested, with the UF2 USB bootloader. We also toss in s
 * Power/enable pin
 * 4 mounting holes
 * Reset button
+
 ## Tutorials
 
 * [CAN Bus with CircuitPython: Using the canio module](https://learn.adafruit.com/using-canio-circuitpython)

--- a/_board/feather_m4_can.md
+++ b/_board/feather_m4_can.md
@@ -15,21 +15,49 @@ features:
   - Breadboard-Friendly
 ---
  
-One of our favorite Feathers, the Feather M4 Express, gets a glow-up here with an upgrade to the SAME51 chipset which has built-in CAN bus support! Like its SAMD51 cousin, the ATSAME51J19 comes with a 120MHz Cortex M4 with floating point support and 512KB Flash and 192KB RAM. Your code will zig and zag and zoom, and with a bunch of extra peripherals for support, this will for sure be your favorite new chipset for CAN interfacing projects.
+One of our favorite Feathers, the Feather M4 Express, gets a glow-up here with an upgrade to the SAME51 chipset which has built-in CAN bus support! Like its SAMD51 cousin, the ATSAME51J19 comes with a 120 MHz Cortex M4 with floating point support and 512 KB Flash and 192 KB RAM. Your code will zig and zag and zoom, and with a bunch of extra peripherals for support, this will for sure be your favorite new chipset for CAN interfacing projects.
 
-At the end of the board we have placed a CAN transceiver chip as well as a 5V converter to generate 5V power to the transceiver even when running on battery. The two CAN signal lines and ground reference signal are available on a 3-pin 3.5mm terminal block. The chip and booster can be put to sleep for power saving. The built in CAN can read or write packets and has support in both Arduino and CircuitPython.
+At the end of the board we have placed a CAN transceiver chip as well as a 5 V converter to generate 5 V power to the transceiver even when running on battery. The two CAN signal lines and ground reference signal are available on a 3-pin 3.5 mm terminal block. The chip and booster can be put to sleep for power saving. The built in CAN can read or write packets and has support in both Arduino and CircuitPython.
 
 Like the original Feather M4 Express, you'll find a Mini NeoPixel and 2 MB SPI Flash. When used in CircuitPython, the 2 MB flash acts as storage for all your scripts, libraries and files.
 
 And best of all, it's a Feather - so you know it will work with all our FeatherWings! What a great way to quickly get up and running. It's even pin-compatible with the original Feather M4.
 
-Easy reprogramming: the Feather M4 CAN comes pre-loaded with the UF2 bootloader, which looks like a USB storage key. Simply drag firmware on to program, no special tools or drivers needed! It can be used to load up CircuitPython or Arduino IDE (it is bossa-compatible)
+Easy reprogramming: the Feather M4 CAN comes pre-loaded with the UF2 bootloader, which looks like a USB storage key. Simply drag firmware on to program, no special tools or drivers needed! It can be used to load up CircuitPython or Arduino IDE (it is bossa-compatible).
 
 Comes fully assembled and tested, with the UF2 USB bootloader. We also toss in some headers so you can solder it in and plug into a solderless breadboard.
 
+## Technical details
+
+* Measures 2.0" x 0.9" x 0.28" (50. mm x 22.8 mm x 7 mm) without headers soldered in
+* Light as a (large?) feather - 5 grams
+* ATSAME51 32-bit Cortex M4 core running at 120 MHz, 32-bit, 3.3 V logic and power
+* Hardware CAN bus support with built-in transceiver, 5V booster and terminal connection.
+* Floating point support with Cortex M4 DSP instructions
+* 512 KB flash, 192 KB RAM
+* 2 MB SPI FLASH chip for storing files and CircuitPython code storage.
+* No EEPROM
+* 32.768 kHz crystal for clock generation & RTC
+* 3.3V regulator with 500mA peak current output
+* USB Type C connector for USB native support, comes with USB bootloader and serial port debugging
+* Built in crypto engines with AES (256 bit), true RNG, Pubkey controller
+* 21 x GPIO pins with following capabilities:
+  * Dual 1 MSPS 12 bit true analog DAC (A0 and A1) - can be used to play 12-bit stereo audio clips
+  * Dual 1 MSPS 12 bit ADC (6 analog pins some on ADC1 and some on ADC2)
+  * 6x hardware SERCOM - Native hardware SPI, I2C and Serial all available
+  * 16x PWM outputs - for servos, LEDs, etc
+  * I2S input and output
+  * 8-bit Parallel capture controller (for camera/video in)
+* Built in 100 mA lipoly charger with charging status indicator LED
+* Pin #13 red LED for general purpose blinking
+* Power/enable pin
+* 4 mounting holes
+* Reset button
 ## Tutorials
+
 * [CAN Bus with CircuitPython: Using the canio module](https://learn.adafruit.com/using-canio-circuitpython)
 
 ## Purchase
+
 * [Adafruit](https://www.adafruit.com/product/4759)
 * [Digikey](https://www.adafruit.com/product/4759)

--- a/_board/feather_m4_express.md
+++ b/_board/feather_m4_express.md
@@ -15,7 +15,7 @@ features:
   - Breadboard-Friendly
 ---
 
-This feather is powered by the ATSAMD51J19 -  with its 120MHz Cortex M4 with floating point support and 512KB Flash and 192KB RAM. Your code will zig and zag and zoom, and with a bunch of extra peripherals for support, this will for sure be your favorite new chipset.
+This feather is powered by the ATSAMD51J19 -  with its 120 MHz Cortex M4 with floating point support and 512 KB Flash and 192 KB RAM. Your code will zig and zag and zoom, and with a bunch of extra peripherals for support, this will for sure be your favorite new chipset.
 
 And best of all, it's a Feather - so you know it will work with all our FeatherWings! What a great way to quickly get up and running.
 
@@ -23,13 +23,41 @@ The most exciting part of the Feather M4 is that while you can use it with the A
 
 The Feather M4 Express uses the extra space left over to add a Mini NeoPixel, 2 MB SPI Flash storage and a little prototyping space. You can use the SPI Flash storage like a very tiny hard drive. When used in CircuitPython, the 2 MB flash acts as storage for all your scripts, libraries and files. When used in Arduino, you can read/write files to it, like a little datalogger or SD card, and then with our helper program, access the files over USB.
 
-Easy reprogramming: the Feather M4 comes pre-loaded with the UF2 bootloader, which looks like a USB storage key. Simply drag firmware on to program, no special tools or drivers needed! It can be used to load up CircuitPython or Arduino IDE (it is bossa-compatible)
+Easy reprogramming: the Feather M4 comes pre-loaded with the UF2 bootloader, which looks like a USB storage key. Simply drag firmware on to program, no special tools or drivers needed! It can be used to load up CircuitPython or Arduino IDE (it is bossa-compatible).
 
 Comes fully assembled and tested, with the UF2 USB bootloader. We also toss in some headers so you can solder it in and plug into a solderless breadboard.
 
+## Technical details
+
+* Measures 2.0" x 0.9" x 0.28" (50.8 mm x 22.8 mm x 7 mm) without headers soldered in
+* Light as a (large?) feather - 5 grams
+* ATSAMD51 32-bit Cortex M4 core running at 120 MHz, 32-bit, 3.3 V logic and power
+* Floating point support with Cortex M4 DSP instructions
+* 512 KB flash, 192 KB RAM
+* 2 MB SPI FLASH chip for storing files and CircuitPython code storage.
+* No EEPROM
+* 32.768 kHz crystal for clock generation & RTC
+* 3.3 V regulator with 500 mA peak current output
+* USB native support, comes with USB bootloader and serial port debugging
+* Built in crypto engines with AES (256 bit), true RNG, Pubkey controller
+* 21x GPIO pins with following capabilities:
+  * Dual 1 MSPS 12 bit true analog DAC (A0 and A1) - can be used to play 12-bit stereo audio clips
+  * Dual 1 MSPS 12 bit ADC (6 analog pins some on ADC1 and some on ADC2)
+  * 6x hardware SERCOM - Native hardware SPI, I2C and Serial all available
+  * 16x PWM outputs - for servos, LEDs, etc
+  * I2S input and output
+  * 8-bit Parallel capture controller (for camera/video in)
+* Built in 100 mA lipoly charger with charging status indicator LED
+* Pin #13 red LED for general purpose blinking
+* Power/enable pin
+* 4 mounting holes
+* Reset button
+
 ## Tutorials
+
 * [Feather M4 Express Overview](https://learn.adafruit.com/adafruit-feather-m4-express-atsamd51)
 
 ## Purchase
+
 * [Adafruit](https://www.adafruit.com/product/3857)
 * [Digi-Key](https://www.digikey.com/short/p87f17)

--- a/_board/feather_m7_1011.md
+++ b/_board/feather_m7_1011.md
@@ -22,7 +22,7 @@ The NXP iMX RT1011 microcontroller powers this board with a 500 MHz ARM Cortex M
 
 * NXP iMX RT1011 processor - ARM Cortex M7 processor running at 500 MHz, with 128 KB SRAM and high speed USB!
 * AirLift WiFi Co-processor, with TLS/SSL support, plenty of RAM for sockets, communication is over SPI and has CircuitPython library support ready to go for fast wireless integration.
-* Power options - 6-12 V DC barrel jack or USB type C
+* Power options - 6-12 V DC barrel jack or USB-C
 * UNO-shape so shields can plug in
 * Reset  button - Click to restart, double-click to enter UF2 bootloder
 * Boot-mode switches to get into the ROM bootloader (you can always reload code over USB if TinyUF2 gets corrupted somehow)

--- a/_board/feather_m7_1011.md
+++ b/_board/feather_m7_1011.md
@@ -4,7 +4,7 @@ board_id: "feather_m7_1011"
 title: "Feather M7 1011 Download"
 name: "Feather M7 1011"
 manufacturer: "Adafruit"
-board_url: ""
+board_url: "https://www.adafruit.com/product/4950"
 board_image: "feather_m7_1011.jpg"
 date_added: 2020-2-27
 family: mimxrt10xx
@@ -16,7 +16,28 @@ features:
   - Breadboard-Friendly
 ---
 
-Coming Soon!
+The NXP iMX RT1011 microcontroller powers this board with a 500 MHz ARM Cortex M7 processor. There's 4 MB of execute-in-place QSPI for firmware and disk storage plus 128 KB of SRAM in-chip.
+
+## Technical details
+
+* NXP iMX RT1011 processor - ARM Cortex M7 processor running at 500 MHz, with 128 KB SRAM and high speed USB!
+* AirLift WiFi Co-processor, with TLS/SSL support, plenty of RAM for sockets, communication is over SPI and has CircuitPython library support ready to go for fast wireless integration.
+* Power options - 6-12 V DC barrel jack or USB type C
+* UNO-shape so shields can plug in
+* Reset  button - Click to restart, double-click to enter UF2 bootloder
+* Boot-mode switches to get into the ROM bootloader (you can always reload code over USB if TinyUF2 gets corrupted somehow)
+* SWD connector for advanced debugging access.
+* On/Off switch
+* STEMMA QT connector for I2C devices
+* On/User LEDs and status NeoPixel
+* 53.2 mm x 72 mm / 2" x 2.8"
+* Height (w/ barrel jack): 14.8 mm / 0.6"
+* Weight: 22.5 g
+
+## Purchase
+
+* [Adafruit](https://www.adafruit.com/product/4950)
 
 ## Learn More
+
 * [YouTube](https://www.youtube.com/watch?time_continue=1059&v=k62kM94gieo)

--- a/_board/feather_mimxrt1011.md
+++ b/_board/feather_mimxrt1011.md
@@ -19,9 +19,9 @@ A Work-In-Progress Feather featuring the NXP i.MX RT1011 MCU and a ESP32.
 
 ## Technical details
 
-- ARM Cortex-M7 MCU running at 500MHz, 128KB of RAM
-- 8MB of Flash shared between MCU code and CircuitPython storage
-- USB Type-C connector
+- ARM Cortex-M7 MCU running at 500 MHz, 128 KB of RAM
+- 8 MB of Flash shared between MCU code and CircuitPython storage
+- USB-C connector
 - ESP32 that can be used as a SPI slave with the AirLift firmware
 - Neopixel indicator
 - Works with CircuitPython!

--- a/_board/feather_mimxrt1062.md
+++ b/_board/feather_mimxrt1062.md
@@ -19,15 +19,16 @@ A Work-In-Progress Feather featuring the NXP i.MX RT1062 MCU.
 
 ## Technical details
 
-- ARM Cortex-M7 MCU running at 600MHz, 1MB of RAM (!)
-- 8MB of Flash shared between MCU code and CircuitPython storage
-- USB Type-C connector
-- High density connector with LCD interface supporting up to 1366x768
-- Neopixel indicator
-- MicroSD slot on the bottom
-- Works with CircuitPython!
-- I2C, UART, SPI, GPIO, ADCs
-- Comes with a UF2 bootloader for easy FW update
+* ARM Cortex-M7 MCU running at 600 MHz, 1 MB of RAM (!)
+* 8 MB of Flash shared between MCU code and CircuitPython storage
+* USB-C connector
+* High density connector with LCD interface supporting up to 1366x768
+* Neopixel indicator
+* MicroSD slot on the bottom
+* Works with CircuitPython!
+* I2C, UART, SPI, GPIO, ADCs
+* Comes with a UF2 bootloader for easy FW update
 
 ## Learn More
+
 * [Reveal Tweet](https://twitter.com/arturo182/status/1199841134253682690)

--- a/_board/gravitech_cucumber_m.md
+++ b/_board/gravitech_cucumber_m.md
@@ -15,8 +15,15 @@ features:
   - Breadboard-Friendly
 ---
 
-Cucumber M is a WiFi IoT development board. It features the latest ESP32-S2 chipset from Espressif (ESP32-S2-WROOM). M version is using integrated PCB antenna. It is packed with many goodies. I.E. x2 USB Type-C (debug and OTG), FTDI chip for USB-to-Serial converter which highly compatible with most computers, RGB LED which use only one signal line and can mix up to over 16 million color, TX/RX, IO2 and PWR LED, colorful sticker indicate the pin function. Cucumber M come in a nice clear plastic box for ease of storage. All these functions in less than $14USD.
+Cucumber M is a WiFi IoT development board. It features the latest ESP32-S2 chipset from Espressif (ESP32-S2-WROOM). M version is using integrated PCB antenna.
+
+## Features
+
+- x2 USB-C (debug and OTG)
+- FTDI chip for USB-to-Serial converter
+- RGB LED which use only one signal line and can mix up to over 16 million color
+- TX/RX, IO2 and PWR LED
 
 ## Purchase
-Add any links to purchase the board
+
 * [Gravitech](https://www.gravitech.us/cumesdebo.html)

--- a/_board/gravitech_cucumber_ms.md
+++ b/_board/gravitech_cucumber_ms.md
@@ -15,8 +15,18 @@ features:
   - Breadboard-Friendly
 ---
 
-Cucumber MS is a WiFi IoT development board. It features the latest ESP32-S2 chipset from Espressif (ESP32-S2-WROOM). MS version is using integrated PCB antenna. It is a special version which include many on-board sensors. I.E. HS221 Temperature & Humidity sensor, MPU-6050 3-axis Accelerometer & 3-axis Gyroscope, BMP280 Pressure sensor. It is packed with many goodies. I.E. x2 USB Type-C (debug and OTG), FTDI chip for USB-to-Serial converter which highly compatible with most computers, RGB LED which use only one signal line and can mix up to over 16 million color, TX/RX, IO2 and PWR LED, colorful sticker indicate the pin function. Cucumber MS come in a nice clear plastic box for ease of storage. All these functions in less than $20USD.
+Cucumber MS is a WiFi IoT development board. It features the latest ESP32-S2 chipset from Espressif (ESP32-S2-WROOM). MS version is using integrated PCB antenna. It is a special version which include on-board sensors. 
+
+## Features
+
+- HS221 Temperature & Humidity sensor
+- MPU-6050 3-axis Accelerometer & 3-axis Gyroscope
+- BMP280 Pressure sensor.
+- 2x USB-C (debug and OTG)
+- FTDI chip for USB-to-Serial converter which highly compatible with most computers
+- RGB LED which use only one signal line and can mix up to over 16 million color
+- TX/RX, IO2 and PWR LED
 
 ## Purchase
-Add any links to purchase the board
+
 * [Gravitech](https://www.gravitech.us/cumsdebowise.html)

--- a/_board/gravitech_cucumber_r.md
+++ b/_board/gravitech_cucumber_r.md
@@ -15,8 +15,15 @@ features:
   - Breadboard-Friendly
 ---
 
-Cucumber R is a WiFi IoT development board. It features the latest ESP32-S2 chipset from Espressif (ESP32-S2-WROVER). It is packed with many goodies. I.E. x2 USB Type-C (debug and OTG), FTDI chip for USB-to-Serial converter which highly compatible with most computers, RGB LED which use only one signal line and can mix up to over 16 million color, TX/RX, IO2 and PWR LED, colorful sticker indicate the pin function. Cucumber R come in a nice clear plastic box for ease of storage. All these functions in less than $15USD.
+Cucumber R is a WiFi IoT development board. It features the latest ESP32-S2 chipset from Espressif (ESP32-S2-WROVER).
+
+## Features
+
+- x2 USB-C (debug and OTG)
+- FTDI chip for USB-to-Serial converter
+- RGB LED which use only one signal line and can mix up to over 16 million color
+- TX/RX, IO2 and PWR LED
 
 ## Purchase
-Add any links to purchase the board
+
 * [Gravitech](https://www.gravitech.us/curesdebo.html)

--- a/_board/gravitech_cucumber_rs.md
+++ b/_board/gravitech_cucumber_rs.md
@@ -15,8 +15,18 @@ features:
   - Breadboard-Friendly
 ---
 
-Cucumber RS is a special version which include many on-board sensors. I.E. HS221 Temperature & Humidity sensor, MPU-6050 3-axis Accelerometer & 3-axis Gyroscope, BMP280 Pressure sensor. It is a WiFi IoT development board. It features the latest ESP32-S2 chipset from Espressif (ESP32-S2-WROVER). It is packed with many goodies. I.E. x2 USB Type-C (debug and OTG), FTDI chip for USB-to-Serial converter which highly compatible with most computers, RGB LED which use only one signal line and can mix up to over 16 million color, TX/RX, IO2 and PWR LED, colorful sticker indicate the pin function. Cucumber R come in a nice clear plastic box for ease of storage. All these functions in less than $21USD.
+Cucumber RS is a special version which include on-board sensors.
+
+## Features
+
+- HS221 Temperature & Humidity sensor
+- MPU-6050 3-axis Accelerometer & 3-axis Gyroscope
+- BMP280 Pressure sensor.
+- 2x USB-C (debug and OTG)
+- FTDI chip for USB-to-Serial converter which highly compatible with most computers
+- RGB LED which use only one signal line and can mix up to over 16 million color
+- TX/RX, IO2 and PWR LED
 
 ## Purchase
-Add any links to purchase the board
+
 * [Gravitech](https://www.gravitech.us/cursdebowise.html)

--- a/_board/hiibot_iots2.md
+++ b/_board/hiibot_iots2.md
@@ -4,7 +4,7 @@ board_id: "hiibot_iots2"
 title: "HiiBot IoTs2 Download"
 name: "HiiBot IoTs2"
 manufacturer: "Hangzhou LeBan"
-board_url: ""
+board_url: "https://www.tindie.com/products/bradchan/hiibot-iots2/"
 board_image: "hiibot_iots2.jpg"
 date_added: 2020-11-20
 family: esp32s2
@@ -17,26 +17,26 @@ features:
   - Breadboard-Friendly
 ---
 
-Introducing the microS2 - An ESP32-S2 based development board with smaller size (25.4*45.9mm). Features:
+An ESP32-S2 based development board with small size (25.4 mm x 45.9 mm).
 
-  - 32-bit 240 MHz single-core processor
-  - 8MB SPI FlashROM
-  - 8MB SPI PSRAM
-  - 2.4 GHz Wi-Fi - 802.11b/g/n
-  - USB Type-C
-  - 1.14" TFT-LCD (IPS 135x240)
-  - 1x Neopixel (IO16)
-  - 1x programmable Blue LED (IO37)
-  - 2x LED indicator (power[Green], charge[Red])
-  - 1x programmable Button (IO21)
-  - 1x System Reset button
-  - 1x 3-axis Accelerometer (LIS3DH, IO1&2)
-  - 20x GPIO pin exposed
-  - Battery Charging and 1.5A DC-DC
-  - 1x Qwiic/STEMMA QT connector (IO1&2)
+## Features
 
+- 32-bit 240 MHz single-core processor
+- 8 MB SPI FlashROM
+- 8 MB SPI PSRAM
+- 2.4 GHz Wi-Fi - 802.11b/g/n
+- USB-C
+- 1.14" TFT-LCD (IPS 135x240)
+- 1x Neopixel (`GPIO16`)
+- 1x programmable Blue LED (`GPIO37`)
+- 2x LED indicator (power[Green], charge[Red])
+- 1x programmable button (`GPIO21`)
+- 1x System Reset button
+- 1x 3-axis Accelerometer (LIS3DH, `GPIO1` & `GPIO2`)
+- 20x GPIO pin exposed
+- Battery Charging and 1.5 A DC-DC
+- 1x Qwiic/STEMMA QT connector (`GPIO1` & `GPIO2`)
 
+## Purchase
 
-
-
-
+* [Tindie](https://www.tindie.com/products/bradchan/hiibot-iots2/)

--- a/_board/makerdiary_m60_keyboard.md
+++ b/_board/makerdiary_m60_keyboard.md
@@ -11,17 +11,22 @@ family: nrf52840
 features:
   - Bluetooth/BTLE
   - USB-C
-  
 ---
 
-USB Type-C & BLE 5.0 Connectivity
-M60 uses Nordic’s nRF52840 SoC to provide USB Type-C wired and Bluetooth LE 5.0 wireless connectivity. It can easily pair to your PC, laptop, smartphone, or tablet with Bluetooth LE.
+The M60 Mechanical Keyboard a 60% keyboard which has USB and BLE 5.0 connectivity and is hot-swappable.
 
-Powered by Python
-It's not just a keyboard but also a USB drive containing Python files. Its Python code can be changed with any text editor and executed simultaneously, which makes it super easy to customize the keyboard or to add a new function. No need to download any software or setup a development environment.
+## Technical details
 
-Modular, Hot-Swappable & Solder-Free
-To take advantage of the removable M.2 module and hot-swap sockets, assembly made easy. Everyday we find innovative assembly solutions to make things even easier for you because we care about the quality of our products.
+* Core Module: nRF52840 M.2 Module, 64MHz Cortex-M4F, 1MB FLASH/256KB RAM, 8MB QSPI Flash Memory, M.2 KEY-E Form Factor
+* Connectivity: USB wired & Bluetooth Low Energy 5.0 and NFC (with cabled PCB antenna)
+* Layout: 60% (61 Keys)
+* Switch Option: Cherry MX compatible Switches
+* RGB Lighting: Programmable 64 RGBs matrix
+* Battery Charger: Up to 890 mA charge current, USB-friendly, Battery Pack temperature monitoring
+* Firmware: Python with UF2 Bootloader
+* Compatibility: Mac/iOS, Windows, Linux, Android
+* Dimensions: 285 mm x 94.6 mm
 
 ## Purchase
+
 * [MakerDiary](https://makerdiary.com/products/m60-mechanical-keyboard-pcba)

--- a/_board/matrixportal_m4.md
+++ b/_board/matrixportal_m4.md
@@ -19,20 +19,22 @@ Folks love our [wide selection of RGB matrices](https://www.adafruit.com/categor
 
 Plug directly into the back of [any HUB-75 compatible display (all the ones we stock will work) from 16x32 up to 64x64](https://www.adafruit.com/category/327)! Use the included screws to attach the power cable to the power plugs with a common screwdriver, then power it with any USB C power supply. (For larger projects, power the matrices with a separate 5V power adapter)
 
-Then code up your project in [CircuitPython](https://learn.adafruit.com/rgb-led-matrices-matrix-panels-with-circuitpython) or [Arduino](https://learn.adafruit.com/adafruit-protomatter-rgb-matrix-library), our Protomatter matrix library works great on the SAMD51 chipset, knowing that you've got the wiring and level shifting all handled. Here's what you get:
+Then code up your project in [CircuitPython](https://learn.adafruit.com/rgb-led-matrices-matrix-panels-with-circuitpython) or [Arduino](https://learn.adafruit.com/adafruit-protomatter-rgb-matrix-library), our Protomatter matrix library works great on the SAMD51 chipset, knowing that you've got the wiring and level shifting all handled.
 
- * **ATSAMD51J19 Cortex M4 processor**, 512KB flash, 192K of SRAM, with full Arduino or CircuitPython support
- * **ESP32 WiFi co-processor** with TLS support and SPI interface to the M4, with full Arduino or CircuitPython support
- * **USB Type C** connector for data and power connectivity
- * [**I2C STEMMA QT connector** for plug-n-play use of any of our STEMMA QT devices or sensors](https://www.adafruit.com/category/620) can also be used with [any Grove I2C devices using this adapter cable](https://www.adafruit.com/product/4528))
- * **JST 3-pin connector** that also has analog input/output, say for adding audio playback to projects
- * **LIS3DH accelerometer** for digital sand projects or detecting taps/orientation.
- * **GPIO breakouts** including 4 analog outputs with PWM and SPI support for adding other hardware.
- * **Address E line jumper** for use with 64x64 matrices (check your matrix to see which pin is used for address E!
- * **Two user interface buttons** + one reset button
- * **Indicator NeoPixel** and red LED
- * **Green power indicator LEDs** for both 3V and 5V power
- * **2x10 socket connector** fits snugly into 2x8 HUB75 ports without worrying about 'off by one' errors.
+### Features
+
+* **ATSAMD51J19 Cortex M4 processor**, 512 KB flash, 192 K of SRAM, with full Arduino or CircuitPython support
+* **ESP32 WiFi co-processor** with TLS support and SPI interface to the M4, with full Arduino or CircuitPython support
+* **USB-C** connector for data and power connectivity
+* [**I2C STEMMA QT connector** for plug-n-play use of any of our STEMMA QT devices or sensors](https://www.adafruit.com/category/620) can also be used with [any Grove I2C devices using this adapter cable](https://www.adafruit.com/product/4528))
+* **JST 3-pin connector** that also has analog input/output, say for adding audio playback to projects
+* **LIS3DH accelerometer** for digital sand projects or detecting taps/orientation.
+* **GPIO breakouts** including 4 analog outputs with PWM and SPI support for adding other hardware.
+* **Address E line jumper** for use with 64x64 matrices (check your matrix to see which pin is used for address E!
+* **Two user interface buttons** + one reset button
+* **Indicator NeoPixel** and red LED
+* **Green power indicator LEDs** for both 3 V and 5 V power
+* **2x10 socket connector** fits snugly into 2x8 HUB75 ports without worrying about 'off by one' errors.
 
 The Matrix Portal uses an ATMEL (Microchip) ATSAMD51J19, and an Espressif ESP32 Wi-Fi coprocessor with TLS/SSL support built-in. The M4 and ESP32 are a great couple - and each bring their own strengths to this board. The SAMD51 M4 has native USB so it can show up like a disk drive, act as a MIDI or HID keyboard/mouse, and of course bootload and debug over a serial port. It also has DACs, ADC, PWM, and tons of GPIO, so it can handle the high speed updating of the RGB matrix.
 

--- a/_board/meowbit_v121.md
+++ b/_board/meowbit_v121.md
@@ -18,8 +18,8 @@ features:
   - Display
 ---
 
-From the creative and cat-lovin' engineers at KittenBot comes the **Meowbit** - a handheld retro gaming computer for coding your own games with MakeCode Arcade and MicroPython. This design is really fun, with a GameBoy-like shape that can plug into micro:bit expansion boards. The built in display is a 160x128 color 1.8" TFT screen with the familiar ST7735 chipset over SPI. You also get 8 buttons (4-way D-Pad, A and B, menu and reset) to make games or interface with, and there's also a built-in speaker and SD card. For inputs there's a bunch of sensors including a light sensor, temperature sensor and even a 6-DoF gyro+accelerometer.
+From the creative and cat-lovin' engineers at KittenBot comes the **Meowbit** - a handheld retro gaming computer for coding your own games with MakeCode Arcade and MicroPython. This design is really fun, with a GameBoy-like shape that can plug into micro:bit expansion boards. The built in display is a 160x128 color 1.8" TFT screen with the familiar ST7735 chipset over SPI. You also get 8 buttons (4-way D-Pad, A and B, menu and reset) to make games or interface with, and there's also a built-in speaker and SD card. For inputs there's a bunch of sensors including a light sensor, temperature sensor and even a 6-DoF gyroscope/accelerometer.
 
 ## Purchase
-Add any links to purchase the board
+
 * [Adafruit](https://www.adafruit.com/product/4324)

--- a/_board/meowmeow.md
+++ b/_board/meowmeow.md
@@ -4,7 +4,7 @@ board_id: "meowmeow"
 title: "Meow Meow Download"
 name: "Meow Meow"
 manufacturer: "Electronic Cats"
-board_url: ""
+board_url: "https://electroniccats.com/store/meowmeow/"
 board_image: "meowmeow.jpg"
 date_added: 2019-4-1
 family: atmel-samd
@@ -18,4 +18,9 @@ Meow Meow is a electronic board that allows you to connect different objects to 
 Meow Meow was designed by Electronic Cats and wants to encourage experimentation, both for beginners and experts, who want to interact with the real world (physical) and with digital world. For this reason, it can be applied in visual and arts, music... engineering, etc. Even, for purposes of physical rehabilitation and related to the interaction between human and technology.
 
 ## Purchase
+
 * [Electronic Cats](https://electroniccats.com/producto/meowmeow/)
+
+## Learn more
+
+* [GitHub](https://github.com/ElectronicCats/MeowMeow)

--- a/_board/odt_bread_2040.md
+++ b/_board/odt_bread_2040.md
@@ -13,12 +13,16 @@ features:
   - Breadboard-Friendly
 ---
 
-BREAD 2040 is a compact and breadboard friendly development board which features the Raspberry Pi RP2040, a NeoPixel compatible SK6812mini, 2MB of QSPI Flash, Reset button, and all GPIO and SWD pins broken out to the side in an easily breadboard design. No weird pins on the ends! This board is also CircuitPython compatible meaning you can develop your projects faster with python.
+BREAD 2040 is a compact and breadboard friendly development board which features the Raspberry Pi RP2040, a NeoPixel compatible SK6812mini, 2M B of QSPI Flash, Reset button, and all GPIO and SWD pins broken out to the side in an easily breadboard design. No weird pins on the ends! This board is also CircuitPython compatible meaning you can develop your projects faster with Python.
 
 The BREAD2040 was designed in an inspirational burst of energy while watching the CircuitPython Day Adafruit Board Tour.
 
-The BREAD 2040 takes an old fashion approach to this design, keeping in mind bread board friendliness as well as providing modern USB style plugs with the USB Type-C connector.
+The BREAD 2040 takes an old fashion approach to this design, keeping in mind bread board friendliness as well as providing modern USB style plugs with the USB-C connector.
 
 ## Purchase
 
 * [Tindie](https://www.tindie.com/products/24791/)
+
+## Learn more
+
+* [Schematics](https://github.com/skerr92/odt-dev-boards/tree/master/boards/BREAD%202040)

--- a/_board/odt_cast_away_rp2040.md
+++ b/_board/odt_cast_away_rp2040.md
@@ -15,15 +15,20 @@ features:
 
 Cast your project fears away with the Cast-Away RP2040, a small and easy to use RP2040 dev board designed to take your project to the beach. This board uses the popular Raspberry Pi RP2040, a dual core ARM Cortex M0 microcontroller.
 
-Features
-USB-C Connector
-NEOPIXEL Compatible SK6812mini Addressable RGB LED
-15 Flexible GPIO (3 Analog, All PWM'able)
-Castellated single sided design for flush mounting
-Buttons on the corners for easy access
-3.3V broken out with 500mA max output
-Raw USB Power (5.5V) and USB PID configured for up to 3A with USB Type-C PID Supply
+## Features
+
+- USB-C Connector
+- NEOPIXEL Compatible SK6812mini Addressable RGB LED
+- 15 Flexible GPIO (3 Analog, All PWM'able)
+- Castellated single sided design for flush mounting
+- Buttons on the corners for easy access
+- 3.3 V broken out with 500 mA max output
+- Raw USB Power (5.5 V) and USB PID configured for up to 3 A with USB-C PID Supply
 
 ## Purchase
 
 * [Tindie](https://www.tindie.com/products/oakdevtech/cast-away-rp2040-a-castellated-rp2040-dev-board/)
+
+## Learn more
+
+* [Schematics](https://github.com/skerr92/odt-dev-boards/tree/master/boards/Cast-Away-RP2040)

--- a/_board/odt_pixelwing_esp32_s2.md
+++ b/_board/odt_pixelwing_esp32_s2.md
@@ -18,8 +18,13 @@ The PixelWing Matrix is a powerful ESP32-S2 RGB Matrix Display board that allows
 
 In addition to this, the PixelWing provides a quick access I2C JST connector that is compatible with Qwiic and Stemma QT connectors allowing you to connect all your favorite Adafruit and Sparkfun sensor breakouts.
 
-All of this is combined with Circuit Python support making it easy to get programming on your project.
+All of this is combined with CircuitPython support making it easy to get programming on your project.
 
 ## Purchase
 
 * [Tindie](https://www.tindie.com/products/oakdevtech/pixelwing-esp32-s2-rgb-matrix/)
+
+
+## Learn more
+
+* [Schematics](https://github.com/skerr92/odt-dev-boards/tree/master/boards/PixelWing-ESP32)

--- a/_board/qtpy_m0.md
+++ b/_board/qtpy_m0.md
@@ -28,26 +28,23 @@ Pinout and shape is [Seeed Xiao](https://wiki.seeedstudio.com/Seeeduino-XIAO/) c
 
 Runs Arduino like a dream, and can be used for basic CircuitPython projects. For more advanced usage like datalogging or file storage, solder an SOIC SPI flash chip onto the bottom pads,
 
- * Same size, form-factor, and pin-out as Seeed Xiao
- * **ATSAMD21E18** 32-bit Cortex M0+ - 48 MHz 32 bit processor with **256KB Flash** and **32 KB RAM**
+ * Same size (20 mm x 17.5 mm), form-factor, and pin-out as Seeed Xiao
+ * **ATSAMD21E18** 32-bit Cortex M0+ - 48 MHz 32-bit processor with 256 KB Flash and 32 KB RAM
  * Native USB supported by every OS - can be used in Arduino or CircuitPython as USB serial console, MIDI, Keyboard/Mouse HID, even a little disk drive for storing Python scripts.
- * Can be used with **Arduino IDE** or **CircuitPython**
- * **Built in RGB NeoPixel LED**
+ * Can be used with Arduino IDE or CircuitPython
+ * Built in RGB NeoPixel LED
  * **11 GPIO pins**:
    * True analog output on one I/O pin - can be used to play 10-bit quality audio clips in Arduino (CircuitPython does not have storage for audio clips)
    * 9 x 12-bit analog inputs (SDA/SCL do not have analog inputs)
-   * 1 x Optional AREF on A1
-   * 9 x PWM outputs (A0 is analog out, A1 is not PWM capable)
+   * 1 x Optional AREF on `A1`
+   * 9 x PWM outputs (`A0` is analog out, `A1` is not PWM capable)
    * Hardware I2C port with STEMMA QT plug-n-play connector
-   * Hardware UART
-   * Hardware SPI
-   * Hardware I2S
+   * Hardware UART, Hardware SPI, Hardware I2S
    * 6 x Capacitive Touch with no additional components required
- * 3.3V regulator with [600mA peak output](https://www.diodes.com/assets/Datasheets/AP2112.pdf)
+ * 3.3 V regulator with [600 mA peak output](https://www.diodes.com/assets/Datasheets/AP2112.pdf)
  * [Optional SOIC-8 SPI Flash chip on bottom](https://www.adafruit.com/product/4763)
  * **Reset switch** for starting your project code over or entering bootloader mode
- * **USB Type C connector**
- * **Really really small**
+ * USB-C connector
 
 ## Purchase
 

--- a/_board/qtpy_m0_haxpress.md
+++ b/_board/qtpy_m0_haxpress.md
@@ -24,29 +24,26 @@ This time it comes with [our favorite connector - the STEMMA QT](http://adafruit
 
 Use any [SparkFun Qwiic](http://www.sparkfun.com/qwiic) boards! [Seeed Grove I2C boards](https://www.adafruit.com/product/4528) will also work with this adapter cable.
 
-Pinout and shape is [Seeed Xiao](https://wiki.seeedstudio.com/Seeeduino-XIAO/) compatible, with castellated pads so you can solder it flat to a PCB. In addition to the QT connector, we also added an **RGB NeoPixel** (with controllable power pin to allow for ultra-low-power usage), **and a reset button** (great for restarting your program, or entering the bootloader)
+Pinout and shape is [Seeed Xiao](https://wiki.seeedstudio.com/Seeeduino-XIAO/) compatible, with castellated pads so you can solder it flat to a PCB. In addition to the QT connector, we also added an **RGB NeoPixel** (with controllable power pin to allow for ultra-low-power usage), **and a reset button** (great for restarting your program, or entering the bootloader).
 
 Runs Arduino like a dream, and can be used for basic CircuitPython projects. For more advanced usage like datalogging or file storage, solder an SOIC SPI flash chip onto the bottom pads,
 
- * Same size, form-factor, and pin-out as Seeed Xiao
- * **ATSAMD21E18** 32-bit Cortex M0+ - 48 MHz 32 bit processor with **256KB Flash** and **32 KB RAM**
+ * Same size (20 mm x 17.5 mm), form-factor, and pin-out as Seeed Xiao
+ * **ATSAMD21E18** 32-bit Cortex M0+ - 48 MHz 32 bit processor with 256 KB Flash and 32 KB RAM
  * Native USB supported by every OS - can be used in Arduino or CircuitPython as USB serial console, MIDI, Keyboard/Mouse HID, even a little disk drive for storing Python scripts.
- * Can be used with **Arduino IDE** or **CircuitPython**
- * **Built in RGB NeoPixel LED**
+ * Can be used with Arduino IDE or CircuitPython
+ * Built in RGB NeoPixel LED
  * **11 GPIO pins**:
    * True analog output on one I/O pin - can be used to play 10-bit quality audio clips in Arduino (CircuitPython does not have storage for audio clips)
    * 9 x 12-bit analog inputs (SDA/SCL do not have analog inputs)
-   * 1 x Optional AREF on A1
-   * 9 x PWM outputs (A0 is analog out, A1 is not PWM capable)
+   * 1 x Optional AREF on `A1`
+   * 9 x PWM outputs (`A0` is analog out, `A1` is not PWM capable)
    * Hardware I2C port with STEMMA QT plug-n-play connector
-   * Hardware UART
-   * Hardware SPI
-   * Hardware I2S
+   * Hardware UART, Hardware SPI, Hardware I2S
    * 6 x Capacitive Touch with no additional components required
- * 3.3V regulator with [600mA peak output](https://www.diodes.com/assets/Datasheets/AP2112.pdf)
+ * 3.3 V regulator with [600 mA peak output](https://www.diodes.com/assets/Datasheets/AP2112.pdf)
  * **Reset switch** for starting your project code over or entering bootloader mode
- * **USB Type C connector**
- * **Really really small**
+ * USB-C connector
 
 ## Purchase
 

--- a/_board/seeeduino_xiao.md
+++ b/_board/seeeduino_xiao.md
@@ -13,29 +13,33 @@ features:
   - USB-C
   - Breadboard-Friendly
 ---
-SEEED Studio's Seeeduino XIAO is a minimal, low-cost board that uses the Atmel ATSAMD21G18, a powerful 32-bit ARM Cortex®-M0+ processor running at 48MHz with 256KB Flash and 32KB SRAM. The board is 20 x 17.5mm in size which is perfect for wearable devices and small projects. It has multiple interfaces including DAC output, SWD Bonding pad interface, I2C, UART and SPI interfaces. It's compatible with both Arduino IDE and CircuitPython and uses a USB-C connector.
 
-Specifications:
-* CPU: ARM Cortex-M0+ CPU (SAMD21G18) running at up to 48MHz
-* Flash Memory: 256KB
-* SRAM: 32KB
+SEEED Studio's Seeeduino XIAO is a minimal, low-cost board that uses the Atmel ATSAMD21G18, a powerful 32-bit ARM Cortex®-M0+ processor running at 48MHz with 256 KB Flash and 32 KB SRAM. The board is 20 mm x 17.5 mm in size which is perfect for wearable devices and small projects. It has multiple interfaces including DAC output, SWD Bonding pad interface, I2C, UART and SPI interfaces. It's compatible with both Arduino IDE and CircuitPython and uses a USB-C connector.
+
+## Technical details
+
+* CPU: ARM Cortex-M0+ CPU (SAMD21G18) running at up to 48 MHz
+* Flash Memory: 256 KB
+* SRAM: 32 KB
 * Digital I/O pins: 11
 * Analog I/O pins: 11
 * I2C interfaces: 1
 * SPI interfaces: 1
 * UART interfaces: 1
-* USB Type-C connector for transferring code and power
-* Power requirements: 3.3V/5V DC
-* Dimensions  20 × 17.5 × 3.5 mm
+* USB-C connector for transferring code and power
+* Power requirements: 3.3 V/5 V DC
+* Dimensions: 20 mm x 17.5 mm x 3.5 mm
 
-Note: This microcontroller runs at 3.3V logic. Using a 5V device may damage the chip or device.
+Note: This microcontroller runs at 3.3 V logic. Using a 5 V device may damage the chip or device.
 
-For power supply pins: The built-in DC-DC converter circuit is able to change 5V voltage into 3.3V, which allows you to power the device with a 5V supply via the VIN pin or 5V pin.
+For power supply pins: The built-in DC-DC converter circuit is able to change 5 V voltage into 3.3 V, which allows you to power the device with a 5 V supply via the VIN pin or 5V pin.
 
 ## Tutorial
+
 * [Installation of CircuitPython](https://wiki.seeedstudio.com/Seeeduino-XIAO-CircuitPython/)
 
 ## Purchase
+
 * [Seeed](https://www.seeedstudio.com/Seeeduino-XIAO-Arduino-Microcontroller-SAMD21-Cortex-M0+-p-4426.html)
 * [Digi-Key](https://www.digikey.com/en/product-highlight/s/seeed/seeeduino-xiao-arduino-microcontroller-samd21-cortex-m0)
 * [Mouser](https://www.mouser.com/ProductDetail/Seeed-Studio/102010328?qs=GBLSl2AkirtQWO8CTzEK9g%3D%3D)

--- a/_board/seeeduino_xiao_kb.md
+++ b/_board/seeeduino_xiao_kb.md
@@ -13,6 +13,7 @@ features:
   - USB-C
   - Breadboard-Friendly
 ---
+
 # Keyboard Optimized
 
 Due to the limited memory and flash of the ATSAMD21G18, an optimized build of CircuitPython is needed for keyboard/keypad/macropad projects.  The following modules are made available:
@@ -32,27 +33,30 @@ If you need one of the modules removed or if you want to absolutely be sure that
 
 This build was tested with a 30 keys macropad which is the largest matrix the XIAO allows for (5x6 matrix = 11 GPIOs).
 
-# Seeduino XIAO:
-SEEED Studio's Seeeduino XIAO is a minimal, low-cost board that uses the Atmel c, a powerful 32-bit ARM Cortex®-M0+ processor running at 48MHz with 256KB Flash and 32KB SRAM.  The board is 20 x 17.5mm in size which is perfect for wearable devices and small projects. It has multiple interfaces including DAC output, SWD Bonding pad interface, I2C, UART and SPI interfaces. It's compatible with both Arduino IDE and CircuitPython and uses a USB-C connector.
+# Seeduino XIAO
 
-Specifications:
-* CPU: ARM Cortex-M0+ CPU (SAMD21G18) running at up to 48MHz
-* Flash Memory: 256KB
-* SRAM: 32KB
+SEEED Studio's Seeeduino XIAO is a minimal, low-cost board that uses the Atmel c, a powerful 32-bit ARM Cortex®-M0+ processor running at 48 MHz with 256 KB Flash and 32 KB SRAM. The board is 20 mm x 17.5 mm in size which is perfect for wearable devices and small projects. It has multiple interfaces including DAC output, SWD Bonding pad interface, I2C, UART and SPI interfaces. It's compatible with both Arduino IDE and CircuitPython and uses a USB-C connector.
+
+## Technical details
+
+* CPU: ARM Cortex-M0+ CPU (SAMD21G18) running at up to 48 MHz
+* Flash Memory: 256 KB
+* SRAM: 32 KB
 * Digital I/O pins: 11
 * Analog I/O pins: 11
 * I2C interfaces: 1
 * SPI interfaces: 1
 * UART interfaces: 1
-* USB Type-C connector for transferring code and power
-* Power requirements: 3.3V/5V DC
-* Dimensions  20 × 17.5 × 3.5 mm
+* USB-C connector for transferring code and power
+* Power requirements: 3.3 V/5 V DC
+* Dimensions: 20 mm x 17.5 mm x 3.5 mm
 
-Note: This microcontroller runs at 3.3V logic. Using a 5V device may damage the chip or device.
+Note: This microcontroller runs at 3.3 V logic. Using a 5 V device may damage the chip or device.
 
-For power supply pins: The built-in DC-DC converter circuit is able to change 5V voltage into 3.3V, which allows you to power the device with a 5V supply via the VIN pin or 5V pin.
+For power supply pins: The built-in DC-DC converter circuit is able to change 5 V voltage into 3.3 V, which allows you to power the device with a 5 V supply via the VIN pin or 5V pin.
 
 ## Purchase
+
 * [Seeed](https://www.seeedstudio.com/Seeeduino-XIAO-Arduino-Microcontroller-SAMD21-Cortex-M0+-p-4426.html)
 * [Digi-Key](https://www.digikey.com/en/product-highlight/s/seeed/seeeduino-xiao-arduino-microcontroller-samd21-cortex-m0)
 * [Mouser](https://www.mouser.com/ProductDetail/Seeed-Studio/102010328?qs=GBLSl2AkirtQWO8CTzEK9g%3D%3D)

--- a/_board/seeeduino_xiao_rp2040.md
+++ b/_board/seeeduino_xiao_rp2040.md
@@ -28,7 +28,7 @@ Interfaces:
 * 1 SPI interface
 * 1 SWD Bonding pad interface 
 
-Some PINs have various functions, Moreover, XIAO RP2040 supports the USB Type-C interface which can supply power and download code. 1 Reset button, 1 BOOT button, 1 user-programmable RGB LED, 1 power LED, 2 status indicators, and 1 user LED are on board, allowing developers to debug their code very easily.
+Some PINs have various functions, Moreover, XIAO RP2040 supports the USB-C interface which can supply power and download code. 1 Reset button, 1 BOOT button, 1 user-programmable RGB LED, 1 power LED, 2 status indicators, and 1 user LED are on board, allowing developers to debug their code very easily.
 
 The XIAO RP2040 is very compact because all electronic components are soldered on the same board surface, which means you can easily solder the XIAO RP2040 to your own PCB. XIAO RP2040 is pin-compatible with Seeeduino XIAO, so XIAO RP2040 can be learned and developed using the Expansion board of Seeeduino XIAO. 
 

--- a/_board/serpente.md
+++ b/_board/serpente.md
@@ -17,7 +17,7 @@ features:
   - USB-C
 ---
 
-There are two Serpente boards, they are both virtually the same, except for the USB connector. The standard Serpente board contains a USB Type-C connector, and the Serpente Plug uses the board itself as a Type-A USB plug.
+There are two Serpente boards, they are both virtually the same, except for the USB connector. The standard Serpente board contains a USB-C connector, and the Serpente Plug uses the board itself as a Type-A USB plug.
 
 If you are familiar with the Digispark boards, you may notice some similarities. This fact is of course not incidental, the Serpente boards are inspired by the Digispark, both in form-factor as well as use-cases. The Serpente boards are meant to be used as quick and dirty, yet flexible, prototyping tools.
 
@@ -25,18 +25,20 @@ If you are familiar with the Digispark boards, you may notice some similarities.
 
 Here are some of the technical details regarding the boards:
 
-- ATSAMD21E18A 32-bit Cortex-M0+ running at 48MHz
-- 256KB flash and 32KB RAM
-- 4MB Flash for storing files and CircuitPython code
+- ATSAMD21E18A 32-bit Cortex-M0+ running at 48 MHz
+- 256 KB flash and 32 KB RAM
+- 4 MB Flash for storing files and CircuitPython code
 - 6 highly customizable GPIOs
-- 250mA LDO
-- 3.3V logic and power
+- 250 mA LDO
+- 3.3 V logic and power
 - Powered either from USB or external source
 - User-controlled RGB LED
-- Mounting holes on the Serpente Type-C board
-
-* [Documentation](https://serpente.solder.party/)
-* [Hackaday.io Project](https://hackaday.io/project/167192-serpente)
+- Mounting holes on the Serpente board with the USB-C connector
 
 ## Purchase
 * [Tindie](https://www.tindie.com/products/arturo182/serpente-a-tiny-circuitpython-prototyping-board/)
+
+## Learn more
+
+* [Documentation](https://serpente.solder.party/)
+* [Hackaday.io Project](https://hackaday.io/project/167192-serpente)

--- a/_board/tinkeringtech_scoutmakes_azul.md
+++ b/_board/tinkeringtech_scoutmakes_azul.md
@@ -18,32 +18,32 @@ features:
 
 The **ScoutMakes Azul** is an open source Bluetooth (BLE) development platform featuring the nRF52840 (32bit ARM Cortex-M4 processor) from Nordic semiconductors enabling excellent Bluetooth development capabilities for your project. It conforms to the Adafruit feather format, runs CircuitPython, Arduino. The platform also has native USB support.
 
-To enable even more integration, a 128×32 OLED is also built in along with USB type-C support and a power switch for ease of use.
+To enable even more integration, a 128x32 OLED is also built in along with USB-C support and a power switch for ease of use.
 
 The platform come pre-programmed with a UF2 bootloader and CircuitPython ready to go out of box. You can pair the Azul with Adafruit bluefruit application in iOS or Android to get going. The application includes a color picker, quaternion/accelerometer/gyro/magnetometer or location (GPS), and an 8-button control game pad. This data can be read over BLE and processed directly by the nRF52 microcontroller.
 
-**Features:**
+## Technical details
 
-*   ARM Cortex M4F (with HW floating point acceleration) running at 64MHz
-*   1MB flash and 256KB SRAM
-*   **Native Open Source USB stack** - pre-programmed with UF2 bootloader
-*   Bluetooth Low Energy compatible 2.4GHz radio (Details available in the [nRF52840](https://www.nordicsemi.com/Products/Low-power-short-range-wireless/nRF52840) product specification)
-*   **FCC / IC / TELEC certified module**
-*   Up to +8dBm output power
-*   Built-in 128-32 OLED display
-*   USB type-C connector
-*   ON/OFF power switch
-*   1.7v to 3.3v operation with internal linear and DC/DC voltage regulators
-*   21 GPIO, 6 x 12-bit ADC pins, up to 12 PWM outputs (3 PWM modules with 4 outputs each)
-*   Pin #3 red LED for general purpose blinking, NeoPixel for colorful feedback
-*   4 mounting holes
-*   Reset button
-*   Open source design
-*   Works out of the box with Adafruit's feather wings
+* ARM Cortex M4F (with HW floating point acceleration) running at 64 MHz
+* 1 MB flash and 256 KB SRAM
+* Pre-programmed with UF2 bootloader
+* Bluetooth Low Energy compatible 2.4 GHz radio (Details available in the [nRF52840](https://www.nordicsemi.com/Products/Low-power-short-range-wireless/nRF52840) product specification)
+* Up to +8 dBm output power
+* Built-in 128-32 OLED display
+* USB-C connector
+* ON/OFF power switch
+* 1.7 V to 3.3 V operation with internal linear and DC/DC voltage regulators
+* 21 GPIO, 6 12-bit ADC pins, up to 12 PWM outputs (3 PWM modules with 4 outputs each)
+* Pin #3 red LED for general purpose blinking, NeoPixel for colorful feedback
+* 4 mounting holes
+* Reset button
+* Open source design
+* Works out of the box with Adafruit's feather wings
 ## Tutorial
 
 - [ScoutMakes Azul Overview](https://tinkeringtech.com/blog/scoutmakes-azul/)
 - [ScoutMakes Youtube Channel](https://www.youtube.com/channel/UCYcssarGk-M_4w-jmb3To0Q/featured/)
 
 ## Purchase
+
 * [TinkeringTech](https://tinkeringtech.com/blog/scoutmakes-azul/)


### PR DESCRIPTION
The most significant (and maybe controversial) change in this set of commits is to follow the SI standard more closely. In short: Between the numerical value and the unit of measurement is a space. Or `1Apple` is now `1 Apple` :wink: 

This will require more iterations as only a partial amount of boards is covered so far.

Other changes:

- Use USB-C instead of USB Type c, USB Type C or USB Type-C
- Add periods
- Update specs
- Remove some marketing statements
- Add blank line after heading
- Remove leftovers from the template
- Add a couple of links to GitHub/schematics
