### PR TITLE
More howto install links

### DIFF
--- a/_board/adafruit_esp32s3_camera.md
+++ b/_board/adafruit_esp32s3_camera.md
@@ -10,6 +10,7 @@ board_image: "adafruit_esp32s3_camera.jpg"
 date_added: 2023-10-27
 family: esp32s3
 bootloader_id: adafruit_camera_esp32s3
+download_instructions: https://learn.adafruit.com/adafruit-memento-camera-board/install-circuitpython
 features:
   - Wi-Fi
   - Bluetooth/BTLE

--- a/_board/adafruit_feather_esp32_v2.md
+++ b/_board/adafruit_feather_esp32_v2.md
@@ -10,6 +10,7 @@ board_image: "adafruit_feather_esp32_v2.jpg"
 date_added: 2022-08-19
 family: esp32
 downloads_display: true
+download_instructions: https://learn.adafruit.com/adafruit-esp32-feather-v2/circuitpython
 features:
   - Feather-Compatible
   - Battery Charging

--- a/_board/adafruit_feather_esp32c6_4mbflash_nopsram.md
+++ b/_board/adafruit_feather_esp32c6_4mbflash_nopsram.md
@@ -10,6 +10,7 @@ board_image: "adafruit_feather_esp32c6_4mbflash_nopsram.jpg"
 date_added: 2024-03-18
 family: esp32c6
 downloads_display: true
+download_instructions: https://learn.adafruit.com/adafruit-esp32-c6-feather/install-circuitpython
 features:
   - Feather-Compatible
   - Battery Charging

--- a/_board/adafruit_funhouse.md
+++ b/_board/adafruit_funhouse.md
@@ -11,6 +11,7 @@ board_image: "adafruit_funhouse.jpg"
 date_added: 2021-04-06
 family: esp32s2
 bootloader_id: adafruit_funhouse_esp32s2
+download_instructions: https://learn.adafruit.com/adafruit-funhouse/circuitpython
 features:
   - Wi-Fi
   - STEMMA QT/QWIIC

--- a/_board/adafruit_itsybitsy_esp32.md
+++ b/_board/adafruit_itsybitsy_esp32.md
@@ -10,6 +10,7 @@ board_image: "adafruit_itsybitsy_esp32.jpg"
 date_added: 2024-02-20
 family: esp32
 downloads_display: true
+download_instructions: https://learn.adafruit.com/adafruit-itsybitsy-esp32/circuitpython-setup
 features:
   - Bluetooth/BTLE
   - Wi-Fi

--- a/_board/adafruit_itsybitsy_rp2040.md
+++ b/_board/adafruit_itsybitsy_rp2040.md
@@ -9,6 +9,7 @@ board_url:
 board_image: "adafruit_itsybitsy_rp2040.jpg"
 date_added: 2021-04-06
 family: raspberrypi
+download_instructions: https://learn.adafruit.com/adafruit-itsybitsy-rp2040/circuitpython
 features:
   - Breadboard-Friendly
 ---

--- a/_board/adafruit_kb2040.md
+++ b/_board/adafruit_kb2040.md
@@ -9,6 +9,7 @@ board_url:
 board_image: "adafruit_kb2040.jpg"
 date_added: 2021-11-15
 family: raspberrypi
+download_instructions: https://learn.adafruit.com/adafruit-kb2040/circuitpython
 features:
   - STEMMA QT/QWIIC
   - USB-C

--- a/_board/adafruit_led_glasses_nrf52840.md
+++ b/_board/adafruit_led_glasses_nrf52840.md
@@ -11,6 +11,7 @@ board_image: "adafruit_led_glasses_nrf52840.jpg"
 date_added: 2021-09-03
 family: nrf52840
 bootloader_id: ledglasses_nrf52840
+download_instructions: https://learn.adafruit.com/adafruit-eyelights-led-glasses-and-driver/circuitpython
 features:
   - USB-C
   - Bluetooth/BTLE

--- a/_board/adafruit_macropad_rp2040.md
+++ b/_board/adafruit_macropad_rp2040.md
@@ -10,6 +10,7 @@ board_url:
 board_image: "adafruit_macropad_rp2040.jpg"
 date_added: 2021-06-04
 family: raspberrypi
+download_instructions: https://learn.adafruit.com/adafruit-macropad-rp2040/circuitpython
 features:
   - USB-C
   - STEMMA QT/QWIIC

--- a/_board/adafruit_magtag_2.9_grayscale.md
+++ b/_board/adafruit_magtag_2.9_grayscale.md
@@ -10,6 +10,7 @@ board_url:
 board_image: "adafruit_magtag_2.9_grayscale.jpg"
 date_added: 2020-11-10
 family: esp32s2
