### PR TITLE
Pin ruby at 3.1.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         python-version: 3.x
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.0
+        ruby-version: '3.1'
         bundler-cache: true
     - name: Install Dependencies
       run: |


### PR DESCRIPTION
.. it looks like the non-string value `3.0` was probably being interpreted as `3` aka `3.x`?

Previously it looks like we built with 'ruby 3.1.3p185 (2022-11-24 revision 1a6b16756e) [x86_64-linux]' so I chose to pin at "3.1"