### PR TITLE
Make sure all 3 board use "Switch Science, Inc"

### DIFF
--- a/_board/bless_dev_board_multi_sensor.md
+++ b/_board/bless_dev_board_multi_sensor.md
@@ -3,7 +3,7 @@ layout: download
 board_id: "bless_dev_board_multi_sensor"
 title: "BLE-SS Dev Board Multi Sensor Download"
 name: "BLE-SS Dev Board Multi Sensor"
-manufacturer: "Switch Science, Inc."
+manufacturer: "Switch Science, Inc"
 board_url: "http://ssci.to/6250"
 board_image: "bless_dev_board_multi_sensor.jpg"
 downloads_display: true


### PR DESCRIPTION
3 board but two spelling:
* Two board use `manufacturer: "Switch Science, Inc"`
* One board use `manufacturer: "Switch Science, Inc."`

So I moved to the majority without that "."