### PR TITLE
List frozen modules in the download page

### DIFF
--- a/_data/files.json
+++ b/_data/files.json
@@ -8,8 +8,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_HID",
-     "Adafruit_CircuitPython_SD"
+     "adafruit_hid",
+     "adafruit_sdcard"
     ],
     "languages": [
      "de_DE",
@@ -65,8 +65,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_HID",
-     "Adafruit_CircuitPython_SD"
+     "adafruit_hid",
+     "adafruit_sdcard"
     ],
     "languages": [
      "de_DE",
@@ -497,19 +497,18 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_BusDevice",
-     "Adafruit_CircuitPython_Register",
-     "Adafruit_CircuitPython_ST7789",
-     "Adafruit_CircuitPython_Display_Shapes",
-     "Adafruit_CircuitPython_Display_Text",
-     "Adafruit_CircuitPython_ProgressBar",
-     "Adafruit_CircuitPython_LSM6DS",
-     "Adafruit_CircuitPython_FocalTouch",
-     "Adafruit_CircuitPython_DS3231",
-     "Adafruit_CircuitPython_LC709203F",
-     "Adafruit_CircuitPython_DRV2605",
-     "Adafruit_CircuitPython_BLE",
-     "Adafruit_CircuitPython_BLE_Apple_Notification_Center"
+     "adafruit_ble",
+     "adafruit_ble_apple_notification_center",
+     "adafruit_display_shapes",
+     "adafruit_display_text",
+     "adafruit_drv2605",
+     "adafruit_ds3231",
+     "adafruit_focaltouch",
+     "adafruit_lc709203f",
+     "adafruit_lsm6ds",
+     "adafruit_progressbar",
+     "adafruit_register",
+     "adafruit_st7789"
     ],
     "languages": [
      "de_DE",
@@ -599,18 +598,18 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_Register",
-     "Adafruit_CircuitPython_ST7789",
-     "Adafruit_CircuitPython_Display_Shapes",
-     "Adafruit_CircuitPython_Display_Text",
-     "Adafruit_CircuitPython_ProgressBar",
-     "Adafruit_CircuitPython_LSM6DS",
-     "Adafruit_CircuitPython_FocalTouch",
-     "Adafruit_CircuitPython_DS3231",
-     "Adafruit_CircuitPython_LC709203F",
-     "Adafruit_CircuitPython_DRV2605",
-     "Adafruit_CircuitPython_BLE",
-     "Adafruit_CircuitPython_BLE_Apple_Notification_Center"
+     "adafruit_ble",
+     "adafruit_ble_apple_notification_center",
+     "adafruit_display_shapes",
+     "adafruit_display_text",
+     "adafruit_drv2605",
+     "adafruit_ds3231",
+     "adafruit_focaltouch",
+     "adafruit_lc709203f",
+     "adafruit_lsm6ds",
+     "adafruit_progressbar",
+     "adafruit_register",
+     "adafruit_st7789"
     ],
     "languages": [
      "de_DE",
@@ -1318,10 +1317,9 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_Requests",
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_BusDevice",
-     "Adafruit_CircuitPython_Register"
+     "adafruit_register",
+     "adafruit_requests",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -1420,9 +1418,9 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_Requests",
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Register"
+     "adafruit_register",
+     "adafruit_requests",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -1825,11 +1823,11 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_PortalBase",
-     "Adafruit_CircuitPython_FakeRequests",
-     "Adafruit_CircuitPython_Requests",
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Display_Text"
+     "adafruit_display_text",
+     "adafruit_fakerequests",
+     "adafruit_portalbase",
+     "adafruit_requests",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -1928,11 +1926,11 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_PortalBase",
-     "Adafruit_CircuitPython_FakeRequests",
-     "Adafruit_CircuitPython_Requests",
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Display_Text"
+     "adafruit_display_text",
+     "adafruit_fakerequests",
+     "adafruit_portalbase",
+     "adafruit_requests",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -2799,12 +2797,12 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_PortalBase",
-     "Adafruit_CircuitPython_FakeRequests",
-     "Adafruit_CircuitPython_Requests",
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Display_Text",
-     "Adafruit_CircuitPython_LIS3DH"
+     "adafruit_display_text",
+     "adafruit_fakerequests",
+     "adafruit_lis3dh",
+     "adafruit_portalbase",
+     "adafruit_requests",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -2903,12 +2901,12 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_PortalBase",
-     "Adafruit_CircuitPython_FakeRequests",
-     "Adafruit_CircuitPython_Requests",
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Display_Text",
-     "Adafruit_CircuitPython_LIS3DH"
+     "adafruit_display_text",
+     "adafruit_fakerequests",
+     "adafruit_lis3dh",
+     "adafruit_portalbase",
+     "adafruit_requests",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -3218,8 +3216,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_HID"
+     "adafruit_hid",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -3268,8 +3266,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_HID"
+     "adafruit_hid",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -3325,8 +3323,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_APDS9960",
-     "Adafruit_CircuitPython_NeoPixel"
+     "adafruit_apds9960",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -3377,8 +3375,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_APDS9960",
-     "Adafruit_CircuitPython_NeoPixel"
+     "adafruit_apds9960",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -3922,10 +3920,9 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_Requests",
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_BusDevice",
-     "Adafruit_CircuitPython_Register"
+     "adafruit_register",
+     "adafruit_requests",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -4022,9 +4019,9 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_Requests",
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Register"
+     "adafruit_register",
+     "adafruit_requests",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -4320,8 +4317,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_HID"
+     "adafruit_hid",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -4371,8 +4368,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_HID"
+     "adafruit_hid",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -4429,9 +4426,9 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_SimpleMath",
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_HID"
+     "adafruit_hid",
+     "adafruit_simplemath",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -4481,9 +4478,9 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_SimpleMath",
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_HID"
+     "adafruit_hid",
+     "adafruit_simplemath",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -9676,11 +9673,11 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_CircuitPlayground",
-     "Adafruit_CircuitPython_HID",
-     "Adafruit_CircuitPython_LIS3DH",
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Thermistor"
+     "adafruit_circuitplayground",
+     "adafruit_hid",
+     "adafruit_lis3dh",
+     "adafruit_thermistor",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -9744,11 +9741,11 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_CircuitPlayground",
-     "Adafruit_CircuitPython_HID",
-     "Adafruit_CircuitPython_LIS3DH",
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Thermistor"
+     "adafruit_circuitplayground",
+     "adafruit_hid",
+     "adafruit_lis3dh",
+     "adafruit_thermistor",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -9819,11 +9816,11 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_CircuitPlayground",
-     "Adafruit_CircuitPython_HID",
-     "Adafruit_CircuitPython_LIS3DH",
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Thermistor"
+     "adafruit_circuitplayground",
+     "adafruit_hid",
+     "adafruit_lis3dh",
+     "adafruit_thermistor",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -9887,11 +9884,11 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_CircuitPlayground",
-     "Adafruit_CircuitPython_HID",
-     "Adafruit_CircuitPython_LIS3DH",
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Thermistor"
+     "adafruit_circuitplayground",
+     "adafruit_hid",
+     "adafruit_lis3dh",
+     "adafruit_thermistor",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -9962,13 +9959,13 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_CircuitPlayground",
-     "Adafruit_CircuitPython_Crickit",
-     "Adafruit_CircuitPython_LIS3DH",
-     "Adafruit_CircuitPython_Motor",
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_seesaw",
-     "Adafruit_CircuitPython_Thermistor"
+     "adafruit_circuitplayground",
+     "adafruit_crickit",
+     "adafruit_lis3dh",
+     "adafruit_motor",
+     "adafruit_seesaw",
+     "adafruit_thermistor",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -10030,13 +10027,13 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_CircuitPlayground",
-     "Adafruit_CircuitPython_Crickit",
-     "Adafruit_CircuitPython_LIS3DH",
-     "Adafruit_CircuitPython_Motor",
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_seesaw",
-     "Adafruit_CircuitPython_Thermistor"
+     "adafruit_circuitplayground",
+     "adafruit_crickit",
+     "adafruit_lis3dh",
+     "adafruit_motor",
+     "adafruit_seesaw",
+     "adafruit_thermistor",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -10104,11 +10101,11 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_CircuitPlayground",
-     "Adafruit_CircuitPython_HID",
-     "Adafruit_CircuitPython_LIS3DH",
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Thermistor"
+     "adafruit_circuitplayground",
+     "adafruit_hid",
+     "adafruit_lis3dh",
+     "adafruit_thermistor",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -10172,11 +10169,11 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_CircuitPlayground",
-     "Adafruit_CircuitPython_HID",
-     "Adafruit_CircuitPython_LIS3DH",
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Thermistor"
+     "adafruit_circuitplayground",
+     "adafruit_hid",
+     "adafruit_lis3dh",
+     "adafruit_thermistor",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -10247,10 +10244,10 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_CircuitPlayground",
-     "Adafruit_CircuitPython_LIS3DH",
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Thermistor"
+     "adafruit_circuitplayground",
+     "adafruit_lis3dh",
+     "adafruit_thermistor",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -10310,10 +10307,10 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_CircuitPlayground",
-     "Adafruit_CircuitPython_LIS3DH",
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Thermistor"
+     "adafruit_circuitplayground",
+     "adafruit_lis3dh",
+     "adafruit_thermistor",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -11301,8 +11298,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_SimpleIO"
+     "neopixel",
+     "simpleio"
     ],
     "languages": [
      "de_DE",
@@ -11395,8 +11392,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_SimpleIO"
+     "neopixel",
+     "simpleio"
     ],
     "languages": [
      "de_DE",
@@ -11498,9 +11495,9 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Motor",
-     "Adafruit_CircuitPython_SimpleIO"
+     "adafruit_motor",
+     "neopixel",
+     "simpleio"
     ],
     "languages": [
      "de_DE",
@@ -11593,9 +11590,9 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Motor",
-     "Adafruit_CircuitPython_SimpleIO"
+     "adafruit_motor",
+     "neopixel",
+     "simpleio"
     ],
     "languages": [
      "de_DE",
@@ -12478,8 +12475,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_RFM9x"
+     "adafruit_rfm9x",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -12534,8 +12531,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_RFM9x"
+     "adafruit_rfm9x",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -12917,7 +12914,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "pybadge"
+     "stage",
+     "ugame"
     ],
     "languages": [
      "de_DE",
@@ -13007,7 +13005,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "pybadge"
+     "stage",
+     "ugame"
     ],
     "languages": [
      "de_DE",
@@ -17216,10 +17215,10 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_Crickit",
-     "Adafruit_CircuitPython_Motor",
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_seesaw"
+     "adafruit_crickit",
+     "adafruit_motor",
+     "adafruit_seesaw",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -17280,10 +17279,10 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_Crickit",
-     "Adafruit_CircuitPython_Motor",
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_seesaw"
+     "adafruit_crickit",
+     "adafruit_motor",
+     "adafruit_seesaw",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -17352,7 +17351,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_RFM69"
+     "adafruit_rfm69"
     ],
     "languages": [
      "de_DE",
@@ -17402,7 +17401,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_RFM69"
+     "adafruit_rfm69"
     ],
     "languages": [
      "de_DE",
@@ -17459,7 +17458,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_RFM9x"
+     "adafruit_rfm9x"
     ],
     "languages": [
      "de_DE",
@@ -17509,7 +17508,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_RFM9x"
+     "adafruit_rfm9x"
     ],
     "languages": [
      "de_DE",
@@ -18080,8 +18079,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_ESP32SPI",
-     "Adafruit_CircuitPython_Requests"
+     "adafruit_esp32spi",
+     "adafruit_requests"
     ],
     "languages": [
      "de_DE",
@@ -18158,8 +18157,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_ESP32SPI",
-     "Adafruit_CircuitPython_Requests"
+     "adafruit_esp32spi",
+     "adafruit_requests"
     ],
     "languages": [
      "de_DE",
@@ -18244,8 +18243,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_ESP32SPI",
-     "Adafruit_CircuitPython_Requests"
+     "adafruit_esp32spi",
+     "adafruit_requests"
     ],
     "languages": [
      "de_DE",
@@ -18322,8 +18321,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_ESP32SPI",
-     "Adafruit_CircuitPython_Requests"
+     "adafruit_esp32spi",
+     "adafruit_requests"
     ],
     "languages": [
      "de_DE",
@@ -20788,8 +20787,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_LIS3DH",
-     "Adafruit_CircuitPython_NeoPixel"
+     "adafruit_lis3dh",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -20853,8 +20852,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_LIS3DH",
-     "Adafruit_CircuitPython_NeoPixel"
+     "adafruit_lis3dh",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -21117,7 +21116,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel"
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -21929,8 +21928,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_ESP32SPI",
-     "Adafruit_CircuitPython_Requests"
+     "adafruit_esp32spi",
+     "adafruit_requests"
     ],
     "languages": [
      "de_DE",
@@ -22007,8 +22006,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_ESP32SPI",
-     "Adafruit_CircuitPython_Requests"
+     "adafruit_esp32spi",
+     "adafruit_requests"
     ],
     "languages": [
      "de_DE",
@@ -24633,7 +24632,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel"
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -24732,7 +24731,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel"
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -24840,7 +24839,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel"
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -24939,7 +24938,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel"
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -25784,9 +25783,9 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_Requests",
-     "Adafruit_CircuitPython_ESP32SPI",
-     "Adafruit_CircuitPython_NeoPixel"
+     "adafruit_esp32spi",
+     "adafruit_requests",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -25875,9 +25874,9 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_Requests",
-     "Adafruit_CircuitPython_ESP32SPI",
-     "Adafruit_CircuitPython_NeoPixel"
+     "adafruit_esp32spi",
+     "adafruit_requests",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -26163,7 +26162,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "meowbit"
+     "stage",
+     "ugame"
     ],
     "languages": [
      "de_DE",
@@ -26239,7 +26239,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "meowbit"
+     "stage",
+     "ugame"
     ],
     "languages": [
      "de_DE",
@@ -26944,8 +26945,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_ESP32SPI",
-     "Adafruit_CircuitPython_Requests"
+     "adafruit_esp32spi",
+     "adafruit_requests"
     ],
     "languages": [
      "de_DE",
@@ -27022,8 +27023,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_ESP32SPI",
-     "Adafruit_CircuitPython_Requests"
+     "adafruit_esp32spi",
+     "adafruit_requests"
     ],
     "languages": [
      "de_DE",
@@ -27800,7 +27801,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_DotStar"
+     "adafruit_dotstar"
     ],
     "languages": [
      "de_DE",
@@ -27892,7 +27893,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_DotStar"
+     "adafruit_dotstar"
     ],
     "languages": [
      "de_DE",
@@ -29011,8 +29012,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_HID",
-     "Adafruit_CircuitPython_NeoPixel"
+     "adafruit_hid",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -29061,8 +29062,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_HID",
-     "Adafruit_CircuitPython_NeoPixel"
+     "adafruit_hid",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -32026,7 +32027,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "pew-pewpew-standalone-10.x"
+     "pew"
     ],
     "languages": [
      "de_DE",
@@ -32077,7 +32078,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "pew-pewpew-standalone-10.x"
+     "pew"
     ],
     "languages": [
      "de_DE",
@@ -32135,7 +32136,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "pew-pewpew-standalone-10.x"
+     "pew"
     ],
     "languages": [
      "de_DE",
@@ -32186,7 +32187,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "pew-pewpew-standalone-10.x"
+     "pew"
     ],
     "languages": [
      "de_DE",
@@ -32244,7 +32245,9 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "pewpew_m4"
+     "pew",
+     "stage",
+     "ugame"
     ],
     "languages": [
      "de_DE",
@@ -32300,7 +32303,9 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "pewpew_m4"
+     "pew",
+     "stage",
+     "ugame"
     ],
     "languages": [
      "de_DE",
@@ -33628,7 +33633,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "picosystem"
+     "stage",
+     "ugame"
     ],
     "languages": [
      "de_DE",
@@ -33722,7 +33728,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "picosystem"
+     "stage",
+     "ugame"
     ],
     "languages": [
      "de_DE",
@@ -34829,7 +34836,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "pybadge"
+     "stage",
+     "ugame"
     ],
     "languages": [
      "de_DE",
@@ -34919,7 +34927,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "pybadge"
+     "stage",
+     "ugame"
     ],
     "languages": [
      "de_DE",
@@ -35195,8 +35204,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Register"
+     "adafruit_register",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -35275,8 +35284,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Register"
+     "adafruit_register",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -35364,8 +35373,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Register"
+     "adafruit_register",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -35444,8 +35453,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Register"
+     "adafruit_register",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -35533,8 +35542,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Register"
+     "adafruit_register",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -35613,8 +35622,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Register"
+     "adafruit_register",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -35702,8 +35711,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Register"
+     "adafruit_register",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -35782,8 +35791,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Register"
+     "adafruit_register",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -35871,7 +35880,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "pygamer"
+     "stage",
+     "ugame"
     ],
     "languages": [
      "de_DE",
@@ -35961,7 +35971,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "pygamer"
+     "stage",
+     "ugame"
     ],
     "languages": [
      "de_DE",
@@ -36065,12 +36076,12 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_PortalBase",
-     "Adafruit_CircuitPython_Requests",
-     "Adafruit_CircuitPython_ESP32SPI",
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Display_Text",
-     "Adafruit_CircuitPython_FakeRequests"
+     "adafruit_display_text",
+     "adafruit_esp32spi",
+     "adafruit_fakerequests",
+     "adafruit_portalbase",
+     "adafruit_requests",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -36163,12 +36174,12 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_PortalBase",
-     "Adafruit_CircuitPython_Requests",
-     "Adafruit_CircuitPython_ESP32SPI",
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Display_Text",
-     "Adafruit_CircuitPython_FakeRequests"
+     "adafruit_display_text",
+     "adafruit_esp32spi",
+     "adafruit_fakerequests",
+     "adafruit_portalbase",
+     "adafruit_requests",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -36270,12 +36281,12 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_PortalBase",
-     "Adafruit_CircuitPython_Requests",
-     "Adafruit_CircuitPython_ESP32SPI",
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Display_Text",
-     "Adafruit_CircuitPython_FakeRequests"
+     "adafruit_display_text",
+     "adafruit_esp32spi",
+     "adafruit_fakerequests",
+     "adafruit_portalbase",
+     "adafruit_requests",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -36368,12 +36379,12 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_PortalBase",
-     "Adafruit_CircuitPython_Requests",
-     "Adafruit_CircuitPython_ESP32SPI",
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Display_Text",
-     "Adafruit_CircuitPython_FakeRequests"
+     "adafruit_display_text",
+     "adafruit_esp32spi",
+     "adafruit_fakerequests",
+     "adafruit_portalbase",
+     "adafruit_requests",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -36475,12 +36486,12 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_PortalBase",
-     "Adafruit_CircuitPython_Requests",
-     "Adafruit_CircuitPython_ESP32SPI",
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Display_Text",
-     "Adafruit_CircuitPython_FakeRequests"
+     "adafruit_display_text",
+     "adafruit_esp32spi",
+     "adafruit_fakerequests",
+     "adafruit_portalbase",
+     "adafruit_requests",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -36573,12 +36584,12 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_PortalBase",
-     "Adafruit_CircuitPython_Requests",
-     "Adafruit_CircuitPython_ESP32SPI",
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Display_Text",
-     "Adafruit_CircuitPython_FakeRequests"
+     "adafruit_display_text",
+     "adafruit_esp32spi",
+     "adafruit_fakerequests",
+     "adafruit_portalbase",
+     "adafruit_requests",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -38514,7 +38525,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel"
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -38595,7 +38606,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel"
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -38685,7 +38696,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel"
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -38778,7 +38789,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel"
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -39366,8 +39377,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_HID",
-     "Adafruit_CircuitPython_NeoPixel"
+     "adafruit_hid",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -39418,8 +39429,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_HID",
-     "Adafruit_CircuitPython_NeoPixel"
+     "adafruit_hid",
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -40458,11 +40469,10 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "solderparty_rp2040_stamp",
-     "Adafruit_CircuitPython_BusDevice",
-     "Adafruit_CircuitPython_HID",
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Register"
+     "adafruit_hid",
+     "adafruit_register",
+     "neopixel",
+     "stamp_carrier_board"
     ],
     "languages": [
      "de_DE",
@@ -40555,10 +40565,10 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "solderparty_rp2040_stamp",
-     "Adafruit_CircuitPython_HID",
-     "Adafruit_CircuitPython_NeoPixel",
-     "Adafruit_CircuitPython_Register"
+     "adafruit_hid",
+     "adafruit_register",
+     "neopixel",
+     "stamp_carrier_board"
     ],
     "languages": [
      "de_DE",
@@ -40660,7 +40670,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_DotStar"
+     "adafruit_dotstar"
     ],
     "languages": [
      "de_DE",
@@ -40722,7 +40732,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_DotStar"
+     "adafruit_dotstar"
     ],
     "languages": [
      "de_DE",
@@ -46929,7 +46939,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "ugame10"
+     "stage",
+     "ugame"
     ],
     "languages": [
      "de_DE",
@@ -46986,7 +46997,8 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "ugame10"
+     "stage",
+     "ugame"
     ],
     "languages": [
      "de_DE",
@@ -47254,7 +47266,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel"
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -47353,7 +47365,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel"
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -47664,7 +47676,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel"
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -47761,7 +47773,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel"
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -47867,7 +47879,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel"
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -47964,7 +47976,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel"
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -48070,7 +48082,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel"
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -48170,7 +48182,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel"
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -48279,7 +48291,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel"
+     "neopixel"
     ],
     "languages": [
      "de_DE",
@@ -48377,7 +48389,7 @@
      "uf2"
     ],
     "frozen_libraries": [
-     "Adafruit_CircuitPython_NeoPixel"
+     "neopixel"
     ],
     "languages": [
      "de_DE",

--- a/_includes/download/board.html
+++ b/_includes/download/board.html
@@ -119,6 +119,12 @@
         <span class="download-modules {% if version.stable %}stable{% else %}unstable{% endif %}">{{ version.modules | join: ', ' }}</span>
     </p>
     {% endif %}
+    {% if version.frozen_libraries and version.frozen_libraries.size != 0 %}
+    <p>
+        Included frozen<sup><a href="https://docs.circuitpython.org/en/latest/docs/reference/glossary.html?highlight=frozen#term-frozen-module" title="What is a frozen module">(?)</a></sup> modules:
+        <span class="download-modules {% if version.stable %}stable{% else %}unstable{% endif %}">{{ version.frozen_libraries | join: ', ' }}</span>
+    </p>
+    {% endif %}
   </div>
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
This lists the frozen modules below the built-in ones on boards pages.
Also includes a fix of files.json to replace frozen dir names with actual module names, [as mentioned here](https://github.com/adafruit/circuitpython-org/issues/684#issuecomment-1100794905).

The (?) link points to [the glossary's short paragraph on frozen modules](https://docs.circuitpython.org/en/latest/docs/reference/glossary.html?highlight=frozen#term-frozen-module).
Another possibility was [the frozen modules page in the "building circuitpython" guide](https://learn.adafruit.com/building-circuitpython/adding-frozen-modules).

It would be nice to have a more end-user-oriented reference on frozen modules, explaining that they take precedence over the lib directory, and how to replace them with a newer version (by placing a new version in the root directory). Maybe as a page in docs.circuitpython.org.

<img width="636" alt="Capture d’écran 2022-05-11 à 13 53 34" src="https://user-images.githubusercontent.com/6160205/167852147-43a7205e-f721-450c-aefb-53177c29ecf5.png">
