### PR TITLE
Continue trying to fix RSS feed absolute URLs

### DIFF
--- a/_includes/downloads/board_image.html
+++ b/_includes/downloads/board_image.html
@@ -1,8 +1,7 @@
   {% assign small_image = "/assets/images/boards/small/" | append: include.board_image %}
   {% assign large_image = "/assets/images/boards/large/" | append: include.board_image %}
-  <!-- (uses an absolute URL for better compatibility with RSS readers -->
-  <img srcset="{{ small_image | absolute_url }} 300w,
-               {{ large_image | absolute_url }} 700w"
+  <img srcset="{{ small_image }} 300w,
+               {{ large_image }} 700w"
        sizes="(max-width: 1024px) 700px,
               300px"
-       src="{{ large_image | absolute_url }}" alt="Image of Board" loading="lazy">
+       src="{{ large_image }}" alt="Image of Board" loading="lazy">

--- a/_includes/downloads/feed_board_image.html
+++ b/_includes/downloads/feed_board_image.html
@@ -1,7 +1,7 @@
-{% assign small_image = "/assets/images/boards/small/" | append: include.board_image %}
-{% assign large_image = "/assets/images/boards/large/" | append: include.board_image %}
-<img srcset="https://circuitpython.org{{ small_image }} 300w,
-             https://circuitpython.org{{ large_image }} 700w"
+{% assign small_image = "/assets/images/boards/small/" | append: include.board_image | absolute_url %}
+{% assign large_image = "/assets/images/boards/large/" | append: include.board_image | absolute_url %}
+<img srcset="{{ small_image }} 300w,
+             {{ large_image }} 700w"
      sizes="(max-width: 1024px) 700px,
             300px"
-     src="https://circuitpython.org{{ large_image }}" alt="Image of Board" loading="lazy">
+     src="{{ large_image }}" alt="Image of Board" loading="lazy">


### PR DESCRIPTION
Originally, both the RSS feed and the board list pages used the same board_image.html include; I added `| absolute_url` to this file for the RSS feed, which functions better when all links are absolute.

Using `| absolute_url` is preferable to just prepending `https://circuitpython.org` because it can give a correct URL when previewing locally with `bundle run jekyll serve`.

This crossed with a change by @makermelissa to switch the feeds to use a separate include, presumably (though I didn't specifically ask her about it) to avoid having the absoulute URLs where they were not needed.

In this commit, I remove the use of `absolute_url` in the include that's used to generate regular pages, while switching from prepending `https://circuitpython.org` to using `| absolute_url` on the include that is used just for the feed.