### PR TITLE
Set to latest TinyUF2 release 0.8.0

### DIFF
--- a/_data/bootloaders.json
+++ b/_data/bootloaders.json
@@ -7,7 +7,7 @@
             "version": "v3.14.0"
         },
         "esp32s2": {
-            "version": "0.7.0"
+            "version": "0.8.0"
         },
         "stm": {},
         "cxd56": {},


### PR DESCRIPTION
Changelog for 0.8.0

* Rename board lolin_s2-pico to lolin-s2_pico (match CircuitPython board)
* NXP SPSDK for MIMXRT builds
* add custom esp32s2 board
* fix double tap issue

https://github.com/adafruit/tinyuf2/releases/tag/0.8.0