### PR TITLE
Update m5stack_dial documentation name in the link

### DIFF
--- a/_board/m5stack_dial.md
+++ b/_board/m5stack_dial.md
@@ -36,7 +36,7 @@ M5Dial provides versatile power supply options to cater to various needs. It acc
 
 ## Documentation
 
-* [AtomS3 Lite](https://docs.m5stack.com/en/core/M5Dial)
+* [M5Dial](https://docs.m5stack.com/en/core/M5Dial)
 
 ## Purchase
 


### PR DESCRIPTION
Seems that this was made by copy and paste from another m5stack board.