+download_instructions: https://learn.adafruit.com/adafruit-magtag/circuitpython
 bootloader_id: adafruit_magtag_29gray
 features:
   - Wi-Fi

--- a/_board/adafruit_matrixportal_s3.md
+++ b/_board/adafruit_matrixportal_s3.md
@@ -10,6 +10,7 @@ board_image: "adafruit_matrixportal_s3.jpg"
 date_added: 2023-06-26
 family: esp32s3
 bootloader_id: adafruit_matrixportal_s3
+download_instructions: https://learn.adafruit.com/adafruit-matrixportal-s3/install-circuitpython
 tags:
   - Matrix Portal
 features:

--- a/_board/adafruit_metro_esp32s2.md
+++ b/_board/adafruit_metro_esp32s2.md
@@ -10,6 +10,7 @@ board_image: "adafruit_metro_esp32s2.jpg"
 date_added: 2020-10-02
 family: esp32s2
 bootloader_id: adafruit_metro_esp32s2
+download_instructions: https://learn.adafruit.com/adafruit-metro-esp32-s2/circuitpython
 features:
   - Wi-Fi
   - Battery Charging

--- a/_board/adafruit_metro_esp32s3.md
+++ b/_board/adafruit_metro_esp32s3.md
@@ -10,6 +10,7 @@ board_image: "adafruit_metro_esp32s3.jpg"
 date_added: 2023-07-28
 family: esp32s3
 bootloader_id: adafruit_metro_esp32s3
+download_instructions: https://learn.adafruit.com/adafruit-metro-esp32-s3/circuitpython
 features:
   - Wi-Fi
   - Battery Charging

--- a/_board/adafruit_metro_m7_1011_sd.md
+++ b/_board/adafruit_metro_m7_1011_sd.md
@@ -9,6 +9,7 @@ board_url:
 board_image: "adafruit_metro_m7_1011_sd.jpg"
 date_added: 2023-09-06
 family: mimxrt10xx
+download_instructions: https://learn.adafruit.com/adafruit-metro-m7-microsd/circuitpython
 features:
   - STEMMA QT/QWIIC
   - USB-C

--- a/_board/adafruit_metro_rp2040.md
+++ b/_board/adafruit_metro_rp2040.md
@@ -9,6 +9,7 @@ board_url:
 board_image: "adafruit_metro_rp2040.jpg"
 date_added: 2023-07-28
 family: raspberrypi
+download_instructions: https://learn.adafruit.com/adafruit-metro-rp2040/circuitpython
 features:
   - STEMMA QT/QWIIC
   - USB-C

--- a/_board/adafruit_neokey_trinkey_m0.md
+++ b/_board/adafruit_neokey_trinkey_m0.md
@@ -10,6 +10,7 @@ board_image: "adafruit_neokey_trinkey_m0.jpg"
 date_added: 2021-04-14
 family: atmel-samd
 bootloader_id: neokey_trinkey_m0
+download_instructions: https://learn.adafruit.com/adafruit-neokey-trinkey/circuitpython
 features:
 
 ---

--- a/_board/adafruit_pixel_trinkey_m0.md
+++ b/_board/adafruit_pixel_trinkey_m0.md
@@ -9,6 +9,7 @@ board_url:
 board_image: "adafruit_pixel_trinkey_m0.jpg"
 date_added: 2024-05-14
 family: atmel-samd
+download_instructions: https://learn.adafruit.com/adafruit-pixel-trinkey/install-circuitpython
 features:
 ---
 

--- a/_board/adafruit_proxlight_trinkey_m0.md
+++ b/_board/adafruit_proxlight_trinkey_m0.md
@@ -10,6 +10,7 @@ board_image: "adafruit_proxlight_trinkey_m0.jpg"
 date_added: 2021-04-14
 family: atmel-samd
 bootloader_id: proxsense_trinkey_m0
+download_instructions: https://learn.adafruit.com/adafruit-proximity-trinkey/circuitpython
 features:
 
 ---

--- a/_board/adafruit_qt2040_trinkey.md
+++ b/_board/adafruit_qt2040_trinkey.md
@@ -9,6 +9,7 @@ board_url:
 board_image: "adafruit_qt2040_trinkey.jpg"
 date_added: 2021-05-26
 family: raspberrypi
+download_instructions: https://learn.adafruit.com/adafruit-trinkey-qt2040/circuitpython
 features:
 
 ---

