### PR TITLE
Turn libraries list on board pages into links

### DIFF
--- a/_includes/download/board.html
+++ b/_includes/download/board.html
@@ -147,13 +147,25 @@
     {% if version.modules %}
     <p>
         Built-in modules available:
-        <span class="download-modules {% if version.stable %}stable{% else %}unstable{% endif %}">{{ version.modules | join: ', ' }}</span>
+        <span class="download-modules {% if version.stable %}stable{% else %}unstable{% endif %}">
+          {% for module_name in version.modules %}
+          <a class="library-link" href="https://docs.circuitpython.org/en/latest/shared-bindings/{{module_name}}">
+            {{ module_name }}
+          </a>{% if module_name != version.modules[version.modules.size - 1] %}, {% endif %}
+          {% endfor %}
+        </span>
     </p>
     {% endif %}
     {% if version.frozen_libraries and version.frozen_libraries.size != 0 %}
     <p>
         Included frozen<sup><a href="https://docs.circuitpython.org/en/latest/docs/reference/glossary.html?highlight=frozen#term-frozen-module" title="What is a frozen module">(?)</a></sup> modules:
-        <span class="download-modules {% if version.stable %}stable{% else %}unstable{% endif %}">{{ version.frozen_libraries | join: ', ' }}</span>
+        <span class="download-modules {% if version.stable %}stable{% else %}unstable{% endif %}">
+          {% for module_name in version.frozen_libraries %}
+          <a class="library-link" href="https://docs.circuitpython.org/en/latest/shared-bindings/{{module_name}}">
+            {{ module_name }}
+          </a>{% if module_name != version.frozen_libraries[version.frozen_libraries.size - 1] %}, {% endif %}
+          {% endfor %}
+        </span>
     </p>
     {% endif %}
   </div>

--- a/_includes/download/board.html
+++ b/_includes/download/board.html
@@ -149,7 +149,11 @@
         Built-in modules available:
         <span class="download-modules {% if version.stable %}stable{% else %}unstable{% endif %}">
           {% for module_name in version.modules %}
-          <a class="library-link" href="https://docs.circuitpython.org/en/latest/shared-bindings/{{module_name}}">
+          {% if module_name contains "." %}
+          <a target="_blank" class="library-link" href="https://docs.circuitpython.org/en/latest/shared-bindings/{{ module_name | split: '.' | first }}/#{{ module_name }}">
+          {% else %}
+          <a target="_blank" class="library-link" href="https://docs.circuitpython.org/en/latest/shared-bindings/{{ module_name }}">
+          {% endif %}
             {{ module_name }}
           </a>{% if module_name != version.modules[version.modules.size - 1] %}, {% endif %}
           {% endfor %}
@@ -161,7 +165,7 @@
         Included frozen<sup><a href="https://docs.circuitpython.org/en/latest/docs/reference/glossary.html?highlight=frozen#term-frozen-module" title="What is a frozen module">(?)</a></sup> modules:
         <span class="download-modules {% if version.stable %}stable{% else %}unstable{% endif %}">
           {% for module_name in version.frozen_libraries %}
-          <a class="library-link" href="https://docs.circuitpython.org/en/latest/shared-bindings/{{module_name}}">
+          <a target="_blank" class="library-link" href="https://docs.circuitpython.org/projects/{{ module_name | split: 'adafruit_' | last }}">
             {{ module_name }}
           </a>{% if module_name != version.frozen_libraries[version.frozen_libraries.size - 1] %}, {% endif %}
           {% endfor %}


### PR DESCRIPTION
This turns the library list on board pages into clickable docs links.
It supports having class links like busio.SPI and frozen modules.
There were a few modules that don't have docs (_asyncio for example), and one frozen module (adafruit_connection_manager) that doesn't follow the expected path (it's just connectionmanager), but ignoring that it's working well.

Context from discord:
> I was going to add the links to the modules lists on boards pages (after imaginging they existed earlier 😁 ). I've got that sorted but the frozen modules are more tricky, mainly removing adafruit_ from the name and sticking after https://docs.circuitpython.org/projects/ works, e.g. https://docs.circuitpython.org/projects/display_text but not for connection_manager as it's page is without the underscore. Can RTD do aliases to fix that or do I need a more cunning plan?

Tested on the pico page (for normal modules), and pyportal (for frozen modules)