### PR TITLE
Fix Adafruit Feather ESP32S2 bootloader id and bump tinyuf2

### DIFF
--- a/_board/adafruit_feather_esp32s3_4mbflash_2mbpsram.md
+++ b/_board/adafruit_feather_esp32s3_4mbflash_2mbpsram.md
@@ -8,7 +8,7 @@ board_url: "https://www.adafruit.com/product/5477"
 board_image: "adafruit_feather_esp32s3_4mbflash_2mbpsram.jpg"
 date_added: 2022-6-9
 family: esp32s3
-bootloader_id: adafruit_feather_esp32s3_4mbflash_2mbpsram
+bootloader_id: adafruit_feather_esp32s3
 downloads_display: true
 features:
   - Feather-Compatible

--- a/_data/bootloaders.json
+++ b/_data/bootloaders.json
@@ -7,10 +7,10 @@
             "version": "v3.14.0"
         },
         "esp32s2": {
-            "version": "0.9.2"
+            "version": "0.9.4"
         },
         "esp32s3": {
-            "version": "0.9.2"
+            "version": "0.9.4"
         },
         "esp32c3": {},
         "stm": {},


### PR DESCRIPTION
Fixes the bootloader_id for Feather ESP32-S3 4MB Flash 2MB PSRAM.
Bump tinyuf2 from 0.9.2 to 0.9.4 as required.

https://github.com/adafruit/tinyuf2/releases/tag/0.9.3