### PR TITLE
Fix board dates to always be of the form YYYY-MM-DD

### DIFF
--- a/_blinka/adafruit_feather_rp2040.md
+++ b/_blinka/adafruit_feather_rp2040.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "adafruit_feather_rp2040.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-libraries-on-any-computer-with-raspberry-pi-pico"
 blinka: true
-date_added: 2021-12-6
+date_added: 2021-12-06
 features:
   - Feather-Compatible
   - STEMMA QT/QWIIC

--- a/_blinka/adafruit_feather_rp2040_can.md
+++ b/_blinka/adafruit_feather_rp2040_can.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/5724"
 board_image: "adafruit_feather_rp2040_can.jpg"
 blinka: true
-date_added: 2023-5-2
+date_added: 2023-05-02
 tags:
   - CAN Bus Feather
   - Feather CAN Bus

--- a/_blinka/adafruit_feather_rp2040_rfm.md
+++ b/_blinka/adafruit_feather_rp2040_rfm.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/5714"
 board_image: "adafruit_feather_rp2040_rfm9x.jpg"
 blinka: true
-date_added: 2023-4-4
+date_added: 2023-04-04
 features:
   - Feather-Compatible
   - STEMMA QT/QWIIC

--- a/_blinka/adafruit_feather_rp2040_rfm69.md
+++ b/_blinka/adafruit_feather_rp2040_rfm69.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/5712"
 board_image: "adafruit_feather_rp2040_rfm69.jpg"
 blinka: true
-date_added: 2023-4-4
+date_added: 2023-04-04
 features:
   - Feather-Compatible
   - STEMMA QT/QWIIC

--- a/_blinka/adafruit_feather_rp2040_thinkink.md
+++ b/_blinka/adafruit_feather_rp2040_thinkink.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/5727"
 board_image: "adafruit_feather_rp2040_thinkink.jpg"
 blinka: true
-date_added: 2023-5-2
+date_added: 2023-05-02
 tags:
   - ThinkInk Feather
   - Feather ThinkInk

--- a/_blinka/adafruit_itsybitsy_rp2040.md
+++ b/_blinka/adafruit_itsybitsy_rp2040.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "adafruit_itsybitsy_rp2040.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-libraries-on-any-computer-with-raspberry-pi-pico"
 blinka: true
-date_added: 2021-12-6
+date_added: 2021-12-06
 features:
 
 ---

--- a/_blinka/adafruit_kb2040.md
+++ b/_blinka/adafruit_kb2040.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "adafruit_kb2040.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-libraries-on-any-computer-with-raspberry-pi-pico"
 blinka: true
-date_added: 2023-9-6
+date_added: 2023-09-06
 features:
   - STEMMA QT/QWIIC
 

--- a/_blinka/adafruit_macropad_rp2040.md
+++ b/_blinka/adafruit_macropad_rp2040.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "adafruit_macropad_rp2040.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-libraries-on-any-computer-with-raspberry-pi-pico"
 blinka: true
-date_added: 2021-12-6
+date_added: 2021-12-06
 features:
   - STEMMA QT/QWIIC
 ---

--- a/_blinka/adafruit_qt2040_trinkey.md
+++ b/_blinka/adafruit_qt2040_trinkey.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "adafruit_qt2040_trinkey.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-libraries-on-any-computer-with-raspberry-pi-pico"
 blinka: true
-date_added: 2021-12-6
+date_added: 2021-12-06
 features:
   - STEMMA QT/QWIIC
 

--- a/_blinka/adafruit_qtpy_rp2040.md
+++ b/_blinka/adafruit_qtpy_rp2040.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "adafruit_qtpy_rp2040.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-libraries-on-any-computer-with-raspberry-pi-pico"
 blinka: true
-date_added: 2021-12-6
+date_added: 2021-12-06
 features:
   - STEMMA QT/QWIIC
 ---

--- a/_blinka/avnet_iiot_gateway.md
+++ b/_blinka/avnet_iiot_gateway.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "avnet_iiot_gateway.jpg"
 downloads_display: true
 blinka: true
-date_added: 2020-5-15
+date_added: 2020-05-15
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/banana_pi_bpi_m5.md
+++ b/_blinka/banana_pi_bpi_m5.md
@@ -10,7 +10,7 @@ board_image: "banana_pi_bpi_m5.jpg"
 download_instructions: ""
 downloads_display: true
 blinka: true
-date_added: 2022-7-22
+date_added: 2022-07-22
 features:
   - HDMI/DisplayPort
   - 40-pin GPIO

--- a/_blinka/beaglebone.md
+++ b/_blinka/beaglebone.md
@@ -10,7 +10,7 @@ board_image: "beaglebone.jpg"
 download_instructions: ""
 downloads_display: true
 blinka: true
-date_added: 2021-4-6
+date_added: 2021-04-06
 features:
   - Ethernet
 ---

--- a/_blinka/beaglebone_ai.md
+++ b/_blinka/beaglebone_ai.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "beaglebone_ai.jpg"
 downloads_display: true
 blinka: true
-date_added: 2021-1-20
+date_added: 2021-01-20
 features:
   - Ethernet
   - Wi-Fi

--- a/_blinka/beaglebone_black.md
+++ b/_blinka/beaglebone_black.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "beaglebone_black.jpg"
 downloads_display: true
 blinka: true
-date_added: 2019-12-3
+date_added: 2019-12-03
 features:
   - Ethernet
   - HDMI/DisplayPort

--- a/_blinka/beaglebone_black_industrial.md
+++ b/_blinka/beaglebone_black_industrial.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "beaglebone_black_industrial.jpg"
 downloads_display: true
 blinka: true
-date_added: 2019-12-3
+date_added: 2019-12-03
 features:
   - Ethernet
   - HDMI/DisplayPort

--- a/_blinka/beaglebone_black_wireless.md
+++ b/_blinka/beaglebone_black_wireless.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "beaglebone_black_wireless.jpg"
 downloads_display: true
 blinka: true
-date_added: 2020-3-25
+date_added: 2020-03-25
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/beaglebone_blue.md
+++ b/_blinka/beaglebone_blue.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "beaglebone_blue.jpg"
 downloads_display: true
 blinka: true
-date_added: 2023-5-4
+date_added: 2023-05-04
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/beaglebone_green_gateway.md
+++ b/_blinka/beaglebone_green_gateway.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "beaglebone_green_gateway.jpg"
 downloads_display: true
 blinka: true
-date_added: 2020-11-1
+date_added: 2020-11-01
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/beaglebone_green_wireless.md
+++ b/_blinka/beaglebone_green_wireless.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "beaglebone_green_wireless.jpg"
 downloads_display: true
 blinka: true
-date_added: 2019-12-3
+date_added: 2019-12-03
 features:
   - Wi-Fi
 ---

--- a/_blinka/beaglev_starlight.md
+++ b/_blinka/beaglev_starlight.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "beaglev_starlight.jpg"
 downloads_display: true
 blinka: true
-date_added: 2021-7-17
+date_added: 2021-07-17
 features:
   - Ethernet
   - HDMI/DisplayPort

--- a/_blinka/binho_nova.md
+++ b/_blinka/binho_nova.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "binho_nova.jpg"
 downloads_display: true
 blinka: true
-date_added: 2019-12-3
+date_added: 2019-12-03
 features:
 ---
 

--- a/_blinka/clara_agx_xavier.md
+++ b/_blinka/clara_agx_xavier.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "clara_agx_xavier.jpg"
 downloads_display: true
 blinka: true
-date_added: 2020-10-6
+date_added: 2020-10-06
 features:
 
 ---

--- a/_blinka/clockworkpi.md
+++ b/_blinka/clockworkpi.md
@@ -10,7 +10,7 @@ board_image: "clockworkpi.jpg"
 download_instructions: ""
 downloads_display: true
 blinka: true
-date_added: 2020-4-16
+date_added: 2020-04-16
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/diodes_delight_piunora.md
+++ b/_blinka/diodes_delight_piunora.md
@@ -10,7 +10,7 @@ board_image: "diodes_delight_piunora.jpg"
 download_instructions:
 downloads_display: true
 blinka: true
-date_added: 2021-12-6
+date_added: 2021-12-06
 features:
   - HDMI/DisplayPort
   - Wi-Fi

--- a/_blinka/dragonboard_410c.md
+++ b/_blinka/dragonboard_410c.md
@@ -10,7 +10,7 @@ board_image: "dragonboard_410c.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-libraries-on-linux-and-the-96boards-dragonboard-410c"
 downloads_display: true
 blinka: true
-date_added: 2019-6-29
+date_added: 2019-06-29
 features:
   - Wi-Fi
   - HDMI/DisplayPort

--- a/_blinka/ft232h.md
+++ b/_blinka/ft232h.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "ft232h.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-any-computer-with-ft232h"
 downloads_display: true
-date_added: 2019-9-30
+date_added: 2019-09-30
 blinka: true
 features:
 ---

--- a/_blinka/giant_board.md
+++ b/_blinka/giant_board.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "giant_board.jpg"
 downloads_display: true
 blinka: true
-date_added: 2019-12-3
+date_added: 2019-12-03
 features:
   - Feather-Compatible
 ---

--- a/_blinka/google_coral.md
+++ b/_blinka/google_coral.md
@@ -10,7 +10,7 @@ board_image: "google_coral.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-google-coral-linux-blinka"
 downloads_display: true
 blinka: true
-date_added: 2019-5-13
+date_added: 2019-05-13
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/google_coral_mini.md
+++ b/_blinka/google_coral_mini.md
@@ -10,7 +10,7 @@ board_image: "google_coral_mini.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-google-coral-linux-blinka"
 downloads_display: true
 blinka: true
-date_added: 2020-12-7
+date_added: 2020-12-07
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/greatfet_one.md
+++ b/_blinka/greatfet_one.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "greatfet_one.jpg"
 downloads_display: true
 blinka: true
-date_added: 2020-5-15
+date_added: 2020-05-15
 features:
   - 40-pin GPIO
 ---

--- a/_blinka/hifive_unleashed.md
+++ b/_blinka/hifive_unleashed.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "hifive_unleashed.jpg"
 downloads_display: true
 blinka: true
-date_added: 2020-3-25
+date_added: 2020-03-25
 features:
   - Ethernet
 ---

--- a/_blinka/jetson_agx_orin.md
+++ b/_blinka/jetson_agx_orin.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "jetson_agx_orin.jpg"
 downloads_display: true
 blinka: true
-date_added: 2022-7-27
+date_added: 2022-07-27
 features:
   - Ethernet
   - 40-pin GPIO

--- a/_blinka/jetson_nano.md
+++ b/_blinka/jetson_nano.md
@@ -10,7 +10,7 @@ board_image: "jetson_nano.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-libraries-on-linux-and-the-nvidia-jetson-nano"
 downloads_display: true
 blinka: true
-date_added: 2019-9-10
+date_added: 2019-09-10
 features:
   - Ethernet
   - HDMI/DisplayPort

--- a/_blinka/jetson_orin_nano.md
+++ b/_blinka/jetson_orin_nano.md
@@ -10,7 +10,7 @@ board_image: "jetson_orin_nano.jpg"
 download_instructions: ""
 downloads_display: true
 blinka: true
-date_added: 2023-5-8
+date_added: 2023-05-08
 features:
   - Ethernet
   - 40-pin GPIO

--- a/_blinka/jetson_orin_nx.md
+++ b/_blinka/jetson_orin_nx.md
@@ -10,7 +10,7 @@ board_image: "jetson_orin_nx.jpg"
 download_instructions: ""
 downloads_display: true
 blinka: true
-date_added: 2023-5-8
+date_added: 2023-05-08
 features:
   - Ethernet
   - 40-pin GPIO

--- a/_blinka/jetson_tx1.md
+++ b/_blinka/jetson_tx1.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "jetson_tx1.jpg"
 downloads_display: true
 blinka: true
-date_added: 2019-12-3
+date_added: 2019-12-03
 features:
   - Ethernet
   - HDMI/DisplayPort

--- a/_blinka/jetson_tx2.md
+++ b/_blinka/jetson_tx2.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "jetson_tx2.jpg"
 downloads_display: true
 blinka: true
-date_added: 2019-12-3
+date_added: 2019-12-03
 features:
   - Ethernet
   - HDMI/DisplayPort

--- a/_blinka/jetson_tx2_nx.md
+++ b/_blinka/jetson_tx2_nx.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "jetson_tx2_nx.jpg"
 downloads_display: true
 blinka: true
-date_added: 2021-2-25
+date_added: 2021-02-25
 features:
 
 ---

--- a/_blinka/jetson_xavier.md
+++ b/_blinka/jetson_xavier.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "jetson_xavier.jpg"
 downloads_display: true
 blinka: true
-date_added: 2019-12-3
+date_added: 2019-12-03
 features:
   - Ethernet
   - HDMI/DisplayPort

--- a/_blinka/jetson_xavier_nx.md
+++ b/_blinka/jetson_xavier_nx.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "jetson_xavier_nx.jpg"
 downloads_display: true
 blinka: true
-date_added: 2020-3-25
+date_added: 2020-03-25
 features:
 
 ---

--- a/_blinka/khadas_vim3.md
+++ b/_blinka/khadas_vim3.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "khadas_vim3.jpg"
 downloads_display: true
 blinka: true
-date_added: 2022-4-1
+date_added: 2022-04-01
 features:
   - Ethernet
   - HDMI/DisplayPort

--- a/_blinka/lemaker_banana_pro.md
+++ b/_blinka/lemaker_banana_pro.md
@@ -10,7 +10,7 @@ board_image: "lemaker_banana_pro.jpg"
 download_instructions: ""
 downloads_display: true
 blinka: true
-date_added: 2023-9-6
+date_added: 2023-09-06
 features:
   - HDMI/DisplayPort
   - 40-pin GPIO

--- a/_blinka/libre_roc-rk3328-cc.md
+++ b/_blinka/libre_roc-rk3328-cc.md
@@ -10,7 +10,7 @@ board_image: "libre_roc-rk3328-cc.jpg"
 download_instructions: ""
 downloads_display: true
 blinka: true
-date_added: 2023-5-8
+date_added: 2023-05-08
 features:
   - HDMI/DisplayPort
   - 40-pin GPIO

--- a/_blinka/lichee_rv_dock_d1.md
+++ b/_blinka/lichee_rv_dock_d1.md
@@ -10,7 +10,7 @@ board_image: "lichee_rv_dock_d1.jpg"
 download_instructions: ""
 downloads_display: true
 blinka: true
-date_added: 2022-10-6
+date_added: 2022-10-06
 features:
   - HDMI/DisplayPort
   - Wi-Fi

--- a/_blinka/lubancat1.md
+++ b/_blinka/lubancat1.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "lubancat1.jpg"
 download_instructions: ""
 blinka: true
-date_added: 2023-5-8
+date_added: 2023-05-08
 features:
   - HDMI/DisplayPort
   - Ethernet

--- a/_blinka/lubancat1n.md
+++ b/_blinka/lubancat1n.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "lubancat1n.jpg"
 download_instructions: ""
 blinka: true
-date_added: 2023-5-8
+date_added: 2023-05-08
 features:
   - HDMI/DisplayPort
   - Ethernet

--- a/_blinka/lubancat2.md
+++ b/_blinka/lubancat2.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "lubancat2.jpg"
 download_instructions: ""
 blinka: true
-date_added: 2023-5-8
+date_added: 2023-05-08
 features:
   - HDMI/DisplayPort
   - Ethernet

--- a/_blinka/lubancat2n.md
+++ b/_blinka/lubancat2n.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "lubancat2n.jpg"
 download_instructions: ""
 blinka: true
-date_added: 2023-5-8
+date_added: 2023-05-08
 features:
   - HDMI/DisplayPort
   - Ethernet

--- a/_blinka/lubancat_i.mx6ull.md
+++ b/_blinka/lubancat_i.mx6ull.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "lubancat_i.mx6ull.jpg"
 download_instructions: ""
 blinka: true
-date_added: 2021-1-15
+date_added: 2021-01-15
 features:
   - Ethernet
   - 40-pin GPIO

--- a/_blinka/lubancat_zero_n.md
+++ b/_blinka/lubancat_zero_n.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "lubancat_zero_n.jpg"
 download_instructions: ""
 blinka: true
-date_added: 2023-5-8
+date_added: 2023-05-08
 features:
   - HDMI/DisplayPort
   - Ethernet

--- a/_blinka/lubancat_zero_w.md
+++ b/_blinka/lubancat_zero_w.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "lubancat_zero_w.jpg"
 download_instructions: ""
 blinka: true
-date_added: 2023-5-8
+date_added: 2023-05-08
 features:
   - HDMI/DisplayPort
   - Ethernet

--- a/_blinka/mcp2221.md
+++ b/_blinka/mcp2221.md
@@ -10,7 +10,7 @@ board_image: "mcp2221.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-libraries-on-any-computer-with-mcp2221"
 downloads_display: true
 blinka: true
-date_added: 2020-3-25
+date_added: 2020-03-25
 features:
 ---
 

--- a/_blinka/milkv_duo.md
+++ b/_blinka/milkv_duo.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "milkv_duo.jpg"
 downloads_display: true
 blinka: true
-date_added: 2024-3-13
+date_added: 2024-03-13
 features:
 
 ---

--- a/_blinka/nanopi_duo2.md
+++ b/_blinka/nanopi_duo2.md
@@ -10,7 +10,7 @@ board_image: "nanopi_duo2.jpg"
 download_instructions: ""
 downloads_display: true
 blinka: true
-date_added: 2021-2-5
+date_added: 2021-02-05
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/nanopi_neo_air.md
+++ b/_blinka/nanopi_neo_air.md
@@ -10,7 +10,7 @@ board_image: "nanopi_neo_air.jpg"
 download_instructions: ""
 downloads_display: true
 blinka: true
-date_added: 2021-1-20
+date_added: 2021-01-20
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/nanopi_neo_h3.md
+++ b/_blinka/nanopi_neo_h3.md
@@ -10,7 +10,7 @@ board_image: "nanopi_neo.jpg"
 download_instructions: ""
 downloads_display: true
 blinka: true
-date_added: 2022-1-4
+date_added: 2022-01-04
 features:
   - Ethernet
 

--- a/_blinka/octavo_osd32mp1_brk.md
+++ b/_blinka/octavo_osd32mp1_brk.md
@@ -10,7 +10,7 @@ board_image: "octavo_osd32mp1_brk.jpg"
 download_instructions:
 downloads_display: true
 blinka: true
-date_added: 2021-12-6
+date_added: 2021-12-06
 features:
 
 ---

--- a/_blinka/octavo_osd32mp1_red.md
+++ b/_blinka/octavo_osd32mp1_red.md
@@ -10,7 +10,7 @@ board_image: "octavo_osd32mp1_red.jpg"
 download_instructions:
 downloads_display: true
 blinka: true
-date_added: 2021-12-6
+date_added: 2021-12-06
 features:
   - Wi-Fi
   - Ethernet

--- a/_blinka/odroid_c2.md
+++ b/_blinka/odroid_c2.md
@@ -10,7 +10,7 @@ board_image: "odroid_c2.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-libaries-linux-odroid-c2"
 downloads_display: true
 blinka: true
-date_added: 2019-6-17
+date_added: 2019-06-17
 features:
   - Ethernet
   - HDMI/DisplayPort

--- a/_blinka/odroid_c4.md
+++ b/_blinka/odroid_c4.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "odroid_c4.jpg"
 downloads_display: true
 blinka: true
-date_added: 2020-5-15
+date_added: 2020-05-15
 features:
   - Ethernet
   - HDMI/DisplayPort

--- a/_blinka/odroid_n2.md
+++ b/_blinka/odroid_n2.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "odroid_n2.jpg"
 downloads_display: true
 blinka: true
-date_added: 2019-12-3
+date_added: 2019-12-03
 features:
   - Ethernet
   - USB 3.0

--- a/_blinka/odroid_xu4.md
+++ b/_blinka/odroid_xu4.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "odroid_xu4.jpg"
 downloads_display: true
 blinka: true
-date_added: 2020-5-29
+date_added: 2020-05-29
 features:
   - Ethernet
   - HDMI/DisplayPort

--- a/_blinka/odroid_xu4q.md
+++ b/_blinka/odroid_xu4q.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "odroid_xu4q.jpg"
 downloads_display: true
 blinka: true
-date_added: 2020-5-29
+date_added: 2020-05-29
 features:
   - Ethernet
   - HDMI/DisplayPort

--- a/_blinka/onion_omega2plus.md
+++ b/_blinka/onion_omega2plus.md
@@ -10,7 +10,7 @@ board_image: "onion_omega2plus.jpg"
 download_instructions: ""
 downloads_display: true
 blinka: true
-date_added: 2020-4-22
+date_added: 2020-04-22
 features:
   - Wi-Fi
 ---

--- a/_blinka/orange_pi_2.md
+++ b/_blinka/orange_pi_2.md
@@ -10,7 +10,7 @@ board_image: "orange_pi_2.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-orangepi-linux/circuitpython-orangepi"
 downloads_display: true
 blinka: true
-date_added: 2020-5-11
+date_added: 2020-05-11
 features:
   - Wi-Fi
   - Ethernet

--- a/_blinka/orange_pi_3.md
+++ b/_blinka/orange_pi_3.md
@@ -10,7 +10,7 @@ board_image: "orange_pi_3.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-orangepi-linux/circuitpython-orangepi"
 downloads_display: true
 blinka: true
-date_added: 2022-1-4
+date_added: 2022-01-04
 features:
   - Wi-Fi
   - Ethernet

--- a/_blinka/orange_pi_4.md
+++ b/_blinka/orange_pi_4.md
@@ -10,7 +10,7 @@ board_image: "orange_pi_4.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-orangepi-linux/circuitpython-orangepi"
 downloads_display: true
 blinka: true
-date_added: 2022-10-6
+date_added: 2022-10-06
 features:
   - Wi-Fi
   - Ethernet

--- a/_blinka/orange_pi_4_lts.md
+++ b/_blinka/orange_pi_4_lts.md
@@ -10,7 +10,7 @@ board_image: "orange_pi_4_lts.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-orangepi-linux/circuitpython-orangepi"
 downloads_display: true
 blinka: true
