### PR TITLE
Document the use of GPIO11 on the Luatos Core ESP32-C3 board

### DIFF
--- a/_board/luatos_core_esp32c3.md
+++ b/_board/luatos_core_esp32c3.md
@@ -37,7 +37,9 @@ A low-cost WiFi/BLE board based on ESP32-C3.
 There are 2 versions of this board, differing in the inclusion of a CH343 UART to USB component. This board definition targets the
 version without the CH343 which connects the built-in USB-CDC/JTAG to the USB-C connector.
 
-Onboard LDO can be disabled by grounding the PWB pin (15)
+Onboard LDO can be disabled by grounding the PWB pin (15).
+
+GPIO11 can only be used by setting the EFUSE_VDD_SPI_AS_GPIO efuse and building a custom Circuitpython image.
 
 ## Learn More
 


### PR DESCRIPTION
GPIO11 on the ESP32-C3 is by default dedicated as the VDD pin for external SPI flash.

This board does not use the pin for that purpose, instead directly connecting flash VDD to the 3.3V bus and breaks the GPIO out to a board pin. In order to actually use it as a GPIO in Circuitpython requires setting an efuse on the chip (and beyond that will require modifications to ports/espressif/common_hal/microcontroller/Pin.c) and building a custom image. I removed the GPIO from pins.c in https://github.com/adafruit/circuitpython/pull/7372

This PR documents that information in the notes section.