### PR TITLE
Update espressif_esp32s3_devkitc_1_n8r8.md

### DIFF
--- a/_board/espressif_esp32s3_devkitc_1_n8r8.md
+++ b/_board/espressif_esp32s3_devkitc_1_n8r8.md
@@ -40,7 +40,7 @@ There are three mutually exclusive ways to provide power to the board:
 - **Boot Button**: Download button. Holding down **Boot** and then pressing **Reset** initiates Firmware Download mode for downloading firmware through the serial port.
 - **Reset Button**
 - **USB-to-UART Bridge:** Single USB-to-UART bridge chip provides transfer rates up to 3 Mbps.
-- **RGB LED**: Addressable RGB LED, driven by GPIO48.
+- **RGB LED**: Addressable RGB LED, a Rose Lighting model SK68XXMINI-HS, driven by GPIO48 aka board.NEOPIXEL, works with CircuitPython NeoPixel driver.  Note that version 1.1 of this board has the LED wired to GPIO38, aka board.IO38.  
 - **3.3V Power On LED**: Turns on when the USB power is connected to the board.
 
 ## Purchase


### PR DESCRIPTION
Added mfgr information for the RGB LED, mentioned which CircuitPython library is compatible with this LED, added information about the respin version 1.1 of the board which primarily moves the LED from GPIO 48 to GPIO 38

See https://docs.espressif.com/projects/esp-idf/en/stable/esp32s3/hw-reference/esp32s3/user-guide-devkitc-1.html#hardware-revision-details for details.

To quote Espressif:

"Both versions of ESP32-S3-DevKitC-1 are available on the market. The main difference lies in that the RGB LED is connected to different pins."

So its probably not worth the effort to create a 1.1 of the board that merely changes the alias for board.NEOPIXEL