-date_added: 2022-10-6
+date_added: 2022-10-06
 features:
   - Wi-Fi
   - Ethernet

--- a/_blinka/orange_pi_5.md
+++ b/_blinka/orange_pi_5.md
@@ -10,7 +10,7 @@ board_image: "orange_pi_5.jpg"
 download_instructions: ""
 downloads_display: true
 blinka: true
-date_added: 2023-5-8
+date_added: 2023-05-08
 features:
   - Ethernet
   - USB 3.0

--- a/_blinka/orange_pi_lite.md
+++ b/_blinka/orange_pi_lite.md
@@ -10,7 +10,7 @@ board_image: "orange_pi_lite.png"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-orangepi-linux/circuitpython-orangepi"
 downloads_display: true
 blinka: true
-date_added: 2020-1-18
+date_added: 2020-01-18
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/orange_pi_one.md
+++ b/_blinka/orange_pi_one.md
@@ -10,7 +10,7 @@ board_image: "orange_pi_one.png"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-orangepi-linux/circuitpython-orangepi"
 downloads_display: true
 blinka: true
-date_added: 2020-1-18
+date_added: 2020-01-18
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/orange_pi_pc.md
+++ b/_blinka/orange_pi_pc.md
@@ -10,7 +10,7 @@ board_image: "orange_pi_pc.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-orangepi-linux/circuitpython-orangepi"
 downloads_display: true
 blinka: true
-date_added: 2019-6-4
+date_added: 2019-06-04
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/orange_pi_pc_plus.md
+++ b/_blinka/orange_pi_pc_plus.md
@@ -10,7 +10,7 @@ board_image: "orange_pi_pc_plus.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-orangepi-linux/circuitpython-orangepi"
 downloads_display: true
 blinka: true
-date_added: 2020-3-25
+date_added: 2020-03-25
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/orange_pi_plus_2e.md
+++ b/_blinka/orange_pi_plus_2e.md
@@ -10,7 +10,7 @@ board_image: "orange_pi_plus_2e.png"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-orangepi-linux/circuitpython-orangepi"
 downloads_display: true
 blinka: true
-date_added: 2020-1-18
+date_added: 2020-01-18
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/orange_pi_r1.md
+++ b/_blinka/orange_pi_r1.md
@@ -10,7 +10,7 @@ board_image: "orange_pi_r1.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-orangepi-linux/circuitpython-orangepi"
 downloads_display: true
 blinka: true
-date_added: 2019-6-4
+date_added: 2019-06-04
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/orange_pi_zero.md
+++ b/_blinka/orange_pi_zero.md
@@ -10,7 +10,7 @@ board_image: "orange_pi_zero.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-orangepi-linux/circuitpython-orangepi"
 downloads_display: true
 blinka: true
-date_added: 2019-12-3
+date_added: 2019-12-03
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/orange_pi_zero2.md
+++ b/_blinka/orange_pi_zero2.md
@@ -10,7 +10,7 @@ board_image: "orange_pi_zero.jpg"
 download_instructions: ""
 downloads_display: true
 blinka: true
-date_added: 2020-2-8
+date_added: 2020-02-08
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/orange_pi_zero_plus.md
+++ b/_blinka/orange_pi_zero_plus.md
@@ -10,7 +10,7 @@ board_image: "orange_pi_zero_plus.jpg"
 download_instructions: ""
 downloads_display: true
 blinka: true
-date_added: 2021-1-14
+date_added: 2021-01-14
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/orange_pi_zero_plus2_h5.md
+++ b/_blinka/orange_pi_zero_plus2_h5.md
@@ -10,7 +10,7 @@ board_image: "orange_pi_zero_plus2_h5.jpg"
 download_instructions: ""
 downloads_display: true
 blinka: true
-date_added: 2020-11-2
+date_added: 2020-11-02
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/pine64.md
+++ b/_blinka/pine64.md
@@ -10,7 +10,7 @@ board_image: "pine64.png"
 download_instructions: ""
 downloads_display: true
 blinka: true
-date_added: 2020-1-9
+date_added: 2020-01-09
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/pine_h64.md
+++ b/_blinka/pine_h64.md
@@ -10,7 +10,7 @@ board_image: "pine_h64.jpg"
 download_instructions: ""
 downloads_display: true
 blinka: true
-date_added: 2020-11-1
+date_added: 2020-11-01
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/pocketbeagle.md
+++ b/_blinka/pocketbeagle.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "pocketbeagle.jpg"
 downloads_display: true
 blinka: true
-date_added: 2019-12-3
+date_added: 2019-12-03
 features:
   - Ethernet
   - HDMI/DisplayPort

--- a/_blinka/pyboard_v11.md
+++ b/_blinka/pyboard_v11.md
@@ -8,7 +8,7 @@ blinka: true
 board_url:
  - "https://www.adafruit.com/product/2390"
 board_image: "pyboard_v11.jpg"
-date_added: 2021-5-24
+date_added: 2021-05-24
 
 ---
 

--- a/_blinka/radxa_cm3_io_board.md
+++ b/_blinka/radxa_cm3_io_board.md
@@ -10,7 +10,7 @@ board_image: "radxa_cm3_io_board.jpg"
 download_instructions: ""
 downloads_display: true
 blinka: true
-date_added: 2023-5-5
+date_added: 2023-05-05
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/radxa_rock_3a.md
+++ b/_blinka/radxa_rock_3a.md
@@ -10,7 +10,7 @@ board_image: "radxa_rock_3a.jpg"
 download_instructions: ""
 downloads_display: true
 blinka: true
-date_added: 2023-5-5
+date_added: 2023-05-05
 features:
   - Wi-Fi
   - Ethernet

--- a/_blinka/radxa_rock_3c.md
+++ b/_blinka/radxa_rock_3c.md
@@ -10,7 +10,7 @@ board_image: "radxa_rock_3a.jpg"
 download_instructions: ""
 downloads_display: true
 blinka: true
-date_added: 2024-3-13
+date_added: 2024-03-13
 features:
   - Wi-Fi
   - Ethernet

--- a/_blinka/radxa_rock_4se.md
+++ b/_blinka/radxa_rock_4se.md
@@ -10,7 +10,7 @@ board_image: "radxa_rock_4se.jpg"
 download_instructions: ""
 downloads_display: true
 blinka: true
-date_added: 2024-3-13
+date_added: 2024-03-13
 features:
   - Wi-Fi
   - Ethernet

--- a/_blinka/radxa_rock_5b.md
+++ b/_blinka/radxa_rock_5b.md
@@ -10,7 +10,7 @@ board_image: "radxa_rock_5b.jpg"
 download_instructions: ""
 downloads_display: true
 blinka: true
-date_added: 2023-5-5
+date_added: 2023-05-05
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/radxa_zero.md
+++ b/_blinka/radxa_zero.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "radxa_zero.jpg"
 downloads_display: true
 blinka: true
-date_added: "2022-6-2"
+date_added: 2022-06-02
 features:
   - HDMI/DisplayPort
   - Wi-Fi

--- a/_blinka/raspberry_pi_1a.md
+++ b/_blinka/raspberry_pi_1a.md
@@ -10,7 +10,7 @@ board_image: "raspberry_pi_1a.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
-date_added: 2019-6-17
+date_added: 2019-06-17
 features:
 - HDMI/DisplayPort
 ---

--- a/_blinka/raspberry_pi_1aplus.md
+++ b/_blinka/raspberry_pi_1aplus.md
@@ -10,7 +10,7 @@ board_image: "raspberry_pi_1aplus.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
-date_added: 2019-6-17
+date_added: 2019-06-17
 features:
   - HDMI/DisplayPort
   - 40-pin GPIO

--- a/_blinka/raspberry_pi_1b.md
+++ b/_blinka/raspberry_pi_1b.md
@@ -10,7 +10,7 @@ board_image: "raspberry_pi_1b.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
-date_added: 2019-6-17
+date_added: 2019-06-17
 features:
 - Ethernet
 - HDMI/DisplayPort

--- a/_blinka/raspberry_pi_1bplus.md
+++ b/_blinka/raspberry_pi_1bplus.md
@@ -10,7 +10,7 @@ board_image: "raspberry_pi_1bplus.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
-date_added: 2019-6-17
+date_added: 2019-06-17
 features:
   - Ethernet
   - HDMI/DisplayPort

--- a/_blinka/raspberry_pi_2b.md
+++ b/_blinka/raspberry_pi_2b.md
@@ -10,7 +10,7 @@ board_image: "raspberry_pi_2b.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
-date_added: 2019-6-17
+date_added: 2019-06-17
 features:
   - Ethernet
   - HDMI/DisplayPort

--- a/_blinka/raspberry_pi_3aplus.md
+++ b/_blinka/raspberry_pi_3aplus.md
@@ -10,7 +10,7 @@ board_image: "raspberry_pi_3aplus.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
-date_added: 2019-6-17
+date_added: 2019-06-17
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/raspberry_pi_3b.md
+++ b/_blinka/raspberry_pi_3b.md
@@ -10,7 +10,7 @@ board_image: "raspberry_pi_3b.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
-date_added: 2019-6-17
+date_added: 2019-06-17
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/raspberry_pi_3bplus.md
+++ b/_blinka/raspberry_pi_3bplus.md
@@ -10,7 +10,7 @@ board_image: "raspberry_pi_3bplus.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
-date_added: 2019-6-17
+date_added: 2019-06-17
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/raspberry_pi_400.md
+++ b/_blinka/raspberry_pi_400.md
@@ -10,7 +10,7 @@ board_image: "raspberry_pi_400.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
-date_added: 2020-11-2
+date_added: 2020-11-02
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/raspberry_pi_4b.md
+++ b/_blinka/raspberry_pi_4b.md
@@ -10,7 +10,7 @@ board_image: "raspberry_pi_4b.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
-date_added: 2019-6-24
+date_added: 2019-06-24
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/raspberry_pi_cm1.md
+++ b/_blinka/raspberry_pi_cm1.md
@@ -10,7 +10,7 @@ board_image: "raspberry_pi_cm1.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
-date_added: 2019-6-24
+date_added: 2019-06-24
 features:
   - HDMI/DisplayPort
 ---

--- a/_blinka/raspberry_pi_cm3.md
+++ b/_blinka/raspberry_pi_cm3.md
@@ -10,7 +10,7 @@ board_image: "raspberry_pi_cm3.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
-date_added: 2019-6-24
+date_added: 2019-06-24
 features:
   - HDMI/DisplayPort
 ---

--- a/_blinka/raspberry_pi_cm3lite.md
+++ b/_blinka/raspberry_pi_cm3lite.md
@@ -10,7 +10,7 @@ board_image: "raspberry_pi_cm3lite.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
-date_added: 2019-6-24
+date_added: 2019-06-24
 features:
   - HDMI/DisplayPort
 ---

--- a/_blinka/raspberry_pi_cm3plus.md
+++ b/_blinka/raspberry_pi_cm3plus.md
@@ -10,7 +10,7 @@ board_image: "raspberry_pi_cm3plus.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
-date_added: 2019-6-24
+date_added: 2019-06-24
 features:
   - HDMI/DisplayPort
 ---

--- a/_blinka/raspberry_pi_cm3pluslite.md
+++ b/_blinka/raspberry_pi_cm3pluslite.md
@@ -10,7 +10,7 @@ board_image: "raspberry_pi_cm3pluslite.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
-date_added: 2019-6-24
+date_added: 2019-06-24
 features:
   - HDMI/DisplayPort
 ---

--- a/_blinka/raspberry_pi_pico.md
+++ b/_blinka/raspberry_pi_pico.md
@@ -10,7 +10,7 @@ board_image: "raspberry_pi_pico.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-libraries-on-micropython-using-the-raspberry-pi-pico"
 downloads_display: true
 blinka: true
-date_added: 2021-5-20
+date_added: 2021-05-20
 ---
 
 The Raspberry Pi foundation changed single-board computing when they released the Raspberry Pi computer, now they're ready to do the same for microcontrollers with the release of the brand new **Raspberry Pi Pico**. This low-cost microcontroller board features a powerful new chip, the **RP2040**, and all the fixin's to get started with embedded electronics projects at a stress-free price.

--- a/_blinka/raspberry_pi_zero.md
+++ b/_blinka/raspberry_pi_zero.md
@@ -10,7 +10,7 @@ board_image: "raspberry_pi_zero.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
-date_added: 2019-6-17
+date_added: 2019-06-17
 features:
 - HDMI/DisplayPort
 - 40-pin GPIO

--- a/_blinka/raspberry_pi_zero_2_w.md
+++ b/_blinka/raspberry_pi_zero_2_w.md
@@ -10,7 +10,7 @@ board_image: "raspberry_pi_zero_2_w.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
-date_added: 2021-11-1
+date_added: 2021-11-01
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/raspberry_pi_zerow.md
+++ b/_blinka/raspberry_pi_zerow.md
@@ -10,7 +10,7 @@ board_image: "raspberry_pi_zerow.jpg"
 download_instructions: "https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/installing-circuitpython-on-raspberry-pi"
 downloads_display: true
 blinka: true
-date_added: 2019-6-17
+date_added: 2019-06-17
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/rock_pi_4c.md
+++ b/_blinka/rock_pi_4c.md
@@ -10,7 +10,7 @@ board_image: "rock_pi_4c.jpg"
 download_instructions: ""
 downloads_display: true
 blinka: true
-date_added: 2021-4-6
+date_added: 2021-04-06
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/rock_pi_4c_plus.md
+++ b/_blinka/rock_pi_4c_plus.md
@@ -10,7 +10,7 @@ board_image: "rock_pi_4c_plus.jpg"
 download_instructions: ""
 downloads_display: true
 blinka: true
-date_added: 2023-5-5
+date_added: 2023-05-05
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/rock_pi_e.md
+++ b/_blinka/rock_pi_e.md
@@ -10,7 +10,7 @@ board_image: "rock_pi_e.jpg"
 download_instructions: ""
 downloads_display: true
 blinka: true
-date_added: 2021-5-20
+date_added: 2021-05-20
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/rock_pi_s.md
+++ b/_blinka/rock_pi_s.md
@@ -10,7 +10,7 @@ board_image: "rock_pi_s.jpg"
 download_instructions: ""
 downloads_display: true
 blinka: true
-date_added: 2020-4-29
+date_added: 2020-04-29
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/siemens_simatic_iot2050.md
+++ b/_blinka/siemens_simatic_iot2050.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "siemens_simatic_iot2050.jpg"
 downloads_display: true
 blinka: true
-date_added: 2022-10-6
+date_added: 2022-10-06
 features:
   - Ethernet
   - HDMI/DisplayPort

--- a/_blinka/siemens_simatic_iot2050_advance.md
+++ b/_blinka/siemens_simatic_iot2050_advance.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "siemens_simatic_iot2050.jpg"
 downloads_display: true
 blinka: true
-date_added: 2022-10-6
+date_added: 2022-10-06
 features:
   - Ethernet
   - HDMI/DisplayPort

--- a/_blinka/stm32mp157c_dk2.md
+++ b/_blinka/stm32mp157c_dk2.md
@@ -10,7 +10,7 @@ board_image: "stm32mp157c_dk2.jpg"
 download_instructions: ""
 downloads_display: true
 blinka: true
-date_added: 2020-9-10
+date_added: 2020-09-10
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_blinka/udoo_x86_ii_ultra.md
+++ b/_blinka/udoo_x86_ii_ultra.md
@@ -10,7 +10,7 @@ board_image: "udoo_x86_ii_ultra.jpg"
 download_instructions: ""
 downloads_display: true
 blinka: true
-date_added: 2020-8-17
+date_added: 2020-08-17
 features:
   - Wi-Fi
   - Bluetooth/BLE

--- a/_board/01space_lcd042_esp32c3.md
+++ b/_board/01space_lcd042_esp32c3.md
@@ -7,7 +7,7 @@ manufacturer: "01space"
 board_url:
  - "https://github.com/01Space/ESP32-C3-0.42LCD"
 board_image: "01space_lcd042_esp32c3.jpg"
-date_added: 2023-5-4
+date_added: 2023-05-04
 family: esp32c3
 downloads_display: true
 features:

--- a/_board/8086_commander.md
+++ b/_board/8086_commander.md
@@ -7,7 +7,7 @@ manufacturer: "8086 Consultancy"
 board_url:
  - "https://8086.net/p/commander"
 board_image: "8086_commander.jpg"
-date_added: 2020-3-24
+date_added: 2020-03-24
 family: atmel-samd
 bootloader_id: 8086_commander
 

--- a/_board/TG-Watch.md
+++ b/_board/TG-Watch.md
@@ -7,7 +7,7 @@ manufacturer: "TG-Techie"
 board_url:
  - "https://github.com/TG-Techie/TG-Watch02-PCB"
 board_image: "TG-Watch.jpg"
-date_added: 2020-3-31
+date_added: 2020-03-31
 family: atmel-samd
 features:
   - Display

--- a/_board/adafruit_feather_esp32_v2.md
+++ b/_board/adafruit_feather_esp32_v2.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5400"
 board_image: "adafruit_feather_esp32_v2.jpg"
-date_added: 2022-8-19
+date_added: 2022-08-19
 family: esp32
 downloads_display: true
 features:

--- a/_board/adafruit_feather_esp32c6_4mbflash_nopsram.md
+++ b/_board/adafruit_feather_esp32c6_4mbflash_nopsram.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/"
 board_image: "adafruit_feather_esp32c6_4mbflash_nopsram.jpg"
-date_added: 2024-3-18
+date_added: 2024-03-18
 family: esp32c6
 downloads_display: true
 features:

--- a/_board/adafruit_feather_esp32s2.md
+++ b/_board/adafruit_feather_esp32s2.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5000"
 board_image: "adafruit_feather_esp32s2.jpg"
-date_added: 2021-4-6
+date_added: 2021-04-06
 family: esp32s2
 bootloader_id: adafruit_feather_esp32s2
 features:

--- a/_board/adafruit_feather_esp32s2_bme280.md
+++ b/_board/adafruit_feather_esp32s2_bme280.md
@@ -8,7 +8,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5303"
 board_image: "adafruit_feather_esp32s2_bme280.jpg"
-date_added: 2021-12-6
+date_added: 2021-12-06
 family: esp32s2
 bootloader_id: adafruit_feather_esp32s2
 features:

--- a/_board/adafruit_feather_esp32s2_reverse_tft.md
+++ b/_board/adafruit_feather_esp32s2_reverse_tft.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5345"
 board_image: "adafruit_feather_esp32s2_reverse_tft.jpg"
-date_added: 2023-1-31
+date_added: 2023-01-31
 family: esp32s2
 bootloader_id: adafruit_feather_esp32s2_reverse_tft
 tags:

--- a/_board/adafruit_feather_esp32s2_tft.md
+++ b/_board/adafruit_feather_esp32s2_tft.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5300"
 board_image: "adafruit_feather_esp32s2_tft.jpg"
-date_added: 2021-4-6
+date_added: 2021-04-06
 family: esp32s2
 bootloader_id: adafruit_feather_esp32s2_tft
 features:

--- a/_board/adafruit_feather_esp32s3_4mbflash_2mbpsram.md
+++ b/_board/adafruit_feather_esp32s3_4mbflash_2mbpsram.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5477"
 board_image: "adafruit_feather_esp32s3_4mbflash_2mbpsram.jpg"
-date_added: 2022-6-9
+date_added: 2022-06-09
 family: esp32s3
 bootloader_id: adafruit_feather_esp32s3
 downloads_display: true

--- a/_board/adafruit_feather_esp32s3_nopsram.md
+++ b/_board/adafruit_feather_esp32s3_nopsram.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5323"
 board_image: "adafruit_feather_esp32s3_nopsram.jpg"
-date_added: 2022-4-1
+date_added: 2022-04-01
 family: esp32s3
 bootloader_id: adafruit_feather_esp32s3_nopsram
 downloads_display: true

--- a/_board/adafruit_feather_esp32s3_reverse_tft.md
+++ b/_board/adafruit_feather_esp32s3_reverse_tft.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5691"
 board_image: "adafruit_feather_esp32s3_reverse_tft.jpg"
-date_added: 2023-1-31
+date_added: 2023-01-31
 family: esp32s3
 bootloader_id: adafruit_feather_esp32s3_reverse_tft
 tags:

--- a/_board/adafruit_feather_esp32s3_tft.md
+++ b/_board/adafruit_feather_esp32s3_tft.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5483"
 board_image: "adafruit_feather_esp32s3_tft.jpg"
-date_added: 2022-6-9
+date_added: 2022-06-09
 family: esp32s3
 bootloader_id: adafruit_feather_esp32s3_tft
 downloads_display: true

--- a/_board/adafruit_feather_huzzah32.md
+++ b/_board/adafruit_feather_huzzah32.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/3707"
 board_image: "adafruit_feather_huzzah32.jpg"
-date_added: 2022-8-19
+date_added: 2022-08-19
 family: esp32
 downloads_display: true
 features:

--- a/_board/adafruit_feather_rp2040.md
+++ b/_board/adafruit_feather_rp2040.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/4884"
 board_image: "adafruit_feather_rp2040.jpg"
-date_added: 2021-1-21
+date_added: 2021-01-21
 family: raspberrypi
 features:
   - Feather-Compatible

--- a/_board/adafruit_feather_rp2040_can.md
+++ b/_board/adafruit_feather_rp2040_can.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5724"
 board_image: "adafruit_feather_rp2040_can.jpg"
-date_added: 2023-5-2
+date_added: 2023-05-02
 family: raspberrypi
 tags:
   - CAN Bus Feather

--- a/_board/adafruit_feather_rp2040_dvi.md
+++ b/_board/adafruit_feather_rp2040_dvi.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5710"
 board_image: "adafruit_feather_rp2040_dvi.jpg"
-date_added: 2023-3-27
+date_added: 2023-03-27
 family: raspberrypi
 tags:
   - DVI Feather

--- a/_board/adafruit_feather_rp2040_prop_maker.md
+++ b/_board/adafruit_feather_rp2040_prop_maker.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5768"
 board_image: "adafruit_feather_rp2040_prop_maker.jpg"
-date_added: 2023-5-4
+date_added: 2023-05-04
 family: raspberrypi
 tags:
   - Propmaker Feather

