### PR TITLE
This is ESP32-S3 not ESP32-S2

### DIFF
--- a/_board/adafruit_qtpy_esp32s3_nopsram.md
+++ b/_board/adafruit_qtpy_esp32s3_nopsram.md
@@ -1,8 +1,8 @@
 ---
 layout: download
 board_id: "adafruit_qtpy_esp32s3_nopsram"
-title: "Adafruit QT Py ESP32-S2 No PSRAM Download"
-name: "Adafruit QT Py ESP32-S2 No PSRAM"
+title: "Adafruit QT Py ESP32-S3 No PSRAM Download"
+name: "Adafruit QT Py ESP32-S3 No PSRAM"
 manufacturer: "Adafruit"
 board_url: ""
 board_image: "adafruit_qtpy_esp32s3_nopsram.jpg"


### PR DESCRIPTION
Just changing the obvious confusion between ESP32-S2 and ESP32-S3...

But maybe the first YouTube video need to be removed, it does not seems to talk about ESP32-S3 but only about ESP32 and playing doom or game emulation.