### PR TITLE
match hyphenated or unhyphenated search terms

### DIFF
--- a/assets/javascript/downloads.js
+++ b/assets/javascript/downloads.js
@@ -419,7 +419,9 @@ function shouldDisplayDownload(download, displayedManufacturers, displayedMcufam
 
 
     for (const term of downloadsSearch.searchTerm.toLowerCase().split(" ")) {
-        if (!downloadData.includes(term)) {
+        if (!
+            (downloadData.includes(term) ||
+             downloadData.includes(term.replaceAll("-", "")))) {
             return false;
         }
     }


### PR DESCRIPTION
- Addresses #1438 

Some boards uses a hyphenated name for the microcontroller chip or other feature, and some do not. Right now the search will give different results in the two cases. For instance, searching for "ESP32C6" yields different results than "ESP32-C6".

This change makes the match ignore hyphens, producing a more inclusive search.

We used to use a regexp, which would have made for an easy fix, but that was too slow (see #1328), so this is "hand-coded".

Tested locally.

@Carla-Guo FYI