### PR TITLE
Clarify which version of Luatos Core ESP32-C3 board is targeted

### DIFF
--- a/_board/luatos_core_esp32c3.md
+++ b/_board/luatos_core_esp32c3.md
@@ -34,6 +34,9 @@ A low-cost WiFi/BLE board based on ESP32-C3.
 
 ## Note
 
+There are 2 versions of this board, differing in the inclusion of a CH343 UART to USB component. This board definition targets the
+version without the CH343 which connects the built-in USB-CDC/JTAG to the USB-C connector.
+
 Onboard LDO can be disabled by grounding the PWB pin (15)
 
 ## Learn More


### PR DESCRIPTION
There are 2 versions of this board differing in what is connected to the USB-C port. This PR clarifies that the board definition is intended to target the newer version using the ESP32-C3 built-in USB-CDC/JTAG pins rather than via a CH343 UART to USB chip.