### PR TITLE
fix filtering for null search term

### DIFF
--- a/assets/javascript/downloads.js
+++ b/assets/javascript/downloads.js
@@ -351,13 +351,14 @@ function filterResults() {
       download.style.display = 'block';
       board_count++;
       // exact tag match re-order
-      let searched = downloadsSearch.searchTerm.toLowerCase();
-      let tags = download.getAttribute("data-tags").split(",");
-      if (tags.indexOf(searched) >= 0 ){
+      if (downloadsSearch.searchTerm !== null && downloadsSearch.searchTerm !== undefined) {
+        let searched = downloadsSearch.searchTerm.toLowerCase();
+        let tags = download.getAttribute("data-tags").split(",");
+        if (searched !== "" && tags.indexOf(searched) >= 0) {
           let parent = download.parentElement;
           parent.removeChild(download);
           parent.prepend(download);
-
+        }
       }
     }
   });
@@ -365,7 +366,10 @@ function filterResults() {
 }
 
 function handleSortResults(event) {
-  let searched = downloadsSearch.searchTerm.toLowerCase();
+  let searched;
+  if (downloadsSearch.searchTerm !== null && downloadsSearch.searchTerm !== undefined) {
+    searched = downloadsSearch.searchTerm.toLowerCase();
+  }
   var sortType = event.target.value;
   setURL('sort-by', sortType);
   var downloads = document.querySelector('.downloads-section');
@@ -373,7 +377,9 @@ function handleSortResults(event) {
     .map(function (download) { return downloads.removeChild(download); })
     .sort(function (a, b) {
       // exact tag match re-order
-      if (a.dataset.tags.split(",").indexOf(searched) >= 0){
+      if (searched !== undefined && searched !== "" &&
+          a.dataset.tags.split(",").indexOf(searched) >= 0){
+
         return -2;
       }
       switch(sortType) {


### PR DESCRIPTION
Resolves: #1540 

The new search logic broke the page by assuming that `downloadsSearch.searchTerm` would not be `undefined` which was an unsafe assumption and caused the rest of the JS to stop when an error was thrown. Its now wrapped in logic that ensures it isn't undefined or null before attempting to access properties. 

This also includes a fix for a seperate issue I noticed were after you search for something and then erase it from the search box you are left with the page in a very strange order that doesn't match the default sorting order. This turned out to be due to every device matching to the search term of empty string. The logic now ignores the empty string as a search term. 