### PR TITLE
Remove reference to TTGO T8 ESP32-S2

### DIFF
--- a/_board/lilygo_ttgo_t8_s2_st7789.md
+++ b/_board/lilygo_ttgo_t8_s2_st7789.md
@@ -38,12 +38,9 @@ The display has native CircuitPython support.
 
 * [LILYGO Github repository](https://github.com/Xinyuan-LilyGO/LilyGo-T-Display-S2)
 
-## Board compatibility
+## Setup
 
-This image is working on the TTGO T8 ESP32-S2 V1.1 as well.
-It's basically the same board as the ST7789 just without the display.
-
-To flash this image use this command:
+To flash this image, use this command:
 
 ```sh
 esptool.py  --chip esp32s2 --port (COMPORT) --baud 115200 write_flash 0x000 \


### PR DESCRIPTION
TTGO T8 ESP32-S2 is now also [supported](https://circuitpython.org/board/lilygo_ttgo_t8_s2/).