### PR TITLE
fix image URLs in the RSS feed.

### DIFF
--- a/_includes/downloads/board_image.html
+++ b/_includes/downloads/board_image.html
@@ -1,7 +1,7 @@
   {% assign small_image = "/assets/images/boards/small/" | append: include.board_image %}
   {% assign large_image = "/assets/images/boards/large/" | append: include.board_image %}
-  <img srcset="{{ small_image }} 300w,
-               {{ large_image }} 700w"
+  <img srcset="https://circuitpython.org{{ small_image }} 300w,
+               https://circuitpython.org{{ large_image }} 700w"
        sizes="(max-width: 1024px) 700px,
               300px"
-       src="{{ large_image }}" alt="Image of Board" loading="lazy">
+       src="https://circuitpython.org{{ large_image }}" alt="Image of Board" loading="lazy">


### PR DESCRIPTION
I noticed while testing the other RSS feed changes that the images weren't loading successfully (at least in the client app I tested which was FeedR on Android). They appeared as "broken image" icons.

Inspecting the code of the feed item within the app revealed that the image URLs were relative rather than absolute. When the page gets rendered in an HTML page that works fine because the client browser will know it's relative to the host of the page being viewed. 

I don't know if RSS spec includes something about relative URLs within feed items pointing back to the host of the feed source, but in this app that doesn't appear to occur automatically. 

Adding a hardcoded portion to the URL with the host allows those images to load successfully.

Originally I had hoped there was some way to dynamically include the hostname rather than hardcoding it. That way when viewed locally the images would be loaded from the local instance rather than the public one. I was unable to figure out a way to make it dynamic though and settled for hardcoding the public URL.