### PR TITLE
Update bootloader versions to latest

### DIFF
--- a/_data/bootloaders.json
+++ b/_data/bootloaders.json
@@ -1,16 +1,16 @@
 {
     "bootloaders": {
         "nrf52840": {
-            "version": "0.6.4"
+            "version": "0.7.0"
         },
         "atmel-samd": {
             "version": "v3.14.0"
         },
         "esp32s2": {
-            "version": "0.9.4"
+            "version": "0.10.2"
         },
         "esp32s3": {
-            "version": "0.9.4"
+            "version": "0.10.2"
         },
         "esp32c3": {},
         "stm": {},


### PR DESCRIPTION
Updated after checking the following repos:
https://github.com/adafruit/Adafruit_nRF52_Bootloader/releases (nRF52 Bootloaders)
https://github.com/adafruit/uf2-samdx1/releases (SAMD Bootloaders)
https://github.com/adafruit/tinyuf2/releases (ESPS2 and ESPS3 Bootloaders)