--- a/_board/adafruit_qtpy_esp32_pico.md
+++ b/_board/adafruit_qtpy_esp32_pico.md
@@ -10,6 +10,7 @@ board_image: "adafruit_qtpy_esp32_pico.jpg"
 date_added: 2022-08-19
 family: esp32
 downloads_display: true
+download_instructions: https://learn.adafruit.com/circuitpython-with-esp32-quick-start/installing-circuitpython
 features:
   - Xiao / QTPy Form Factor
   - Bluetooth/BTLE

--- a/_board/adafruit_qtpy_esp32s2.md
+++ b/_board/adafruit_qtpy_esp32s2.md
@@ -11,6 +11,7 @@ board_image: "adafruit_qtpy_esp32s2.jpg"
 date_added: 2021-11-30
 family: esp32s2
 bootloader_id: adafruit_qtpy_esp32s2
+download_instructions: https://learn.adafruit.com/adafruit-qt-py-esp32-s2/circuitpython
 features:
   - STEMMA QT/QWIIC
   - USB-C

--- a/_board/adafruit_qtpy_esp32s3_4mbflash_2mbpsram.md
+++ b/_board/adafruit_qtpy_esp32s3_4mbflash_2mbpsram.md
@@ -10,6 +10,7 @@ board_image: "adafruit_qtpy_esp32s3_4mbflash_2mbpsram.jpg"
 date_added: 2023-07-11
 family: esp32s3
 bootloader_id: adafruit_qtpy_esp32s3_n4r2
+download_instructions: https://learn.adafruit.com/adafruit-qt-py-esp32-s3/circuitpython-2
 features:
   - STEMMA QT/QWIIC
   - USB-C

--- a/_board/adafruit_qtpy_esp32s3_nopsram.md
+++ b/_board/adafruit_qtpy_esp32s3_nopsram.md
@@ -11,6 +11,7 @@ date_added: 2022-02-14
 family: esp32s3
 bootloader_id: adafruit_qtpy_esp32s3
 downloads_display: true
+download_instructions: https://learn.adafruit.com/adafruit-qt-py-esp32-s3/circuitpython-2
 features:
   - STEMMA QT/QWIIC
   - USB-C

--- a/_board/adafruit_qtpy_rp2040.md
+++ b/_board/adafruit_qtpy_rp2040.md
@@ -9,6 +9,7 @@ board_url:
 board_image: "adafruit_qtpy_rp2040.jpg"
 date_added: 2021-04-06
 family: raspberrypi
+download_instructions: https://learn.adafruit.com/adafruit-qt-py-2040/circuitpython
 features:
   - STEMMA QT/QWIIC
   - USB-C

--- a/_board/adafruit_qualia_s3_rgb666.md
+++ b/_board/adafruit_qualia_s3_rgb666.md
@@ -12,6 +12,7 @@ family: esp32s3
 bootloader_id: adafruit_qualia_s3_rgb666
 tags:
   - Qualia S3
+download_instructions: https://learn.adafruit.com/adafruit-qualia-esp32-s3-for-rgb666-displays/circuitpython-5
 features:
   - External Display
   - Wi-Fi

--- a/_board/adafruit_rotary_trinkey_m0.md
+++ b/_board/adafruit_rotary_trinkey_m0.md
@@ -10,6 +10,7 @@ board_image: "adafruit_rotary_trinkey_m0.jpg"
 date_added: 2021-04-06
 family: atmel-samd
 bootloader_id: rotary_trinkey_m0
+download_instructions: https://learn.adafruit.com/adafruit-rotary-trinkey/circuitpython
 features:
 
 ---

--- a/_board/adafruit_sht4x_trinkey_m0.md
+++ b/_board/adafruit_sht4x_trinkey_m0.md
@@ -10,6 +10,7 @@ board_url:
 board_image: "adafruit_sht4x_trinkey_m0.jpg"
 date_added: 2024-03-13
 family: atmel-samd
+download_instructions: https://learn.adafruit.com/adafruit-sht4x-trinkey/install-circuitpython
 features:
 
 ---

--- a/_board/adafruit_slide_trinkey_m0.md
+++ b/_board/adafruit_slide_trinkey_m0.md
@@ -10,6 +10,7 @@ board_image: "adafruit_slide_trinkey_m0.jpg"
 date_added: 2021-04-14
 family: atmel-samd
 bootloader_id: slide_trinkey_m0
+download_instructions: https://learn.adafruit.com/adafruit-slider-trinkey/circuitpython
 features:
 
 ---

