### PR TITLE
Fix the feature list for the two Waveshare -GEEK boards

### DIFF
--- a/_board/waveshare_esp32_s3_geek.md
+++ b/_board/waveshare_esp32_s3_geek.md
@@ -10,7 +10,7 @@ board_image: "waveshare_esp32_s3_geek.jpg"
 date_added: 2024-03-25
 family: esp32s3
 features:
-  - USB-C
+  - STEMMA QT/QWIIC
   - Wi-Fi
   - Bluetooth/BTLE
   - Display

--- a/_board/waveshare_rp2040_geek.md
+++ b/_board/waveshare_rp2040_geek.md
@@ -10,8 +10,7 @@ board_image: "waveshare_rp2040_geek.jpg"
 date_added: 2024-03-29
 family: raspberrypi
 features:
-  - USB-C
-  - Wi-Fi
+  - STEMMA QT/QWIIC
   - Display
 ---
 


### PR DESCRIPTION
@jvprat spotted some mistakes in the new Waveshare RP2040-GEEK and ESP32-S3-GEEK devices. The RP2040 device does not support WiFi and neither board has a USB-C port. While double checking the feature list I also realized that the board does have a Stemma QT compatible connector so I added that feature as well.