### PR TITLE
Remove dev version of google-protobuf from Gemlock

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         bundler-cache: true
     - name: Install Dependencies
       run: |
-        gem install bundler:1.17.3
+        gem install bundler:2.2.26
         bundle install --full-index
         pip install python-frontmatter pillow python-dateutil
     - name: Check feature names and other data

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,6 @@ GEM
     ffi (1.15.5)
     forwardable-extended (2.6.0)
     google-protobuf (3.22.0)
-    google-protobuf (3.22.0-x86_64-linux)
     http_parser.rb (0.8.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)


### PR DESCRIPTION
This appears to mostly be a duplicate, but a dev version. I think this will make it so actions stops failing.