--- a/_board/adafruit_feather_rp2040_rfm69.md
+++ b/_board/adafruit_feather_rp2040_rfm69.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5712"
 board_image: "adafruit_feather_rp2040_rfm69.jpg"
-date_added: 2023-4-4
+date_added: 2023-04-04
 family: raspberrypi
 features:
   - Feather-Compatible

--- a/_board/adafruit_feather_rp2040_rfm9x.md
+++ b/_board/adafruit_feather_rp2040_rfm9x.md
@@ -8,7 +8,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5714"
 board_image: "adafruit_feather_rp2040_rfm9x.jpg"
-date_added: 2023-4-4
+date_added: 2023-04-04
 family: raspberrypi
 features:
   - Feather-Compatible

--- a/_board/adafruit_feather_rp2040_thinkink.md
+++ b/_board/adafruit_feather_rp2040_thinkink.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5727"
 board_image: "adafruit_feather_rp2040_thinkink.jpg"
-date_added: 2023-5-2
+date_added: 2023-05-02
 family: raspberrypi
 tags:
   - ThinkInk Feather

--- a/_board/adafruit_feather_rp2040_usb_host.md
+++ b/_board/adafruit_feather_rp2040_usb_host.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5723"
 board_image: "adafruit_feather_rp2040_usb_host.jpg"
-date_added: 2023-5-2
+date_added: 2023-05-02
 family: raspberrypi
 tags:
   - USB Host Feather

--- a/_board/adafruit_floppsy_rp2040.md
+++ b/_board/adafruit_floppsy_rp2040.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/"
 board_image: "adafruit_floppsy_rp2040.jpg"
-date_added: 2024-3-13
+date_added: 2024-03-13
 family: raspberrypi
 features:
   - Display

--- a/_board/adafruit_funhouse.md
+++ b/_board/adafruit_funhouse.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/4985"
  - "https://www.adafruit.com/product/5069"
 board_image: "adafruit_funhouse.jpg"
-date_added: 2021-4-6
+date_added: 2021-04-06
 family: esp32s2
 bootloader_id: adafruit_funhouse_esp32s2
 features:

--- a/_board/adafruit_huzzah32_breakout.md
+++ b/_board/adafruit_huzzah32_breakout.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/4172"
 board_image: "adafruit_huzzah32_breakout.jpg"
-date_added: 2023-3-1
+date_added: 2023-03-01
 family: esp32
 downloads_display: true
 features:

--- a/_board/adafruit_itsybitsy_esp32.md
+++ b/_board/adafruit_itsybitsy_esp32.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5889"
 board_image: "adafruit_itsybitsy_esp32.jpg"
-date_added: 2024-2-20
+date_added: 2024-02-20
 family: esp32
 downloads_display: true
 features:

--- a/_board/adafruit_itsybitsy_rp2040.md
+++ b/_board/adafruit_itsybitsy_rp2040.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/4888"
 board_image: "adafruit_itsybitsy_rp2040.jpg"
-date_added: 2021-4-6
+date_added: 2021-04-06
 family: raspberrypi
 features:
   - Breadboard-Friendly

--- a/_board/adafruit_led_glasses_nrf52840.md
+++ b/_board/adafruit_led_glasses_nrf52840.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/5217"
  - "https://www.adafruit.com/product/5255"
 board_image: "adafruit_led_glasses_nrf52840.jpg"
-date_added: 2021-9-3
+date_added: 2021-09-03
 family: nrf52840
 bootloader_id: ledglasses_nrf52840
 features:

--- a/_board/adafruit_macropad_rp2040.md
+++ b/_board/adafruit_macropad_rp2040.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/5128"
  - "https://www.adafruit.com/product/5100"
 board_image: "adafruit_macropad_rp2040.jpg"
-date_added: 2021-6-4
+date_added: 2021-06-04
 family: raspberrypi
 features:
   - USB-C

--- a/_board/adafruit_matrixportal_s3.md
+++ b/_board/adafruit_matrixportal_s3.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5778"
 board_image: "adafruit_matrixportal_s3.jpg"
-date_added: 2023-6-26
+date_added: 2023-06-26
 family: esp32s3
 bootloader_id: adafruit_matrixportal_s3
 tags:

--- a/_board/adafruit_metro_esp32s2.md
+++ b/_board/adafruit_metro_esp32s2.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/4775"
 board_image: "adafruit_metro_esp32s2.jpg"
-date_added: 2020-10-2
+date_added: 2020-10-02
 family: esp32s2
 bootloader_id: adafruit_metro_esp32s2
 features:

--- a/_board/adafruit_metro_esp32s3.md
+++ b/_board/adafruit_metro_esp32s3.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5500"
 board_image: "adafruit_metro_esp32s3.jpg"
-date_added: 2023-7-28
+date_added: 2023-07-28
 family: esp32s3
 bootloader_id: adafruit_metro_esp32s3
 features:

--- a/_board/adafruit_metro_m7_1011_sd.md
+++ b/_board/adafruit_metro_m7_1011_sd.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5600"
 board_image: "adafruit_metro_m7_1011_sd.jpg"
-date_added: 2023-9-6
+date_added: 2023-09-06
 family: mimxrt10xx
 features:
   - STEMMA QT/QWIIC

--- a/_board/adafruit_metro_rp2040.md
+++ b/_board/adafruit_metro_rp2040.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5786"
 board_image: "adafruit_metro_rp2040.jpg"
-date_added: 2023-7-28
+date_added: 2023-07-28
 family: raspberrypi
 features:
   - STEMMA QT/QWIIC

--- a/_board/adafruit_neokey_trinkey_m0.md
+++ b/_board/adafruit_neokey_trinkey_m0.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5020"
 board_image: "adafruit_neokey_trinkey_m0.jpg"
-date_added: 2021-4-14
+date_added: 2021-04-14
 family: atmel-samd
 bootloader_id: neokey_trinkey_m0
 features:

--- a/_board/adafruit_proxlight_trinkey_m0.md
+++ b/_board/adafruit_proxlight_trinkey_m0.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5022"
 board_image: "adafruit_proxlight_trinkey_m0.jpg"
-date_added: 2021-4-14
+date_added: 2021-04-14
 family: atmel-samd
 bootloader_id: proxsense_trinkey_m0
 features:

--- a/_board/adafruit_qt2040_trinkey.md
+++ b/_board/adafruit_qt2040_trinkey.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5056"
 board_image: "adafruit_qt2040_trinkey.jpg"
-date_added: 2021-5-26
+date_added: 2021-05-26
 family: raspberrypi
 features:
 

--- a/_board/adafruit_qtpy_esp32_pico.md
+++ b/_board/adafruit_qtpy_esp32_pico.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5395"
 board_image: "adafruit_qtpy_esp32_pico.jpg"
-date_added: 2022-8-19
+date_added: 2022-08-19
 family: esp32
 downloads_display: true
 features:

--- a/_board/adafruit_qtpy_esp32c3.md
+++ b/_board/adafruit_qtpy_esp32c3.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5405"
 board_image: "adafruit_qtpy_esp32c3.jpg"
-date_added: 2022-4-1
+date_added: 2022-04-01
 family: esp32c3
 downloads_display: true
 features:

--- a/_board/adafruit_qtpy_esp32s3_nopsram.md
+++ b/_board/adafruit_qtpy_esp32s3_nopsram.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5426"
 board_image: "adafruit_qtpy_esp32s3_nopsram.jpg"
-date_added: 2022-2-14
+date_added: 2022-02-14
 family: esp32s3
 bootloader_id: adafruit_qtpy_esp32s3
 downloads_display: true

--- a/_board/adafruit_qtpy_rp2040.md
+++ b/_board/adafruit_qtpy_rp2040.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/4900"
 board_image: "adafruit_qtpy_rp2040.jpg"
-date_added: 2021-4-6
+date_added: 2021-04-06
 family: raspberrypi
 features:
   - STEMMA QT/QWIIC

--- a/_board/adafruit_qualia_s3_rgb666.md
+++ b/_board/adafruit_qualia_s3_rgb666.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5800"
 board_image: "adafruit_qualia_s3_rgb666.jpg"
-date_added: 2023-10-3
+date_added: 2023-10-03
 family: esp32s3
 bootloader_id: adafruit_qualia_s3_rgb666
 tags:

--- a/_board/adafruit_rotary_trinkey_m0.md
+++ b/_board/adafruit_rotary_trinkey_m0.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/4964"
 board_image: "adafruit_rotary_trinkey_m0.jpg"
-date_added: 2021-4-6
+date_added: 2021-04-06
 family: atmel-samd
 bootloader_id: rotary_trinkey_m0
 features:

--- a/_board/adafruit_sht4x_trinkey_m0.md
+++ b/_board/adafruit_sht4x_trinkey_m0.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/"
 board_image: "adafruit_sht4x_trinkey_m0.jpg"
-date_added: 2024-3-13
+date_added: 2024-03-13
 family: atmel-samd
 features:
 

--- a/_board/adafruit_slide_trinkey_m0.md
+++ b/_board/adafruit_slide_trinkey_m0.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5021"
 board_image: "adafruit_slide_trinkey_m0.jpg"
-date_added: 2021-4-14
+date_added: 2021-04-14
 family: atmel-samd
 bootloader_id: slide_trinkey_m0
 features:

--- a/_board/ai_thinker_esp_12k_nodemcu.md
+++ b/_board/ai_thinker_esp_12k_nodemcu.md
@@ -7,7 +7,7 @@ manufacturer: "Ai-Thinker"
 board_url:
  - "https://docs.ai-thinker.com/en/12k_development_board_esp32-s2"
 board_image: "ai_thinker_esp_12k_nodemcu.jpg"
-date_added: 2021-8-24
+date_added: 2021-08-24
 family: esp32s2
 bootloader_id: adafruit_qtpy_esp32s2
 features:

--- a/_board/aloriumtech_evo_m51.md
+++ b/_board/aloriumtech_evo_m51.md
@@ -7,7 +7,7 @@ manufacturer: "Alorium Technology, LLC"
 board_url:
  - "https://www.aloriumtech.com/evom51"
 board_image: "aloriumtech_evo_m51.jpg"
-date_added: 2020-5-21
+date_added: 2020-05-21
 family: atmel-samd
 downloads_display: true
 blinka: false

--- a/_board/aramcon2_badge.md
+++ b/_board/aramcon2_badge.md
@@ -7,7 +7,7 @@ manufacturer: "ARAMCON Badge Team"
 board_url:
  - "https://github.com/aramcon-badge/"
 board_image: "aramcon2_badge.jpg"
-date_added: 2021-4-14
+date_added: 2021-04-14
 family: nrf52840
 bootloader_id: aramcon2_badge
 downloads_display: true

--- a/_board/aramcon_badge_2019.md
+++ b/_board/aramcon_badge_2019.md
@@ -7,7 +7,7 @@ manufacturer: "ARAMCON Badge Team"
 board_url:
  - "https://github.com/aramcon-badge/"
 board_image: "aramcon_badge_2019.jpg"
-date_added: 2020-1-25
+date_added: 2020-01-25
 family: nrf52840
 bootloader_id: aramcon_badge_2019
 features:

--- a/_board/arduino_mkrzero.md
+++ b/_board/arduino_mkrzero.md
@@ -7,7 +7,7 @@ manufacturer: "Arduino"
 board_url:
  - "https://www.arduino.cc/en/Guide/ArduinoMKRZero"
 board_image: "arduino_mkr_zero.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: mkrzero
 features:

--- a/_board/arduino_nano_33_iot.md
+++ b/_board/arduino_nano_33_iot.md
@@ -7,7 +7,7 @@ manufacturer: "Arduino"
 board_url:
  - "https://www.arduino.cc/en/Guide/NANO33IoT"
 board_image: "arduino_nano_33_iot.jpg"
-date_added: 2020-2-27
+date_added: 2020-02-27
 family: atmel-samd
 bootloader_id: nano33iot
 features:

--- a/_board/arduino_nano_esp32s3.md
+++ b/_board/arduino_nano_esp32s3.md
@@ -7,7 +7,7 @@ manufacturer: "Arduino"
 board_url:
  - "https://store.arduino.cc/pages/nano-esp32"
 board_image: "arduino_nano_esp32s3.jpg"
-date_added: 2023-9-6
+date_added: 2023-09-06
 family: esp32s3
 features:
   - Wi-Fi

--- a/_board/arduino_nano_esp32s3_inverted_statusled.md
+++ b/_board/arduino_nano_esp32s3_inverted_statusled.md
@@ -7,7 +7,7 @@ manufacturer: "Arduino"
 board_url:
  - "https://store.arduino.cc/pages/nano-esp32"
 board_image: "arduino_nano_esp32s3.jpg"
-date_added: 2023-9-6
+date_added: 2023-09-06
 family: esp32s3
 features:
   - Wi-Fi

--- a/_board/arduino_nano_rp2040_connect.md
+++ b/_board/arduino_nano_rp2040_connect.md
@@ -7,7 +7,7 @@ manufacturer: "Arduino"
 board_url:
  - "https://store.arduino.cc/usa/nano-rp2040-connect-with-headers"
 board_image: "arduino_nano_rp2040_connect.jpg"
-date_added: 2021-5-24
+date_added: 2021-05-24
 family: raspberrypi
 features:
   - Wi-Fi

--- a/_board/arduino_zero.md
+++ b/_board/arduino_zero.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.arduino.cc/en/Guide/ArduinoZero"
  - "https://www.adafruit.com/product/2843"
 board_image: "arduino_zero.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: zero
 features:

--- a/_board/atmegazero_esp32s2.md
+++ b/_board/atmegazero_esp32s2.md
@@ -7,7 +7,7 @@ manufacturer: "ATMegaZero"
 board_url:
  - "https://www.atmegazero.com"
 board_image: "atmegazero_esp32s2.jpg"
-date_added: 2021-4-19
+date_added: 2021-04-19
 family: esp32s2
 bootloader_id: atmegazero_esp32s2
 features:

--- a/_board/bast_pro_mini_m0.md
+++ b/_board/bast_pro_mini_m0.md
@@ -7,7 +7,7 @@ manufacturer: "Electronic Cats"
 board_url:
  - "https://electroniccats.com/store/bast-pro-mini-m0/"
 board_image: "bast_pro_mini_m0.jpg"
-date_added: 2019-4-13
+date_added: 2019-04-13
 family: atmel-samd
 features:
   - Breadboard-Friendly

--- a/_board/bdmicro_vina_d21.md
+++ b/_board/bdmicro_vina_d21.md
@@ -7,7 +7,7 @@ manufacturer: "BDMICRO, LLC"
 board_url:
  - "https://bdmicro.com/products/vina-d21"
 board_image: "bdmicro_vina_d21.jpg"
-date_added: 2020-9-28
+date_added: 2020-09-28
 family: atmel-samd
 features:
   - Battery Charging

--- a/_board/bdmicro_vina_d51_pcb7.md
+++ b/_board/bdmicro_vina_d51_pcb7.md
@@ -7,7 +7,7 @@ manufacturer: "BDMICRO, LLC"
 board_url:
  - "https://bdmicro.com/products/vina-d51"
 board_image: "bdmicro_vina_d51.jpg"
-date_added: 2021-5-26
+date_added: 2021-05-26
 family: atmel-samd
 features:
   - Wi-Fi

--- a/_board/blm_badge.md
+++ b/_board/blm_badge.md
@@ -8,7 +8,7 @@ board_url:
  - "https://github.com/adafruit/BLM-Badge-PCB"
  - "https://www.adafruit.com/product/4703"
 board_image: "blmbadge.jpg"
-date_added: 2020-9-1
+date_added: 2020-09-01
 family: atmel-samd
 bootloader_id: blm_badge
 features:

--- a/_board/boardsource_blok.md
+++ b/_board/boardsource_blok.md
@@ -7,7 +7,7 @@ manufacturer: "Boardsource"
 board_url:
  - "https://boardsource.xyz/store/628b95b494dfa308a6581622"
 board_image: "boardsource_blok.jpg"
-date_added: 2021-4-6
+date_added: 2021-04-06
 family: raspberrypi
 features:
   - Breadboard-Friendly

--- a/_board/bpi_bit_s2.md
+++ b/_board/bpi_bit_s2.md
@@ -7,7 +7,7 @@ manufacturer: "Banana Pi"
 board_url:
  - "https://wiki.banana-pi.org/BPI-Bit-S2"
 board_image: "bpi_bit_s2.jpg"
-date_added: 2022-9-14
+date_added: 2022-09-14
 family: esp32s2
 bootloader_id: bpi_bit_s2
 features:

--- a/_board/bpi_leaf_s3.md
+++ b/_board/bpi_leaf_s3.md
@@ -7,7 +7,7 @@ manufacturer: "Banana Pi"
 board_url:
  - "https://wiki.banana-pi.org/BPI-Leaf-S3"
 board_image: "bpi_leaf_s3.jpg"
-date_added: 2022-7-4
+date_added: 2022-07-04
 family: esp32s3
 bootloader_id: bpi_leaf_s3
 features:

--- a/_board/bwshockley_figpi.md
+++ b/_board/bwshockley_figpi.md
@@ -7,7 +7,7 @@ manufacturer: "Benjamin Shockley"
 board_url:
  - "https://minifigboards.com/fig-pi"
 board_image: "bwshockley_figpi.jpg"
-date_added: 2022-8-22
+date_added: 2022-08-22
 family: raspberrypi
 features:
   - STEMMA QT/QWIIC

--- a/_board/capablerobot_usbhub.md
+++ b/_board/capablerobot_usbhub.md
@@ -7,7 +7,7 @@ manufacturer: "Capable Robot Components"
 board_url:
  - "https://www.crowdsupply.com/capable-robot-components/programmable-usb-hub"
 board_image: "capablerobot_usbhub.jpg"
-date_added: 2019-5-25
+date_added: 2019-05-25
 family: atmel-samd
 bootloader_id: capablerobot_usbhub
 features:

--- a/_board/catwan_usbstick.md
+++ b/_board/catwan_usbstick.md
@@ -7,7 +7,7 @@ manufacturer: "Electronic Cats"
 board_url:
  - "https://electroniccats.com/producto/catwan_usb-stick/"
 board_image: "catwan_usbstick.jpg"
-date_added: 2019-4-2
+date_added: 2019-04-02
 family: atmel-samd
 features:
   - LoRa/Radio

--- a/_board/challenger_840.md
+++ b/_board/challenger_840.md
@@ -7,7 +7,7 @@ manufacturer: "Invector Labs"
 board_url:
  - "https://ilabs.se/product/challenger-840-ble/"
 board_image: "challenger_840.jpg"
-date_added: 2022-4-1
+date_added: 2022-04-01
 family: nrf52840
 features:
   - Bluetooth/BTLE

--- a/_board/challenger_rp2040_lora.md
+++ b/_board/challenger_rp2040_lora.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.tindie.com/products/invector/challenger-rp2040-lora-915mhz/"
  - "https://thepihut.com/products/challenger-rp2040-lora-868mhz"
 board_image: "challenger_rp2040_lora.jpg"
-date_added: 2022-6-9
+date_added: 2022-06-09
 family: raspberrypi
 features:
   - LoRa/Radio

--- a/_board/challenger_rp2040_subghz.md
+++ b/_board/challenger_rp2040_subghz.md
@@ -7,7 +7,7 @@ manufacturer: "Invector Labs"
 board_url:
  - "https://ilabs.se/product/challenger-rp2040-subghz-915mhz/"
 board_image: "challenger_rp2040_subghz.jpg"
-date_added: 2022-10-6
+date_added: 2022-10-06
 family: raspberrypi
 features:
   - LoRa/Radio

--- a/_board/challenger_rp2040_wifi.md
+++ b/_board/challenger_rp2040_wifi.md
@@ -7,7 +7,7 @@ manufacturer: "Invector Labs"
 board_url:
  - "https://www.tindie.com/products/invector/challenger-rp2040-wifi/"
 board_image: "challenger_rp2040_wifi.jpg"
-date_added: 2021-9-16
+date_added: 2021-09-16
 family: raspberrypi
 features:
   - Wi-Fi

--- a/_board/challenger_rp2040_wifi_ble.md
+++ b/_board/challenger_rp2040_wifi_ble.md
@@ -7,7 +7,7 @@ manufacturer: "Invector Labs"
 board_url:
  - "https://ilabs.se/product/challenger-rp2040-wifi-ble-with-chip-antenna/"
 board_image: "challenger_rp2040_wifi_ble.jpg"
-date_added: 2022-10-6
+date_added: 2022-10-06
 family: raspberrypi
 features:
   - Wi-Fi

--- a/_board/circuitbrains_basic_m0.md
+++ b/_board/circuitbrains_basic_m0.md
@@ -7,7 +7,7 @@ manufacturer: "Null Byte Labs LLC"
 board_url:
  - "https://github.com/neubauek/CircuitBrains"
 board_image: "circuitbrains_basic.jpg"
-date_added: 2020-2-27
+date_added: 2020-02-27
 family: atmel-samd
 bootloader_id: circuitbrains_basic_m0
 downloads_display: true

--- a/_board/circuitbrains_deluxe_m4.md
+++ b/_board/circuitbrains_deluxe_m4.md
@@ -8,7 +8,7 @@ board_url:
  - "https://github.com/neubauek/CircuitBrains"
  - "https://www.adafruit.com/product/4802"
 board_image: "circuitbrains_deluxe.jpg"
-date_added: 2020-2-27
+date_added: 2020-02-27
 family: atmel-samd
 bootloader_id: circuitbrains_deluxe_m4
 downloads_display: true

--- a/_board/circuitplayground_bluefruit.md
+++ b/_board/circuitplayground_bluefruit.md
@@ -10,7 +10,7 @@ board_url:
  - "https://www.adafruit.com/product/4504"
  - "https://www.adafruit.com/product/4371"
 board_image: "circuitplayground_bluefruit.jpg"
-date_added: 2019-8-30
+date_added: 2019-08-30
 family: nrf52840
 bootloader_id: circuitplayground_nrf52840
 features:

--- a/_board/circuitplayground_express_4h.md
+++ b/_board/circuitplayground_express_4h.md
@@ -9,7 +9,7 @@ board_url:
  - "https://www.adafruit.com/product/4241"
  - "https://www.adafruit.com/product/4263"
 board_image: "circuitplayground_express_4h.jpg"
