### PR TITLE
Boards without a "Display" but with a "connector" for one.

### DIFF
--- a/_board/beetle-esp32-c3.md
+++ b/_board/beetle-esp32-c3.md
@@ -15,7 +15,6 @@ features:
   - Battery Charging
   - Bluetooth/BTLE
   - Breadboard-Friendly
-  - Display
   - USB-C
   - Wi-Fi
 ---

--- a/_board/beetle-esp32-c3.md
+++ b/_board/beetle-esp32-c3.md
@@ -15,6 +15,7 @@ features:
   - Battery Charging
   - Bluetooth/BTLE
   - Breadboard-Friendly
+  - External Display
   - USB-C
   - Wi-Fi
 ---

--- a/_board/matrixportal_m4.md
+++ b/_board/matrixportal_m4.md
@@ -10,7 +10,7 @@ date_added: 2020-9-16
 family: atmel-samd
 bootloader_id: matrixportal_m4
 features:
-  - Display
+  - External Display
   - Wi-Fi
   - STEMMA QT/QWIIC
   - USB-C

--- a/_board/pimoroni_interstate75.md
+++ b/_board/pimoroni_interstate75.md
@@ -9,6 +9,7 @@ board_image: "pimoroni_interstate75.jpg"
 date_added: 2021-12-02
 family: raspberrypi
 features:
+  - External Display
   - STEMMA QT/QWIIC
   - USB-C
   - Breadboard-Friendly

--- a/template.md
+++ b/template.md
@@ -19,6 +19,7 @@ features:
   - Bluetooth/BTLE
   - Breadboard-Friendly
   - Display
+  - External Display
   - Feather-Compatible
   - GPS
   - LoRa/Radio


### PR DESCRIPTION
This beetle-esp32-c3 board has a connector so that you can attach a display sold separatly.
Do we consider that a display?

From the documentation:
* "Besides, the onboard easy-to-connect GDI saves the trouble of wiring when using a screen."
* "Comes with expansion board, more convenient to make projects or use with a screen"