### PR TITLE
workflows/build.yml: update to actions/checkout@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     # be limited (they run on all forks' default branches).
     if: startswith(github.repository, 'adafruit/')
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Update Awesome CircuitPython


### PR DESCRIPTION
Missed this in the previous PR to update to Node.20. This should get rid of the last warning we're seeing on the builds.