### PR TITLE
sort rss feed with newest at top

### DIFF
--- a/_board/espressif_esp32s3_box_lite.md
+++ b/_board/espressif_esp32s3_box_lite.md
@@ -7,7 +7,7 @@ manufacturer: "Espressif"
 board_url:
  - "https://www.adafruit.com/product/5511"
 board_image: "espressif_esp32s3_box_lite.jpg"
-date_added: 22-07-08
+date_added: 2022-07-08
 family: esp32s3
 features:
   - Wi-Fi

--- a/_board/lilygo_tdisplay_s3.md
+++ b/_board/lilygo_tdisplay_s3.md
@@ -7,7 +7,7 @@ manufacturer: "LILYGO"
 board_url:
  - "https://www.lilygo.cc/products/t-display-s3"
 board_image: "lilygo_tdisplay_s3.jpg"
-date_added: 2024-3-9
+date_added: 2024-3-09
 family: esp32s3
 features:
   - Wi-Fi

--- a/feed.html
+++ b/feed.html
@@ -8,7 +8,8 @@ permalink: /feed.rss
 <link>{{ "/" | absolute_url }}</link>
 <description>A list of CircuitPython and Blinka supported boards</description>
 <lastBuildDate>{{ "now" | date_to_rfc822 }}</lastBuildDate>
-{% for board in site.board %}
+{% assign chronological_boards = site.board | sort: "date_added" %}
+{% for board in chronological_boards reversed %}
   {%- if board.downloads_display == false -%}
     {%- continue -%}
   {%- endif -%}
@@ -23,7 +24,8 @@ permalink: /feed.rss
   </item>
   {%- endif -%}
 {% endfor %}
-{% for board in site.blinka %}
+{% assign chronological_blinka_boards = site.board | sort: "date_added" %}
+{% for board in chronological_blinka_boards reversed %}
     <item>
       <title>{{ board.name }}</title>
       <link>{{ board.url | absolute_url }}</link>


### PR DESCRIPTION
resolves #1354 

After this change there were two devices showing up at the top of the list (out of chronological order) It turns out the date parsing format is very specific, it needs 4 digit years and zero padded single digits, with those changes these devices now get put into the proper place of the order.

Worth considering breaking out the Blinka boards as a separate feed. Right now they effectively get rendered one after another in the same giant RSS feed. This means they won't ever appear at the top of the feed for any RSS client that doesn't do it's own sorting locally on pubDate. Or another option is to try to intermix them into 1 list, and then sort that and render it as the RSS feed, I'm not certain if it's possible but can check into it if that is something that other folks think is a good way to do it.