### PR TITLE
Improve ESP32-nn bootloader installation instructions

### DIFF
--- a/_includes/download/board.html
+++ b/_includes/download/board.html
@@ -197,14 +197,17 @@ By the way, boolean operation precedence is right to left! (yeesh)
   </p>
 
   <p>
-    <em>Note: <b>update.uf2</b> files are not currently working on ESP32-S2 boards.</em>
+    <em>Note: <b>update.uf2</b> files are not currently working on ESP32-S2 or ESP32-S3 boards.</em>
   </p>
 
   <p><strong><em>Important</em></strong>:
     <em>this will erase previously flashed firmware and sketches from the board,
       but needs to be perfomed only once.</em>
   </p>
-
+  <p><em>The instructions here are general.
+      We recommend you consult the manufacturer's board documentation for detailed
+      instructions, which may be different.</em>
+  </p>
  <ul>
   <li>Unzip to find the file <b>combined.bin</b>.</li>
   <li>Place board in bootloader mode:
@@ -230,8 +233,13 @@ By the way, boolean operation precedence is right to left! (yeesh)
   </li>
  </ul>
  <p>
- After you update, check <b>INFO_UF2.TXT</b> to verify that the bootloader version has been updated.
- Then you will need to load or reload CircuitPython using the <b>.uf2</b> file.
+   After installing the UF2 bootloader, enter the bootloader by double-clicking the reset button.
+   On boards with an RGB status LED, tap reset once, wait for the LED to turn purple, and tap
+   again before the purple goes away. On other boards, consult the board documentation.
+   </p>
+ <p>
+   After you update, check <b>INFO_UF2.TXT</b> to verify that the bootloader version has been updated.
+   Then you will need to load or reload CircuitPython using the <b>.uf2</b> file.
  </p>
  <div>
     <a class="download-button" href="https://github.com/adafruit/tinyuf2/releases/download/{{ bootloader_version }}/tinyuf2-{{ bootloader_id }}-{{ bootloader_version }}.zip">DOWNLOAD BOOTLOADER ZIP<i class="fas fa-download" aria-hidden="true"></i></a>


### PR DESCRIPTION
Fixes #1001.

Caution users to refer to board documentation to update or install UF2 bootloader.
Describe how to enter UF2 bootloader.