### PR TITLE
Change Naming Style of Deneyap Boards

### DIFF
--- a/_board/deneyap_kart.md
+++ b/_board/deneyap_kart.md
@@ -1,11 +1,11 @@
 ---
 layout: download
-board_id: "deneyapkart1A"
-title: "Deneyap Kart 1A Download"
-name: "Deneyap Kart 1A"
+board_id: "deneyapkart"
+title: "Deneyap Kart Download"
+name: "Deneyap Kart"
 manufacturer: "Turkish Technology Team Foundation"
-board_url: "https://docs.deneyapkart.org/tr/content/contentDetail/deneyap-kart-1a"
-board_image: "deneyapkart1A.jpg"
+board_url: "https://docs.deneyapkart.org/tr/content/contentDetail/deneyap-kart"
+board_image: "deneyapkart.jpg"
 date_added: 2023-03-14
 family: esp32
 downloads_display: true
@@ -28,8 +28,10 @@ features:
     - 802.11b/g/n 2.4 GHz Wi-Fi
     - Bluetooth v4.2 BR/EDR and BLE
     - Magnetic Field (Hall-Effect) Sensor
-  - Addressable RGB LED
-  - 24 x Digital Input Pins
+  - MEMS 6-axis IMU Accelerometer and Gyroscope (ST LSM6DSM)
+  - MEMS PDM Microphone (ST MP34DT05-A)
+  - RGB LED
+  - 24 x Digital Input Pins (16 x PTC Fuse for Over Current Protection)
   - 20 x Digital Output Pins
   - 16 x Analog Input Pins (two 12-bit SAR ADCs)
   -  2 x Analog Output Pins (two 8-bit DACs)
@@ -37,7 +39,4 @@ features:
   - PWM, I2C, SPI, UART, I2S, PCNT, RMT, TWAI, JTAG and SD/SDIO/MMC Interface
 
 ## Purchase
