### PR TITLE
Display issue labels for open issues

### DIFF
--- a/assets/sass/pages/_contributing.scss
+++ b/assets/sass/pages/_contributing.scss
@@ -23,4 +23,60 @@
       }
     }
   }
+
+  ul.issues-list{
+    li {
+      .issue-label {
+        border-radius: 2em;
+        padding: 0 7px;
+        margin-left: 5px;
+        font-size: 12px;
+        font-weight: 500;
+        line-height: 18px;
+        white-space: nowrap;
+        border: 1px solid transparent;
+      }
+      .wontfix {
+        background-color: #e4e669;
+        color: #ffffff;
+        border-color: #000;
+      }
+      .question {
+        background-color: #cc317c;
+        color: #fff;
+      }
+      .invalid {
+        background-color: #e4e669;
+        color: #000;
+      }
+      .help-wanted {
+        background-color: #008672;
+        color: #fff;
+      }
+      .hacktoberfest {
+        background-color: #f2b36f;
+        color: #000;
+      }
+      .good-first-issue {
+        background-color: #7057ff;
+        color: #fff;
+      }
+      .enhancement {
+        background-color: #a2eeef;
+        color: #000;
+      }
+      .duplicate {
+        background-color: #cfd3d7;
+        color: #000;
+      }
+      .documentation {
+        background-color: #0075ca;
+        color: #fff;
+      }
+      .bug {
+        background-color: #d73a4a;
+        color: #fff;
+      }
+    }
+  }
 }

--- a/contributing/open_issues.html
+++ b/contributing/open_issues.html
@@ -32,12 +32,13 @@ permalink: /contributing/open-issues
         {{library[0]}}
         <ul class="issues-list">
         {% for issue in library[1] %}
-        {% capture classes %}
-          {% for label in issue.labels %}
-            {{ label | downcase | replace: ' ', '-' }}
-          {% endfor %}
-        {% endcapture %}
-        <li class="{{ classes | strip }}"><a href="{{ issue.url }}">{{ issue.title }}</a></li>
+        <li><a href="{{ issue.url }}">{{ issue.title }}</a>
+            {% for label in issue.labels %}
+              {% if label != 'None' %}
+                <span class="issue-label {{ label | downcase | replace: ' ', '-' }}">{{label}}</span>
+              {% endif %}
+            {% endfor %}
+        </li>
         {% endfor %}
         </ul>
       </li>


### PR DESCRIPTION
Fixes #646. I attempted to use `:after` style css labels first, but css spec only allows 1 `:after` per item, so this was the best approach to display multiple tags.