### PR TITLE
Update to peaceiris/actions-gh-pages@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
       run: |
         bundle exec jekyll build -d build
     - name: Deploy
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build


### PR DESCRIPTION
updates remaining action that needed update to Node.js 20. See https://github.com/peaceiris/actions-gh-pages/issues/1070.