### PR TITLE
Boards JSON API

### DIFF
--- a/api/boards.json
+++ b/api/boards.json
@@ -1,0 +1,7 @@
+---
+layout: null
+permalink: /api/boards.json
+excerpt: CircuitPython supported boards.
+---
+
+{{ site.board | jsonify }}


### PR DESCRIPTION
This just takes the board files and exposes them as an api endpoint. This would allow folks to pull this data down easier. A specific use case is for the Adafruit shop to figure out what boards work with circuitpython easily. If there are other/better endpoints that already exist, we could use those instead. This could work for anyone that needs the board file details though (which don't exist in the files.json or bootloaders.json file).

Endpoint:
circuitpython.org/api/boards.json

Example Output:
![image](https://github.com/adafruit/circuitpython-org/assets/311256/0e057e2f-92f3-46d3-9182-fc97e75aed90)
