### PR TITLE
update board_id for circuitart zero s3

### DIFF
--- a/_board/circuitart_esp32s3_zero.md
+++ b/_board/circuitart_esp32s3_zero.md
@@ -1,6 +1,6 @@
 ---
 layout: download
-board_id: "CircuitArt_ESP32S3_Zero"
+board_id: "circuitart_zero_s3"
 title: "CircuitArt ESP32S3 Zero Download"
 name: "CircuitArt ESP32S3 Zero"
 manufacturer: "CircuitArt"


### PR DESCRIPTION
This board_id didn't match the core repo which broke the download link for this board, and added a 2nd "unknown" instance to the downloads listing.
![image](https://github.com/user-attachments/assets/58c33b7f-512b-4da6-944a-63ed3c745016)

I tested this fix locally and it seems to resolve the issue, leaving only a single instance listed and the firmware download buttons work now