### PR TITLE
installation instructions button

### DIFF
--- a/_board/adafruit_feather_huzzah32.md
+++ b/_board/adafruit_feather_huzzah32.md
@@ -10,6 +10,7 @@ board_image: "adafruit_feather_huzzah32.jpg"
 date_added: 2022-08-19
 family: esp32
 downloads_display: true
+download_instructions: https://learn.adafruit.com/circuitpython-with-esp32-quick-start
 features:
   - Feather-Compatible
   - Battery Charging

--- a/_includes/download/board.html
+++ b/_includes/download/board.html
@@ -142,6 +142,12 @@
         version="{{ version.version }}"
         >OPEN INSTALLER <i class="fas fa-magic" aria-hidden="true"></i></button>
       {% endif %}
+      {% if page.download_instructions != nil and page.download_instructions != "" %}
+        <div>
+            <a class="download-button" href="{{ page.download_instructions }}">INSTALLATION INSTRUCTIONS<i class="fas fa-arrow-circle-right" aria-hidden="true"></i></a>
+          <div class="clear"></div>
+        </div>
+      {% endif %}
       </div>
     </div>
     {% if version.modules %}

--- a/_includes/download/board.html
+++ b/_includes/download/board.html
@@ -50,7 +50,7 @@
         <a href="https://github.com/adafruit/circuitpython/releases/tag/{{ version.version }}">Release Notes for {{ version.version }}</a>
       </p>
       {% if page.download_instructions != nil and page.download_instructions != "" %}
-        <a class="download-button install-instructions-button" target="_blank" href="{{ page.download_instructions }}">INSTALL INSTRUCTIONS<i class="fas fa-arrow-circle-right" aria-hidden="true"></i></a>
+        <a class="download-button install-instructions-button" target="_blank" href="{{ page.download_instructions }}">HOW TO INSTALL<i class="fas fa-arrow-circle-right" aria-hidden="true"></i></a>
       {% endif %}
     </div>
     <div class="download-details">

--- a/_includes/download/board.html
+++ b/_includes/download/board.html
@@ -45,9 +45,14 @@
         Older bootloaders cannot load the firmware. See <i>Update UF2 Bootloader</i> below.</b>
       </p>
     {% endif %}
-    <p>
-      <a href="https://github.com/adafruit/circuitpython/releases/tag/{{ version.version }}">Release Notes for {{ version.version }}</a>
-    </p>
+    <div class="release-details">
+      <p>
+        <a href="https://github.com/adafruit/circuitpython/releases/tag/{{ version.version }}">Release Notes for {{ version.version }}</a>
+      </p>
+      {% if page.download_instructions != nil and page.download_instructions != "" %}
+        <a class="download-button install-instructions-button" target="_blank" href="{{ page.download_instructions }}">INSTALL INSTRUCTIONS<i class="fas fa-arrow-circle-right" aria-hidden="true"></i></a>
+      {% endif %}
+    </div>
     <div class="download-details">
       {% comment %}
       Create a list of language codes and names so it can be sorted.
@@ -141,12 +146,6 @@
         {% endfor %}
         version="{{ version.version }}"
         >OPEN INSTALLER <i class="fas fa-magic" aria-hidden="true"></i></button>
-      {% endif %}
-      {% if page.download_instructions != nil and page.download_instructions != "" %}
-        <div>
-            <a class="download-button" href="{{ page.download_instructions }}">INSTALLATION INSTRUCTIONS<i class="fas fa-arrow-circle-right" aria-hidden="true"></i></a>
-          <div class="clear"></div>
-        </div>
       {% endif %}
       </div>
     </div>

--- a/assets/sass/pages/_download.scss
+++ b/assets/sass/pages/_download.scss
@@ -58,7 +58,12 @@
         }
       }
 
-      .download-details {
+      .install-instructions-button{
+        width: 100%;
+        margin-bottom: 1em;
+      }
+
+      .download-details, .release-details {
         display: grid;
         grid-template-columns: repeat(2, 1fr);
       }
@@ -192,7 +197,7 @@
       grid-template-columns: 1fr 1fr;
 
       .download {
-        .download-details {
+        .download-details, .release-details {
           grid-template-columns: repeat(1, 1fr);
         }
 

--- a/assets/sass/pages/_download.scss
+++ b/assets/sass/pages/_download.scss
@@ -60,6 +60,7 @@
 
       .install-instructions-button{
         width: 100%;
+        text-align: center;
         margin-bottom: 1em;
       }
 

--- a/template.md
+++ b/template.md
@@ -11,12 +11,12 @@ board_image: "unknown.jpg"
 date_added: 2020-03-31
 downloads_display: true
 blinka: false
-download_instructions: "BLINKA ONLY - url"
+download_instructions: "url"
+family: esp32  # See _data/bootloaders.json
+bootloader_id:
 # Features are tags; they should be limited to the items in this list and spelled exactly the same.
 # Include only the features your board supports, and remove these comment lines before committing.
 # Breadboard-Friendly is a parallel pin layout with minimal non-critical perpendicular pins
-family: esp32  # See _data/bootloaders.json
-bootloader_id:
 features:
   - Arduino Shield Compatible
   - Battery Charging


### PR DESCRIPTION
Resolves: #1034 

Make the `download_instructions` metadata field valid for CircuitPython core in addition to Blinka. If it has a value add a button linking to it to the download page.

![image](https://github.com/user-attachments/assets/00001a97-047d-423c-9196-b066d8d4cab1)

I've only added the metadata to a single esp32 so far, but the rest of them could get updated to point to this guide if the way this has been added looks okay.