### PR TITLE
Fixing case for microDev vs MicroDev

### DIFF
--- a/_board/microdev_micro_c3.md
+++ b/_board/microdev_micro_c3.md
@@ -3,7 +3,7 @@ layout: download
 board_id: "microdev_micro_c3"
 title: "MicroDev microC3 Download"
 name: "MicroDev microC3"
-manufacturer: "MicroDev"
+manufacturer: "microDev"
 board_url: "https://microdev.systems/"
 board_image: "microdev_micro_c3.jpg"
 date_added: 2021-10-06


### PR DESCRIPTION
There are two board by "microDev" but one is spelled "MicroDev", so I decided on a single case:
* manufacturer: "microDev"

Otherwise you have two entry in the Filter part.