### PR TITLE
Change bootloader link to match tinyuf2 repository

### DIFF
--- a/_board/adafruit_esp32s3_camera.md
+++ b/_board/adafruit_esp32s3_camera.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "adafruit_esp32s3_camera.jpg"
 date_added: 2023-10-27
 family: esp32s3
-bootloader_id: adafruit_esp32s3_camera
+bootloader_id: adafruit_camera_esp32s3
 features:
   - Wi-Fi
   - Bluetooth/BTLE


### PR DESCRIPTION
I believe this will resolve the broken link...

Fixes #1324 adafruit/circuitpython#8903