### PR TITLE
Replace link for ESP Web Flasher

### DIFF
--- a/_includes/download/board.html
+++ b/_includes/download/board.html
@@ -192,7 +192,7 @@ By the way, boolean operation precedence is right to left! (yeesh)
   </p>
   <p>
     If a UF2 bootloader has never been installed on the board, or the UF2 bootloader was removed by erasing or overwriting the flash, the UF2 bootloader must be installed in order to flash <b>.uf2</b> files onto the board. <b>.bin</b> files can be uploaded without a UF2 bootloader, using the
-    <a href="https://nabucasa.github.io/esp-web-flasher/">ESP Web Flasher</a>
+    <a href="https://adafruit.github.io/Adafruit_WebSerial_ESPTool/">ESP Web Flasher</a>
     or <b>esptool.py</b>.
   </p>
 


### PR DESCRIPTION
The previous link went to a version that wasn't being maintained and had a banner directing users to a different tool. Replace with a link to the version of ESP Web Flasher hosted on adafruit.github.io.