### PR TITLE
exact match tags search

### DIFF
--- a/_board/raspberry_pi_pico2.md
+++ b/_board/raspberry_pi_pico2.md
@@ -10,6 +10,8 @@ board_url:
 board_image: "raspberry_pi_pico2.jpg"
 date_added: 2024-08-08
 family: raspberrypi
+tags:
+  - pico 2
 features:
   - Breadboard-Friendly
   - Castellated Pads

--- a/assets/javascript/downloads.js
+++ b/assets/javascript/downloads.js
@@ -374,7 +374,6 @@ function handleSortResults(event) {
     .sort(function (a, b) {
       // exact tag match re-order
       if (a.dataset.tags.split(",").indexOf(searched) >= 0){
-        console.log("found tag match, returning -2");
         return -2;
       }
       switch(sortType) {

--- a/assets/javascript/downloads.js
+++ b/assets/javascript/downloads.js
@@ -350,18 +350,33 @@ function filterResults() {
     } else {
       download.style.display = 'block';
       board_count++;
+      // exact tag match re-order
+      let searched = downloadsSearch.searchTerm.toLowerCase();
+      let tags = download.getAttribute("data-tags").split(",");
+      if (tags.indexOf(searched) >= 0 ){
+          let parent = download.parentElement;
+          parent.removeChild(download);
+          parent.prepend(download);
+
+      }
     }
   });
   document.getElementById("board_count").innerHTML = board_count;
 }
 
 function handleSortResults(event) {
+  let searched = downloadsSearch.searchTerm.toLowerCase();
   var sortType = event.target.value;
   setURL('sort-by', sortType);
   var downloads = document.querySelector('.downloads-section');
   Array.prototype.slice.call(downloads.children)
     .map(function (download) { return downloads.removeChild(download); })
     .sort(function (a, b) {
+      // exact tag match re-order
+      if (a.dataset.tags.split(",").indexOf(searched) >= 0){
+        console.log("found tag match, returning -2");
+        return -2;
+      }
       switch(sortType) {
         case 'alpha-asc':
           return a.dataset.name.localeCompare(b.dataset.name);


### PR DESCRIPTION
Resolves: #1536 

This changes makes it so that exact matches on tags will get higher priority in the resulting list of boards. It adds "pico 2" to the pico 2 tags so that it will appear as the first result for "pico 2" now.