### PR TITLE
Generate the S3 link for inkown boards using URL query string

### DIFF
--- a/assets/javascript/download.js
+++ b/assets/javascript/download.js
@@ -19,6 +19,24 @@ document.addEventListener('DOMContentLoaded',function() {
     script.setAttribute('src', '//accounts.adafruit.com/users/locale?callback=setLocale');
     document.body.appendChild(script);
   }
+
+  // set the board ID based on query string
+  const hereurl = new URL(window.location.href);
+  const board_id = hereurl.searchParams.get("unknown_id");
+  if(board_id) {
+    for(var link of document.querySelectorAll("a")) {
+      if(link.href.search("bin/unknown") > 0) {
+        link.href = link.href.replace("bin/unknown", `bin/${board_id}`);
+      }
+    }
+    // change the title too
+    const title_tag = document.querySelector("#download-page h1");
+    var unknown_title = board_id.replaceAll("_"," ");
+    unknown_title = unknown_title[0].toUpperCase() + unknown_title.substr(1);
+    title_tag.textContent = unknown_title;
+    document.title = `${unknown_title} Download`;
+  }
+
 },false);
 
 // update the links of the download buttons for the given langage menu item

--- a/downloads.html
+++ b/downloads.html
@@ -108,6 +108,12 @@ excerpt: CircuitPython supported boards.
         {% continue %}
       {% endif %}
 
+      {% if info.board_id != 'unknown' %}
+        {% assign download_url = info.url %}
+      {% else %}
+        {% capture download_url %}{{ info.url }}?unknown_id={{ board.id }}{% endcapture %}
+      {% endif %}
+
       <div class="download" data-id="{{ board.id }}"
                             data-name="{{ info.name | default: board.id }}"
                             data-downloads="{{ board.downloads }}"
@@ -115,7 +121,7 @@ excerpt: CircuitPython supported boards.
                             data-mcufamily="{{ info.family }}"
                             data-features="{{ info.features | join: ','}}"
                             data-date="{{ info.date_added }}">
-        <a href="{{ info.url | relative_url }}">
+        <a href="{{ download_url | relative_url }}">
           <div>
             <div class="img-responsive-4by3">
               {% include downloads/board_image.html board_image=info.board_image %}


### PR DESCRIPTION
resolves #1025 

- adds `?unknown_id=...` to the unknown boards URL
- the javascript on the board page looks for it
  - sets the title (and html title) by replacing underscores with spaces and uppercasing the first letter
  - replaces "unknown" with the ID in the URLs href, making them point to the right place
