### PR TITLE
refer to guide pages for nRF bootloader updates

### DIFF
--- a/_includes/download/board.html
+++ b/_includes/download/board.html
@@ -287,9 +287,9 @@ By the way, boolean operation precedence is right to left! (yeesh)
 
   {% if page.family == 'nrf52840' %}
   <p>
-    Updating the bootloader on nRF52840 boards is an involved process right now.
-    Follow the instructions in this
-    <a href="https://github.com/adafruit/Adafruit_nRF52_Bootloader/blob/master/README.md">README</a>.
+    To update the bootloader on an nRF board, refer to the "Update Bootloader" page in the guide for
+    your board, or start with
+    <a href="https://learn.adafruit.com/introducing-the-adafruit-nrf52840-feather/update-bootloader">this page</a>.
   </p>
   <p>
     After you update, check <b>INFO_UF2.TXT</b> to verify that the bootloader version has been updated.

--- a/_includes/download/board.html
+++ b/_includes/download/board.html
@@ -287,7 +287,12 @@ By the way, boolean operation precedence is right to left! (yeesh)
 
   {% if page.family == 'nrf52840' %}
   <p>
-    To update the bootloader on an nRF board, refer to the "Update Bootloader" page in the guide for
+    <b>On nRF boards, CircuitPython 8.2.0 and later require bootloader version 0.6.1 or later.
+      Older bootloaders cannot load the firmware.
+    To check the version of your board's bootloader,
+      look at <i>INFO_UF2.TXT</i> when the <i>BOOT</i> drive is present.
+    </b>
+    To update the bootloader, refer to the "Update Bootloader" page in the guide for
     your board, or start with
     <a href="https://learn.adafruit.com/introducing-the-adafruit-nrf52840-feather/update-bootloader">this page</a>.
   </p>


### PR DESCRIPTION
The nRF bootloader update blurb referred to the README in the bootloader repo. There are now guide pages for this that are more comprehensive, so point to them.