### PR TITLE
Make it clearer that broadcom builds are very alpha

### DIFF
--- a/_board/raspberrypi_cm4.md
+++ b/_board/raspberrypi_cm4.md
@@ -11,6 +11,8 @@ family: broadcom
 
 ---
 
+**NOTE**: This build is alpha quality and is for experimental use. It is [missing features and has known issues](https://github.com/adafruit/circuitpython/labels/broadcom).
+
 The **Raspberry Pi Compute Module 4** is based on the [Raspberry Pi 4 Model B](http://www.adafruit.com/product/4297), but in a smaller form factor - perfect for embedding into products or projects without the bulk of a classic Raspberry Pi. You get all the computational power of Raspberry Pi 4 in a compact form factor for deeply embedded applications. The CM4 incorporates the same quad-core ARM Cortex-A72 processor, dual video output, gigabit Ethernet, UART, I2C, SPI, I2S, and a few PWM for good measure.
 
 This module is available in **multiple variants**, with a range of RAM and eMMC Flash options, and with or without wireless connectivity. The modules are available with 1GB, 2GB, 4GB or 8GB LPDDR4-3200 SDRAM with optional storage of 8GB, 16GB or 32GB eMMC Flash. The wireless option includes 2.4GHz and 5GHz 802.11b/g/n/ac wireless LAN and Bluetooth 5.0 for BT classic and BTLE support.
@@ -48,7 +50,7 @@ This significantly reduces the overall footprint of the module on its carrier bo
 
 ## CircuitPython
 
-These downloads are for CircuitPython standalone on the Raspberry Pi (not Blinka). There is no underlying operating system. It is in its early developments.
+These downloads are for CircuitPython standalone on the Raspberry Pi (not Blinka). There is no underlying operating system. It is in early development.
 
 After installing the disk image on an SD card, the normal CircuitPython USB workflow will be available on the micro-B connector on the IO board. EMMC compute modules are not supported yet.
 

--- a/_board/raspberrypi_cm4io.md
+++ b/_board/raspberrypi_cm4io.md
@@ -11,7 +11,7 @@ family: broadcom
 
 ---
 
-**NOTE**: Not all features are supported in CircuitPython.
+**NOTE**: This build is alpha quality and is for experimental use. It is [missing features and has known issues](https://github.com/adafruit/circuitpython/labels/broadcom).
 
 Exposing every interface from Raspberry Pi Compute Module 4, the Compute Module 4 IO Board provides a development platform and reference base-board design for the most powerful Compute Module yet.
 
@@ -21,7 +21,7 @@ While the Compute Module contains the guts of a Raspberry Pi 4 (1.2GHz, quad-cor
 
 ## CircuitPython
 
-These downloads are for CircuitPython standalone on the Raspberry Pi (not Blinka). There is no underlying operating system. It is in its early developments.
+These downloads are for CircuitPython standalone on the Raspberry Pi (not Blinka). There is no underlying operating system. It is in early development.
 
 After installing the disk image on an SD card, the normal CircuitPython USB workflow will be available on the micro-B connector on the IO board. EMMC compute modules are not supported yet.
 

--- a/_board/raspberrypi_pi4b.md
+++ b/_board/raspberrypi_pi4b.md
@@ -11,7 +11,7 @@ family: broadcom
 
 ---
 
-**NOTE**: Not all features are supported in CircuitPython.
+**NOTE**: This build is alpha quality and is for experimental use. It is [missing features and has known issues](https://github.com/adafruit/circuitpython/labels/broadcom).
 
 The Raspberry Pi 4 Model B is the newest Raspberry Pi computer made, and the Pi Foundation knows you can always make a good thing better! And what could make the Pi 4 better than the 3? How about a faster processor, USB 3.0 ports, and updated Gigabit Ethernet chip with PoE capability? Good guess - that's exactly what they did!
 
@@ -38,7 +38,7 @@ The Raspberry Pi 4 is the latest product in the Raspberry Pi range, boasting an 
 
 ## CircuitPython
 
-These downloads are for CircuitPython standalone on the Raspberry Pi (not Blinka). There is no underlying operating system. It is in its early developments.
+These downloads are for CircuitPython standalone on the Raspberry Pi (not Blinka). There is no underlying operating system. It is in early development.
 
 After installing the disk image on an SD card, the normal CircuitPython USB workflow is available over the USB-C connector used for power-only usually. A powered USB hub is needed to power the Pi while allowing USB data to also connect.
 

--- a/_board/raspberrypi_zero.md
+++ b/_board/raspberrypi_zero.md
@@ -12,7 +12,7 @@ features:
 
 ---
 
-**NOTE**: Not all features are supported in CircuitPython.
+**NOTE**: This build is alpha quality and is for experimental use. It is [missing features and has known issues](https://github.com/adafruit/circuitpython/labels/broadcom).
 
 At first glance, the Pi Zero isn't much.  It just looks like a slimmed down version of the Raspberry Pi we know and love.  But when we started to think of the possibilities - and what a well-chosen set of accessories could add - we realized the appeal.  And then we saw the price...could it be true? Yes!
 
@@ -20,7 +20,7 @@ This is the slimmest, most pared down Raspberry Pi to date.  It's kind of like t
 
 ## CircuitPython
 
-These downloads are for CircuitPython standalone on the Raspberry Pi (not Blinka). There is no underlying operating system. It is in its early developments.
+These downloads are for CircuitPython standalone on the Raspberry Pi (not Blinka). There is no underlying operating system. It is in early development.
 
 After installing the disk image on an SD card, the normal CircuitPython USB workflow is available over the micro-B USB connector labeled "USB".
 

--- a/_board/raspberrypi_zero2w.md
+++ b/_board/raspberrypi_zero2w.md
@@ -11,7 +11,7 @@ family: broadcom
 
 ---
 
-**NOTE**: Not all features are supported in CircuitPython.
+**NOTE**: This build is alpha quality and is for experimental use. It is [missing features and has known issues](https://github.com/adafruit/circuitpython/labels/broadcom).
 
 **Raspberry Pi Zero 2 W** is the latest product in Raspberry Pi's most affordable range of single-board computers. The successor to the breakthrough Raspberry Pi Zero W, **Raspberry Pi Zero 2 W** is a form factor–compatible drop-in replacement for the original board.
 
@@ -21,7 +21,7 @@ The board has a microSD card slot, a CSI-2 camera connector, a USB On-The-Go (OT
 
 ## CircuitPython
 
-These downloads are for CircuitPython standalone on the Raspberry Pi (not Blinka). There is no underlying operating system. It is in its early developments.
+These downloads are for CircuitPython standalone on the Raspberry Pi (not Blinka). There is no underlying operating system. It is in early development.
 
 After installing the disk image on an SD card, the normal CircuitPython USB workflow is available over the micro-B USB connector labeled "USB".
 

--- a/_board/raspberrypi_zero_w.md
+++ b/_board/raspberrypi_zero_w.md
@@ -11,7 +11,7 @@ family: broadcom
 
 ---
 
-**NOTE**: Not all features are supported in CircuitPython.
+**NOTE**: This build is alpha quality and is for experimental use. It is [missing features and has known issues](https://github.com/adafruit/circuitpython/labels/broadcom).
 
 **Raspberry Pi Zero W** Is the first small size (Wifi enabled) Raspberry Pi's single-board computers. This is the predecessor of **Raspberry Pi Zero 2 W** with the same form factor.
 
@@ -21,7 +21,7 @@ The board has a microSD card slot, a CSI-2 camera connector, a USB On-The-Go (OT
 
 ## CircuitPython
 
-These downloads are for CircuitPython standalone on the Raspberry Pi (not Blinka). There is no underlying operating system. It is in its early developments.
+These downloads are for CircuitPython standalone on the Raspberry Pi (not Blinka). There is no underlying operating system. It is in early development.
 
 This image could work on non Wifi Pi Zero but was primarly develop for the Wifi version.
 


### PR DESCRIPTION
This adds more obvious warnings (and fixes grammar a bit) that the broadcom builds are very alpha and have significant issues. I've encountered this as a support issue several times recently. It's in the release notes but those are often not read.