### PR TITLE
Update seeed_xiao_esp32c3.md to refer to installation guide

### DIFF
--- a/_board/seeed_xiao_esp32c3.md
+++ b/_board/seeed_xiao_esp32c3.md
@@ -41,3 +41,7 @@ Being a number to the Seeed Studio XIAO family, the board deservedly maintains t
 
 ## Purchase
 * [Seeed Studio](https://www.seeedstudio.com/Seeed-XIAO-ESP32C3-p-5431.html)
+
+## Getting Started
+Since the ESP32C3 chip does not have support for native USB, you won't see a CIRCUITPY drive appear when you plug it into your computer. [Here is a complete guide](https://learn.adafruit.com/circuitpython-with-esp32-quick-start/overview) for getting Circuitpython installed onto an ESP32C3 device, and for enabling [Web Workflow](https://docs.circuitpython.org/en/latest/docs/workflows.html#web) so you can load your Python code onto it.
+


### PR DESCRIPTION
Add reference to https://learn.adafruit.com/circuitpython-with-esp32-quick-start/overview since ESP32C3 chips don't get installed or used the same was as typical cp devices.