### PR TITLE
Update atmel-samd bootloader to version 3.15.0

### DIFF
--- a/_data/bootloaders.json
+++ b/_data/bootloaders.json
@@ -4,7 +4,7 @@
             "version": "0.7.0"
         },
         "atmel-samd": {
-            "version": "v3.14.0"
+            "version": "v3.15.0"
         },
         "esp32s2": {
             "version": "0.12.3"


### PR DESCRIPTION
3.15.0 has brownout protection on SAMD21. (typo in commit msg: should be 3.15.0)