### PR TITLE
update nrf52840 bootloader version

### DIFF
--- a/_data/bootloaders.json
+++ b/_data/bootloaders.json
@@ -1,7 +1,7 @@
 {
     "bootloaders": {
         "nrf52840": {
-            "version": "0.8.3"
+            "version": "0.9.2"
         },
         "atmel-samd": {
             "version": "v3.15.0"


### PR DESCRIPTION
Resolves an issue reported on discord by @dglaude. https://discord.com/channels/327254708534116352/327298996332658690/1306026424183816222

Updates the nrf bootloader version to match the latest one linked in the guide pages about updating bootloader.