### PR TITLE
Add IoTS2 firmware ID and bump tinyuf2 version

### DIFF
--- a/_board/hiibot_iots2.md
+++ b/_board/hiibot_iots2.md
@@ -8,6 +8,7 @@ board_url: "https://www.tindie.com/products/bradchan/hiibot-iots2/"
 board_image: "hiibot_iots2.jpg"
 date_added: 2020-11-20
 family: esp32s2
+bootloader_id: hiibot_iots2
 features:
   - Display
   - Wi-Fi

--- a/_data/bootloaders.json
+++ b/_data/bootloaders.json
@@ -7,10 +7,10 @@
             "version": "v3.14.0"
         },
         "esp32s2": {
-            "version": "0.9.0"
+            "version": "0.9.2"
         },
         "esp32s3": {
-            "version": "0.9.0"
+            "version": "0.9.2"
         },
         "esp32c3": {},
         "stm": {},


### PR DESCRIPTION
`tinyuf2` 0.9.2 was released, adding the Hiibot IoTS2 files to the assets.