--- a/_board/adafruit_trrs_trinkey_m0.md
+++ b/_board/adafruit_trrs_trinkey_m0.md
@@ -9,6 +9,7 @@ board_url:
 board_image: "adafruit_trrs_trinkey_m0.jpg"
 date_added: 2024-05-14
 family: atmel-samd
+download_instructions: https://learn.adafruit.com/adafruit-trrs-trinkey/install-circuitpython
 features:
 ---
 

--- a/_board/blm_badge.md
+++ b/_board/blm_badge.md
@@ -11,6 +11,7 @@ board_image: "blmbadge.jpg"
 date_added: 2020-09-01
 family: atmel-samd
 bootloader_id: blm_badge
+download_instructions: https://learn.adafruit.com/black-lives-matter-badge/circuitpython
 features:
   - STEMMA QT/QWIIC
   - USB-C

--- a/_board/circuitplayground_bluefruit.md
+++ b/_board/circuitplayground_bluefruit.md
@@ -13,6 +13,7 @@ board_image: "circuitplayground_bluefruit.jpg"
 date_added: 2019-08-30
 family: nrf52840
 bootloader_id: circuitplayground_nrf52840
+download_instructions: https://learn.adafruit.com/adafruit-circuit-playground-bluefruit/circuitpython
 features:
   - Speaker
   - Solder-Free Alligator Clip

--- a/_board/circuitplayground_express.md
+++ b/_board/circuitplayground_express.md
@@ -19,6 +19,7 @@ board_image: "circuitplayground_express.jpg"
 date_added: 2018-12-13
 family: atmel-samd
 bootloader_id: circuitplay_m0
+download_instructions: https://learn.adafruit.com/adafruit-circuit-playground-express/circuitpython-quickstart
 features:
   - Speaker
   - Solder-Free Alligator Clip

--- a/_board/circuitplayground_express_4h.md
+++ b/_board/circuitplayground_express_4h.md
@@ -12,6 +12,7 @@ board_image: "circuitplayground_express_4h.jpg"
 date_added: 2019-04-13
 family: atmel-samd
 bootloader_id: circuitplay_m0
+download_instructions: https://learn.adafruit.com/adafruit-circuit-playground-express/circuitpython-quickstart
 features:
   - Speaker
   - Solder-Free Alligator Clip

--- a/_board/circuitplayground_express_crickit.md
+++ b/_board/circuitplayground_express_crickit.md
@@ -10,6 +10,7 @@ board_image: "circuitplayground_express_crickit.jpg"
 date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: circuitplay_m0
+download_instructions: https://learn.adafruit.com/adafruit-crickit-creative-robotic-interactive-construction-kit/circuitpython-code
 features:
   - Speaker
   - Robotics

--- a/_board/circuitplayground_express_digikey_pycon2019.md
+++ b/_board/circuitplayground_express_digikey_pycon2019.md
@@ -10,6 +10,7 @@ board_image: "circuitplayground_express_digikey_pycon2019.jpg"
 date_added: 2019-04-13
 family: atmel-samd
 bootloader_id: circuitplay_m0
+download_instructions: https://learn.adafruit.com/adafruit-circuit-playground-express/circuitpython-quickstart
 features:
   - Speaker
   - Solder-Free Alligator Clip

--- a/_board/clue_nrf52840_express.md
+++ b/_board/clue_nrf52840_express.md
@@ -12,6 +12,7 @@ board_image: "clue_nrf52840_express.jpg"
 date_added: 2019-12-30
 family: nrf52840
 bootloader_id: clue_nrf52840
+download_instructions: https://learn.adafruit.com/adafruit-clue/circuitpython
 features:
   - Display
   - Bluetooth/BTLE

--- a/_board/edgebadge.md
+++ b/_board/edgebadge.md
@@ -10,6 +10,7 @@ board_image: "edgebadge.jpg"
 date_added: 2019-11-19
 family: atmel-samd
 bootloader_id: arcade_pybadge
+download_instructions: 
 features:
   - Display
   - Speaker

--- a/_board/edgebadge.md
+++ b/_board/edgebadge.md
@@ -10,7 +10,6 @@ board_image: "edgebadge.jpg"
 date_added: 2019-11-19
 family: atmel-samd
 bootloader_id: arcade_pybadge
-download_instructions: 
 features:
   - Display
   - Speaker

--- a/_board/feather_bluefruit_sense.md
+++ b/_board/feather_bluefruit_sense.md
@@ -10,6 +10,7 @@ board_image: "feather_bluefruit_sense.jpg"
 date_added: 2020-02-01
 family: nrf52840
 bootloader_id: feather_nrf52840_sense
