### PR TITLE
Restore deleted Waveshare RP2040-Zero

### DIFF
--- a/_board/waveshare_rp2040_pizero.md
+++ b/_board/waveshare_rp2040_pizero.md
@@ -1,8 +1,8 @@
 ---
 layout: download
 board_id: "waveshare_rp2040_pizero"
-title: "Waveshare RP2040-Zero Download"
-name: "RP2040-Zero"
+title: "Waveshare RP2040-PiZero Download"
+name: "RP2040-PiZero"
 manufacturer: "Waveshare"
 board_url:
  - "https://www.waveshare.com/rp2040-pizero.htm"

--- a/_board/waveshare_rp2040_zero.md
+++ b/_board/waveshare_rp2040_zero.md
@@ -1,0 +1,37 @@
+---
+layout: download
+board_id: "waveshare_rp2040_zero"
+title: "Waveshare RP2040-Zero Download"
+name: "RP2040-Zero"
+manufacturer: "Waveshare"
+board_url:
+ - "https://www.waveshare.com/rp2040-zero.htm"
+board_image: "waveshare_rp2040_zero.jpg"
+date_added: 2022-01-12
+family: raspberrypi
+features:
+  - USB-C
+  - Breadboard-Friendly
+---
+
+a Pico-like MCU board based on Raspberry Pi RP2040
+
+**Board specifications**
+
+  - RP2040 microcontroller chip designed by Raspberry Pi in the United Kingdom
+  - Dual-core Arm Cortex M0+ processor, flexible clock running up to 133 MHz
+  - 264KB of SRAM, and 2MB of on-board Flash memory
+  - USB-C connector, keeps it up to date, easier to use
+  - Castellated module allows soldering direct to carrier boards
+  - USB 1.1 with device and host support
+  - Low-power sleep and dormant modes
+  - Drag-and-drop programming using mass storage over USB
+  - 29 × multi-function GPIO pins (20× via edge pinout, others via solder points)
+  - 2 × SPI, 2 × I2C, 2 × UART, 4 × 12-bit ADC, 16 × controllable PWM channels
+  - Accurate clock and timer on-chip
+  - Temperature sensor
+  - Accelerated floating-point libraries on-chip
+  - 8 × Programmable I/O (PIO) state machines for custom peripheral support
+
+## Purchase
+* [Waveshare](https://www.waveshare.com/rp2040-zero.htm)


### PR DESCRIPTION
Board Waveshare RP2040-Zero was deleted by:

https://github.com/adafruit/circuitpython-org/commit/6ec46b6a51823d7e134d964288428a9df6fa1f4e#diff-12e6a57bd2b4284f5f5f93d010e3d3ecd0aafe75a5c10991432549441c27f873

Where file `_board/waveshare_rp2040_zero.md` was moved to `_board/waveshare_rp2040_one.md`.

Also, the board Waveshare RP2040-PiZero is not to be confused with Waveshare RP2040-Zero.

This commit gets that fixed by:
- Fixing Waveshare RP2040-PiZero title and name.
- Restoring Waveshare RP2040-Zero board information.