### PR TITLE
bump esp32s2 & esp32s3 bootloader version

### DIFF
--- a/_data/bootloaders.json
+++ b/_data/bootloaders.json
@@ -7,10 +7,10 @@
             "version": "v3.15.0"
         },
         "esp32s2": {
-            "version": "0.18.1"
+            "version": "0.18.2"
         },
         "esp32s3": {
-            "version": "0.18.1"
+            "version": "0.18.2"
         },
         "esp32c3": {},
         "esp32c6": {},


### PR DESCRIPTION
Bumping ESP32-S2 and ESP32-S3 bootloader versions.

Check https://github.com/adafruit/tinyuf2/releases/tag/0.18.2