### PR TITLE
Changed some details in the names of the "Seeed Studio XIAO ESP32C3" and "Seeed Studio XIAO ESP32C6" boards.

### DIFF
--- a/_board/seeed_xiao_esp32c3.md
+++ b/_board/seeed_xiao_esp32c3.md
@@ -1,8 +1,8 @@
 ---
 layout: download
 board_id: "seeed_xiao_esp32c3"
-title: "Seeed Studio XIAO ESP32C3 Download"
-name: "Seeed Studio XIAO ESP32C3"
+title: "Seeed Studio XIAO ESP32-C3 Download"
+name: "Seeed Studio XIAO ESP32-C3"
 manufacturer: "Seeed Studio"
 board_url:
  - "https://www.seeedstudio.com/Seeed-XIAO-ESP32C3-p-5431.html"

--- a/_board/seeed_xiao_esp32c6.md
+++ b/_board/seeed_xiao_esp32c6.md
@@ -1,8 +1,8 @@
 ---
 layout: download
 board_id: "seeed_xiao_esp32c6"
-title: "Seeed Studio XIAO ESP32C6 Download"
-name: "Seeed Studio XIAO ESP32C6"
+title: "Seeed Studio XIAO ESP32-C6 Download"
+name: "Seeed Studio XIAO ESP32-C6"
 manufacturer: "Seeed Studio"
 board_url:
  - "https://www.seeedstudio.com/Seeed-Studio-XIAO-ESP32C6-p-5884.html"


### PR DESCRIPTION
We noticed that we couldn't find these two boards by searching for "ESP32-C3" and "ESP32-C6".So it needed a change in the title of these two boards, changing "ESP32C3" to "ESP32-C3" and "ESP32C6" to "ESP32-C6". Thank you!