### PR TITLE
Fix starting bootloader json key for gen board info script

### DIFF
--- a/generate-board-info.py
+++ b/generate-board-info.py
@@ -24,7 +24,7 @@ def main():
 
     # Get CircuitPython Bootloader Info
     with open("./_data/bootloaders.json", "rt") as f:
-        bootloaders = json.load(f)
+        bootloaders = json.load(f)['bootloaders']
 
     with open("./_data/files.json", "rt") as f:
         board_info = json.load(f)


### PR DESCRIPTION
Found a bug while trying to use the file where the bootloader was always null. Apparently it was looking in the wrong place in the bootloader json file.