-date_added: 2019-4-13
+date_added: 2019-04-13
 family: atmel-samd
 bootloader_id: circuitplay_m0
 features:

--- a/_board/circuitplayground_express_crickit.md
+++ b/_board/circuitplayground_express_crickit.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/3093"
 board_image: "circuitplayground_express_crickit.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: circuitplay_m0
 features:

--- a/_board/circuitplayground_express_digikey_pycon2019.md
+++ b/_board/circuitplayground_express_digikey_pycon2019.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://github.com/adafruit/PyCon2019"
 board_image: "circuitplayground_express_digikey_pycon2019.jpg"
-date_added: 2019-4-13
+date_added: 2019-04-13
 family: atmel-samd
 bootloader_id: circuitplay_m0
 features:

--- a/_board/columbia-dsl-sensor.md
+++ b/_board/columbia-dsl-sensor.md
@@ -6,7 +6,7 @@ name: "Colombia DSL Sensor"
 manufacturer: "Double Take Labs"
 board_url:
 board_image: "unknown.jpg"
-date_added: 2024-2-7
+date_added: 2024-02-07
 family: esp32s3
 downloads_display: false
 ---

--- a/_board/cosmo_pico.md
+++ b/_board/cosmo_pico.md
@@ -7,7 +7,7 @@ manufacturer: "Potekku"
 board_url:
  - "https://edtechzine.jp/article/detail/8715"
 board_image: "cosmo_pico.jpg"
-date_added: 2023-3-1
+date_added: 2023-03-01
 family: raspberrypi
 features:
   - Wi-Fi

--- a/_board/cp32-m4.md
+++ b/_board/cp32-m4.md
@@ -8,7 +8,7 @@ board_url:
  - "https://github.com/siddacious/CP32-M4"
 board_image: "unknown.jpg"
 downloads_display: false
-date_added: 2019-4-5
+date_added: 2019-04-05
 family: atmel-samd
 features:
 ---

--- a/_board/cp_sapling_m0_revb.md
+++ b/_board/cp_sapling_m0_revb.md
@@ -7,7 +7,7 @@ manufacturer: "Oak Development Technologies"
 board_url:
  - "https://www.oakdev.tech/store/p10/%28Coming_Soon%29_CP_Sapling_Rev_B.html#/"
 board_image: "cp_sapling_m0_revb.jpg"
-date_added: 2021-6-4
+date_added: 2021-06-04
 family: atmel-samd
 bootloader_id: cp_sapling_m0
 features:

--- a/_board/cp_sapling_m0_spiflash.md
+++ b/_board/cp_sapling_m0_spiflash.md
@@ -7,7 +7,7 @@ manufacturer: "Oak Development Technologies"
 board_url:
  - "https://www.oakdev.tech/store/p7/CP-Sapling-m0-development-board.html#/"
 board_image: "cp_sapling_m0.jpg"
-date_added: 2021-4-6
+date_added: 2021-04-06
 family: atmel-samd
 bootloader_id: cp_sapling_m0
 features:

--- a/_board/crumpspace_crumps2.md
+++ b/_board/crumpspace_crumps2.md
@@ -7,7 +7,7 @@ manufacturer: "CrumpSpace"
 board_url:
  - "https://github.com/tylercrumpton/CrumpS2"
 board_image: "crumpspace_crumps2.jpg"
-date_added: 2021-8-13
+date_added: 2021-08-13
 family: esp32s2
 features:
   - Wi-Fi

--- a/_board/cytron_edu_pico_w.md
+++ b/_board/cytron_edu_pico_w.md
@@ -7,7 +7,7 @@ manufacturer: "Cytron Technologies"
 board_url:
  - "https://www.cytron.io/p-edu-project-and-innovation-kits-for-pico-w"
 board_image: "cytron_edu_pico_w.jpg"
-date_added: 2024-1-24
+date_added: 2024-01-24
 family: raspberrypi
 features:
   - Battery Charging

--- a/_board/cytron_maker_nano_rp2040.md
+++ b/_board/cytron_maker_nano_rp2040.md
@@ -7,7 +7,7 @@ manufacturer: "Cytron Technologies"
 board_url:
  - "https://www.cytron.io/p-maker-nano-rp2040"
 board_image: "cytron_maker_nano_rp2040.jpg"
-date_added: 2021-12-6
+date_added: 2021-12-06
 family: raspberrypi
 features:
   - Speaker

--- a/_board/cytron_maker_pi_rp2040.md
+++ b/_board/cytron_maker_pi_rp2040.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.cytron.io/p-maker-pi-rp2040"
  - "https://www.adafruit.com/product/5129"
 board_image: "cytron_maker_pi_rp2040.jpg"
-date_added: 2021-5-31
+date_added: 2021-05-31
 family: raspberrypi
 features:
   - Battery Charging

--- a/_board/datalore_ip_m4.md
+++ b/_board/datalore_ip_m4.md
@@ -7,7 +7,7 @@ manufacturer: "TG-Techie"
 board_url:
  - "https://github.com/TG-Techie/Datalore-IP-M4"
 board_image: "datalore_ip_m4.jpg"
-date_added: 2019-4-5
+date_added: 2019-04-05
 family: atmel-samd
 features:
 ---

--- a/_board/datanoise_picoadk.md
+++ b/_board/datanoise_picoadk.md
@@ -7,7 +7,7 @@ manufacturer: "DatanoiseTV"
 board_url:
  - "https://www.tindie.com/products/datanoisetv/picoadk-audio-development-kit-raspberry-rp2040/"
 board_image: "datanoise_picoadk.jpg"
-date_added: 2023-7-28
+date_added: 2023-07-28
 family: raspberrypi
 features:
   - STEMMA QT/QWIIC

--- a/_board/datum_distance.md
+++ b/_board/datum_distance.md
@@ -7,7 +7,7 @@ manufacturer: "J&J Studios"
 board_url:
  - "https://jandjstudios.io/datum/datum-Distance/"
 board_image: "datum_distance.jpg"
-date_added: 2019-7-12
+date_added: 2019-07-12
 family: atmel-samd
 features:
   - Breadboard-Friendly

--- a/_board/datum_imu.md
+++ b/_board/datum_imu.md
@@ -7,7 +7,7 @@ manufacturer: "J&J Studios"
 board_url:
  - "https://jandjstudios.io/datum/datum-IMU/"
 board_image: "datum_imu.jpg"
-date_added: 2019-7-12
+date_added: 2019-07-12
 family: atmel-samd
 features:
   - Breadboard-Friendly

--- a/_board/datum_light.md
+++ b/_board/datum_light.md
@@ -7,7 +7,7 @@ manufacturer: "J&J Studios"
 board_url:
  - "https://jandjstudios.io/datum/datum-Light/"
 board_image: "datum_light.jpg"
-date_added: 2019-7-12
+date_added: 2019-07-12
 family: atmel-samd
 features:
   - Breadboard-Friendly

--- a/_board/datum_weather.md
+++ b/_board/datum_weather.md
@@ -7,7 +7,7 @@ manufacturer: "J&J Studios"
 board_url:
  - "https://jandjstudios.io/datum/datum-Weather/"
 board_image: "datum_weather.jpg"
-date_added: 2019-7-12
+date_added: 2019-07-12
 family: atmel-samd
 features:
   - Breadboard-Friendly

--- a/_board/diodes_delight_piunora.md
+++ b/_board/diodes_delight_piunora.md
@@ -10,7 +10,7 @@ board_url:
  - "https://www.adafruit.com/product/5403"
 board_image: "diodes_delight_piunora.jpg"
 download_instructions:
-date_added: 2021-2-14
+date_added: 2021-02-14
 family: broadcom
 features:
   - Wi-Fi

--- a/_board/doit_esp32_devkit_v1.md
+++ b/_board/doit_esp32_devkit_v1.md
@@ -7,7 +7,7 @@ manufacturer: "DOIT"
 board_url:
  - "https://www.aliexpress.us/item/2251832638296842.html"
 board_image: "doit_esp32_devkit_v1.jpg"
-date_added: 2023-1-31
+date_added: 2023-01-31
 family: esp32
 features:
   - Wi-Fi

--- a/_board/e_fidget.md
+++ b/_board/e_fidget.md
@@ -7,7 +7,7 @@ manufacturer: "2231puppy"
 board_url:
  - "https://e-fidget.xyz"
 board_image: "e_fidget.jpg"
-date_added: 2023-1-4
+date_added: 2023-01-04
 family: raspberrypi
 features:
   - Battery Charging

--- a/_board/elecfreaks_picoed.md
+++ b/_board/elecfreaks_picoed.md
@@ -7,7 +7,7 @@ manufacturer: "ELECFREAKS"
 board_url:
  - "https://www.elecfreaks.com/picoed.html"
 board_image: "elecfreaks_picoed.jpg"
-date_added: 2022-4-21
+date_added: 2022-04-21
 family: raspberrypi
 features:
   - Speaker

--- a/_board/electrolama_minik.md
+++ b/_board/electrolama_minik.md
@@ -7,7 +7,7 @@ manufacturer: "Electrolama"
 board_url:
  - "https://github.com/electrolama/minik"
 board_image: "electrolama_minik.jpg"
-date_added: 2022-8-22
+date_added: 2022-08-22
 family: raspberrypi
 features:
 

--- a/_board/electronut_labs_blip.md
+++ b/_board/electronut_labs_blip.md
@@ -7,7 +7,7 @@ manufacturer: "Electronut Labs"
 board_url:
  - "https://gitlab.com/electronutlabs-public/ElectronutLabs-blip"
 board_image: "electronut_labs_blip.png"
-date_added: 2019-5-23
+date_added: 2019-05-23
 family: nrf52840
 downloads_display: true
 features:

--- a/_board/electronut_labs_papyr.md
+++ b/_board/electronut_labs_papyr.md
@@ -8,7 +8,7 @@ board_url:
  - "https://gitlab.com/electronutlabs-public/papyr"
 board_image: "electronut_labs_papyr.jpg"
 downloads_display: true
-date_added: 2019-4-23
+date_added: 2019-04-23
 family: nrf52840
 bootloader_id: electronut_labs_papyr
 features:

--- a/_board/escornabot_makech.md
+++ b/_board/escornabot_makech.md
@@ -7,7 +7,7 @@ manufacturer: "Electronic Cats"
 board_url:
  - "https://github.com/ElectronicCats/escornabot"
 board_image: "escornabot_makech.jpg"
-date_added: 2019-5-25
+date_added: 2019-05-25
 family: atmel-samd
 features:
   - Robotics

--- a/_board/espressif_esp32_devkitc_v4_wroom_32e.md
+++ b/_board/espressif_esp32_devkitc_v4_wroom_32e.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/3269"
  - "https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-devkitc.html"
 board_image: "espressif_esp32_devkitc_v4_wroom_32e.jpg"
-date_added: 2024-2-6
+date_added: 2024-02-06
 family: esp32
 features:
   - Wi-Fi

--- a/_board/espressif_esp32_devkitc_v4_wrover.md
+++ b/_board/espressif_esp32_devkitc_v4_wrover.md
@@ -7,7 +7,7 @@ manufacturer: "Espressif"
 board_url:
  - "https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-devkitc.html"
 board_image: "espressif_esp32_devkitc_v4_wrover.jpg"
-date_added: 2024-2-6
+date_added: 2024-02-06
 family: esp32
 features:
   - Wi-Fi

--- a/_board/espressif_esp32_lyrat.md
+++ b/_board/espressif_esp32_lyrat.md
@@ -7,7 +7,7 @@ manufacturer: "Espressif"
 board_url:
  - "https://www.espressif.com/en/products/devkits/esp32-lyrat"
 board_image: "espressif_esp32_lyrat.jpg"
-date_added: 2023-3-1
+date_added: 2023-03-01
 family: esp32
 features:
   - Wi-Fi

--- a/_board/espressif_esp32c3_devkitm_1_n4.md
+++ b/_board/espressif_esp32c3_devkitm_1_n4.md
@@ -7,7 +7,7 @@ manufacturer: "Espressif"
 board_url:
  - "https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/hw-reference/esp32c3/user-guide-devkitm-1.html"
 board_image: "espressif_esp32c3_devkitm_1_n4.jpg"
-date_added: 2022-2-14
+date_added: 2022-02-14
 family: esp32c3
 features:
   - Wi-Fi

--- a/_board/espressif_esp32s2_devkitc_1_n4.md
+++ b/_board/espressif_esp32s2_devkitc_1_n4.md
@@ -7,7 +7,7 @@ manufacturer: "Espressif"
 board_url:
  - "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-s2-devkitc-1.html"
 board_image: "espressif_esp32s2_devkitc_1_n4.jpg"
-date_added: 2022-4-1
+date_added: 2022-04-01
 family: esp32s2
 features:
   - Wi-Fi

--- a/_board/espressif_esp32s2_devkitc_1_n4r2.md
+++ b/_board/espressif_esp32s2_devkitc_1_n4r2.md
@@ -7,7 +7,7 @@ manufacturer: "Espressif"
 board_url:
  - "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-s2-devkitc-1.html"
 board_image: "espressif_esp32s2_devkitc_1_n4r2.jpg"
-date_added: 2022-2-14
+date_added: 2022-02-14
 family: esp32s2
 features:
   - Wi-Fi

--- a/_board/espressif_esp32s3_devkitc_1_n32r8.md
+++ b/_board/espressif_esp32s3_devkitc_1_n32r8.md
@@ -7,7 +7,7 @@ manufacturer: "Espressif"
 board_url:
  - "https://www.adafruit.com/product/5364"
 board_image: "espressif_esp32s3_devkitc_1.jpg"
-date_added: 2023-1-31
+date_added: 2023-01-31
 family: esp32s3
 bootloader_id: espressif_esp32s3_devkitc_1
 features:

--- a/_board/espressif_esp32s3_devkitc_1_n8.md
+++ b/_board/espressif_esp32s3_devkitc_1_n8.md
@@ -7,7 +7,7 @@ manufacturer: "Espressif"
 board_url:
  - "https://www.adafruit.com/product/5312"
 board_image: "espressif_esp32s3_devkitc_1.jpg"
-date_added: 2022-1-4
+date_added: 2022-01-04
 family: esp32s3
 bootloader_id: espressif_esp32s3_devkitc_1
 features:

--- a/_board/espressif_esp32s3_devkitc_1_n8r2.md
+++ b/_board/espressif_esp32s3_devkitc_1_n8r2.md
@@ -7,7 +7,7 @@ manufacturer: "Espressif"
 board_url:
  - "https://www.adafruit.com/product/5310"
 board_image: "espressif_esp32s3_devkitc_1.jpg"
-date_added: 2021-12-7
+date_added: 2021-12-07
 family: esp32s3
 bootloader_id: espressif_esp32s3_devkitc_1
 features:

--- a/_board/espressif_esp32s3_devkitc_1_n8r8.md
+++ b/_board/espressif_esp32s3_devkitc_1_n8r8.md
@@ -7,7 +7,7 @@ manufacturer: "Espressif"
 board_url:
  - "https://www.adafruit.com/product/5336"
 board_image: "espressif_esp32s3_devkitc_1.jpg"
-date_added: 2022-1-15
+date_added: 2022-01-15
 family: esp32s3
 bootloader_id: espressif_esp32s3_devkitc_1
 features:

--- a/_board/espressif_esp32s3_devkitm_1_n8.md
+++ b/_board/espressif_esp32s3_devkitm_1_n8.md
@@ -7,7 +7,7 @@ manufacturer: "Espressif"
 board_url:
  - "https://www.adafruit.com/product/5311"
 board_image: "espressif_esp32s3_devkitm_1_n8.jpg"
-date_added: 2022-4-1
+date_added: 2022-04-01
 family: esp32s3
 bootloader_id: espressif_esp32s3_devkitm_1
 features:

--- a/_board/espressif_esp32s3_usb_otg_n8.md
+++ b/_board/espressif_esp32s3_usb_otg_n8.md
@@ -7,7 +7,7 @@ manufacturer: "Espressif"
 board_url:
  - "https://docs.espressif.com/projects/espressif-esp-dev-kits/en/latest/esp32s3/esp32-s3-usb-otg/user_guide.html"
 board_image: "espressif_esp32s3_usb_otg_n8.jpg"
-date_added: 2022-4-1
+date_added: 2022-04-01
 family: esp32s3
 features:
   - Display

--- a/_board/espressif_hmi_devkit_1.md
+++ b/_board/espressif_hmi_devkit_1.md
@@ -7,7 +7,7 @@ manufacturer: "Espressif"
 board_url:
  - "https://www.adafruit.com/product/5207"
 board_image: "espressif_hmi_devkit_1.jpg"
-date_added: 2021-9-03
+date_added: 2021-09-03
 family: esp32s2
 bootloader_id: espressif_hmi_1
 features:

--- a/_board/espruino_banglejs2.md
+++ b/_board/espruino_banglejs2.md
@@ -7,7 +7,7 @@ manufacturer: "Espruino"
 board_url:
  - "https://www.adafruit.com/product/5427"
 board_image: "espruino_banglejs2.jpg"
-date_added: 2023-3-1
+date_added: 2023-03-01
 family: nrf52840
 features:
   - Bluetooth/BTLE

--- a/_board/espruino_pico.md
+++ b/_board/espruino_pico.md
@@ -7,7 +7,7 @@ manufacturer: "Espruino"
 board_url:
  - "https://www.adafruit.com/product/2621"
 board_image: "espruino_pico.jpg"
-date_added: 2020-2-7
+date_added: 2020-02-07
 family: stm
 features:
 

--- a/_board/espruino_wifi.md
+++ b/_board/espruino_wifi.md
@@ -7,7 +7,7 @@ manufacturer: "Espruino"
 board_url:
  - "https://www.adafruit.com/product/3514"
 board_image: "espruino_wifi.jpg"
-date_added: 2020-2-13
+date_added: 2020-02-13
 family: stm
 features:
   - Wi-Fi

--- a/_board/feather_bluefruit_sense.md
+++ b/_board/feather_bluefruit_sense.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/4516"
 board_image: "feather_bluefruit_sense.jpg"
-date_added: 2020-2-1
+date_added: 2020-02-01
 family: nrf52840
 bootloader_id: feather_nrf52840_sense
 features:

--- a/_board/feather_m0_adalogger.md
+++ b/_board/feather_m0_adalogger.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/2796"
 board_image: "feather_m0_adalogger.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: feather_m0
 features:

--- a/_board/feather_m0_basic.md
+++ b/_board/feather_m0_basic.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/2772"
 board_image: "feather_m0_basic.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: feather_m0
 features:

--- a/_board/feather_m0_express.md
+++ b/_board/feather_m0_express.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/3403"
 board_image: "feather_m0_express.jpg"
-date_added: 2019-3-8
+date_added: 2019-03-08
 family: atmel-samd
 bootloader_id: feather_m0_express
 features:

--- a/_board/feather_m0_express_crickit.md
+++ b/_board/feather_m0_express_crickit.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/3343"
 board_image: "feather_m0_express_crickit.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: feather_m0_express
 features:

--- a/_board/feather_m0_rfm69.md
+++ b/_board/feather_m0_rfm69.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/3176"
  - "https://www.adafruit.com/product/3177"
 board_image: "feather_m0_rfm69.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: radiofruit_m0
 features:

--- a/_board/feather_m0_rfm9x.md
+++ b/_board/feather_m0_rfm9x.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/3178"
  - "https://www.adafruit.com/product/3179"
 board_image: "feather_m0_rfm9x.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: radiofruit_m0
 features:

--- a/_board/feather_m0_supersized.md
+++ b/_board/feather_m0_supersized.md
@@ -7,7 +7,7 @@ manufacturer: "Dave Astels"
 board_url:
  - "https://blog.adafruit.com/2017/10/27/supersizing-the-feather-m0-express-with-8mb-spi-flash-memory-s25fl064l/"
 board_image: "feather_m0_supersized.jpg"
-date_added: 2019-3-19
+date_added: 2019-03-19
 family: atmel-samd
 bootloader_id: feather_m0_express
 features:

--- a/_board/feather_m4_can.md
+++ b/_board/feather_m4_can.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/4759"
 board_image: "feather_m4_can.jpg"
-date_added: 2020-9-28
+date_added: 2020-09-28
 family: atmel-samd
 bootloader_id: feather_m4_can
 features:

--- a/_board/feather_m4_express.md
+++ b/_board/feather_m4_express.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/3857"
  - "https://www.adafruit.com/product/4352"
 board_image: "feather_m4_express.jpg"
-date_added: 2019-3-8
+date_added: 2019-03-08
 family: atmel-samd
 bootloader_id: feather_m4
 features:

--- a/_board/feather_m7_1011.md
+++ b/_board/feather_m7_1011.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/4950"
 board_image: "feather_m7_1011.jpg"
-date_added: 2020-2-27
+date_added: 2020-02-27
 family: mimxrt10xx
 features:
   - Feather-Compatible

--- a/_board/feather_mimxrt1011.md
+++ b/_board/feather_mimxrt1011.md
@@ -7,7 +7,7 @@ manufacturer: "arturo182"
 board_url:
  - "https://hackaday.io/project/169387-mimxrt10xx-feathers-rt1011-and-rt1062"
 board_image: "feather_mimxrt1011.jpg"
-date_added: 2020-1-8
+date_added: 2020-01-08
 family: mimxrt10xx
 features:
   - Feather-Compatible

--- a/_board/feather_mimxrt1062.md
+++ b/_board/feather_mimxrt1062.md
@@ -7,7 +7,7 @@ manufacturer: "arturo182"
 board_url:
  - "https://hackaday.io/project/169387-mimxrt10xx-feathers-rt1011-and-rt1062"
 board_image: "feather_mimxrt1062.jpg"
-date_added: 2020-1-8
+date_added: 2020-01-08
 family: mimxrt10xx
 features:
   - Feather-Compatible

--- a/_board/feather_nrf52840_express.md
+++ b/_board/feather_nrf52840_express.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/4062"
 board_image: "feather_nrf52840_express.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: nrf52840
 bootloader_id: feather_nrf52840_express
 features:

--- a/_board/feather_radiofruit_zigbee.md
+++ b/_board/feather_radiofruit_zigbee.md
@@ -6,7 +6,7 @@ name: "feather_radiofruit_zigbee"
 manufacturer: "Adafruit"
 board_url:
 board_image: "unknown.jpg"
