### PR TITLE
Update waveshare_rp2040_touch_lcd_1_28.md

### DIFF
--- a/_board/waveshare_rp2040_touch_lcd_1_28.md
+++ b/_board/waveshare_rp2040_touch_lcd_1_28.md
@@ -1,8 +1,8 @@
 ---
 layout: download
 board_id: "waveshare_rp2040_touch_lcd_1_28"
-title: "RP2040-LCD-1.28 Download"
-name: "RP2040-LCD-1.28"
+title: "RP2040-Touch-LCD-1.28 Download"
+name: "RP2040-Touch-LCD-1.28"
 manufacturer: "Waveshare"
 board_url:
  - "https://www.waveshare.com/product/raspberry-pi/boards-kits/raspberry-pi-pico-cat/rp2040-touch-lcd-1.28.htm"


### PR DESCRIPTION
I hope this is not a breaking change, but currently there are two board that are "hard" to distinguish because they have the same name in the main download page:
* https://circuitpython.org/board/waveshare_rp2040_lcd_1_28/
* https://circuitpython.org/board/waveshare_rp2040_touch_lcd_1_28/