-* [DENEYAPKART1A](https://magaza.deneyapkart.org/tr/product/detail/deneyap-kart-1a)
-
-## Contribute
-* [Github](https://github.com/deneyapkart)
+* [DENEYAPKART](https://magaza.deneyapkart.org/tr/product/detail/deneyap-kart)

--- a/_board/deneyap_kart_1A.md
+++ b/_board/deneyap_kart_1A.md
@@ -1,11 +1,11 @@
 ---
 layout: download
-board_id: "deneyapkart"
-title: "Deneyap Kart Download"
-name: "Deneyap Kart"
+board_id: "deneyapkart1A"
+title: "Deneyap Kart 1A Download"
+name: "Deneyap Kart 1A"
 manufacturer: "Turkish Technology Team Foundation"
-board_url: "https://docs.deneyapkart.org/tr/content/contentDetail/deneyap-kart"
-board_image: "deneyapkart.jpg"
+board_url: "https://docs.deneyapkart.org/tr/content/contentDetail/deneyap-kart-1a"
+board_image: "deneyapkart1A.jpg"
 date_added: 2023-03-14
 family: esp32
 downloads_display: true
@@ -28,10 +28,8 @@ features:
     - 802.11b/g/n 2.4 GHz Wi-Fi
     - Bluetooth v4.2 BR/EDR and BLE
     - Magnetic Field (Hall-Effect) Sensor
-  - MEMS 6-axis IMU Accelerometer and Gyroscope (ST LSM6DSM)
-  - MEMS PDM Microphone (ST MP34DT05-A)
-  - RGB LED
-  - 24 x Digital Input Pins (16 x PTC Fuse for Over Current Protection)
+  - Addressable RGB LED
+  - 24 x Digital Input Pins
   - 20 x Digital Output Pins
   - 16 x Analog Input Pins (two 12-bit SAR ADCs)
   -  2 x Analog Output Pins (two 8-bit DACs)
@@ -39,7 +37,4 @@ features:
   - PWM, I2C, SPI, UART, I2S, PCNT, RMT, TWAI, JTAG and SD/SDIO/MMC Interface
 
 ## Purchase
-* [DENEYAPKART](https://magaza.deneyapkart.org/tr/product/detail/deneyap-kart)
-
-## Contribute
-* [Github](https://github.com/deneyapkart)
+* [DENEYAPKART1A](https://magaza.deneyapkart.org/tr/product/detail/deneyap-kart-1a)

--- a/_board/deneyap_kart_1A_v2.md
+++ b/_board/deneyap_kart_1A_v2.md
@@ -38,6 +38,3 @@ features:
 
 ## Purchase
 * [DENEYAPKART1Av2](https://magaza.deneyapkart.org/tr/product/detail/deneyap-kart-1a-v2-type-c)
-
-## Contribute
-* [Github](https://github.com/deneyapkart)

--- a/_board/deneyap_kart_g.md
+++ b/_board/deneyap_kart_g.md
@@ -34,6 +34,3 @@ features:
 
 ## Purchase
 * [DENEYAPKARTG](https://magaza.deneyapkart.org/tr/product/detail/deneyap-kart-g-type-c)
-
-## Contribute
-* [Github](https://github.com/deneyapkart)

--- a/_board/deneyap_mini.md
+++ b/_board/deneyap_mini.md
@@ -1,33 +1,31 @@
 ---
 layout: download
-board_id: "deneyapminiv2"
-title: "Deneyap Mini v2 Download"
-name: "Deneyap Mini v2"
+board_id: "deneyapmini"
+title: "Deneyap Mini Download"
+name: "Deneyap Mini"
 manufacturer: "Turkish Technology Team Foundation"
-board_url: "https://docs.deneyapkart.org/tr/content/contentDetail/deneyap-mini-v2"
-board_image: "deneyapminiv2.jpg"
+board_url: "https://docs.deneyapkart.org/tr/content/contentDetail/deneyap-mini"
+board_image: "deneyapmini.jpg"
 date_added: 2023-03-14
 family: esp32s2
-bootloader_id: deneyapmini_v2
+bootloader_id: deneyapmini
 features:
   - Wi-Fi
   - Battery Charging
   - STEMMA QT/QWIIC
   - Breadboard-Friendly
-  - USB-C
 ---
 
 ## Technical Specs
-  - Espressif ESP32-S2FN4R2 SoC
+  - Espressif ESP32-S2FH4 SoC
     - 240 MHz Single-Core Xtensa 32-bit LX7 CPU (Espressif ESP32-S2)
     - Two Ultra Low Power (ULP) Co-processor (ULP­-RISC-­V and ULP-FSM)
     - 320 KB SRAM
     - 128 KB ROM
     - 4 MB Flash
-    - 2 MB PSRAM
     - 802.11b/g/n 2.4 GHz Wi-Fi
     - Temperature Sensor
-  - Addressable RGB LED
+  - RGB LED
   - 21 x Digital Input/Output Pins
   -  9 x Analog Input Pins (two 13-bit SAR ADCs)
   -  2 x Analog Output Pins (two 8-bit DACs)
@@ -35,7 +33,4 @@ features:
   -  PWM, I2C, SPI, UART, I2S, PCNT, RMT, TWAI and JTAG Interface
 
 ## Purchase
-* [DENEYAPMINIV2](https://magaza.deneyapkart.org/tr/product/detail/deneyap-mini-v2-type-c)
-
-## Contribute
-* [Github](https://github.com/deneyapkart).
+* [DENEYAPMINI](https://magaza.deneyapkart.org/tr/product/detail/deneyap-mini)

--- a/_board/deneyap_mini_v2.md
+++ b/_board/deneyap_mini_v2.md
@@ -1,31 +1,33 @@
 ---
 layout: download
-board_id: "deneyapmini"
-title: "Deneyap Mini Download"
-name: "Deneyap Mini"
+board_id: "deneyapminiv2"
+title: "Deneyap Mini v2 Download"
+name: "Deneyap Mini v2"
 manufacturer: "Turkish Technology Team Foundation"
-board_url: "https://docs.deneyapkart.org/tr/content/contentDetail/deneyap-mini"
-board_image: "deneyapmini.jpg"
+board_url: "https://docs.deneyapkart.org/tr/content/contentDetail/deneyap-mini-v2"
+board_image: "deneyapminiv2.jpg"
 date_added: 2023-03-14
 family: esp32s2
-bootloader_id: deneyapmini
+bootloader_id: deneyapmini_v2
 features:
   - Wi-Fi
   - Battery Charging
   - STEMMA QT/QWIIC
   - Breadboard-Friendly
+  - USB-C
 ---
 
 ## Technical Specs
-  - Espressif ESP32-S2FH4 SoC
+  - Espressif ESP32-S2FN4R2 SoC
     - 240 MHz Single-Core Xtensa 32-bit LX7 CPU (Espressif ESP32-S2)
     - Two Ultra Low Power (ULP) Co-processor (ULP­-RISC-­V and ULP-FSM)
     - 320 KB SRAM
     - 128 KB ROM
     - 4 MB Flash
+    - 2 MB PSRAM
     - 802.11b/g/n 2.4 GHz Wi-Fi
     - Temperature Sensor
-  - RGB LED
+  - Addressable RGB LED
   - 21 x Digital Input/Output Pins
   -  9 x Analog Input Pins (two 13-bit SAR ADCs)
   -  2 x Analog Output Pins (two 8-bit DACs)
@@ -33,7 +35,4 @@ features:
   -  PWM, I2C, SPI, UART, I2S, PCNT, RMT, TWAI and JTAG Interface
 
 ## Purchase
-* [DENEYAPMINI](https://magaza.deneyapkart.org/tr/product/detail/deneyap-mini)
-
-## Contribute
-* [Github](https://github.com/deneyapkart).
+* [DENEYAPMINIV2](https://magaza.deneyapkart.org/tr/product/detail/deneyap-mini-v2-type-c)


### PR DESCRIPTION
Fix the problem about not listing .bin or .uf2 file when clicking "Browse S3" button on own page of the board because of naming style of Deneyap boards. 

Delete contribute section.