-date_added: 2019-4-5
+date_added: 2019-04-05
 family: atmel-samd
 bootloader_id: radiofruit_m0
 downloads_display: false

--- a/_board/feather_stm32f405_express.md
+++ b/_board/feather_stm32f405_express.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/4382"
 board_image: "feather_stm32f405_express.jpg"
-date_added: 2019-9-26
+date_added: 2019-09-26
 family: stm
 features:
   - Feather-Compatible

--- a/_board/fluff_m0.md
+++ b/_board/fluff_m0.md
@@ -7,7 +7,7 @@ manufacturer: "Radomir Dopieralski"
 board_url:
  - "https://hackaday.io/project/171381-fluff-m0"
 board_image: "fluff_m0.jpg"
-date_added: 2020-5-22
+date_added: 2020-05-22
 family: atmel-samd
 bootloader_id: fluff_m0
 features:

--- a/_board/fomu.md
+++ b/_board/fomu.md
@@ -8,7 +8,7 @@ board_url:
  - "https://tomu.im/fomu.html"
  - "https://www.adafruit.com/product/4332"
 board_image: "fomu.jpg"
-date_added: 2020-4-16
+date_added: 2020-04-16
 family: litex
 ---
 

--- a/_board/franzininho_wifi_wroom.md
+++ b/_board/franzininho_wifi_wroom.md
@@ -7,7 +7,7 @@ manufacturer: "Franzininho"
 board_url:
  - "https://github.com/Franzininho/Franzininho-WIFI"
 board_image: "Franzininho-wifi-wroom.jpg"
-date_added: 2021-3-13
+date_added: 2021-03-13
 family: esp32s2
 downloads_display: true
 features:

--- a/_board/franzininho_wifi_wrover.md
+++ b/_board/franzininho_wifi_wrover.md
@@ -7,7 +7,7 @@ manufacturer: "Franzininho"
 board_url:
  - "https://github.com/Franzininho/Franzininho-WIFI"
 board_image: "Franzininho-wifi-wrover.jpg"
-date_added: 2021-3-13
+date_added: 2021-03-13
 family: esp32s2
 downloads_display: true
 features:

--- a/_board/gb_m4.md
+++ b/_board/gb_m4.md
@@ -7,7 +7,7 @@ manufacturer: "Scott Shawcroft"
 board_url:
  - "https://github.com/chickadee-tech/pygb"
 board_image: "gb_m4.jpg"
-date_added: 2019-4-5
+date_added: 2019-04-05
 family: atmel-samd
 ---
 

--- a/_board/gemma_m0.md
+++ b/_board/gemma_m0.md
@@ -9,7 +9,7 @@ board_url:
  - "https://www.adafruit.com/product/1657"
  - "https://www.adafruit.com/product/3778"
 board_image: "gemma_m0.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: gemma_m0
 features:

--- a/_board/gemma_m0_pycon2018.md
+++ b/_board/gemma_m0_pycon2018.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://github.com/adafruit/CircuitPython_Badge_README/tree/master/final_versions/PYCON_2018"
 board_image: "gemma_m0_pycon2018.jpg"
-date_added: 2019-4-13
+date_added: 2019-04-13
 family: atmel-samd
 bootloader_id: gemma_m0
 features:

--- a/_board/grandcentral_m4_express.md
+++ b/_board/grandcentral_m4_express.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/4064"
  - "https://www.adafruit.com/product/4084"
 board_image: "grandcentral_m4_express.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: grandcentral_m4
 features:

--- a/_board/gravitech_cucumber_m.md
+++ b/_board/gravitech_cucumber_m.md
@@ -7,7 +7,7 @@ manufacturer: "Gravitech"
 board_url:
  - "https://www.gravitech.us/cumesdebo.html"
 board_image: "gravitech_cucumber_m.jpg"
-date_added: 2021-8-13
+date_added: 2021-08-13
 family: esp32s2
 bootloader_id: gravitech_cucumberRIS_v1.1
 downloads_display: true

--- a/_board/gravitech_cucumber_ms.md
+++ b/_board/gravitech_cucumber_ms.md
@@ -7,7 +7,7 @@ manufacturer: "Gravitech"
 board_url:
  - "https://www.gravitech.us/cumsdebowise.html"
 board_image: "gravitech_cucumber_ms.jpg"
-date_added: 2021-8-13
+date_added: 2021-08-13
 family: esp32s2
 bootloader_id: gravitech_cucumberRIS_v1.1
 downloads_display: true

--- a/_board/gravitech_cucumber_r.md
+++ b/_board/gravitech_cucumber_r.md
@@ -7,7 +7,7 @@ manufacturer: "Gravitech"
 board_url:
  - "https://www.gravitech.us/curesdebo.html"
 board_image: "gravitech_cucumber_r.jpg"
-date_added: 2021-8-13
+date_added: 2021-08-13
 family: esp32s2
 bootloader_id: gravitech_cucumberRIS_v1.1
 downloads_display: true

--- a/_board/gravitech_cucumber_rs.md
+++ b/_board/gravitech_cucumber_rs.md
@@ -7,7 +7,7 @@ manufacturer: "Gravitech"
 board_url:
  - "https://www.gravitech.us/cursdebowise.html"
 board_image: "gravitech_cucumber_rs.jpg"
-date_added: 2021-8-13
+date_added: 2021-08-13
 family: esp32s2
 bootloader_id: gravitech_cucumberRIS_v1.1
 downloads_display: true

--- a/_board/hack_club_sprig.md
+++ b/_board/hack_club_sprig.md
@@ -7,7 +7,7 @@ manufacturer: "Hack Club"
 board_url:
  - "https://sprig.hackclub.com"
 board_image: "hack_club_sprig.jpeg"
-date_added: "2023-02-03"
+date_added: 2023-02-03
 family: raspberrypi
 features:
   - Display

--- a/_board/hallowing_m0_express.md
+++ b/_board/hallowing_m0_express.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/3900"
  - "https://www.adafruit.com/product/3956"
 board_image: "hallowing_m0_express.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: hallowing_m0
 features:

--- a/_board/hallowing_m4_express.md
+++ b/_board/hallowing_m4_express.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/4300"
 board_image: "hallowing_m4_express.jpg"
-date_added: 2019-8-30
+date_added: 2019-08-30
 family: atmel-samd
 bootloader_id: hallowing_m4
 features:

--- a/_board/hardkernel_odroid_go.md
+++ b/_board/hardkernel_odroid_go.md
@@ -7,7 +7,7 @@ manufacturer: "HardKernel"
 board_url:
  - "https://www.hardkernel.com/shop/odroid-go/"
 board_image: "hardkernel_odroid_go.jpg"
-date_added: 2022-8-22
+date_added: 2022-08-22
 family: esp32
 downloads_display: true
 features:

--- a/_board/hexky_s2.md
+++ b/_board/hexky_s2.md
@@ -7,7 +7,7 @@ manufacturer: "FutureKeys"
 board_url:
 board_image: "unknown.jpg"
 downloads_display: false
-date_added: 2022-4-1
+date_added: 2022-04-01
 family: esp32s2
 bootloader_id: hexky_s2
 features:

--- a/_board/hiibot_bluefi.md
+++ b/_board/hiibot_bluefi.md
@@ -7,7 +7,7 @@ manufacturer: "Hangzhou LeBan"
 board_url:
  - "https://www.tindie.com/products/bradchan/hiibot-bluefi/"
 board_image: "hiibot_bluefi.jpg"
-date_added: 2020-5-19
+date_added: 2020-05-19
 family: nrf52840
 bootloader_id: hiibot_bluefi
 features:

--- a/_board/huntercat_nfc.md
+++ b/_board/huntercat_nfc.md
@@ -7,7 +7,7 @@ manufacturer: "Electronic Cats"
 board_url:
  - "https://electroniccats.com/store/hunter-cat-nfc/"
 board_image: "huntercat_nfc.jpg"
-date_added: 2021-5-26
+date_added: 2021-05-26
 family: atmel-samd
 features:
   - USB-C

--- a/_board/imxrt1010_evk.md
+++ b/_board/imxrt1010_evk.md
@@ -7,7 +7,7 @@ manufacturer: "NXP"
 board_url:
  - "https://www.nxp.com/design/development-boards/i.mx-evaluation-and-development-boards/i.mx-rt1010-evaluation-kit:MIMXRT1010-EVK"
 board_image: "imxrt1010_evk.jpg"
-date_added: 2020-1-8
+date_added: 2020-01-08
 family: mimxrt10xx
 features:
 

--- a/_board/imxrt1015_evk.md
+++ b/_board/imxrt1015_evk.md
@@ -7,7 +7,7 @@ manufacturer: "NXP"
 board_url:
  - "https://www.nxp.com/design/development-boards/i-mx-evaluation-and-development-boards/i-mx-rt1015-evaluation-kit:MIMXRT1015-EVK"
 board_image: "imxrt1015_evk.jpg"
-date_added: 2023-6-5
+date_added: 2023-06-05
 family: mimxrt10xx
 features:
 

--- a/_board/imxrt1020_evk.md
+++ b/_board/imxrt1020_evk.md
@@ -7,7 +7,7 @@ manufacturer: "NXP"
 board_url:
  - "https://www.nxp.com/design/development-boards/i.mx-evaluation-and-development-boards/i.mx-rt1020-evaluation-kit:MIMXRT1020-EVK"
 board_image: "imxrt1020_evk.jpg"
-date_added: 2020-1-31
+date_added: 2020-01-31
 family: mimxrt10xx
 features:
 

--- a/_board/imxrt1040_evk.md
+++ b/_board/imxrt1040_evk.md
@@ -7,7 +7,7 @@ manufacturer: "NXP"
 board_url:
  - "https://www.nxp.com/design/development-boards/i-mx-evaluation-and-development-boards/i-mx-rt1040-evaluation-kit:MIMXRT1040-EVK"
 board_image: "imxrt1040_evk.jpg"
-date_added: 2023-6-5
+date_added: 2023-06-05
 family: mimxrt10xx
 features:
 

--- a/_board/imxrt1050_evkb.md
+++ b/_board/imxrt1050_evkb.md
@@ -7,7 +7,7 @@ manufacturer: "NXP"
 board_url:
  - "https://www.nxp.com/part/MIMXRT1060-EVK"
 board_image: "imxrt1050_evkb.jpg"
-date_added: 2023-6-5
+date_added: 2023-06-05
 family: mimxrt10xx
 features:
 

--- a/_board/imxrt1060_evk.md
+++ b/_board/imxrt1060_evk.md
@@ -7,7 +7,7 @@ manufacturer: "NXP"
 board_url:
  - "https://www.nxp.com/design/development-boards/i.mx-evaluation-and-development-boards/i.mx-rt1060-evaluation-kit:MIMXRT1060-EVK"
 board_image: "imxrt1060_evk.jpg"
-date_added: 2020-1-31
+date_added: 2020-01-31
 family: mimxrt10xx
 features:
 

--- a/_board/imxrt1060_evkb.md
+++ b/_board/imxrt1060_evkb.md
@@ -7,7 +7,7 @@ manufacturer: "NXP"
 board_url:
  - "https://www.nxp.com/design/development-boards/i-mx-evaluation-and-development-boards/i-mx-rt1060-evaluation-kit:MIMXRT1060-EVKB"
 board_image: "imxrt1060_evk.jpg"
-date_added: 2023-6-5
+date_added: 2023-06-05
 family: mimxrt10xx
 features:
 

--- a/_board/itsybitsy_m0_express.md
+++ b/_board/itsybitsy_m0_express.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/3727"
 board_image: "itsybitsy_m0_express.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: itsybitsy_m0
 features:

--- a/_board/itsybitsy_m4_express.md
+++ b/_board/itsybitsy_m4_express.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/3800"
  - "https://www.adafruit.com/product/4028"
 board_image: "itsybitsy_m4_express.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: itsybitsy_m4
 features:

--- a/_board/itsybitsy_nrf52840_express.md
+++ b/_board/itsybitsy_nrf52840_express.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/4481"
 board_image: "itsybitsy_nrf52840_express.jpg"
-date_added: 2019-11-4
+date_added: 2019-11-04
 family: nrf52840
 bootloader_id: feather_nrf52840_express
 features:

--- a/_board/kicksat-sprite.md
+++ b/_board/kicksat-sprite.md
@@ -7,7 +7,7 @@ manufacturer: "Max Holliday"
 board_url:
  - "https://github.com/RoboticExplorationLab/sprite"
 board_image: "kicksat-sprite.jpg"
-date_added: 2019-4-13
+date_added: 2019-04-13
 family: atmel-samd
 bootloader_id: itsybitsy_m0
 ---

--- a/_board/lilygo_t_display_rp2040.md
+++ b/_board/lilygo_t_display_rp2040.md
@@ -7,7 +7,7 @@ manufacturer: "LILYGO"
 board_url:
  - "https://www.lilygo.cc/products/t-display-rp2040"
 board_image: "lilygo_t_display_rp2040.jpg"
-date_added: 2023-5-15
+date_added: 2023-05-15
 family: raspberrypi
 features:
   - Battery Charging

--- a/_board/lilygo_tdisplay_s3.md
+++ b/_board/lilygo_tdisplay_s3.md
@@ -7,7 +7,7 @@ manufacturer: "LILYGO"
 board_url:
  - "https://www.lilygo.cc/products/t-display-s3"
 board_image: "lilygo_tdisplay_s3.jpg"
-date_added: 2024-3-09
+date_added: 2024-03-09
 family: esp32s3
 features:
   - Wi-Fi

--- a/_board/lilygo_tembed_esp32s3.md
+++ b/_board/lilygo_tembed_esp32s3.md
@@ -7,7 +7,7 @@ manufacturer: "LILYGO"
 board_url:
  - "https://www.lilygo.cc/products/t-embed"
 board_image: "lilygo_tembed_esp32s3.jpg"
-date_added: 2023-3-1
+date_added: 2023-03-01
 family: esp32s3
 features:
   - Wi-Fi

--- a/_board/lilygo_ttgo_t-01c3.md
+++ b/_board/lilygo_ttgo_t-01c3.md
@@ -7,7 +7,7 @@ manufacturer: "LILYGO"
 board_url:
  - "https://www.aliexpress.com/item/1005003538055090.html"
 board_image: "lilygo_ttgo_t-01c3.jpg"
-date_added: 2022-4-1
+date_added: 2022-04-01
 family: esp32c3
 features:
   - Wi-Fi

--- a/_board/lilygo_ttgo_t-oi-plus.md
+++ b/_board/lilygo_ttgo_t-oi-plus.md
@@ -7,7 +7,7 @@ manufacturer: "LILYGO"
 board_url:
  - "https://www.tindie.com/products/lilygo/lilygo-ttgo-t-oi-plus-risc-v-esp32-c3/"
 board_image: "lilygo_ttgo_t-oi-plus.jpg"
-date_added: 2022-5-16
+date_added: 2022-05-16
 family: esp32c3
 features:
   - Wi-Fi

--- a/_board/lilygo_ttgo_t8_esp32_s2_wroom.md
+++ b/_board/lilygo_ttgo_t8_esp32_s2_wroom.md
@@ -8,7 +8,7 @@ board_url:
  - "http://www.lilygo.cn/prod_view.aspx?TypeId=50063&Id=1320&FId=t3:50063:3"
 board_image: "lilygo_ttgo_t8_esp32_s2_wroom.jpg"
 bootloader_id: "lilygo_ttgo_t8_s2_wroom"
-date_added: 2022-3-1
+date_added: 2022-03-01
 downloads_display: true
 family: esp32s2
 features:

--- a/_board/lilygo_ttgo_tdisplay_esp32_16m.md
+++ b/_board/lilygo_ttgo_tdisplay_esp32_16m.md
@@ -7,7 +7,7 @@ manufacturer: "LILYGO"
 board_url:
  - "https://www.lilygo.cc/products/lilygo%C2%AE-ttgo-t-display-1-14-inch-lcd-esp32-control-board?variant=42159376466101"
 board_image: "lilygo_ttgo_tdisplay_esp32_16m.jpg"
-date_added: 2023-5-3
+date_added: 2023-05-03
 family: esp32
 features:
   - Wi-Fi

--- a/_board/lilygo_ttgo_tdisplay_esp32_4m.md
+++ b/_board/lilygo_ttgo_tdisplay_esp32_4m.md
@@ -7,7 +7,7 @@ manufacturer: "LILYGO"
 board_url:
   - "https://www.lilygo.cc/products/lilygo%C2%AE-ttgo-t-display-1-14-inch-lcd-esp32-control-board?variant=42159376433333"
 board_image: "lilygo_ttgo_tdisplay_esp32_4m.jpg"
-date_added: 2024-1-18
+date_added: 2024-01-18
 family: esp32
 features:
   - Wi-Fi

--- a/_board/lilygo_twatch_2020_v3.md
+++ b/_board/lilygo_twatch_2020_v3.md
@@ -7,7 +7,7 @@ manufacturer: "LILYGO"
 board_url:
  - "https://www.lilygo.cc/products/t-watch-2020-v3"
 board_image: "lilygo_twatch_2020_v3.jpg"
-date_added: 2023-5-3
+date_added: 2023-05-03
 family: esp32
 features:
   - Display

--- a/_board/loc_ber_m4_base_board.md
+++ b/_board/loc_ber_m4_base_board.md
@@ -7,7 +7,7 @@ manufacturer: "Florin Trutiu"
 board_url:
 board_image: "unknown.jpg"
 downloads_display: false
-date_added: 2020-6-14
+date_added: 2020-06-14
 family: atmel-samd
 features:
 ---

--- a/_board/lolin_c3_mini.md
+++ b/_board/lolin_c3_mini.md
@@ -7,7 +7,7 @@ manufacturer: "Wemos"
 board_url:
  - "https://www.wemos.cc/en/latest/c3/c3_mini.html"
 board_image: "lolin_c3_mini.png"
-date_added: 2021-11-2
+date_added: 2021-11-02
 family: esp32c3
 bootloader_id: lolin_c3_mini
 features:

--- a/_board/lolin_c3_pico.md
+++ b/_board/lolin_c3_pico.md
@@ -7,7 +7,7 @@ manufacturer: "Wemos"
 board_url:
  - "https://www.wemos.cc/en/latest/c3/c3_pico.html"
 board_image: "lolin_c3_pico.jpg"
-date_added: 2023-5-24
+date_added: 2023-05-24
 family: esp32c3
 bootloader_id: lolin_c3_pico
 features:

--- a/_board/lolin_s2_mini.md
+++ b/_board/lolin_s2_mini.md
@@ -7,7 +7,7 @@ manufacturer: "Wemos"
 board_url:
  - "https://www.wemos.cc/en/latest/s2/s2_mini.html"
 board_image: "lolin_s2_mini.jpg"
-date_added: 2021-9-3
+date_added: 2021-09-03
 family: esp32s2
 bootloader_id: lolin_s2_mini
 features:

--- a/_board/lolin_s2_pico.md
+++ b/_board/lolin_s2_pico.md
@@ -7,7 +7,7 @@ manufacturer: "Wemos"
 board_url:
  - "https://www.wemos.cc/en/latest/s2/s2_pico.html"
 board_image: "lolin_s2_pico.jpg"
-date_added: 2021-11-2
+date_added: 2021-11-02
 family: esp32s2
 bootloader_id: lolin_s2_pico
 features:

--- a/_board/lolin_s3.md
+++ b/_board/lolin_s3.md
@@ -7,7 +7,7 @@ manufacturer: "Wemos"
 board_url:
  - "https://www.wemos.cc/en/latest/s3/s3.html"
 board_image: "lolin_s3.png"
-date_added: 2022-9-5
+date_added: 2022-09-05
 family: esp32s3
 bootloader_id: lolin_s3
 features:

--- a/_board/lolin_s3_mini.md
+++ b/_board/lolin_s3_mini.md
@@ -7,7 +7,7 @@ manufacturer: "Wemos"
 board_url:
  - "https://www.wemos.cc/en/latest/s3/s3_mini.html"
 board_image: "lolin_s3_mini.jpg"
-date_added: 2023-5-23
+date_added: 2023-05-23
 family: esp32s3
 bootloader_id: lolin_s3_mini
 features:

--- a/_board/lolin_s3_pro.md
+++ b/_board/lolin_s3_pro.md
@@ -7,7 +7,7 @@ manufacturer: "Wemos"
 board_url:
  - "https://www.wemos.cc/en/latest/s3/s3.html"
 board_image: "lolin_s3_pro.jpg"
-date_added: 2024-3-18
+date_added: 2024-03-18
 family: esp32s3
 bootloader_id: lolin_s3_pro
 features:

--- a/_board/m5stack_atom_echo.md
+++ b/_board/m5stack_atom_echo.md
@@ -7,7 +7,7 @@ manufacturer: "M5Stack"
 board_url:
  - "https://docs.m5stack.com/en/atom/atomecho"
 board_image: "m5stack_atom_echo.jpg"
-date_added: 2023-1-31
+date_added: 2023-01-31
 family: esp32
 features:
   - Wi-Fi

--- a/_board/m5stack_atom_lite.md
+++ b/_board/m5stack_atom_lite.md
@@ -7,7 +7,7 @@ manufacturer: "M5Stack"
 board_url:
  - "https://docs.m5stack.com/en/core/atom_lite"
 board_image: "m5stack_atom_lite.jpg"
-date_added: 2022-11-1
+date_added: 2022-11-01
 family: esp32
 features:
   - Wi-Fi

--- a/_board/m5stack_atom_matrix.md
+++ b/_board/m5stack_atom_matrix.md
@@ -8,7 +8,7 @@ board_url:
  - "https://docs.m5stack.com/en/core/atom_matrix"
  - "https://www.adafruit.com/product/4497"
 board_image: "m5stack_atom_matrix.jpg"
-date_added: 2023-1-31
+date_added: 2023-01-31
 family: esp32
 features:
   - Wi-Fi

--- a/_board/m5stack_atom_u.md
+++ b/_board/m5stack_atom_u.md
@@ -7,7 +7,7 @@ manufacturer: "M5Stack"
 board_url:
  - "https://docs.m5stack.com/en/core/atom_u"
 board_image: "m5stack_atom_u.jpg"
