### PR TITLE
change the module links to purple tags and remove the seperating commas

### DIFF
--- a/_includes/download/board.html
+++ b/_includes/download/board.html
@@ -161,7 +161,7 @@
           <a target="_blank" class="library-link" href="https://docs.circuitpython.org/en/latest/shared-bindings/{{ module_name }}">
           {% endif %}
             {{ module_name }}
-          </a>{% if module_name != version.modules[version.modules.size - 1] %}, {% endif %}
+          </a>
           {% endfor %}
         </span>
     </p>
@@ -173,7 +173,7 @@
           {% for module_name in version.frozen_libraries %}
           <a target="_blank" class="library-link" href="https://docs.circuitpython.org/projects/{{ module_name | split: 'adafruit_' | last }}">
             {{ module_name }}
-          </a>{% if module_name != version.frozen_libraries[version.frozen_libraries.size - 1] %}, {% endif %}
+          </a>
           {% endfor %}
         </span>
     </p>

--- a/assets/sass/pages/_download.scss
+++ b/assets/sass/pages/_download.scss
@@ -184,7 +184,7 @@
       }
     }
   }
-  .feature-span {
+  .feature-span, .library-link {
     padding: 2px 4px 2px 4px;
     margin-left: 3px;
     margin-bottom: 3px;
@@ -193,6 +193,12 @@
     color: #fff;
     border-radius: 5px;
     font-size: 14px;
+  }
+
+  .library-link:hover{
+    outline: 2px solid $purple;
+    background-color: #fff;
+    color: $purple;
   }
 }
 


### PR DESCRIPTION
Mentioned recently on discord by @jepler

Trying out changing the style on the built-in and frozen modules to match the newly added feature "tags". Also added an inverse effect on hover to help further convey to the user that they are clickable (unlike the feature ones currently)

They also still retain their "pointer" mouse icon on hover.

In the screenshot `countio` was hovered, but my screenshot utility can't show the mouse. 
![image](https://github.com/user-attachments/assets/5908e7f9-6162-4eb7-bb7d-b93d82f80bd0)
