### PR TITLE
Generate absolute URLs automatically

### DIFF
--- a/_includes/downloads/board_image.html
+++ b/_includes/downloads/board_image.html
@@ -1,7 +1,8 @@
   {% assign small_image = "/assets/images/boards/small/" | append: include.board_image %}
   {% assign large_image = "/assets/images/boards/large/" | append: include.board_image %}
-  <img srcset="{{ small_image }} 300w,
-               {{ large_image }} 700w"
+  <!-- (uses an absolute URL for better compatibility with RSS readers -->
+  <img srcset="{{ small_image | absolute_url }} 300w,
+               {{ large_image | absolute_url }} 700w"
        sizes="(max-width: 1024px) 700px,
               300px"
        src="{{ large_image }}" alt="Image of Board" loading="lazy">


### PR DESCRIPTION
This allows a `localhost:4000`-style URL to be generated for local testing, but still gives an absolute URL, which enhances compatibility with RSS readers. A comment is added explaining the reason for the absolute URL.

Closes #1374