### PR TITLE
Renaming waveshare_esp32s3_pico.md to waveshare_esp32_s3_pico.

### DIFF
--- a/_board/waveshare_esp32_s3_pico.md
+++ b/_board/waveshare_esp32_s3_pico.md
@@ -1,6 +1,6 @@
 ---
 layout: download
-board_id: "waveshare_esp32s3_pico"
+board_id: "waveshare_esp32_s3_pico"
 title: "ESP32-S3-Pico Download"
 name: "ESP32-S3-Pico"
 manufacturer: "Waveshare"

--- a/_board/waveshare_esp32_s3_pico.md
+++ b/_board/waveshare_esp32_s3_pico.md
@@ -6,13 +6,14 @@ name: "ESP32-S3-Pico"
 manufacturer: "Waveshare"
 board_url: "https://www.waveshare.com/esp32-s3.htm"
 board_image: "ESP32-S3-Pico.jpg"
-bootloader_id: waveshare_esp32s3_pico
+bootloader_id: waveshare_esp32_s3_pico
 date_added: 2023-8-30
 family: esp32s3
 features:
   - Breadboard-Friendly
   - USB-C
   - Wi-Fi
+  - Bluetooth/BTLE
 ---
 
 This is a WiFi development board with compact size, plenty peripheral interfaces, integrated low-power Wi-Fi System-on-Chip (SoC) and mass memory, supporting Raspberry Pi Pico expansion board ecosystem.


### PR DESCRIPTION
Updating board name because the name here does not match in circuitpython repo.