### PR TITLE
Add details on how to make BPI-PicoW-S3 enter the bootloader mode.

### DIFF
--- a/_board/bpi_picow_s3.md
+++ b/_board/bpi_picow_s3.md
@@ -28,7 +28,11 @@ up to 240 MHz; 2.4G Wi-Fi + Bluetooth LE; RISC-V Ultra Low Power Co-processor; *
 - **Native USB Port**: ESP32-S3 full-speed USB OTG interface, using microUSB Connector with back-feed protection. The interface is used for power supply to the board, for flashing applications to the chip, for communication with the chip using USB protocols, as well as for JTAG debugging.
 - **5V to 3.3V DC/DC**: Maximum theoretical output 2A 3.3V.
 - **Reset Button**: Support double-clicking the reset button to enter the UF2 bootloader.
-- **BOOT0**: If the UF2 Bootloader is removed, you can use any conductor bar such as metal pins or tweezers to short it to put the EPS32S3 chip into download mode, then the UF2 Bootloader can be re-installed. 
+- **BOOT0**: If the UF2 Bootloader is removed, you can use any conductor bar such as metal pins or tweezers to short it to put the EPS32S3 chip into bootloader mode, then the UF2 Bootloader can be re-installed. 
+  - Plug board into a USB port on your computer using a data/sync cable. Make sure it is the only board plugged in, and that a charge-only cable is not being used.
+  - Short circuit BOOT0 contact.
+  - Press and release the Reset button.
+  - Release the BOOT0 contact.
 - **RGB LED**: Addressable WS2812 RGB LED, control it with board.NEOPIXEL in circuitpython.
 - **Monochrome LED**: Control it with board.GP25 or board.LED in circuitpython.
 


### PR DESCRIPTION
BPI-PicoW-S3 has no BOOT0 button, but retains the BOOT0 contact. 

Update more detailed description to guide  users to enter the bootloader mode.