+download_instructions: https://learn.adafruit.com/adafruit-feather-sense/circuitpython-on-feather-sense
 features:
   - Feather-Compatible
   - Battery Charging

--- a/_board/feather_m0_express.md
+++ b/_board/feather_m0_express.md
@@ -10,6 +10,7 @@ board_image: "feather_m0_express.jpg"
 date_added: 2019-03-08
 family: atmel-samd
 bootloader_id: feather_m0_express
+download_instructions: https://learn.adafruit.com/adafruit-feather-m0-express-designed-for-circuit-python-circuitpython/kattni-circuitpython
 features:
   - Feather-Compatible
   - Battery Charging

--- a/_board/feather_m0_rfm69.md
+++ b/_board/feather_m0_rfm69.md
@@ -11,6 +11,7 @@ board_image: "feather_m0_rfm69.jpg"
 date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: radiofruit_m0
+download_instructions: https://learn.adafruit.com/adafruit-feather-m0-radio-with-rfm69-packet-radio/circuitpython-for-rfm69
 features:
   - Feather-Compatible
   - Battery Charging

--- a/_board/feather_m0_rfm9x.md
+++ b/_board/feather_m0_rfm9x.md
@@ -11,6 +11,7 @@ board_image: "feather_m0_rfm9x.jpg"
 date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: radiofruit_m0
+download_instructions: https://learn.adafruit.com/adafruit-feather-m0-radio-with-lora-radio-module/circuitpython-for-rfm9x-lora
 features:
   - Feather-Compatible
   - Battery Charging

--- a/_board/feather_m4_can.md
+++ b/_board/feather_m4_can.md
@@ -10,6 +10,7 @@ board_image: "feather_m4_can.jpg"
 date_added: 2020-09-28
 family: atmel-samd
 bootloader_id: feather_m4_can
+download_instructions: https://learn.adafruit.com/adafruit-feather-m4-can-express/circuitpython-on-feather-m4-can
 features:
   - Feather-Compatible
   - Battery Charging

--- a/_board/feather_m4_express.md
+++ b/_board/feather_m4_express.md
@@ -11,6 +11,7 @@ board_image: "feather_m4_express.jpg"
 date_added: 2019-03-08
 family: atmel-samd
 bootloader_id: feather_m4
+download_instructions: https://learn.adafruit.com/adafruit-feather-m4-express-atsamd51/circuitpython
 features:
   - Feather-Compatible
   - Battery Charging

--- a/_board/feather_m7_1011.md
+++ b/_board/feather_m7_1011.md
@@ -9,6 +9,7 @@ board_url:
 board_image: "feather_m7_1011.jpg"
 date_added: 2020-02-27
 family: mimxrt10xx
+download_instructions: https://learn.adafruit.com/adafruit-metro-m7-with-airlift/install-circuitpython
 features:
   - Feather-Compatible
   - Battery Charging

--- a/_board/feather_nrf52840_express.md
+++ b/_board/feather_nrf52840_express.md
@@ -10,6 +10,7 @@ board_image: "feather_nrf52840_express.jpg"
 date_added: 2019-03-09
 family: nrf52840
 bootloader_id: feather_nrf52840_express
+download_instructions: https://learn.adafruit.com/introducing-the-adafruit-nrf52840-feather/circuitpython
 features:
   - Feather-Compatible
   - Battery Charging

--- a/_board/feather_stm32f405_express.md
+++ b/_board/feather_stm32f405_express.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "feather_stm32f405_express.jpg"
 date_added: 2019-09-26
 family: stm
-download_instructions: https://learn.adafruit.com/introducing-the-adafruit-nrf52840-feather/circuitpython
+download_instructions: https://learn.adafruit.com/adafruit-stm32f405-feather-express/circuitpython-setup
 features:
   - Feather-Compatible
   - Battery Charging

--- a/_board/feather_stm32f405_express.md
+++ b/_board/feather_stm32f405_express.md
@@ -9,6 +9,7 @@ board_url:
 board_image: "feather_stm32f405_express.jpg"
 date_added: 2019-09-26
 family: stm
+download_instructions: https://learn.adafruit.com/introducing-the-adafruit-nrf52840-feather/circuitpython
 features:
   - Feather-Compatible
   - Battery Charging

--- a/_board/gemma_m0.md
+++ b/_board/gemma_m0.md
@@ -12,7 +12,7 @@ board_image: "gemma_m0.jpg"
 date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: gemma_m0
-download_instructions: https://learn.adafruit.com/introducing-the-adafruit-nrf52840-feather/circuitpython
+download_instructions: https://learn.adafruit.com/adafruit-gemma-m0/circuitpython
 features:
   - Solder-Free Alligator Clip
 ---

