### PR TITLE
Fix modules extra comma and spacing 

### DIFF
--- a/_includes/download/board.html
+++ b/_includes/download/board.html
@@ -178,9 +178,11 @@
     {% endif %}
     {% if page.features %}
     <p>Features:
-    {% for feature in page.features %}
-      <span class="feature-span">{{feature}}</span>
-    {% endfor %}
+      <span class="features-list">
+      {% for feature in page.features %}
+        <a class="library-link" href="/downloads?features={{ feature }}">{{feature}}</a>{% unless forloop.last %}, {% endunless %}
+      {% endfor %}
+      </span>
     </p>
     {% endif %}
   </div>

--- a/_includes/download/board.html
+++ b/_includes/download/board.html
@@ -160,8 +160,7 @@
           {% else %}
           <a target="_blank" class="library-link" href="https://docs.circuitpython.org/en/latest/shared-bindings/{{ module_name }}">
           {% endif %}
-            {{ module_name }}
-          </a>{% if module_name != version.modules[version.modules.size - 1] %}, {% endif %}
+            {{ module_name }}</a>{% unless forloop.last %}, {% endunless %}
           {% endfor %}
         </span>
     </p>
@@ -172,8 +171,7 @@
         <span class="download-modules {% if version.stable %}stable{% else %}unstable{% endif %}">
           {% for module_name in version.frozen_libraries %}
           <a target="_blank" class="library-link" href="https://docs.circuitpython.org/projects/{{ module_name | split: 'adafruit_' | last }}">
-            {{ module_name }}
-          </a>{% if module_name != version.frozen_libraries[version.frozen_libraries.size - 1] %}, {% endif %}
+            {{ module_name }}</a>{% unless forloop.last %}, {% endunless %}
           {% endfor %}
         </span>
     </p>

--- a/assets/sass/pages/_download.scss
+++ b/assets/sass/pages/_download.scss
@@ -116,7 +116,7 @@
           background-color: $purple;
         }
 
-        .download-modules {
+        .download-modules, .features-list {
             color: $purple;
         }
       }
@@ -135,7 +135,7 @@
         a.download-button:hover, a.download-button-unrecommended:hover {
           background-color: $purple;
         }
-        .download-modules {
+        .download-modules, .features-list {
             color: $purple;
         }
       }
@@ -183,16 +183,6 @@
         }
       }
     }
-  }
-  .feature-span {
-    padding: 2px 4px 2px 4px;
-    margin-left: 3px;
-    margin-bottom: 3px;
-    display: inline-block;
-    background-color: $purple;
-    color: #fff;
-    border-radius: 5px;
-    font-size: 14px;
   }
 }
 


### PR DESCRIPTION
And changed the features list to use the modules styling as mentioned in the discussion in #1524.

![image](https://github.com/user-attachments/assets/d3f3fe83-ebf0-4623-85ef-b2ba7f721864)

I found information from the liquid docs here: https://shopify.github.io/liquid/tags/iteration/ that ultimately led to a fix for the extra commas issue. 

The extra spaces before the comma seem to be caused by the closing of `</a>` on the next line instead of the some one as the contents. 