### PR TITLE
Fix download links for RP2040 Feather ThinkInk

### DIFF
--- a/_board/adafruit_feather_rp2040_epd.md
+++ b/_board/adafruit_feather_rp2040_epd.md
@@ -1,7 +1,6 @@
 ---
 layout: download
-board_id: "adafruit_feather_rp2040_thinkink"
-board_alias: "adafruit_feather_rp2040_epd"
+board_id: "adafruit_feather_rp2040_epd"
 title: "Feather RP2040 ThinkInk Download"
 name: "Feather RP2040 ThinkInk"
 manufacturer: "Adafruit"

--- a/_board/adafruit_feather_rp2040_thinkink.md
+++ b/_board/adafruit_feather_rp2040_thinkink.md
@@ -1,6 +1,7 @@
 ---
 layout: download
 board_id: "adafruit_feather_rp2040_thinkink"
+board_alias: "adafruit_feather_rp2040_epd"
 title: "Feather RP2040 ThinkInk Download"
 name: "Feather RP2040 ThinkInk"
 manufacturer: "Adafruit"

--- a/_data/files.json
+++ b/_data/files.json
@@ -3902,7 +3902,7 @@
  },
  {
   "downloads": 0,
-  "id": "adafruit_feather_rp2040_thinkink",
+  "id": "adafruit_feather_rp2040_epd",
   "versions": [
    {
     "extensions": [


### PR DESCRIPTION
Fixes #1199. Apparently in the previous releases it was called `adafruit_feather_rp2040_epd`, but in future releases will be called `adafruit_feather_rp2040_thinkink` because of https://github.com/adafruit/circuitpython/pull/7927. I had to change it to `adafruit_feather_rp2040_epd` for now, but it will need to be reverted on the next release.