--- a/_board/gemma_m0.md
+++ b/_board/gemma_m0.md
@@ -12,6 +12,7 @@ board_image: "gemma_m0.jpg"
 date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: gemma_m0
+download_instructions: https://learn.adafruit.com/introducing-the-adafruit-nrf52840-feather/circuitpython
 features:
   - Solder-Free Alligator Clip
 ---

--- a/_board/gemma_m0_pycon2018.md
+++ b/_board/gemma_m0_pycon2018.md
@@ -10,7 +10,7 @@ board_image: "gemma_m0_pycon2018.jpg"
 date_added: 2019-04-13
 family: atmel-samd
 bootloader_id: gemma_m0
-download_instructions: https://learn.adafruit.com/introducing-the-adafruit-nrf52840-feather/circuitpython
+download_instructions: https://learn.adafruit.com/adafruit-gemma-m0/circuitpython
 features:
   - Solder-Free Alligator Clip
 ---

--- a/_board/gemma_m0_pycon2018.md
+++ b/_board/gemma_m0_pycon2018.md
@@ -10,6 +10,7 @@ board_image: "gemma_m0_pycon2018.jpg"
 date_added: 2019-04-13
 family: atmel-samd
 bootloader_id: gemma_m0
+download_instructions: https://learn.adafruit.com/introducing-the-adafruit-nrf52840-feather/circuitpython
 features:
   - Solder-Free Alligator Clip
 ---

--- a/_board/grandcentral_m4_express.md
+++ b/_board/grandcentral_m4_express.md
@@ -11,6 +11,7 @@ board_image: "grandcentral_m4_express.jpg"
 date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: grandcentral_m4
+download_instructions: https://learn.adafruit.com/adafruit-grand-central/circuitpython
 features:
   - Arduino Shield Compatible
 ---

--- a/_board/hallowing_m0_express.md
+++ b/_board/hallowing_m0_express.md
@@ -11,6 +11,7 @@ board_image: "hallowing_m0_express.jpg"
 date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: hallowing_m0
+download_instructions: https://learn.adafruit.com/adafruit-hallowing/circuitpython
 features:
   - Display
   - Speaker

--- a/_board/hallowing_m4_express.md
+++ b/_board/hallowing_m4_express.md
@@ -10,6 +10,7 @@ board_image: "hallowing_m4_express.jpg"
 date_added: 2019-08-30
 family: atmel-samd
 bootloader_id: hallowing_m4
+download_instructions: https://learn.adafruit.com/adafruit-hallowing-m4/circuitpython
 features:
   - Display
   - Speaker

--- a/_board/itsybitsy_m0_express.md
+++ b/_board/itsybitsy_m0_express.md
@@ -10,6 +10,7 @@ board_image: "itsybitsy_m0_express.jpg"
 date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: itsybitsy_m0
+download_instructions: https://learn.adafruit.com/introducing-itsy-bitsy-m0/circuitpython
 features:
   - Breadboard-Friendly
 ---

--- a/_board/itsybitsy_m4_express.md
+++ b/_board/itsybitsy_m4_express.md
@@ -11,6 +11,7 @@ board_image: "itsybitsy_m4_express.jpg"
 date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: itsybitsy_m4
+download_instructions: https://learn.adafruit.com/introducing-adafruit-itsybitsy-m4/circuitpython
 features:
   - Breadboard-Friendly
 ---

--- a/_board/itsybitsy_nrf52840_express.md
+++ b/_board/itsybitsy_nrf52840_express.md
@@ -10,6 +10,7 @@ board_image: "itsybitsy_nrf52840_express.jpg"
 date_added: 2019-11-04
 family: nrf52840
 bootloader_id: feather_nrf52840_express
+download_instructions: https://learn.adafruit.com/adafruit-itsybitsy-nrf52840-express/circuitpython
 features:
   - Bluetooth/BTLE
   - Breadboard-Friendly

--- a/_board/matrixportal_m4.md
+++ b/_board/matrixportal_m4.md
@@ -11,6 +11,7 @@ board_image: "matrixportal_m4.jpg"
 date_added: 2020-09-16
 family: atmel-samd
 bootloader_id: matrixportal_m4
+download_instructions: https://learn.adafruit.com/adafruit-matrixportal-m4 
 tags:
   - Matrix Portal
 features:

--- a/_board/matrixportal_m4.md
+++ b/_board/matrixportal_m4.md
@@ -11,7 +11,7 @@ board_image: "matrixportal_m4.jpg"
 date_added: 2020-09-16
 family: atmel-samd
 bootloader_id: matrixportal_m4