-date_added: 2023-1-31
+date_added: 2023-01-31
 family: esp32
 tags:
   - Atom U

--- a/_board/m5stack_atoms3_lite.md
+++ b/_board/m5stack_atoms3_lite.md
@@ -7,7 +7,7 @@ manufacturer: "M5Stack"
 board_url:
  - "https://docs.m5stack.com/en/core/AtomS3%20Lite"
 board_image: "m5stack_atoms3_lite.png"
-date_added: 2023-4-4
+date_added: 2023-04-04
 family: esp32s3
 bootloader_id: m5stack_atoms3_lite
 downloads_display: true

--- a/_board/m5stack_cardputer.md
+++ b/_board/m5stack_cardputer.md
@@ -7,7 +7,7 @@ manufacturer: "M5Stack"
 board_url:
  - "https://docs.m5stack.com/en/core/Cardputer"
 board_image: "m5stack_cardputer.jpg"
-date_added: 2024-3-10
+date_added: 2024-03-10
 family: esp32s3
 bootloader_id: adafruit_feather_esp32s3_nopsram
 downloads_display: true

--- a/_board/m5stack_core2.md
+++ b/_board/m5stack_core2.md
@@ -7,7 +7,7 @@ manufacturer: "M5Stack"
 board_url:
  - "https://docs.m5stack.com/en/core/core2"
 board_image: "m5stack_core2.jpg"
-date_added: 2023-5-4
+date_added: 2023-05-04
 family: esp32
 features:
   - Speaker

--- a/_board/m5stack_core_fire.md
+++ b/_board/m5stack_core_fire.md
@@ -7,7 +7,7 @@ manufacturer: "M5Stack"
 board_url:
  - "https://docs.m5stack.com/en/core/fire_v2.6"
 board_image: "m5stack_core_fire.jpg"
-date_added: 2022-11-1
+date_added: 2022-11-01
 family: esp32
 tags:
   - Core Fire

--- a/_board/m5stack_dial.md
+++ b/_board/m5stack_dial.md
@@ -7,7 +7,7 @@ manufacturer: "M5Stack"
 board_url:
  - "https://docs.m5stack.com/en/core/M5Dial"
 board_image: "m5stack_dial.jpg"
-date_added: 2024-2-19
+date_added: 2024-02-19
 family: esp32s3
 bootloader_id: m5stack_dial
 downloads_display: true

--- a/_board/m5stack_stamp_c3.md
+++ b/_board/m5stack_stamp_c3.md
@@ -7,7 +7,7 @@ manufacturer: "M5Stack"
 board_url:
  - "https://docs.m5stack.com/en/core/stamp_c3"
 board_image: "m5stack_stamp_c3.jpg"
-date_added: 2022-11-1
+date_added: 2022-11-01
 family: esp32c3
 features:
   - Wi-Fi

--- a/_board/m5stack_stick_c.md
+++ b/_board/m5stack_stick_c.md
@@ -7,7 +7,7 @@ manufacturer: "M5Stack"
 board_url:
  - "https://docs.m5stack.com/en/core/m5stickc"
 board_image: "m5stack_stick_c.jpg"
-date_added: 2023-1-31
+date_added: 2023-01-31
 family: esp32
 features:
   - Wi-Fi

--- a/_board/m5stack_stick_c_plus.md
+++ b/_board/m5stack_stick_c_plus.md
@@ -9,7 +9,7 @@ board_url:
  - "https://www.adafruit.com/product/4289"
  - "https://www.adafruit.com/product/4290"
 board_image: "m5stack_stick_c_plus.jpg"
-date_added: 2023-1-31
+date_added: 2023-01-31
 family: esp32
 features:
   - Wi-Fi

--- a/_board/m5stack_timer_camera_x.md
+++ b/_board/m5stack_timer_camera_x.md
@@ -8,7 +8,7 @@ board_url:
  - "https://docs.m5stack.com/en/unit/timercam_x"
  - "https://www.adafruit.com/product/4959"
 board_image: "m5stack_timer_camera_x.jpg"
-date_added: 2023-5-22
+date_added: 2023-05-22
 family: esp32
 features:
   - Wi-Fi

--- a/_board/magiclick_s3_n4r2.md
+++ b/_board/magiclick_s3_n4r2.md
@@ -7,7 +7,7 @@ manufacturer: "MakerM0"
 board_url:
  - "https://github.com/MakerM0/MagiClick-esp32s3"
 board_image: "magiclick_s3.jpg"
-date_added: 2023-9-30
+date_added: 2023-09-30
 family: esp32s3
 bootloader_id: magiclick_s3_n4r2
 downloads_display: true

--- a/_board/makerdiary_nrf52840_connectkit.md
+++ b/_board/makerdiary_nrf52840_connectkit.md
@@ -7,7 +7,7 @@ manufacturer: "MakerDiary"
 board_url:
  - "https://makerdiary.com/products/nrf52840-connectkit?variant=43255093035163"
 board_image: "makerdiary_nrf52840_connectkit.jpg"
-date_added: 2023-7-28
+date_added: 2023-07-28
 family: nrf52840
 features:
   - Bluetooth/BTLE

--- a/_board/makerdiary_nrf52840_m2_devkit.md
+++ b/_board/makerdiary_nrf52840_m2_devkit.md
@@ -7,7 +7,7 @@ manufacturer: "MakerDiary"
 board_url:
  - "https://makerdiary.com/collections/frontpage/products/nrf52840-m2-developer-kit"
 board_image: "makerdiary_nrf52840_m2_devkit.jpg"
-date_added: 2020-7-27
+date_added: 2020-07-27
 family: nrf52840
 bootloader_id: nrf52840_m2
 features:

--- a/_board/makerdiary_nrf52840_mdk.md
+++ b/_board/makerdiary_nrf52840_mdk.md
@@ -7,7 +7,7 @@ manufacturer: "MakerDiary"
 board_url:
  - "https://store.makerdiary.com/collections/frontpage/products/nrf52840-mdk-iot-development-kit"
 board_image: "nRF52840_micro_dev_kit.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: nrf52840
 features:
   - Bluetooth/BTLE

--- a/_board/makerdiary_nrf52840_mdk_usb_dongle.md
+++ b/_board/makerdiary_nrf52840_mdk_usb_dongle.md
@@ -7,7 +7,7 @@ manufacturer: "MakerDiary"
 board_url:
  - "https://store.makerdiary.com/collections/frontpage/products/nrf52840-mdk-usb-dongle"
 board_image: "nRF52840_micro_dev_kit_usb_dongle.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: nrf52840
 bootloader_id: mdk_nrf52840_dongle
 features:

--- a/_board/matrixportal_m4.md
+++ b/_board/matrixportal_m4.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/4745"
  - "https://www.adafruit.com/product/4812"
 board_image: "matrixportal_m4.jpg"
-date_added: 2020-9-16
+date_added: 2020-09-16
 family: atmel-samd
 bootloader_id: matrixportal_m4
 tags:

--- a/_board/melopero_shake_rp2040.md
+++ b/_board/melopero_shake_rp2040.md
@@ -7,7 +7,7 @@ manufacturer: "Melopero"
 board_url:
  - "https://www.melopero.com/melopero-shake-rp2040"
 board_image: "melopero_shake_rp2040.jpg"
-date_added: 2021-9-22
+date_added: 2021-09-22
 family: raspberrypi
 features:
   - Feather-Compatible

--- a/_board/meowbit_v121.md
+++ b/_board/meowbit_v121.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "meowbit_v121.jpg"
 downloads_display: true
 blinka: false
-date_added: 2020-1-26
+date_added: 2020-01-26
 family: stm
 bootloader_id: meowbit_v121
 features:

--- a/_board/meowmeow.md
+++ b/_board/meowmeow.md
@@ -7,7 +7,7 @@ manufacturer: "Electronic Cats"
 board_url:
  - "https://electroniccats.com/store/meowmeow/"
 board_image: "meowmeow.jpg"
-date_added: 2019-4-1
+date_added: 2019-04-01
 family: atmel-samd
 bootloader_id: meowmeow
 features:

--- a/_board/metro_m0_express.md
+++ b/_board/metro_m0_express.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/3505"
 board_image: "metro_m0_express.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: metro_m0
 features:

--- a/_board/metro_m4_airlift_lite.md
+++ b/_board/metro_m4_airlift_lite.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/4000"
 board_image: "metro_m4_airlift_lite.jpg"
-date_added: 2019-4-13
+date_added: 2019-04-13
 family: atmel-samd
 bootloader_id: metro_m4_airlift
 features:

--- a/_board/metro_m4_express.md
+++ b/_board/metro_m4_express.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/3382"
 board_image: "metro_m4_express.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: metro_m4
 features:

--- a/_board/metro_nrf52840_express.md
+++ b/_board/metro_nrf52840_express.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/"
 board_image: "metro_nrf52840_express.png"
-date_added: 2019-8-30
+date_added: 2019-08-30
 family: nrf52840
 bootloader_id: metro_nrf52840_express
 features:

--- a/_board/mini_sam_m4.md
+++ b/_board/mini_sam_m4.md
@@ -7,7 +7,7 @@ manufacturer: "Benjamin Shockley"
 board_url:
  - "www.minisam.cc"
 board_image: "mini_sam_m4.jpg"
-date_added: 2019-3-12
+date_added: 2019-03-12
 family: atmel-samd
 bootloader_id: mini_sam_m4
 

--- a/_board/mixgo_ce_serial.md
+++ b/_board/mixgo_ce_serial.md
@@ -7,7 +7,7 @@ manufacturer: "Mixly"
 board_url:
  - "https://mixly.org/"
 board_image: "mixgo_ce_serial.jpg"
-date_added: 2022-5-22
+date_added: 2022-05-22
 family: esp32s2
 features:
   - Display

--- a/_board/mixgo_ce_udisk.md
+++ b/_board/mixgo_ce_udisk.md
@@ -7,7 +7,7 @@ manufacturer: "Mixly"
 board_url:
  - "https://mixly.org/"
 board_image: "mixgo_ce_udisk.jpg"
-date_added: 2022-5-1
+date_added: 2022-05-01
 family: esp32s2
 features:
   - Display

--- a/_board/monster_m4sk.md
+++ b/_board/monster_m4sk.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/4343"
  - "https://www.adafruit.com/product/4281"
 board_image: "monster_m4sk.jpg"
-date_added: 2019-8-30
+date_added: 2019-08-30
 family: atmel-samd
 bootloader_id: hallowing_mask
 features:

--- a/_board/morpheans_morphesp-240.md
+++ b/_board/morpheans_morphesp-240.md
@@ -7,7 +7,7 @@ manufacturer: "Morpheans"
 board_url:
  - "https://github.com/ccadic/ESP32-S2-DevBoardTFT"
 board_image: "morpheans_morphesp-240.jpg"
-date_added: 2021-8-24
+date_added: 2021-08-24
 family: esp32s2
 bootloader_id: morpheans_morphesp-240
 features:

--- a/_board/ndgarage_ndbit6.md
+++ b/_board/ndgarage_ndbit6.md
@@ -7,7 +7,7 @@ manufacturer: "n°Garage"
 board_url:
  - "https://hackaday.io/project/168684-feathersnow"
 board_image: "ndgarage_ndbit6.jpg"
-date_added: 2020-2-5
+date_added: 2020-02-05
 family: atmel-samd
 bootloader_id: ndbit6
 downloads_display: true

--- a/_board/ndgarage_ndbit6_v2.md
+++ b/_board/ndgarage_ndbit6_v2.md
@@ -7,7 +7,7 @@ manufacturer: "n°Garage"
 board_url:
  - "https://hackaday.io/project/173537-feathersnow-v2"
 board_image: "ndgarage_ndbit6_v2.jpg"
-date_added: 2020-09-1
+date_added: 2020-09-01
 family: atmel-samd
 bootloader_id: ndbit7
 tags:

--- a/_board/neopixel_trinkey_m0.md
+++ b/_board/neopixel_trinkey_m0.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/4870"
 board_image: "neopixel_trinkey_m0.jpg"
-date_added: 2021-4-6
+date_added: 2021-04-06
 family: atmel-samd
 bootloader_id: neopixel_trinkey_m0
 features:

--- a/_board/nfc_copy_cat.md
+++ b/_board/nfc_copy_cat.md
@@ -7,7 +7,7 @@ manufacturer: "Electronic Cats"
 board_url:
  - "https://github.com/ElectronicCats/NFC-Copy-Cat"
 board_image: "nfc_copy_cat.jpg"
-date_added: 2020-4-9
+date_added: 2020-04-09
 family: atmel-samd
 features:
   - Robotics

--- a/_board/nullbits_bit_c_pro.md
+++ b/_board/nullbits_bit_c_pro.md
@@ -7,7 +7,7 @@ manufacturer: "nullbits"
 board_url:
  - "https://nullbits.co/bit-c-pro/"
 board_image: "nullbits_bit_c_pro.jpg"
-date_added: "2023-1-31"
+date_added: 2023-01-31
 family: raspberrypi
 features:
   - USB-C

--- a/_board/odt_cast_away_rp2040.md
+++ b/_board/odt_cast_away_rp2040.md
@@ -7,7 +7,7 @@ manufacturer: "Oak Development Technologies"
 board_url:
  - "https://www.tindie.com/products/oakdevtech/cast-away-rp2040-a-castellated-rp2040-dev-board/"
 board_image: "odt_cast_away_rp2040.jpg"
-date_added: 2022-1-4
+date_added: 2022-01-04
 family: raspberrypi
 features:
   - USB-C

--- a/_board/odt_pixelwing_esp32_s2.md
+++ b/_board/odt_pixelwing_esp32_s2.md
@@ -7,7 +7,7 @@ manufacturer: "Oak Development Technologies"
 board_url:
  - "https://www.tindie.com/products/oakdevtech/pixelwing-esp32-s2-rgb-matrix/"
 board_image: "odt_pixelwing_esp32_s2.jpg"
-date_added: 2021-8-24
+date_added: 2021-08-24
 family: esp32s2
 features:
   - Wi-Fi

--- a/_board/ohs2020_badge.md
+++ b/_board/ohs2020_badge.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "ohs2020_badge.jpg"
 downloads_display: true
 blinka: false
-date_added: 2020-1-16
+date_added: 2020-01-16
 family: nrf52840
 bootloader_id: ohs2020_badge
 features:

--- a/_board/openbook_m4.md
+++ b/_board/openbook_m4.md
@@ -7,7 +7,7 @@ manufacturer: "Oddly Specific Objects"
 board_url:
  - "https://github.com/joeycastillo/The-Open-Book"
 board_image: "openbook_m4.jpg"
-date_added: 2020-1-16
+date_added: 2020-01-16
 family: atmel-samd
 bootloader_id: openbook_m4
 features:

--- a/_board/pajenicko_picopad.md
+++ b/_board/pajenicko_picopad.md
@@ -7,7 +7,7 @@ manufacturer: "Pajenicko s.r.o."
 board_url:
  - "https://github.com/Pajenicko/Picopad"
 board_image: "pajenicko_picopad.jpg"
-date_added: 2023-7-25
+date_added: 2023-07-25
 family: raspberrypi
 features:
   - Display

--- a/_board/particle_argon.md
+++ b/_board/particle_argon.md
@@ -9,7 +9,7 @@ board_url:
  - "https://www.adafruit.com/product/3997"
  - "https://www.adafruit.com/product/3993"
 board_image: "particle_argon.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: nrf52840
 bootloader_id: particle_argon
 features:

--- a/_board/particle_boron.md
+++ b/_board/particle_boron.md
@@ -9,7 +9,7 @@ board_url:
  - "https://www.adafruit.com/product/3998"
  - "https://www.adafruit.com/product/3994"
 board_image: "particle_boron.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: nrf52840
 bootloader_id: particle_boron
 features:

--- a/_board/particle_xenon.md
+++ b/_board/particle_xenon.md
@@ -9,7 +9,7 @@ board_url:
  - "https://www.adafruit.com/product/3999"
  - "https://www.adafruit.com/product/3995"
 board_image: "particle_xenon.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: nrf52840
 bootloader_id: particle_xenon
 features:

--- a/_board/pca10056.md
+++ b/_board/pca10056.md
@@ -7,7 +7,7 @@ manufacturer: "Nordic Semiconductor"
 board_url:
  - "https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK"
 board_image: "nRF52840_dk.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: nrf52840
 bootloader_id: pca10056
 features:

--- a/_board/pca10059.md
+++ b/_board/pca10059.md
@@ -7,7 +7,7 @@ manufacturer: "Nordic Semiconductor"
 board_url:
  - "https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-Dongle"
 board_image: "nRF52840_dongle.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: nrf52840
 bootloader_id: pca10059
 features:

--- a/_board/pewpew10.md
+++ b/_board/pewpew10.md
@@ -7,7 +7,7 @@ manufacturer: "Radomir Dopieralski"
 board_url:
  - "https://pewpew.rtfd.io"
 board_image: "pewpew_10.2.jpg"
-date_added: 2019-3-12
+date_added: 2019-03-12
 family: atmel-samd
 bootloader_id: trinket_m0
 features:

--- a/_board/pewpew_m4.md
+++ b/_board/pewpew_m4.md
@@ -7,7 +7,7 @@ manufacturer: "Radomir Dopieralski"
 board_url:
  - "https://hackaday.io/project/165032-pewpew-m4"
 board_image: "pewpew_m4.jpg"
-date_added: 2019-9-16
+date_added: 2019-09-16
 family: atmel-samd
 bootloader_id: pewpew_m4
 features:

--- a/_board/picomo_v2.md
+++ b/_board/picomo_v2.md
@@ -7,7 +7,7 @@ manufacturer: "HEIA-FR"
 board_url: 
   - "https://go.heia-fr.ch/picomo"
 board_image: "picomo_v2.jpg"
-date_added: 2024-1-25
+date_added: 2024-01-25
 family: raspberrypi
 features:
   - Speaker

--- a/_board/picoplanet.md
+++ b/_board/picoplanet.md
@@ -7,7 +7,7 @@ manufacturer: "bleeptrack"
 board_url:
  - "https://picoplanet.bleeptrack.de"
 board_image: "picoplanet.jpg"
-date_added: 2020-3-31
+date_added: 2020-03-31
 family: atmel-samd
 downloads_display: true
 blinka: false

--- a/_board/pimoroni_badger2040.md
+++ b/_board/pimoroni_badger2040.md
@@ -7,7 +7,7 @@ manufacturer: "Pimoroni"
 board_url:
  - "https://shop.pimoroni.com/products/badger-2040"
 board_image: "pimoroni_badger2040.jpg"
-date_added: 2022-2-24
+date_added: 2022-02-24
 family: raspberrypi
 features:
   - Display

--- a/_board/pimoroni_badger2040w.md
+++ b/_board/pimoroni_badger2040w.md
@@ -7,7 +7,7 @@ manufacturer: "Pimoroni"
 board_url:
  - "https://shop.pimoroni.com/products/badger-2040-w"
 board_image: "pimoroni_badger2040w.jpg"
-date_added: 2023-5-9
+date_added: 2023-05-09
 family: raspberrypi
 tags:
   - picow

--- a/_board/pimoroni_inky_frame_5_7.md
+++ b/_board/pimoroni_inky_frame_5_7.md
@@ -7,7 +7,7 @@ manufacturer: "Pimoroni"
 board_url:
  - "https://shop.pimoroni.com/products/inky-frame-5-7"
 board_image: "pimoroni_inky_frame_5_7.jpg"
-date_added: 2023-6-5
+date_added: 2023-06-05
 family: raspberrypi
 tags:
   - picow

--- a/_board/pimoroni_inky_frame_7_3.md
+++ b/_board/pimoroni_inky_frame_7_3.md
@@ -7,7 +7,7 @@ manufacturer: "Pimoroni"
 board_url:
  - "https://shop.pimoroni.com/products/inky-frame-7-3"
 board_image: "pimoroni_inky_frame_7_3.jpg"
-date_added: 2024-3-13
+date_added: 2024-03-13
 family: raspberrypi
 tags:
   - picow

--- a/_board/pimoroni_keybow2040.md
+++ b/_board/pimoroni_keybow2040.md
@@ -8,7 +8,7 @@ board_url:
  - "https://shop.pimoroni.com/products/keybow-2040"
  - "https://www.adafruit.com/product/4144"
 board_image: "pimoroni_keybow2040.jpg"
-date_added: 2021-2-24
+date_added: 2021-02-24
 family: raspberrypi
 features:
   - USB-C

--- a/_board/pimoroni_motor2040.md
+++ b/_board/pimoroni_motor2040.md
@@ -7,7 +7,7 @@ manufacturer: "Pimoroni"
 board_url:
  - "https://shop.pimoroni.com/products/motor-2040"
 board_image: "pimoroni_motor2040.jpg"
-date_added: 2022-6-15
+date_added: 2022-06-15
 family: raspberrypi
 features:
   - Robotics

--- a/_board/pimoroni_pga2040.md
+++ b/_board/pimoroni_pga2040.md
@@ -7,7 +7,7 @@ manufacturer: "Pimoroni"
 board_url:
  - "https://shop.pimoroni.com/products/pga2040"
 board_image: "pimoroni_pga2040.jpg"
-date_added: 2021-6-10
+date_added: 2021-06-10
 family: raspberrypi
 ---
 

--- a/_board/pimoroni_pico_dv_base.md
+++ b/_board/pimoroni_pico_dv_base.md
@@ -8,7 +8,7 @@ board_url:
  - "https://shop.pimoroni.com/en-us/products/pimoroni-pico-dv-demo-base"
  - "https://www.adafruit.com/product/5674"
 board_image: "pimoroni_pico_dv_base.jpg"
-date_added: 2023-5-4
+date_added: 2023-05-04
 family: raspberrypi
 ---
 

--- a/_board/pimoroni_pico_dv_base_w.md
+++ b/_board/pimoroni_pico_dv_base_w.md
@@ -8,7 +8,7 @@ board_url:
  - "https://shop.pimoroni.com/en-us/products/pimoroni-pico-dv-demo-base"
  - "https://www.adafruit.com/product/5674"
 board_image: "pimoroni_pico_dv_base_w.jpg"
-date_added: 2023-8-29
+date_added: 2023-08-29
 family: raspberrypi
 ---
 

