### PR TITLE
show features on board download page

### DIFF
--- a/_includes/download/board.html
+++ b/_includes/download/board.html
@@ -172,6 +172,13 @@
         </span>
     </p>
     {% endif %}
+    {% if page.features %}
+    <p>Features:
+    {% for feature in page.features %}
+      <span class="feature-span">{{feature}}</span>
+    {% endfor %}
+    </p>
+    {% endif %}
   </div>
 {% endfor %}
 {% endif %}

--- a/assets/sass/pages/_download.scss
+++ b/assets/sass/pages/_download.scss
@@ -178,6 +178,16 @@
       }
     }
   }
+  .feature-span {
+    padding: 2px 4px 2px 4px;
+    margin-left: 3px;
+    margin-bottom: 3px;
+    display: inline-block;
+    background-color: $purple;
+    color: #fff;
+    border-radius: 5px;
+    font-size: 14px;
+  }
 }
 
 @media (max-width: $screen-lg) {


### PR DESCRIPTION
Resolves: #1035 

I added them below the built-in modules inside of purple "tag" elements. 

![image](https://github.com/user-attachments/assets/bc88c640-a07c-4938-9d23-0ea595166786)

The do not currently do anything when clicked. 

This was my interpretation of the "little boxes" mentioned in the linked issue. I am open to feedback on the style or placement of them.