### PR TITLE
Correct chip family for Teensy 4.0

### DIFF
--- a/_board/teensy40.md
+++ b/_board/teensy40.md
@@ -9,7 +9,7 @@ board_url:
  - "https://www.adafruit.com/product/4323"
 board_image: "teensy40.jpg"
 date_added: 2020-1-31
-family: stm
+family: mimxrt10xx
 features:
   - Breadboard-Friendly
 ---


### PR DESCRIPTION
The Teensy 4.0 board was incorrectly tagged as part of the STM chip family. 