### PR TITLE
Updated sunton_esp32_2432S028 info for new users

### DIFF
--- a/_board/sunton_esp32_2432S028.md
+++ b/_board/sunton_esp32_2432S028.md
@@ -11,12 +11,16 @@ family: esp32
 
 Sunton ESP32-2432S028 Development Board, Based on ESP32-D0WDQ6 MCU. With 2.8" 65K Color Touch LCD. Supports Wifi & Bluetooth. User accessable GPIO ports. SD card slot.
 
+Depending on your board, you may need to hold down the **BOOT** button while programming.
+
 ## Technical details
 
  - Onboard 2.8inch 240×320 pixels 65K color Touch LCD display.
  - Integrated 2.4GHz WiFi and Bluetooth wireless communication.
  - SPI Touch, Display and SD card slot.
- - Amplified GPIO26 for PWM audio output
+ - Amplified GPIO26 for PWM audio output.
+ - Uses the ILI9341 display driver via SPI.
+ - Uses the XPT2046 touchscreen driver via SPI.
 
 ## Purchase
 * [Aliexpress](https://www.aliexpress.com/item/1005006556177475.html)


### PR DESCRIPTION
Changes:
- Added additional information about the possible need to hold BOOT button while programming.
- Added info about touch and display driver ICs as these can be difficult to find on product pages for this board.

With a board sourced from Banggood, I found that I had to hold down the BOOT button while programming. I also added information on the display driver and touch driver ICs used as this information can be difficult to find on seller's websites.

I think this additional information will be beneficial to users who may be unfamiliar with this board, as I was.