-download_instructions: https://learn.adafruit.com/adafruit-matrixportal-m4 
+download_instructions: https://learn.adafruit.com/adafruit-matrixportal-m4/install-circuitpython 
 tags:
   - Matrix Portal
 features:

--- a/_board/metro_m0_express.md
+++ b/_board/metro_m0_express.md
@@ -10,6 +10,7 @@ board_image: "metro_m0_express.jpg"
 date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: metro_m0
+download_instructions: https://learn.adafruit.com/adafruit-metro-m0-express/circuitpython
 features:
   - Arduino Shield Compatible
 ---

--- a/_board/metro_m4_airlift_lite.md
+++ b/_board/metro_m4_airlift_lite.md
@@ -10,6 +10,7 @@ board_image: "metro_m4_airlift_lite.jpg"
 date_added: 2019-04-13
 family: atmel-samd
 bootloader_id: metro_m4_airlift
+download_instructions: https://learn.adafruit.com/adafruit-metro-m4-express-airlift-wifi/install-circuitpython
 features:
   - Wi-Fi
   - Arduino Shield Compatible

--- a/_board/metro_m4_express.md
+++ b/_board/metro_m4_express.md
@@ -10,6 +10,7 @@ board_image: "metro_m4_express.jpg"
 date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: metro_m4
+download_instructions: https://learn.adafruit.com/adafruit-metro-m4-express-featuring-atsamd51/circuitpython
 features:
   - Arduino Shield Compatible
 ---

--- a/_board/metro_m7_1011.md
+++ b/_board/metro_m7_1011.md
@@ -9,6 +9,7 @@ board_url:
 board_image: "metro_m7_1011.jpg"
 date_added: 2020-10-16
 family: mimxrt10xx
+download_instructions: https://learn.adafruit.com/adafruit-metro-m4-express-featuring-atsamd51/circuitpython
 features:
   - Wi-Fi
   - STEMMA QT/QWIIC

--- a/_board/metro_m7_1011.md
+++ b/_board/metro_m7_1011.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "metro_m7_1011.jpg"
 date_added: 2020-10-16
 family: mimxrt10xx
-download_instructions: https://learn.adafruit.com/adafruit-metro-m4-express-featuring-atsamd51/circuitpython
+download_instructions: https://learn.adafruit.com/adafruit-metro-m7-with-airlift/install-circuitpython
 features:
   - Wi-Fi
   - STEMMA QT/QWIIC

--- a/_board/neopixel_trinkey_m0.md
+++ b/_board/neopixel_trinkey_m0.md
@@ -10,6 +10,7 @@ board_image: "neopixel_trinkey_m0.jpg"
 date_added: 2021-04-06
 family: atmel-samd
 bootloader_id: neopixel_trinkey_m0
+download_instructions: https://learn.adafruit.com/adafruit-neo-trinkey/circuitpython
 features:
 
 ---

--- a/_board/pirkey_m0.md
+++ b/_board/pirkey_m0.md
@@ -10,7 +10,6 @@ board_image: "pirkey_m0.jpg"
 date_added: 2019-03-11
 family: atmel-samd
 bootloader_id: pirkey
-download_instructions: 
 ---
 
 The pIRkey adds an IR remote receiver to any computer, laptop, tablet...any computer or device with a USB port that can use a keyboard. This little board slides into any USB A port, and shows up as an every-day USB keyboard. The onboard ATSAMD21 microcontroller listens for IR remote signals and converts them to keypresses, mouse movements, or even USB serial output.

--- a/_board/pirkey_m0.md
+++ b/_board/pirkey_m0.md
@@ -10,6 +10,7 @@ board_image: "pirkey_m0.jpg"
 date_added: 2019-03-11
 family: atmel-samd
 bootloader_id: pirkey
+download_instructions: 
 ---
 
 The pIRkey adds an IR remote receiver to any computer, laptop, tablet...any computer or device with a USB port that can use a keyboard. This little board slides into any USB A port, and shows up as an every-day USB keyboard. The onboard ATSAMD21 microcontroller listens for IR remote signals and converts them to keypresses, mouse movements, or even USB serial output.

--- a/_board/pybadge.md
+++ b/_board/pybadge.md
@@ -14,6 +14,7 @@ board_image: "pybadge.jpg"
 date_added: 2019-03-19
 family: atmel-samd
 bootloader_id: arcade_pybadge
