### PR TITLE
cpx+displayio & edgebadge

### DIFF
--- a/_board/circuitplayground_express_displayio.md
+++ b/_board/circuitplayground_express_displayio.md
@@ -12,6 +12,7 @@ board_image: "circuitplayground_express_displayio.jpg"
 date_added: 2019-10-17
 family: atmel-samd
 bootloader_id: circuitplay_m0
+download_instructions: https://learn.adafruit.com/adafruit-tft-gizmo/circuitpython-displayio-quickstart
 features:
   - Speaker
   - Display

--- a/_board/edgebadge.md
+++ b/_board/edgebadge.md
@@ -10,6 +10,7 @@ board_image: "edgebadge.jpg"
 date_added: 2019-11-19
 family: atmel-samd
 bootloader_id: arcade_pybadge
+download_instructions: https://learn.adafruit.com/adafruit-pybadge/installing-circuitpython
 features:
   - Display
   - Speaker


### PR DESCRIPTION
A few more to follow up on comments from #1529 

ty @makermelissa for the cpx + displayio link.

I've added the EdgeBadge firmware button as an option on the pybadge learn guide page as well and added a link to that for the edgebadge file here.