### PR TITLE
Update subheader/brief description of board

### DIFF
--- a/_board/lolin_c3_mini.md
+++ b/_board/lolin_c3_mini.md
@@ -17,7 +17,7 @@ features:
 
 ---
 
-A development boards with an OLED and a small form factor.
+A mini Wi-Fi & Bluetooth LE board based on ESP32-C3FH4.
 
 ## Features
 


### PR DESCRIPTION
The live version says this has an OLED, that's not true. I made minor modifications to Wemos's own description of the board [here](https://www.wemos.cc/en/latest/c3/c3_mini.html)