### PR TITLE
Improve search

### DIFF
--- a/assets/javascript/downloads.js
+++ b/assets/javascript/downloads.js
@@ -387,6 +387,17 @@ function setFeaturesChecked() {
   downloadsSearch.featuresChecked = document.querySelectorAll('input[name="feature"]:checked').length > 0;
 }
 
+var cachedSearchTerm;
+var searchRx;
+function searchTermRegex() {
+    if(downloadsSearch.searchTerm != cachedSearchTerm) {
+        cachedSearchTerm = downloadsSearch.searchTerm;
+        mangledSearchTerm = cachedSearchTerm.split(" ").reduce(function(acc, val) { return acc + "(=?.*" + val + ")" }, "")
+        searchRx = new RegExp(mangledSearchTerm, "gi");
+    }
+    return searchRx;
+}
+
 function shouldDisplayDownload(download, displayedManufacturers, displayedMcufamilies, displayedFeatures) {
   var shouldFilterFeatures = downloadsSearch.featuresChecked;
   var shouldFilterManufacturers = displayedManufacturers.length > 0;
@@ -434,7 +445,7 @@ function shouldDisplayDownload(download, displayedManufacturers, displayedMcufam
   }
 
   if (downloadsSearch.searchTerm && downloadsSearch.searchTerm.length > 0 && shouldDisplay) {
-    var regex = new RegExp(downloadsSearch.searchTerm, "gi");
+    var regex = searchTermRegex();
     var dataFields = [
         download.dataset.name,
         download.dataset.id,


### PR DESCRIPTION
This turns the search function into more of a 'fuzzy search': The search is expected to be a series of space-separated terms, but the terms can appear in any order, can be just part of a word (e.g., "uefr" would match "bluefruit") and with other terms between them.

So for instance after this change both "tft feather" or "feather tft" will show the Feather ESP32-S3 TFT PSRAM (as well as 3 other feather boards)

Closes #1321