### PR TITLE
Refactor of search function from regex to string based, massive speedup in searchbar performance 

### DIFF
--- a/assets/javascript/downloads.js
+++ b/assets/javascript/downloads.js
@@ -418,7 +418,7 @@ function shouldDisplayDownload(download, displayedManufacturers, displayedMcufam
     ].join(" ").toLowerCase();
 
 
-    for (const term of downloadsSearch.searchTerm.split(" ")) {
+    for (const term of downloadsSearch.searchTerm.toLowerCase().split(" ")) {
         if (!downloadData.includes(term)) {
             return false;
         }

--- a/assets/javascript/downloads.js
+++ b/assets/javascript/downloads.js
@@ -387,66 +387,27 @@ function setFeaturesChecked() {
   downloadsSearch.featuresChecked = document.querySelectorAll('input[name="feature"]:checked').length > 0;
 }
 
-var cachedSearchTerm;
-var searchRx;
-function searchTermRegex() {
-    if(downloadsSearch.searchTerm != cachedSearchTerm) {
-        cachedSearchTerm = downloadsSearch.searchTerm;
-        mangledSearchTerm = cachedSearchTerm.split(" ").reduce(function(acc, val) { return acc + "(=?.*" + val + ")" }, "")
-        searchRx = new RegExp(mangledSearchTerm, "gi");
-    }
-    return searchRx;
-}
-
 function shouldDisplayDownload(download, displayedManufacturers, displayedMcufamilies, displayedFeatures) {
-  var shouldFilterFeatures = downloadsSearch.featuresChecked;
-  var shouldFilterManufacturers = displayedManufacturers.length > 0;
-  var shouldFilterMcufamilies = displayedMcufamilies.length > 0;
-  var shouldDisplay = false;
+  const shouldFilterFeatures = downloadsSearch.featuresChecked;
+  const shouldFilterManufacturers = displayedManufacturers.length > 0;
+  const shouldFilterMcufamilies = displayedMcufamilies.length > 0;
 
-  var id = download.dataset.id;
+  const boardId = download.dataset.id;
 
-  if (shouldFilterManufacturers) {
-    if (displayedManufacturers.includes(id)) {
-      if (shouldFilterMcufamilies) {
-        if (displayedMcufamilies.includes(id)) {
-          if (shouldFilterFeatures) {
-            if (displayedFeatures.includes(id)) {
-              shouldDisplay = true;
-            }
-          } else {
-            shouldDisplay = true;
-	  }
-	}
-      } else if (shouldFilterFeatures) {
-          if (displayedFeatures.includes(id)) {
-            shouldDisplay = true;
-          }
-      } else {
-        shouldDisplay = true;
-      }
-    }
-  } else if (shouldFilterMcufamilies) {
-    if (displayedMcufamilies.includes(id)) {
-      if (shouldFilterFeatures) {
-        if (displayedFeatures.includes(id)) {
-          shouldDisplay = true;
-        }
-      } else {
-        shouldDisplay = true;
-      }
-    }
-  } else if (shouldFilterFeatures) {
-    if (displayedFeatures.includes(id)) {
-      shouldDisplay = true;
-    }
-  } else {
-    shouldDisplay = true;
+  if (shouldFilterManufacturers && !displayedManufacturers.includes(boardId)) {
+    return false;
   }
 
-  if (downloadsSearch.searchTerm && downloadsSearch.searchTerm.length > 0 && shouldDisplay) {
-    var regex = searchTermRegex();
-    var dataFields = [
+  if (shouldFilterMcufamilies && !displayedMcufamilies.includes(boardId)) {
+    return false;
+  }
+
+  if (shouldFilterFeatures && !displayedFeatures.includes(boardId)) {
+    return false;
+  }
+
+  if (downloadsSearch.searchTerm) {
+    const downloadData = [
         download.dataset.name,
         download.dataset.id,
         download.dataset.manufacturer,
@@ -454,13 +415,17 @@ function shouldDisplayDownload(download, displayedManufacturers, displayedMcufam
         download.dataset.features,
         download.dataset.tags,
         download.dataset.modules,
-    ];
+    ].join(" ").toLowerCase();
 
-    var haystack = dataFields.join(" ");
-    shouldDisplay = haystack.match(regex);
+
+    for (const term of downloadsSearch.searchTerm.split(" ")) {
+        if (!downloadData.includes(term)) {
+            return false;
+        }
+    }
   }
 
-  return shouldDisplay;
+  return true;
 }
 
 function appendFilterTag(type, name) {


### PR DESCRIPTION
Current searching and filtering login implementation uses regexes, which leads to performance issues. If someone would type quickly "matrixportal", the search bar would hang on e.g. 8th character for a moment and then continue to render.

Additionally, current regex makes it that "bit matrix" and "matrix bit" produce different result, which i believe is not intended. 

Overall, this change speed up filtering (in my case, on my computer) from 400-700ms to 2-5ms and produces same results no matter the order of terms in search field.

🏗️ Refactor:

- Function `shouldDisplayDownload` that determined whether to show or not a card with board now uses string based logic instead of regex


Easy way to test this is simply copy-paste the function to console in browser and the search bar will use it from that moment until site reload.