--- a/_board/pimoroni_picolipo_16mb.md
+++ b/_board/pimoroni_picolipo_16mb.md
@@ -7,7 +7,7 @@ manufacturer: "Pimoroni"
 board_url:
  - "https://shop.pimoroni.com/products/picolipo"
 board_image: "pimoroni_picolipo.jpg"
-date_added: 2021-5-12
+date_added: 2021-05-12
 family: raspberrypi
 features:
   - Battery Charging

--- a/_board/pimoroni_picolipo_4mb.md
+++ b/_board/pimoroni_picolipo_4mb.md
@@ -7,7 +7,7 @@ manufacturer: "Pimoroni"
 board_url:
  - "https://shop.pimoroni.com/products/picolipo"
 board_image: "pimoroni_picolipo.jpg"
-date_added: 2021-5-12
+date_added: 2021-05-12
 family: raspberrypi
 features:
   - Battery Charging

--- a/_board/pimoroni_picosystem.md
+++ b/_board/pimoroni_picosystem.md
@@ -7,7 +7,7 @@ manufacturer: "Pimoroni"
 board_url:
  - "https://shop.pimoroni.com/products/picosystem"
 board_image: "pimoroni_picosystem.jpg"
-date_added: 2021-2-24
+date_added: 2021-02-24
 family: raspberrypi
 features:
   - Speaker

--- a/_board/pimoroni_plasma2040w.md
+++ b/_board/pimoroni_plasma2040w.md
@@ -7,7 +7,7 @@ manufacturer: "Pimoroni"
 board_url:
  - "https://shop.pimoroni.com/products/plasma-stick-2040-w"
 board_image: "pimoroni_plasma2040w.jpg"
-date_added: 2023-5-9
+date_added: 2023-05-09
 family: raspberrypi
 tags:
   - picow

--- a/_board/pimoroni_servo2040.md
+++ b/_board/pimoroni_servo2040.md
@@ -8,7 +8,7 @@ board_url:
  - "https://shop.pimoroni.com/products/servo-2040"
  - "https://www.adafruit.com/product/5437"
 board_image: "pimoroni_servo2040.jpg"
-date_added: 2022-4-1
+date_added: 2022-04-01
 family: raspberrypi
 features:
   - Robotics

--- a/_board/pimoroni_tiny2040.md
+++ b/_board/pimoroni_tiny2040.md
@@ -7,7 +7,7 @@ manufacturer: "Pimoroni"
 board_url:
  - "https://shop.pimoroni.com/products/tiny-2040"
 board_image: "pimoroni_tiny2040.jpg"
-date_added: 2021-2-24
+date_added: 2021-02-24
 family: raspberrypi
 
 features:

--- a/_board/pirkey_m0.md
+++ b/_board/pirkey_m0.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/3364"
 board_image: "pirkey_m0.jpg"
-date_added: 2019-3-11
+date_added: 2019-03-11
 family: atmel-samd
 bootloader_id: pirkey
 ---

--- a/_board/pybadge.md
+++ b/_board/pybadge.md
@@ -11,7 +11,7 @@ board_url:
  - "https://www.adafruit.com/product/4624"
  - "https://www.adafruit.com/product/4317"
 board_image: "pybadge.jpg"
-date_added: 2019-3-19
+date_added: 2019-03-19
 family: atmel-samd
 bootloader_id: arcade_pybadge
 features:

--- a/_board/pybadge_airlift.md
+++ b/_board/pybadge_airlift.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/"
 board_image: "pybadge_airlift.jpg"
-date_added: 2019-7-1
+date_added: 2019-07-01
 family: atmel-samd
 bootloader_id: arcade_pybadge
 features:

--- a/_board/pyboard_v11.md
+++ b/_board/pyboard_v11.md
@@ -7,7 +7,7 @@ manufacturer: "Damien George"
 board_url:
  - "https://www.adafruit.com/product/2390"
 board_image: "pyboard_v11.jpg"
-date_added: 2019-9-26
+date_added: 2019-09-26
 family: stm
 bootloader_id: pyboard_v11
 ---

--- a/_board/pycubed.md
+++ b/_board/pycubed.md
@@ -7,7 +7,7 @@ manufacturer: "PyCubed.org"
 board_url:
  - "https://pycubed.org/"
 board_image: "pycubed.jpg"
-date_added: 2020-2-27
+date_added: 2020-02-27
 family: atmel-samd
 bootloader_id: pycubed
 features:

--- a/_board/pycubed_mram.md
+++ b/_board/pycubed_mram.md
@@ -7,7 +7,7 @@ manufacturer: "PyCubed.org"
 board_url:
  - "https://pycubed.org/"
 board_image: "pycubed.jpg"
-date_added: 2020-4-07
+date_added: 2020-04-07
 family: atmel-samd
 features:
 ---

--- a/_board/pycubed_mram_v05.md
+++ b/_board/pycubed_mram_v05.md
@@ -7,7 +7,7 @@ manufacturer: "PyCubed.org"
 board_url:
  - "https://pycubed.org/"
 board_image: "pycubed_v05.jpg"
-date_added: 2021-9-12
+date_added: 2021-09-12
 family: atmel-samd
 features:
 

--- a/_board/pycubed_v05.md
+++ b/_board/pycubed_v05.md
@@ -7,7 +7,7 @@ manufacturer: "PyCubed.org"
 board_url:
  - "https://pycubed.org/"
 board_image: "pycubed_v05.jpg"
-date_added: 2021-9-12
+date_added: 2021-09-12
 family: atmel-samd
 features:
 

--- a/_board/pygamer.md
+++ b/_board/pygamer.md
@@ -9,7 +9,7 @@ board_url:
  - "https://www.adafruit.com/product/4185"
  - "https://www.adafruit.com/product/4277"
 board_image: "pygamer.jpg"
-date_added: 2019-5-25
+date_added: 2019-05-25
 family: atmel-samd
 bootloader_id: arcade_pygamer
 features:

--- a/_board/pygamer_advance.md
+++ b/_board/pygamer_advance.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/"
 board_image: "pygamer_advance.jpg"
-date_added: 2019-7-1
+date_added: 2019-07-01
 family: atmel-samd
 bootloader_id: arcade_pygamer
 features:

--- a/_board/pyportal.md
+++ b/_board/pyportal.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/4116"
  - "https://www.adafruit.com/product/4061"
 board_image: "pyportal.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: pyportal_m4
 features:

--- a/_board/pyportal_titano.md
+++ b/_board/pyportal_titano.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/4444"
 board_image: "pyportal_titano.jpg"
-date_added: 2019-8-30
+date_added: 2019-08-30
 family: atmel-samd
 bootloader_id: pyportal_m4
 features:

--- a/_board/pyruler.md
+++ b/_board/pyruler.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/4319"
 board_image: "pyruler.jpg"
-date_added: 2019-7-15
+date_added: 2019-07-15
 family: atmel-samd
 bootloader_id: trinket_m0
 ---

--- a/_board/qtpy_m0.md
+++ b/_board/qtpy_m0.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/4600"
 board_image: "qtpy_m0.jpg"
-date_added: 2020-9-28
+date_added: 2020-09-28
 family: atmel-samd
 bootloader_id: QTPy_m0
 features:

--- a/_board/qtpy_m0_haxpress.md
+++ b/_board/qtpy_m0_haxpress.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/4600"
 board_image: "qtpy_m0_haxpress.jpg"
-date_added: 2020-9-28
+date_added: 2020-09-28
 family: atmel-samd
 bootloader_id: QTPy_m0
 features:

--- a/_board/raspberry_pi_pico.md
+++ b/_board/raspberry_pi_pico.md
@@ -9,7 +9,7 @@ board_url:
  - "https://www.adafruit.com/product/4883"
  - "https://www.adafruit.com/product/5525"
 board_image: "raspberry_pi_pico.jpg"
-date_added: 2021-1-21
+date_added: 2021-01-21
 family: raspberrypi
 features:
   - Breadboard-Friendly

--- a/_board/raspberry_pi_pico_w.md
+++ b/_board/raspberry_pi_pico_w.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/5526"
  - "https://www.adafruit.com/product/5544"
 board_image: "raspberry_pi_pico_w.jpg"
-date_added: 2022-10-2
+date_added: 2022-10-02
 family: raspberrypi
 tags:
   - picow

--- a/_board/raspberrypi_cm4.md
+++ b/_board/raspberrypi_cm4.md
@@ -12,7 +12,7 @@ board_url:
  - "https://www.adafruit.com/product/4791"
  - "https://www.adafruit.com/product/4982"
 board_image: "raspberry_pi_cm4.jpg"
-date_added: 2022-1-4
+date_added: 2022-01-04
 family: broadcom
 
 ---

--- a/_board/raspberrypi_zero.md
+++ b/_board/raspberrypi_zero.md
@@ -9,7 +9,7 @@ board_url:
  - "https://www.adafruit.com/product/2885"
  - "https://www.adafruit.com/product/3644"
 board_image: "raspberry_pi_zero.jpg"
-date_added: 2022-2-14
+date_added: 2022-02-14
 family: broadcom
 features:
 

--- a/_board/robohatmm1_m4.md
+++ b/_board/robohatmm1_m4.md
@@ -7,7 +7,7 @@ manufacturer: "Robotics Masters"
 board_url:
  - "https://www.crowdsupply.com/robotics-masters/robo-hat-mm1"
 board_image: "robohatmm1.jpg"
-date_added: 2019-7-27
+date_added: 2019-07-27
 family: atmel-samd
 bootloader_id: robohatmm1_m4
 features:

--- a/_board/sam32.md
+++ b/_board/sam32.md
@@ -7,7 +7,7 @@ manufacturer: "Max Holliday"
 board_url:
  - "https://github.com/maholli/SAM32"
 board_image: "sam32.jpg"
-date_added: 2019-4-5
+date_added: 2019-04-05
 family: atmel-samd
 bootloader_id: sam32
 features:

--- a/_board/same54_xplained.md
+++ b/_board/same54_xplained.md
@@ -7,7 +7,7 @@ manufacturer: "Microchip"
 board_url:
  - "https://www.microchip.com/DevelopmentTools/ProductDetails/ATSAME54-XPRO"
 board_image: "same54_xplained.jpg"
-date_added: 2020-6-28
+date_added: 2020-06-28
 family: atmel-samd
 bootloader_id: same54_xplained
 ---

--- a/_board/seeed_xiao_esp32c3.md
+++ b/_board/seeed_xiao_esp32c3.md
@@ -7,7 +7,7 @@ manufacturer: "Seeed Studio"
 board_url:
  - "https://www.seeedstudio.com/Seeed-XIAO-ESP32C3-p-5431.html"
 board_image: "seeed_xiao_esp32c3.jpg"
-date_added: 2022-8-22
+date_added: 2022-08-22
 family: esp32c3
 features:
   - Breadboard-Friendly

--- a/_board/seeeduino_wio_terminal.md
+++ b/_board/seeeduino_wio_terminal.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.seeedstudio.com/Wio-Terminal-p-4509.html"
  - "https://www.adafruit.com/product/4707"
 board_image: "seeeduino_wio_terminal.jpg"
-date_added: 2020-7-3
+date_added: 2020-07-03
 family: atmel-samd
 features:
     - Display

--- a/_board/seeeduino_xiao.md
+++ b/_board/seeeduino_xiao.md
@@ -7,7 +7,7 @@ manufacturer: "Seeed Studio"
 board_url:
  - "https://wiki.seeedstudio.com/Seeeduino-XIAO/"
 board_image: "seeeduino_xiao.jpg"
-date_added: 2020-1-17
+date_added: 2020-01-17
 family: atmel-samd
 bootloader_id: XIAO_m0
 

--- a/_board/seeeduino_xiao_rp2040.md
+++ b/_board/seeeduino_xiao_rp2040.md
@@ -7,7 +7,7 @@ manufacturer: "Seeed Studio"
 board_url:
  - "https://www.seeedstudio.com/XIAO-RP2040-v1-0-p-5026.html"
 board_image: "seeeduino_xiao_rp2040.jpg"
-date_added: 2022-1-4
+date_added: 2022-01-04
 family: raspberrypi
 features:
   - Breadboard-Friendly

--- a/_board/sensebox_mcu.md
+++ b/_board/sensebox_mcu.md
@@ -7,7 +7,7 @@ manufacturer: "senseBox"
 board_url:
  - "https://docs.sensebox.de/hardware/allgemein-sensebox-mcu/"
 board_image: "sensebox_mcu.jpg"
-date_added: 2021-4-12
+date_added: 2021-04-12
 family: atmel-samd
 bootloader_id: sensebox-mcu
 features:

--- a/_board/sensebox_mcu_esp32s2.md
+++ b/_board/sensebox_mcu_esp32s2.md
@@ -7,7 +7,7 @@ manufacturer: "senseBox"
 board_url:
  - "https://sensebox.de/de/products-boards"
 board_image: "sensebox_mcu_esp32s2.jpg"
-date_added: 2024-2-21
+date_added: 2024-02-21
 downloads_display: true
 blinka: false
 download_instructions: ""

--- a/_board/serpente.md
+++ b/_board/serpente.md
@@ -9,7 +9,7 @@ board_url:
  - "https://www.adafruit.com/product/4513"
  - "https://www.adafruit.com/product/4514"
 board_image: "serpente.jpg"
-date_added: 2019-9-17
+date_added: 2019-09-17
 family: atmel-samd
 bootloader_id: serpente
 downloads_display: true

--- a/_board/silicognition-m4-shim.md
+++ b/_board/silicognition-m4-shim.md
@@ -7,7 +7,7 @@ manufacturer: "Silicognition LLC"
 board_url:
  - "https://github.com/xorbit/M4-Shim"
 board_image: "silicognition-m4-shim.jpg"
-date_added: 2021-2-19
+date_added: 2021-02-19
 family: atmel-samd
 bootloader_id: silicognition-m4-shim
 features:

--- a/_board/silicognition_rp2040_shim.md
+++ b/_board/silicognition_rp2040_shim.md
@@ -7,7 +7,7 @@ manufacturer: "Silicognition LLC"
 board_url:
  - "https://github.com/xorbit/RP2040-Shim"
 board_image: "silicognition-rp2040-shim.jpg"
-date_added: 2022-7-1
+date_added: 2022-07-01
 family: raspberrypi
 features:
   - Feather-Compatible

--- a/_board/smartbeedesigns_bee_s3.md
+++ b/_board/smartbeedesigns_bee_s3.md
@@ -7,7 +7,7 @@ manufacturer: "Smart Bee Designs"
 board_url:
  - "http://github.com/strid3r21/BeeS3/"
 board_image: "smartbeedesigns_bee_s3.jpg"
-date_added: 2022-8-22
+date_added: 2022-08-22
 family: esp32s3
 features:
   - Wi-Fi

--- a/_board/snekboard.md
+++ b/_board/snekboard.md
@@ -7,7 +7,7 @@ manufacturer: "keithp.com"
 board_url:
  - "https://keithp.com/snek/snekboard"
 board_image: "snekboard.jpg"
-date_added: 2019-7-30
+date_added: 2019-07-30
 family: atmel-samd
 bootloader_id: snekboard
 features:

--- a/_board/sparkfun_lumidrive.md
+++ b/_board/sparkfun_lumidrive.md
@@ -7,7 +7,7 @@ manufacturer: "SparkFun"
 board_url:
  - "https://www.sparkfun.com/products/14779"
 board_image: "sparkfun_lumidrive_01.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: atmel-samd
 features:
   - Battery Charging

--- a/_board/sparkfun_micromod_rp2040.md
+++ b/_board/sparkfun_micromod_rp2040.md
@@ -7,7 +7,7 @@ manufacturer: "SparkFun"
 board_url:
  - "https://www.sparkfun.com/products/17720"
 board_image: "sparkfun_micromod_rp2040.jpg"
-date_added: 2021-5-26
+date_added: 2021-05-26
 family: raspberrypi
 features:
 ---

--- a/_board/sparkfun_nrf52840_micromod.md
+++ b/_board/sparkfun_nrf52840_micromod.md
@@ -7,7 +7,7 @@ manufacturer: "SparkFun"
 board_url:
  - "https://www.sparkfun.com/products/16984"
 board_image: "sparkfun_nrf52840_micromod.jpg"
-date_added: 2021-4-6
+date_added: 2021-04-06
 family: nrf52840
 bootloader_id: sparkfun_nrf52840_micromod
 features:

--- a/_board/sparkfun_nrf52840_mini.md
+++ b/_board/sparkfun_nrf52840_mini.md
@@ -7,7 +7,7 @@ manufacturer: "SparkFun"
 board_url:
  - "https://www.sparkfun.com/products/15025"
 board_image: "sparkfun_nrf52840_mini-01.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: nrf52840
 features:
   - Battery Charging

--- a/_board/sparkfun_pro_micro_rp2040.md
+++ b/_board/sparkfun_pro_micro_rp2040.md
@@ -7,7 +7,7 @@ manufacturer: "SparkFun"
 board_url:
  - "https://www.sparkfun.com/products/17717"
 board_image: "sparkfun_pro_micro_rp2040.jpg"
-date_added: 2021-4-6
+date_added: 2021-04-06
 family: raspberrypi
 features:
   - STEMMA QT/QWIIC

--- a/_board/sparkfun_qwiic_micro_no_flash.md
+++ b/_board/sparkfun_qwiic_micro_no_flash.md
@@ -7,7 +7,7 @@ manufacturer: "SparkFun"
 board_url:
  - "https://www.sparkfun.com/products/15423"
 board_image: "sparkfun_qwiic_micro.jpg"
-date_added: 2019-11-4
+date_added: 2019-11-04
 family: atmel-samd
 features:
   - STEMMA QT/QWIIC

--- a/_board/sparkfun_qwiic_micro_with_flash.md
+++ b/_board/sparkfun_qwiic_micro_with_flash.md
@@ -7,7 +7,7 @@ manufacturer: "SparkFun"
 board_url:
  - "https://www.sparkfun.com/products/15423"
 board_image: "sparkfun_qwiic_micro.jpg"
-date_added: 2019-11-4
+date_added: 2019-11-04
 family: atmel-samd
 features:
   - STEMMA QT/QWIIC

--- a/_board/sparkfun_redboard_turbo.md
+++ b/_board/sparkfun_redboard_turbo.md
@@ -7,7 +7,7 @@ manufacturer: "SparkFun"
 board_url:
  - "https://www.sparkfun.com/products/14812"
 board_image: "sparkfun_redboard_turbo.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: atmel-samd
 features:
   - Battery Charging

--- a/_board/sparkfun_samd21_dev.md
+++ b/_board/sparkfun_samd21_dev.md
@@ -7,7 +7,7 @@ manufacturer: "SparkFun"
 board_url:
  - "https://www.sparkfun.com/products/13672"
 board_image: "sparkfun_samd21_dev.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: sparkfun_samd21_dev
 features:

--- a/_board/sparkfun_samd21_mini.md
+++ b/_board/sparkfun_samd21_mini.md
@@ -7,7 +7,7 @@ manufacturer: "SparkFun"
 board_url:
  - "https://www.sparkfun.com/products/13664"
 board_image: "sparkfun_samd21_mini.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: sparkfun-samd21-mini
 features:

--- a/_board/sparkfun_samd51_micromod.md
+++ b/_board/sparkfun_samd51_micromod.md
@@ -7,7 +7,7 @@ manufacturer: "SparkFun"
 board_url:
  - "https://www.sparkfun.com/products/16791"
 board_image: "sparkfun_samd51_micromod.jpg"
-date_added: 2021-6-4
+date_added: 2021-06-04
 family: atmel-samd
 features:
   - Bluetooth/BTLE

--- a/_board/sparkfun_samd51_thing_plus.md
+++ b/_board/sparkfun_samd51_thing_plus.md
@@ -7,7 +7,7 @@ manufacturer: "SparkFun"
 board_url:
  - "https://www.sparkfun.com/products/14713"
 board_image: "sparkfun_samd51_thing_plus.jpg"
-date_added: 2020-2-26
+date_added: 2020-02-26
 family: atmel-samd
 features:
   - Feather-Compatible

--- a/_board/sparkfun_stm32_thing_plus.md
+++ b/_board/sparkfun_stm32_thing_plus.md
@@ -7,7 +7,7 @@ manufacturer: "SparkFun"
 board_url:
  - "https://www.sparkfun.com/products/17712"
 board_image: "sparkfun_stm32_thing_plus.jpg"
-date_added: 2022-1-4
+date_added: 2022-01-04
 family: stm
 features:
   - Feather-Compatible

--- a/_board/sparkfun_stm32f405_micromod.md
+++ b/_board/sparkfun_stm32f405_micromod.md
@@ -7,7 +7,7 @@ manufacturer: "SparkFun"
 board_url:
  - "https://www.sparkfun.com/products/17713"
 board_image: "sparkfun_stm32f405_micromod.jpg"
-date_added: 2021-8-13
+date_added: 2021-08-13
 family: stm
 features:
 ---

--- a/_board/sparkfun_teensy_micromod.md
+++ b/_board/sparkfun_teensy_micromod.md
@@ -7,7 +7,7 @@ manufacturer: "SparkFun"
 board_url:
  - "https://www.sparkfun.com/products/16402"
 board_image: "sparkfun_teensy_micromod.jpg"
-date_added: 2022-5-3
+date_added: 2022-05-03
 family: mimxrt10xx
 
 ---

--- a/_board/sparkfun_thing_plus_rp2040.md
+++ b/_board/sparkfun_thing_plus_rp2040.md
@@ -7,7 +7,7 @@ manufacturer: "SparkFun"
 board_url:
  - "https://www.sparkfun.com/products/17745"
 board_image: "sparkfun_thing_plus_rp2040.jpg"
-date_added: 2021-4-6
+date_added: 2021-04-06
 family: raspberrypi
 features:
   - Feather-Compatible

--- a/_board/splitkb_liatris.md
+++ b/_board/splitkb_liatris.md
@@ -7,7 +7,7 @@ manufacturer: "SplitKB"
 board_url:
  - "https://splitkb.com/products/liatris"
 board_image: "splitkb_liatris.jpg"
-date_added: 2023-7-28
+date_added: 2023-07-28
 family: raspberrypi
 features:
   - STEMMA QT/QWIIC

