### PR TITLE
Update pimoroni_tiny2040_2mb.md

### DIFF
--- a/_board/pimoroni_tiny2040_2mb.md
+++ b/_board/pimoroni_tiny2040_2mb.md
@@ -5,7 +5,7 @@ title: "Tiny 2040 (2MB) Download"
 name: "Tiny 2040 (2MB)"
 manufacturer: "Pimoroni"
 board_url:
- - "https://shop.pimoroni.com/products/tiny-2040"
+ - "https://shop.pimoroni.com/products/tiny-2040?variant=39560012300371"
 board_image: "pimoroni_tiny2040_2mb.jpg"
 date_added: 2021-12-02
 family: raspberrypi
@@ -35,4 +35,4 @@ The RP2040 microcontroller is a dual core ARM Cortex M0+ running at up to 133Mhz
 One very exciting feature of the RP2040 microcontroller are the programmable IOs which allow you to execute custom programs that can manipulate GPIO pins and transfer data between peripherals - they can offload tasks that require high data transfer rates or precise timing that traditionally would have required a lot of heavy lifting from the CPU.
 
 ## Purchase
-* [Pimoroni](https://shop.pimoroni.com/products/tiny-2040)
+* [Pimoroni](https://shop.pimoroni.com/products/tiny-2040?variant=39560012300371) PIM593


### PR DESCRIPTION
Tiny 2040 has three variant on page https://shop.pimoroni.com/products/tiny-2040

The original link goes by default to one of the two 8MB variant. Someone wanting the 2MB variant need to click on the 2MB (PIM593) once in the page or follow the link I provided.

PS: Not touching the 8MB page yet... but maybe one day Pimoroni will do a 16MB and similar issue will come.