### PR TITLE
Update link for CircuitPython day to latest blog post with schedule

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@ layout: home
 <div id="home-page">
   <div class="promotion-banner">
       <a
-          href="https://blog.adafruit.com/2022/07/20/announcing-circuitpython-day-2022-on-august-19th-circuitpythonday2022-circuitpython-python-copy/">
+          href="https://blog.adafruit.com/2022/08/04/announcing-circuitpython-day-2022-on-august-19th-circuitpythonday2022-circuitpython-python-copy-copy-copy/">
         <img class="image-promotion" alt="CircuitPython Day August 19, 2022 Details"
                                   src="{{ "assets/images/heroes/circuitpython_day_header.jpg" |
                                           relative_url }}"


### PR DESCRIPTION
This PR changes the link to the CircuitPython Day banner on circuitpython.org to the [latest blog post](https://blog.adafruit.com/2022/08/04/announcing-circuitpython-day-2022-on-august-19th-circuitpythonday2022-circuitpython-python-copy-copy-copy/), which includes the schedule of events (the original does not).

Thank you!