### PR TITLE
explicitly set user name for build.yml cronjob

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,4 +71,5 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build
           cname: circuitpython.org
+          user_name: ${{ secrets.ADABOT_GITHUB_USER }}
       if: github.event_name != 'pull_request'


### PR DESCRIPTION
so the gh-pages commits are not always @ladyada