### PR TITLE
Makerfabs_tft7: replace asterisk with 'x'

### DIFF
--- a/_board/makerfabs_tft7.md
+++ b/_board/makerfabs_tft7.md
@@ -15,7 +15,7 @@ features:
   - USB-C
 ---
 
-This ESP32 S3 7-inch IPS display could be an ideal displayer& controller for IOT applications. It has 2 versions: High-resolution version 800*480, and Ultra High-resolution version 1024*600; Display on both versions is IPS, and the display effect is beautiful, together with 5 points capacitive touch, great for applications such as home automation; There on-board SD card, to make it possible to record/play filed data. Also, there 2 Mabee/ Grove connectors, so the users can connect kinds of sensors to this board, to create personal prototype projects instantly.
+This ESP32 S3 7-inch IPS display could be an ideal displayer& controller for IOT applications. It has 2 versions: High-resolution version 800x480, and Ultra High-resolution version 1024x600; Display on both versions is IPS, and the display effect is beautiful, together with 5 points capacitive touch, great for applications such as home automation; There on-board SD card, to make it possible to record/play filed data. Also, there 2 Mabee/ Grove connectors, so the users can connect kinds of sensors to this board, to create personal prototype projects instantly.
 
 Depending on your board variant you may need to:
  - select the correct screen resolution using CIRCUITPY_DISPLAY_WIDTH in [settings.toml](https://docs.circuitpython.org/en/latest/docs/environment.html).
@@ -26,7 +26,7 @@ Depending on your board variant you may need to:
 - Wireless: Wifi& Bluetooth 5.0
 - LCD: 7 inch High Lightness IPS
 - FPS: >30
-- Resolution: 800*480/1024*600
+- Resolution: 800x480/1024x600
 - LCD interface: RGB 565
 - Touch Panel: 5 Points Touch, Capacitive
 - Touch Panel Driver: GT911
@@ -34,7 +34,7 @@ Depending on your board variant you may need to:
 - UART to UART Chip: CP2104
 - Power Supply: USB Type-C 5.0V(4.0V~5.25V)
 - Button: Flash button and reset button
-- Mabee interface: 1*I2C;1*GPIO
+- Mabee interface: 1xI2C;1xGPIO
 - MicroSD: Yes
 - Arduino support: Yes
 - Type-C Power Delivery: Not Supported


### PR DESCRIPTION
The asterisk character in the screen resolution and interface listing gets interpreted as a formatting instruction messing up the output. This replaces the '*' with an 'x'.