### PR TITLE
autofocus downloads search and exclude .idea directory

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -61,3 +61,4 @@ exclude:
   - icon.png
   - template.md
   - Rakefile
+  - .idea

--- a/assets/javascript/downloads.js
+++ b/assets/javascript/downloads.js
@@ -441,3 +441,7 @@ function appendFilterTag(type, name) {
 function removeFilterTag(type, name) {
   document.querySelector("[data-type='" + type + "'][data-name='" + name + "']").parentNode.remove();
 }
+
+window.addEventListener('load', function () {
+    document.querySelector("#search").focus();
+});


### PR DESCRIPTION
this will cause the search input on the downloads page to automatically focused when the page loads, so user can begin typing immediately.

I've also added `.idea` to the exclude list inside of `_config` file because I noticed that the test server command `bundle exec jekyll serve` was noticing changes inside of `.idea` that my IDE is making and using it as a trigger to regenerate all of the pages for the project even though that change it noticed isn't actually related to the project itself.