+download_instructions: https://learn.adafruit.com/adafruit-pybadge/installing-circuitpython
 features:
   - Display
   - Speaker

--- a/_board/pygamer.md
+++ b/_board/pygamer.md
@@ -12,6 +12,7 @@ board_image: "pygamer.jpg"
 date_added: 2019-05-25
 family: atmel-samd
 bootloader_id: arcade_pygamer
+download_instructions: https://learn.adafruit.com/adafruit-pygamer/circuitpython
 features:
   - Display
   - Speaker

--- a/_board/pyportal.md
+++ b/_board/pyportal.md
@@ -11,6 +11,7 @@ board_image: "pyportal.jpg"
 date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: pyportal_m4
+download_instructions: https://learn.adafruit.com/adafruit-pyportal/install-circuitpython
 features:
   - Display
   - Speaker

--- a/_board/pyportal_pynt.md
+++ b/_board/pyportal_pynt.md
@@ -10,6 +10,7 @@ board_image: "pyportal_pynt.jpg"
 date_added: 2019-12-11
 family: atmel-samd
 bootloader_id: pyportal_m4
+download_instructions: https://learn.adafruit.com/adafruit-pyportal/install-circuitpython
 features:
   - Display
   - Speaker

--- a/_board/pyportal_titano.md
+++ b/_board/pyportal_titano.md
@@ -10,6 +10,7 @@ board_image: "pyportal_titano.jpg"
 date_added: 2019-08-30
 family: atmel-samd
 bootloader_id: pyportal_m4
+download_instructions: https://learn.adafruit.com/adafruit-pyportal-titano/circuitpython
 features:
   - Display
   - Speaker

--- a/_board/pyruler.md
+++ b/_board/pyruler.md
@@ -10,6 +10,7 @@ board_image: "pyruler.jpg"
 date_added: 2019-07-15
 family: atmel-samd
 bootloader_id: trinket_m0
+download_instructions: https://learn.adafruit.com/adafruit-pyruler/circuitpython
 ---
 
 CircuitPython rules! The PyRuler is the first ruler to be able to run CircuitPython. It features an embedded Adafruit Trinket M0, which is a tiny microcontroller board, built around the Atmel ATSAMD21E18 powerhouse.

--- a/_board/qtpy_m0.md
+++ b/_board/qtpy_m0.md
@@ -10,6 +10,7 @@ board_image: "qtpy_m0.jpg"
 date_added: 2020-09-28
 family: atmel-samd
 bootloader_id: QTPy_m0
+download_instructions: https://learn.adafruit.com/adafruit-qt-py/circuitpython
 features:
   - STEMMA QT/QWIIC
   - USB-C

--- a/_board/raspberry_pi_pico.md
+++ b/_board/raspberry_pi_pico.md
@@ -11,6 +11,7 @@ board_url:
 board_image: "raspberry_pi_pico.jpg"
 date_added: 2021-01-21
 family: raspberrypi
+download_instructions: https://learn.adafruit.com/getting-started-with-raspberry-pi-pico-circuitpython/circuitpython
 features:
   - Breadboard-Friendly
   - Castellated Pads

--- a/_board/raspberry_pi_pico_w.md
+++ b/_board/raspberry_pi_pico_w.md
@@ -10,6 +10,7 @@ board_url:
 board_image: "raspberry_pi_pico_w.jpg"
 date_added: 2022-10-02
 family: raspberrypi
+download_instructions: https://learn.adafruit.com/pico-w-wifi-with-circuitpython/installing-circuitpython
 tags:
   - picow
   - 🥧🐮

--- a/_board/trellis_m4_express.md
+++ b/_board/trellis_m4_express.md
@@ -12,6 +12,7 @@ board_image: "trellis_m4_express.jpg"
 date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: trellis_m4
+download_instructions: https://learn.adafruit.com/adafruit-neotrellis-m4/circuitpython
 features:
 ---
 

--- a/_board/trinket_m0.md
+++ b/_board/trinket_m0.md
@@ -10,6 +10,7 @@ board_image: "trinket_m0.jpg"
 date_added: 2019-03-09
 family: atmel-samd
 bootloader_id: trinket_m0
+download_instructions: https://learn.adafruit.com/adafruit-trinket-m0-circuitpython-arduino/circuitpython
 features:
   - Breadboard-Friendly
 ---


### PR DESCRIPTION
@ladyada 

This is the rest of the Adafruit devices that I found install instructions guide pages for. 

A few I could not find a page for:
- edgebadge, it could link to pybadge but then it will link to a firmware with different name, though it would still work I think
- pirkey, has guide with pages about using circuitpython but not installing. 