### PR TITLE
Add missing espressif bootloader IDs

### DIFF
--- a/_board/adafruit_qtpy_esp32s2.md
+++ b/_board/adafruit_qtpy_esp32s2.md
@@ -8,6 +8,7 @@ board_url: "https://www.adafruit.com/product/5325"
 board_image: "adafruit_qtpy_esp32s2.jpg"
 date_added: 2021-11-30
 family: esp32s2
+bootloader_id: adafruit_qtpy_esp32s2
 features:
   - STEMMA QT/QWIIC
   - USB-C

--- a/_board/ai_thinker_esp_12k_nodemcu.md
+++ b/_board/ai_thinker_esp_12k_nodemcu.md
@@ -8,6 +8,7 @@ board_url: "https://docs.ai-thinker.com/en/12k_development_board_esp32-s2"
 board_image: "ai_thinker_esp_12k_nodemcu.jpg"
 date_added: 2021-8-24
 family: esp32s2
+bootloader_id: adafruit_qtpy_esp32s2
 features:
   - Breadboard-Friendly
   - Wi-Fi

--- a/_board/espressif_esp32s3_devkitc_1_n8.md
+++ b/_board/espressif_esp32s3_devkitc_1_n8.md
@@ -8,6 +8,7 @@ board_url: "https://www.adafruit.com/product/5312"
 board_image: "espressif_esp32s3_devkitc_1.jpg"
 date_added: 2022-1-4
 family: esp32s3
+bootloader_id: espressif_esp32s3_devkitc_1
 features:
   - Wi-Fi
   - Breadboard-Friendly

--- a/_board/espressif_esp32s3_devkitc_1_n8r2.md
+++ b/_board/espressif_esp32s3_devkitc_1_n8r2.md
@@ -8,6 +8,7 @@ board_url: "https://www.adafruit.com/product/5310"
 board_image: "espressif_esp32s3_devkitc_1.jpg"
 date_added: 2021-12-7
 family: esp32s3
+bootloader_id: espressif_esp32s3_devkitc_1
 features:
   - Wi-Fi
   - Breadboard-Friendly

--- a/_board/espressif_esp32s3_devkitc_1_n8r8.md
+++ b/_board/espressif_esp32s3_devkitc_1_n8r8.md
@@ -8,6 +8,7 @@ board_url: "https://www.adafruit.com/product/5336"
 board_image: "espressif_esp32s3_devkitc_1.jpg"
 date_added: 2022-1-15
 family: esp32s3
+bootloader_id: espressif_esp32s3_devkitc_1
 features:
   - Wi-Fi
   - Breadboard-Friendly

--- a/_board/espressif_esp32s3_devkitm_1_n8.md
+++ b/_board/espressif_esp32s3_devkitm_1_n8.md
@@ -8,6 +8,7 @@ board_url: "https://www.adafruit.com/product/5311"
 board_image: "espressif_esp32s3_devkitm_1_n8.jpg"
 date_added: 2022-4-1
 family: esp32s3
+bootloader_id: espressif_esp32s3_devkitm_1
 features:
   - Wi-Fi
   - Breadboard-Friendly

--- a/_board/espressif_kaluga_1.3.md
+++ b/_board/espressif_kaluga_1.3.md
@@ -8,6 +8,7 @@ board_url: "https://www.adafruit.com/product/4729"
 board_image: "espressif_kaluga_1.jpg"
 date_added: 2021-06-09
 family: esp32s2
+bootloader_id: espressif_kaluga_1
 features:
   - Wi-Fi
 ---

--- a/_board/gravitech_cucumber_m.md
+++ b/_board/gravitech_cucumber_m.md
@@ -8,6 +8,7 @@ board_url: "https://www.gravitech.us/cumesdebo.html"
 board_image: "gravitech_cucumber_m.jpg"
 date_added: 2021-8-13
 family: esp32s2
+bootloader_id: gravitech_cucumberRIS_v1.1
 downloads_display: true
 features:
   - Wi-Fi

--- a/_board/gravitech_cucumber_ms.md
+++ b/_board/gravitech_cucumber_ms.md
@@ -8,6 +8,7 @@ board_url: "https://www.gravitech.us/cumsdebowise.html"
 board_image: "gravitech_cucumber_ms.jpg"
 date_added: 2021-8-13
 family: esp32s2
+bootloader_id: gravitech_cucumberRIS_v1.1
 downloads_display: true
 features:
   - Wi-Fi

--- a/_board/gravitech_cucumber_r.md
+++ b/_board/gravitech_cucumber_r.md
@@ -8,6 +8,7 @@ board_url: "https://www.gravitech.us/curesdebo.html"
 board_image: "gravitech_cucumber_r.jpg"
 date_added: 2021-8-13
 family: esp32s2
+bootloader_id: gravitech_cucumberRIS_v1.1
 downloads_display: true
 features:
   - Wi-Fi