--- a/_board/ssci_isp1807_dev_board.md
+++ b/_board/ssci_isp1807_dev_board.md
@@ -7,7 +7,7 @@ manufacturer: "Switch Science, Inc"
 board_url:
  - "https://ssci.to/6454"
 board_image: "ssci_isp1807_dev_board.jpg"
-date_added: 2022-3-16
+date_added: 2022-03-16
 family: nrf52840
 features:
   - Bluetooth/BTLE

--- a/_board/ssci_isp1807_micro_board.md
+++ b/_board/ssci_isp1807_micro_board.md
@@ -7,7 +7,7 @@ manufacturer: "Switch Science, Inc"
 board_url:
  - "https://ssci.to/6939"
 board_image: "ssci_isp1807_micro_board.jpg"
-date_added: 2022-3-16
+date_added: 2022-03-16
 family: nrf52840
 features:
   - Bluetooth/BTLE

--- a/_board/stackrduino_m0_pro.md
+++ b/_board/stackrduino_m0_pro.md
@@ -7,7 +7,7 @@ manufacturer: "StackRduino"
 board_url:
  - "https://github.com/StackRduino/StackRduino_M0"
 board_image: "stackrduino_m0_pro.jpg"
-date_added: 2021-4-6
+date_added: 2021-04-06
 family: atmel-samd
 bootloader_id: stackrduino_m0_pro
 features:

--- a/_board/stm32f411ce_blackpill_with_flash.md
+++ b/_board/stm32f411ce_blackpill_with_flash.md
@@ -7,7 +7,7 @@ manufacturer: "WeAct Studio"
 board_url:
  - "https://github.com/WeActTC/MiniF4-STM32F4x1"
 board_image: "stm32f411ce_blackpill.jpg"
-date_added: 2021-4-6
+date_added: 2021-04-06
 family: stm
 features:
   - USB-C

--- a/_board/stm32f411ve_discovery.md
+++ b/_board/stm32f411ve_discovery.md
@@ -7,7 +7,7 @@ manufacturer: "ST"
 board_url:
  - "https://www.st.com/en/evaluation-tools/32f411ediscovery.html"
 board_image: "stm32f411.jpg"
-date_added: 2019-9-16
+date_added: 2019-09-16
 family: stm
 ---
 

--- a/_board/stm32f412zg_discovery.md
+++ b/_board/stm32f412zg_discovery.md
@@ -7,7 +7,7 @@ manufacturer: "ST"
 board_url:
  - "https://www.st.com/en/evaluation-tools/32f412gdiscovery.html"
 board_image: "stm32f412.jpg"
-date_added: 2019-9-16
+date_added: 2019-09-16
 family: stm
 features:
   - Display

--- a/_board/stm32f4_discovery.md
+++ b/_board/stm32f4_discovery.md
@@ -7,7 +7,7 @@ manufacturer: "ST"
 board_url:
  - "https://www.st.com/en/evaluation-tools/stm32f4discovery.html"
 board_image: "stm32f407.jpg"
-date_added: 2019-9-18
+date_added: 2019-09-18
 family: stm
 ---
 

--- a/_board/supermini_nrf52840.md
+++ b/_board/supermini_nrf52840.md
@@ -7,7 +7,7 @@ manufacturer: "ICBbuy"
 board_url:
  - "http://wiki.icbbuy.com/doku.php?id=developmentboard:nrf52840"
 board_image: "supermini_nrf52840.png"
-date_added: "2023-10-21"
+date_added: 2023-10-21
 family: nrf52840
 bootloader_id: nice_nano
 downloads_display: true

--- a/_board/swan_r5.md
+++ b/_board/swan_r5.md
@@ -7,7 +7,7 @@ manufacturer: "Blues Wireless"
 board_url:
  - "https://blues.io/products/swan"
 board_image: "swan_r5.jpg"
-date_added: 2021-9-29
+date_added: 2021-09-29
 family: stm
 features:
   - Feather-Compatible

--- a/_board/takayoshiotake_octave_rp2040.md
+++ b/_board/takayoshiotake_octave_rp2040.md
@@ -7,7 +7,7 @@ manufacturer: "OTAKE Takayoshi"
 board_url:
  - "https://github.com/takayoshiotake/octave-12-key-macropad"
 board_image: "takayoshiotake_octave_rp2040.jpg"
-date_added: 2022-8-22
+date_added: 2022-08-22
 family: raspberrypi
 features:
   - USB-C

--- a/_board/targett_module_clip_wroom.md
+++ b/_board/targett_module_clip_wroom.md
@@ -7,7 +7,7 @@ manufacturer: "Targett"
 board_url:
  - "https://www.targettpcb.co.uk/s2-mcb-1"
 board_image: "targett_module_clip_wroom.jpg"
-date_added: 2020-12-6
+date_added: 2020-12-06
 family: esp32s2
 bootloader_id: targett_mcb_wroom
 features:

--- a/_board/targett_module_clip_wrover.md
+++ b/_board/targett_module_clip_wrover.md
@@ -7,7 +7,7 @@ manufacturer: "Targett"
 board_url:
  - "https://www.targettpcb.co.uk/s2-mcb-1"
 board_image: "targett_module_clip_wrover.jpg"
-date_added: 2020-12-6
+date_added: 2020-12-06
 family: esp32s2
 bootloader_id: targett_mcb_wrover
 features:

--- a/_board/teensy40.md
+++ b/_board/teensy40.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.pjrc.com/store/teensy40.html"
  - "https://www.adafruit.com/product/4323"
 board_image: "teensy40.jpg"
-date_added: 2020-1-31
+date_added: 2020-01-31
 family: mimxrt10xx
 features:
   - Breadboard-Friendly

--- a/_board/thunderpack_v11.md
+++ b/_board/thunderpack_v11.md
@@ -7,7 +7,7 @@ manufacturer: "Jeremy Gillick"
 board_url:
  - "https://github.com/jgillick/ThunderPack"
 board_image: "thunderpack_v11.jpg"
-date_added: 2020-4-16
+date_added: 2020-04-16
 family: stm
 features:
 - Battery Charging

--- a/_board/thunderpack_v12.md
+++ b/_board/thunderpack_v12.md
@@ -7,7 +7,7 @@ manufacturer: "Jeremy Gillick"
 board_url:
  - "https://github.com/jgillick/ThunderPack"
 board_image: "thunderpack_v12.jpg"
-date_added: 2020-4-16
+date_added: 2020-04-16
 family: stm
 features:
 - Battery Charging

--- a/_board/trellis_m4_express.md
+++ b/_board/trellis_m4_express.md
@@ -9,7 +9,7 @@ board_url:
  - "https://www.adafruit.com/product/3938"
  - "https://www.adafruit.com/product/4018"
 board_image: "trellis_m4_express.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: trellis_m4
 features:

--- a/_board/trinket_m0.md
+++ b/_board/trinket_m0.md
@@ -7,7 +7,7 @@ manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/3500"
 board_image: "trinket_m0.jpg"
-date_added: 2019-3-9
+date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: trinket_m0
 features:

--- a/_board/trinket_m0_haxpress.md
+++ b/_board/trinket_m0_haxpress.md
@@ -7,7 +7,7 @@ manufacturer: "Dave Astels"
 board_url:
  - "http://daveastels.com/trinket-m0-express-hack.html"
 board_image: "trinket_m0_haxpress.jpg"
-date_added: 2019-3-19
+date_added: 2019-03-19
 family: atmel-samd
 bootloader_id: trinket_m0
 features:

--- a/_board/uartlogger2.md
+++ b/_board/uartlogger2.md
@@ -7,7 +7,7 @@ manufacturer: "unknown"
 board_url:
 board_image: "unknown.jpg"
 downloads_display: false
-date_added: 2020-3-31
+date_added: 2020-03-31
 family: atmel-samd
 bootloader_id: uartlogger2
 features:

--- a/_board/uchip.md
+++ b/_board/uchip.md
@@ -7,7 +7,7 @@ manufacturer: "Itaca Innovation"
 board_url:
  - "https://shop.itaca-innovation.com"
 board_image: "uchip.jpg"
-date_added: 2019-3-25
+date_added: 2019-03-25
 family: atmel-samd
 bootloader_id: uchip
 features:

--- a/_board/ugame10.md
+++ b/_board/ugame10.md
@@ -7,7 +7,7 @@ manufacturer: "Radomir Dopieralski"
 board_url:
  - "https://ugame.rtfd.io"
 board_image: "ugame_10.jpg"
-date_added: 2019-3-12
+date_added: 2019-03-12
 family: atmel-samd
 bootloader_id: trinket_m0
 features:

--- a/_board/unexpectedmaker_feathers2.md
+++ b/_board/unexpectedmaker_feathers2.md
@@ -8,7 +8,7 @@ board_url:
  - "https://unexpectedmaker.com/shop/feathers2-esp32-s2"
  - "https://www.adafruit.com/product/4769"
 board_image: "unexpectedmaker_feathers2.jpg"
-date_added: 2020-10-1
+date_added: 2020-10-01
 family: esp32s2
 bootloader_id: unexpectedmaker_feathers2
 features:

--- a/_board/unexpectedmaker_feathers2_prerelease.md
+++ b/_board/unexpectedmaker_feathers2_prerelease.md
@@ -8,7 +8,7 @@ board_url:
  - "https://unexpectedmaker.com/shop/feathers2-esp32-s2"
  - "https://www.adafruit.com/product/4769"
 board_image: "unexpectedmaker_feathers2_prerelease.jpg"
-date_added: 2020-6-14
+date_added: 2020-06-14
 family: esp32s2
 bootloader_id: unexpectedmaker_feathers2
 features:

--- a/_board/unexpectedmaker_nanos3.md
+++ b/_board/unexpectedmaker_nanos3.md
@@ -7,7 +7,7 @@ manufacturer: "Unexpected Maker"
 board_url:
  - "https://unexpectedmaker.com/shop/nanos3"
 board_image: "unexpectedmaker_nanos3.jpg"
-date_added: 2023-6-26
+date_added: 2023-06-26
 family: esp32s3
 bootloader_id: unexpectedmaker_nanos3
 features:

--- a/_board/unexpectedmaker_tinypico.md
+++ b/_board/unexpectedmaker_tinypico.md
@@ -9,7 +9,7 @@ board_url:
  - "https://www.adafruit.com/product/5028"
  - "https://www.adafruit.com/product/5750"
 board_image: "unexpectedmaker_tinypico.jpg"
-date_added: 2022-9-18
+date_added: 2022-09-18
 family: esp32
 downloads_display: true
 features:

--- a/_board/unexpectedmaker_tinypico_nano.md
+++ b/_board/unexpectedmaker_tinypico_nano.md
@@ -7,7 +7,7 @@ manufacturer: "Unexpected Maker"
 board_url:
  - "https://unexpectedmaker.com/shop/tinypico-nano"
 board_image: "unexpectedmaker_tinypico_nano.jpg"
-date_added: 2022-9-18
+date_added: 2022-09-18
 family: esp32
 downloads_display: true
 features:

--- a/_board/warmbit_bluepixel.md
+++ b/_board/warmbit_bluepixel.md
@@ -6,7 +6,7 @@ name: "Warmbit BluePixel"
 manufacturer: "Warmbit"
 board_url:
 board_image: "unknown.jpg"
-date_added: 2021-9-3
+date_added: 2021-09-03
 family: nrf52840
 downloads_display: false
 ---

--- a/_board/waveshare_esp32_s2_pico_lcd.md
+++ b/_board/waveshare_esp32_s2_pico_lcd.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.waveshare.com/wiki/ESP32-S2-Pico"
 board_image: "waveshare_esp32_s2_pico_lcd.jpg"
 bootloader_id: waveshare_esp32_s2_pico_lcd
-date_added: 2022-8-22
+date_added: 2022-08-22
 family: esp32s2
 features:
   - Wi-Fi

--- a/_board/waveshare_esp32_s3_pico.md
+++ b/_board/waveshare_esp32_s3_pico.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.waveshare.com/esp32-s3.htm"
 board_image: "ESP32-S3-Pico.jpg"
 bootloader_id: waveshare_esp32_s3_pico
-date_added: 2023-8-30
+date_added: 2023-08-30
 family: esp32s3
 features:
   - Breadboard-Friendly

--- a/_board/waveshare_esp32s2_pico.md
+++ b/_board/waveshare_esp32s2_pico.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.waveshare.com/esp32-s2.htm"
 board_image: "waveshare_esp32s2_pico.jpg"
 bootloader_id: waveshare_esp32s2_pico
-date_added: 2022-8-21
+date_added: 2022-08-21
 family: esp32s2
 features:
   - Breadboard-Friendly

--- a/_board/waveshare_rp2040_lcd_0_96.md
+++ b/_board/waveshare_rp2040_lcd_0_96.md
@@ -7,7 +7,7 @@ manufacturer: "Waveshare"
 board_url:
  - "https://www.waveshare.com/rp2040-lcd-0.96.htm"
 board_image: "waveshare_rp2040_lcd_0_96.jpg"
-date_added: 2023-4-7
+date_added: 2023-04-07
 downloads_display: true
 family: raspberrypi
 features:

--- a/_board/waveshare_rp2040_lcd_1_28.md
+++ b/_board/waveshare_rp2040_lcd_1_28.md
@@ -7,7 +7,7 @@ manufacturer: "Waveshare"
 board_url:
  - "https://www.waveshare.com/rp2040-lcd-1.28.htm"
 board_image: "waveshare_rp2040_lcd_1_28.jpg"
-date_added: 2023-1-31
+date_added: 2023-01-31
 family: raspberrypi
 features:
   - USB-C

--- a/_board/waveshare_rp2040_tiny.md
+++ b/_board/waveshare_rp2040_tiny.md
@@ -7,7 +7,7 @@ manufacturer: "Waveshare"
 board_url:
  - "https://www.waveshare.com/wiki/RP2040-Tiny"
 board_image: "waveshare_rp2040_tiny.jpg"
-date_added: 2024-3-18
+date_added: 2024-03-18
 family: raspberrypi
 features:
   - Breadboard-Friendly

--- a/_board/waveshare_rp2040_zero.md
+++ b/_board/waveshare_rp2040_zero.md
@@ -7,7 +7,7 @@ manufacturer: "Waveshare"
 board_url:
  - "https://www.waveshare.com/rp2040-zero.htm"
 board_image: "waveshare_rp2040_zero.jpg"
-date_added: 2022-1-12
+date_added: 2022-01-12
 family: raspberrypi
 features:
   - USB-C

--- a/_board/weact_studio_pico.md
+++ b/_board/weact_studio_pico.md
@@ -7,7 +7,7 @@ manufacturer: "WeAct Studio"
 board_url:
  - "https://www.aliexpress.com/item/3256803521775546.html"
 board_image: "weact_studio_pico.jpg"
-date_added: 2022-6-9
+date_added: 2022-06-09
 family: raspberrypi
 features:
   - USB-C

--- a/_board/winterbloom_big_honking_button.md
+++ b/_board/winterbloom_big_honking_button.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "honk.jpg"
 downloads_display: true
 blinka: false
-date_added: 2019-4-10
+date_added: 2019-04-10
 family: atmel-samd
 bootloader_id: winterbloom_big_honking_button
 ---

--- a/_board/winterbloom_sol.md
+++ b/_board/winterbloom_sol.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "sol.jpg"
 downloads_display: true
 blinka: false
-date_added: 2019-11-7
+date_added: 2019-11-07
 family: atmel-samd
 bootloader_id: winterbloom_sol
 ---

--- a/_board/wiznet_w5100s_evb_pico.md
+++ b/_board/wiznet_w5100s_evb_pico.md
@@ -7,7 +7,7 @@ manufacturer: "WIZnet"
 board_url:
  - "https://www.wiznet.io/product-item/w5100s-evb-pico/"
 board_image: "w5100s-evb-pico.jpg"
-date_added: 2022-4-26
+date_added: 2022-04-26
 family: raspberrypi
 features:
     - Breadboard-Friendly

--- a/_board/wiznet_w5500_evb_pico.md
+++ b/_board/wiznet_w5500_evb_pico.md
@@ -7,7 +7,7 @@ manufacturer: "WIZnet"
 board_url:
  - "https://www.wiznet.io/product-item/w5500-evb-pico/"
 board_image: "w5500-evb-pico.jpg"
-date_added: 2022-7-25
+date_added: 2022-07-25
 family: raspberrypi
 features:
     - Breadboard-Friendly

--- a/_board/yd_esp32_s3_n16r8.md
+++ b/_board/yd_esp32_s3_n16r8.md
@@ -7,7 +7,7 @@ manufacturer: "VCC-GND Studio"
 board_url:
  - "https://www.aliexpress.com/item/3256803838808294.html?skuId=12000028793982306"
 board_image: "yd_esp32_s3.jpg"
-date_added: 2023-5-3
+date_added: 2023-05-03
 family: esp32s3
 features:
   - Breadboard-Friendly

--- a/_board/yd_esp32_s3_n8r8.md
+++ b/_board/yd_esp32_s3_n8r8.md
@@ -7,7 +7,7 @@ manufacturer: "VCC-GND Studio"
 board_url:
  - "https://www.aliexpress.com/item/3256803838808294.html?skuId=12000028793982305"
 board_image: "yd_esp32_s3.jpg"
-date_added: 2023-5-3
+date_added: 2023-05-03
 family: esp32s3
 features:
   - Breadboard-Friendly

--- a/_board/zrichard_rp2.65-f.md
+++ b/_board/zrichard_rp2.65-f.md
@@ -7,7 +7,7 @@ manufacturer: "Zach Richard"
 board_url:
  - "https://github.com/BigTuna94/RP2.65-F"
 board_image: "zrichard_rp2.65-f.jpg"
-date_added: 2022-5-16
+date_added: 2022-05-16
 family: raspberrypi
 features:
 

--- a/feed.html
+++ b/feed.html
@@ -8,8 +8,8 @@ permalink: /feed.rss
 <link>{{ "/" | absolute_url }}</link>
 <description>A list of CircuitPython and Blinka supported boards</description>
 <lastBuildDate>{{ "now" | date_to_rfc822 }}</lastBuildDate>
-{% assign chronological_boards = site.board | sort: "date_added" %}
-{% for board in chronological_boards reversed %}
+{% assign all_boards = site.board | concat: site.blinka | sort: "date_added" | reverse %}
+{% for board in all_boards %}
   {%- if board.downloads_display == false -%}
     {%- continue -%}
   {%- endif -%}
@@ -18,20 +18,13 @@ permalink: /feed.rss
     <title>{{ board.name }}</title>
     <link>{{ board.url | absolute_url }}</link>
     <description><![CDATA[ {% include downloads/board_image.html board_image=board.board_image %}<p>By {{ board.manufacturer }}</p> {{ board.content }} ]]></description>
+    {% if board.blinka %}
+    <category>Blinka</category>
+    {% else %}
     <category>CircuitPython</category>
-    <pubDate>{{ board.date_added | date: '%s' | plus: twelve_hours | date_to_rfc822 }}</pubDate>
+    {% endif %}
+    <pubDate>{{ board.date_added | date: "%a, %d %b %Y 00:00:00 GMT" }}</pubDate>
     <guid>{{ board.url | absolute_url }}</guid>
   </item>
   {%- endif -%}
-{% endfor %}
-{% assign chronological_blinka_boards = site.board | sort: "date_added" %}
-{% for board in chronological_blinka_boards reversed %}
-    <item>
-      <title>{{ board.name }}</title>
-      <link>{{ board.url | absolute_url }}</link>
-      <description><![CDATA[ {% include downloads/board_image.html board_image=board.board_image %}<p>By {{ board.manufacturer }}</p> {{ board.content }} ]]></description>
-      <category>Blinka</category>
-      <pubDate>{{ board.date_added | date: '%s' | plus: twelve_hours | date_to_rfc822 }}</pubDate>
-      <guid>{{ board.url | absolute_url }}</guid>
-    </item>
 {% endfor %}

--- a/tools/check-boards.py
+++ b/tools/check-boards.py
@@ -1,10 +1,10 @@
 #!/usr/bin/python3
+import datetime
 import os
 import json
 import re
 from pathlib import Path
 import frontmatter
-from dateutil.parser import parse
 
 # Check CircuitPython Download Features
 with open('template.md', "rt") as f:
@@ -31,14 +31,7 @@ def verify_board_id(folder):
     return valid
 
 def valid_date(date):
-    date = str(date)
-    if date:
-        try:
-            parse(date)
-            return True
-        except:
-            return False
-    return False
+    return isinstance(date, datetime.date)
 
 def verify_features(folder, valid_features):
     valid = True
@@ -160,7 +153,7 @@ if not verify_family("_board"):
     print("Family or not found or invalid value. See https://learn.adafruit.com/how-to-add-a-new-board-to-the-circuitpython-org-website/adding-to-downloads for details")
     raise SystemExit(True)
 
-if not verify_date_added("_board") or not verify_date_added("blinka"):
+if not verify_date_added("_board") or not verify_date_added("_blinka"):
     print("Date Added field not found or invalid value. See https://learn.adafruit.com/how-to-add-a-new-board-to-the-circuitpython-org-website/adding-to-downloads for details")
     raise SystemExit(True)
 


### PR DESCRIPTION
.. leading zeros are required for `frontmatter` to treat them as dates
rather than strings, apparently per the YAML specification.

This was done by script:
```py
import re
import datetime
import pathlib
import sys

import frontmatter

rx = re.compile(r'^(\s*)date_added:.*$', re.M)

for path_str in sys.argv[1:]:
    print(path_str)
    path = pathlib.Path(path_str)

    post = frontmatter.load(path)
    date_added = post.get("date_added", "")

    if isinstance(date_added, datetime.date):
        continue

    if isinstance(date_added, str):
        try:
            date_added = datetime.datetime.strptime(date_added, "%Y-%m-%d")
        except ValueError as exc:
            print(f"Failed to parse date {date_added} in {path_str}: {exc}")
            continue

    date_added = date_added.date()
    content = path.read_text("utf-8")
    new_content = rx.sub(lambda m: f"{m.group(1)}date_added: {date_added}", content)
    assert content != new_content

    path.write_text(new_content, "utf-8")
```

This PR replaces #1356 and I think is preferable because it doesn't make indentation & order changes to the .md files and it doesn't require adding an unused time-of-day to each board's date_added field.