### PR TITLE
Check features at build time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,10 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: true
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.0
@@ -38,6 +42,9 @@ jobs:
       run: |
         gem install bundler:1.17.3
         bundle install --full-index
+        pip install python-frontmatter
+    - name: Check feature names
+      run: python3 check-features.py
     - name: Build site with jekyll
       run: |
         bundle exec jekyll build -d build

--- a/_board/adafruit_qtpy_esp32s2.md
+++ b/_board/adafruit_qtpy_esp32s2.md
@@ -12,7 +12,7 @@ features:
   - STEMMA QT/QWIIC
   - USB-C
   - Breadboard-Friendly
-  - Wi-Fi (two version, onboard antenna or uFL connector)
+  - Wi-Fi
 ---
 
 What has your favorite Espressif WiFi microcontroller, comes with [our favorite connector - the STEMMA QT](http://adafruit.com/stemma), a chainable I2C port, and has lots of Flash and RAM memory for your next IoT project? What will make your next IoT project flyyyyy? What a cutie pie! Or is it... a **QT Py**? This diminutive dev board comes with one of our new favorite lil chips, the **ESP32-S2**! 

--- a/_board/diodes_delight_piunora.md
+++ b/_board/diodes_delight_piunora.md
@@ -10,7 +10,7 @@ download_instructions:
 date_added: 2021-2-14
 features:
   - Wi-Fi
-  - Bluetooth/BLE
+  - Bluetooth/BTLE
   - STEMMA QT/QWIIC
   - Arduino Shield Compatible
   - USB-C

--- a/_board/raspberrypi_zero.md
+++ b/_board/raspberrypi_zero.md
@@ -8,7 +8,6 @@ board_url: "https://www.raspberrypi.com/products/raspberry-pi-zero/"
 board_image: "raspberry_pi_zero.jpg"
 date_added: 2022-2-14
 features:
-- 40-pin GPIO
 ---
 
 **NOTE**: Not all features are supported in CircuitPython.

--- a/check-features.py
+++ b/check-features.py
@@ -1,0 +1,18 @@
+#!/usr/bin/python3
+from pathlib import Path
+import frontmatter
+
+with open('template.md', "rt") as f:
+    metadata, content = frontmatter.parse(f.read())
+    acceptable_features = set(metadata['features'])
+
+failed = False
+for filename in Path('_board').glob("*.md"):
+    with open(filename, "rt") as f:
+        metadata, content = frontmatter.parse(f.read())
+    features = metadata.get('features') or ()
+    for feature in sorted(set(features) - acceptable_features):
+        print(f"{filename}:0: Non-standard feature: {feature}")
+        failed = True
+
+raise SystemExit(failed)


### PR DESCRIPTION
Before this, people were requested to follow a set list of features, but we had no automated check for it. Do this as a step of the CI, or a step that can be run locally.

I found several boards that had non-standard features listed; I corrected or deleted them as I saw appropriate.

There are also a number of boards without any features: blocks. I did not attempt to fix this. However, if this were fixed we could add an additional check in this script for future boards. However, this assumes every board has at least one feature in the list of features, which may not be true.