--- a/_board/gravitech_cucumber_rs.md
+++ b/_board/gravitech_cucumber_rs.md
@@ -8,6 +8,7 @@ board_url: "https://www.gravitech.us/cursdebowise.html"
 board_image: "gravitech_cucumber_rs.jpg"
 date_added: 2021-8-13
 family: esp32s2
+bootloader_id: gravitech_cucumberRIS_v1.1
 downloads_display: true
 features:
   - Wi-Fi

--- a/_board/hexky_s2.md
+++ b/_board/hexky_s2.md
@@ -9,7 +9,9 @@ board_image: "unknown.jpg"
 downloads_display: false
 date_added: 2022-4-1
 family: esp32s2
+bootloader_id: hexky_s2
 features:
+
 ---
 
 This board hasn't been fully documented yet. Please make a pull request adding more info to this file.

--- a/_board/lilygo_ttgo_t8_s2.md
+++ b/_board/lilygo_ttgo_t8_s2.md
@@ -8,6 +8,7 @@ board_url: "http://www.lilygo.cn/prod_view.aspx?TypeId=50033&Id=1321"
 board_image: "lilygo_ttgo_t8_s2.jpg"
 date_added:
 family: esp32s2
+bootloader_id: lilygo_ttgo_t8_s2
 features:
   - Wi-Fi
   - Battery Charging

--- a/_board/lilygo_ttgo_t8_s2_st7789.md
+++ b/_board/lilygo_ttgo_t8_s2_st7789.md
@@ -8,6 +8,7 @@ board_url: "http://www.lilygo.cn/prod_view.aspx?TypeId=50033&Id=1321"
 board_image: "lilygo_ttgo_t8_s2_st7789.jpg"
 date_added:
 family: esp32s2
+bootloader_id: lilygo_ttgo_t8_s2_st7789
 features:
   - Wi-Fi
   - Display 

--- a/_board/microdev_micro_c3.md
+++ b/_board/microdev_micro_c3.md
@@ -8,7 +8,6 @@ board_url: "https://microdev.systems/"
 board_image: "microdev_micro_c3.jpg"
 date_added: 2021-10-06
 family: esp32c3
-bootloader_id: microdev_micro_c3
 features:
   - Bluetooth/BTLE
   - Breadboard-Friendly

--- a/_board/unexpectedmaker_feathers2_prerelease.md
+++ b/_board/unexpectedmaker_feathers2_prerelease.md
@@ -8,6 +8,7 @@ board_url: ""
 board_image: "unexpectedmaker_feathers2_prerelease.jpg"
 date_added: 2020-6-14
 family: esp32s2
+bootloader_id: unexpectedmaker_feathers2
 features:
   - Feather-Compatible
   - Battery Charging

--- a/_includes/download/board.html
+++ b/_includes/download/board.html
@@ -167,7 +167,7 @@ By the way, boolean operation precedence is right to left! (yeesh)
 {% assign bootloader_id = page.bootloader_id %}
 {% if bootloader_version and bootloader_id %}
 
-{% if page.family == 'esp32s2' %}
+{% if page.family == 'esp32s2' or page.family == 'esp32c3' or page.family == 'esp32s3' %}
 <div class="section unrecommended">
   <h3>Install, Repair, or Update UF2 Bootloader</h3>
   <p>
@@ -186,7 +186,7 @@ By the way, boolean operation precedence is right to left! (yeesh)
   </p>
   <p>
     If a UF2 bootloader has never been installed on the board, or the UF2 bootloader was removed by erasing or overwriting the flash, the UF2 bootloader must be installed in order to flash <b>.uf2</b> files onto the board. <b>.bin</b> files can be uploaded without a UF2 bootloader, using the
-    <a href="https://adafruit.github.io/Adafruit_WebSerial_ESPTool/">Adafruit WebSerial ESPTool</a>
+    <a href="https://nabucasa.github.io/esp-web-flasher/">ESP Web Flasher</a>
     or <b>esptool.py</b>.
   </p>
 
@@ -211,7 +211,7 @@ By the way, boolean operation precedence is right to left! (yeesh)
   </li>
   <li>Upload <b>combined.bin</b> (Google Chrome 89 or newer):
    <ul>
-    <li>Open <a href="https://adafruit.github.io/Adafruit_WebSerial_ESPTool/">Adafruit WebSerial ESPTool</a> in a new window/tab.</li>
+    <li>Open <a href="https://nabucasa.github.io/esp-web-flasher/">ESP Web Flasher</a> in a new window/tab.</li>
     <li>Select <b>460800 Baud</b> from the pull-down menu (top-right).</li>
     <li>Click <b>Connect</b> (top-right).</li>
     <li>Select the COM or Serial port from the pop-up window.</li>


### PR DESCRIPTION
Fixes #943. Pulled IDs from here: https://github.com/adafruit/tinyuf2/releases. Some were missing. A couple C3 bootloader IDs removed due to not using native USB.