### PR TITLE
fix language selection for beta download

### DIFF
--- a/assets/javascript/download.js
+++ b/assets/javascript/download.js
@@ -46,7 +46,9 @@ function updateFileLinks(option, language) {
   files.forEach(function(file) {
     var extension = file.substr(file.lastIndexOf('.') + 1);
     parentNode.querySelector(".download-button." + extension).href = file;
-    parentNode.querySelector(".installer-button").setAttribute(extension + "file", file);
+    if (parentNode.querySelector(".installer-button") !== null){
+      parentNode.querySelector(".installer-button").setAttribute(extension + "file", file);
+    }
   });
 }
 


### PR DESCRIPTION
Resolves: #1390

The lack of installer button caused an exception to be thrown when attempting to access attributes of null. 

Since this occured in a for loop going over the download buttons when it failed on the first iteration it stopped subsequent iterations from ever happening. 

The solution proposed is to check for null before attempting to access properties of the element.

I confirmed the issue reported in the issue on the W5500-EVB-Pico both on the live site and in a local build.

I tested the fix successfully on the W5500-EVB-Pico in the local build. 