### PR TITLE
split raspberrypi family to rp2040 and rp2350

### DIFF
--- a/_blinka/waveshare_rp2040_one.md
+++ b/_blinka/waveshare_rp2040_one.md
@@ -10,7 +10,7 @@ download_instructions: "https://learn.adafruit.com/circuitpython-libraries-on-an
 downloads_display: true
 blinka: true
 date_added: 2024-08-07
-family: raspberrypi
+family: rp2040
 ---
 
 A Trinkey-like MCU board based on Raspberry Pi RP2040

--- a/_board/0xcb_gemini.md
+++ b/_board/0xcb_gemini.md
@@ -8,7 +8,7 @@ board_url:
  - "https://github.com/0xCB-dev/0xCB-Gemini"
 board_image: "0xcb_gemini.jpg"
 date_added: 2024-11-11
-family: raspberrypi
+family: rp2040
 features:
   - USB-C
   - Breadboard-Friendly

--- a/_board/0xcb_helios.md
+++ b/_board/0xcb_helios.md
@@ -8,7 +8,7 @@ board_url:
  - "https://github.com/0xCB-dev/0xCB-Helios"
 board_image: "0xcb_helios.jpg"
 date_added: 2023-01-05
-family: raspberrypi
+family: rp2040
 features:
   - USB-C
   - Breadboard-Friendly

--- a/_board/42keebs_frood.md
+++ b/_board/42keebs_frood.md
@@ -8,7 +8,7 @@ board_url:
  - "https://github.com/piit79/frood"
 board_image: "42keebs_frood.jpg"
 date_added: 2022-10-26
-family: raspberrypi
+family: rp2040
 features:
   - USB-C
   - Breadboard-Friendly

--- a/_board/8086_usb_interposer.md
+++ b/_board/8086_usb_interposer.md
@@ -7,7 +7,7 @@ manufacturer: "8086 Consultancy"
 board_url: "https://www.tindie.com/products/8086net/usb-interposer/"
 board_image: "8086_usb_interposer.jpg"
 date_added: 2024-07-03
-family: raspberrypi
+family: rp2040
 features:
   - STEMMA QT/QWIIC
 

--- a/_board/adafruit_feather_rp2040.md
+++ b/_board/adafruit_feather_rp2040.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/4884"
 board_image: "adafruit_feather_rp2040.jpg"
 date_added: 2021-01-21
-family: raspberrypi
+family: rp2040
 download_instructions: https://learn.adafruit.com/adafruit-feather-rp2040-pico/circuitpython
 features:
   - Feather-Compatible

--- a/_board/adafruit_feather_rp2040_adalogger.md
+++ b/_board/adafruit_feather_rp2040_adalogger.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/5980"
 board_image: "adafruit_feather_rp2040_adalogger.jpg"
 date_added: 2024-06-28
-family: raspberrypi
+family: rp2040
 download_instructions: https://learn.adafruit.com/adafruit-feather-rp2040-adalogger/install-circuitpython
 tags:
   - Adalogger Feather

--- a/_board/adafruit_feather_rp2040_can.md
+++ b/_board/adafruit_feather_rp2040_can.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/5724"
 board_image: "adafruit_feather_rp2040_can.jpg"
 date_added: 2023-05-02
-family: raspberrypi
+family: rp2040
 download_instructions: https://learn.adafruit.com/adafruit-rp2040-can-bus-feather/circuitpython
 tags:
   - CAN Bus Feather

--- a/_board/adafruit_feather_rp2040_dvi.md
+++ b/_board/adafruit_feather_rp2040_dvi.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/5710"
 board_image: "adafruit_feather_rp2040_dvi.jpg"
 date_added: 2023-03-27
-family: raspberrypi
+family: rp2040
 download_instructions: https://learn.adafruit.com/adafruit-feather-rp2040-dvi/circuitpython
 tags:
   - DVI Feather

--- a/_board/adafruit_feather_rp2040_prop_maker.md
+++ b/_board/adafruit_feather_rp2040_prop_maker.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/5768"
 board_image: "adafruit_feather_rp2040_prop_maker.jpg"
 date_added: 2023-05-04
-family: raspberrypi
+family: rp2040
 download_instructions: https://learn.adafruit.com/adafruit-rp2040-prop-maker-feather/circuitpython
 tags:
   - Propmaker Feather

--- a/_board/adafruit_feather_rp2040_rfm69.md
+++ b/_board/adafruit_feather_rp2040_rfm69.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/5712"
 board_image: "adafruit_feather_rp2040_rfm69.jpg"
 date_added: 2023-04-04
-family: raspberrypi
+family: rp2040
 download_instructions: https://learn.adafruit.com/feather-rp2040-rfm69/circuitpython
 features:
   - Feather-Compatible

--- a/_board/adafruit_feather_rp2040_rfm9x.md
+++ b/_board/adafruit_feather_rp2040_rfm9x.md
@@ -9,7 +9,7 @@ board_url:
  - "https://www.adafruit.com/product/5714"
 board_image: "adafruit_feather_rp2040_rfm9x.jpg"
 date_added: 2023-04-04
-family: raspberrypi
+family: rp2040
 download_instructions: https://learn.adafruit.com/feather-rp2040-rfm95/circuitpython
 features:
   - Feather-Compatible

--- a/_board/adafruit_feather_rp2040_scorpio.md
+++ b/_board/adafruit_feather_rp2040_scorpio.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/5650"
 board_image: "adafruit_feather_rp2040_scorpio.jpg"
 date_added: 2022-12-23
-family: raspberrypi
+family: rp2040
 download_instructions: https://learn.adafruit.com/introducing-feather-rp2040-scorpio/install-circuitpython
 features:
   - Feather-Compatible

--- a/_board/adafruit_feather_rp2040_thinkink.md
+++ b/_board/adafruit_feather_rp2040_thinkink.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/5727"
 board_image: "adafruit_feather_rp2040_thinkink.jpg"
 date_added: 2023-05-02
-family: raspberrypi
+family: rp2040
 download_instructions: https://learn.adafruit.com/adafruit-rp2040-feather-thinkink/circuitpython
 tags:
   - ThinkInk Feather

--- a/_board/adafruit_feather_rp2040_usb_host.md
+++ b/_board/adafruit_feather_rp2040_usb_host.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/5723"
 board_image: "adafruit_feather_rp2040_usb_host.jpg"
 date_added: 2023-05-02
-family: raspberrypi
+family: rp2040
 download_instructions: https://learn.adafruit.com/adafruit-feather-rp2040-with-usb-type-a-host/circuitpython
 tags:
   - USB Host Feather

--- a/_board/adafruit_feather_rp2350.md
+++ b/_board/adafruit_feather_rp2350.md
@@ -8,7 +8,7 @@ board_url:
     - "https://www.adafruit.com/product/6000"
 board_image: "adafruit_feather_rp2350.jpg"
 date_added: 2024-08-08
-family: raspberrypi
+family: rp2350
 download_instructions: https://learn.adafruit.com/adafruit-feather-rp2350/install-circuitpython-2
 features:
   - Feather-Compatible

--- a/_board/adafruit_floppsy_rp2040.md
+++ b/_board/adafruit_floppsy_rp2040.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/"
 board_image: "adafruit_floppsy_rp2040.jpg"
 date_added: 2024-03-13
-family: raspberrypi
+family: rp2040
 features:
   - Display
   - USB-C

--- a/_board/adafruit_itsybitsy_rp2040.md
+++ b/_board/adafruit_itsybitsy_rp2040.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/4888"
 board_image: "adafruit_itsybitsy_rp2040.jpg"
 date_added: 2021-04-06
-family: raspberrypi
+family: rp2040
 download_instructions: https://learn.adafruit.com/adafruit-itsybitsy-rp2040/circuitpython
 features:
   - Breadboard-Friendly

--- a/_board/adafruit_kb2040.md
+++ b/_board/adafruit_kb2040.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/5302"
 board_image: "adafruit_kb2040.jpg"
 date_added: 2021-11-15
-family: raspberrypi
+family: rp2040
 download_instructions: https://learn.adafruit.com/adafruit-kb2040/circuitpython
 features:
   - STEMMA QT/QWIIC

--- a/_board/adafruit_macropad_rp2040.md
+++ b/_board/adafruit_macropad_rp2040.md
@@ -9,7 +9,7 @@ board_url:
  - "https://www.adafruit.com/product/5100"
 board_image: "adafruit_macropad_rp2040.jpg"
 date_added: 2021-06-04
-family: raspberrypi
+family: rp2040
 download_instructions: https://learn.adafruit.com/adafruit-macropad-rp2040/circuitpython
 features:
   - USB-C

--- a/_board/adafruit_metro_rp2040.md
+++ b/_board/adafruit_metro_rp2040.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/5786"
 board_image: "adafruit_metro_rp2040.jpg"
 date_added: 2023-07-28
-family: raspberrypi
+family: rp2040
 download_instructions: https://learn.adafruit.com/adafruit-metro-rp2040/circuitpython
 features:
   - STEMMA QT/QWIIC

--- a/_board/adafruit_metro_rp2350.md
+++ b/_board/adafruit_metro_rp2350.md
@@ -8,7 +8,7 @@ board_url:
     - "https://www.adafruit.com/product/6003"
 board_image: "adafruit_metro_rp2350.jpg"
 date_added: 2024-08-08
-family: raspberrypi
+family: rp2350
 features:
   - STEMMA QT/QWIIC
   - USB-C

--- a/_board/adafruit_qt2040_trinkey.md
+++ b/_board/adafruit_qt2040_trinkey.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/5056"
 board_image: "adafruit_qt2040_trinkey.jpg"
 date_added: 2021-05-26
-family: raspberrypi
+family: rp2040
 download_instructions: https://learn.adafruit.com/adafruit-trinkey-qt2040/circuitpython
 features:
 

--- a/_board/adafruit_qtpy_rp2040.md
+++ b/_board/adafruit_qtpy_rp2040.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.adafruit.com/product/4900"
 board_image: "adafruit_qtpy_rp2040.jpg"
 date_added: 2021-04-06
-family: raspberrypi
+family: rp2040
 download_instructions: https://learn.adafruit.com/adafruit-qt-py-2040/circuitpython
 features:
   - STEMMA QT/QWIIC

--- a/_board/archi.md
+++ b/_board/archi.md
@@ -8,7 +8,7 @@ board_url:
  - "https://archikids.com.ar/documentacion"
 board_image: "archi.jpg"
 date_added: 2022-06-26
-family: raspberrypi
+family: rp2040
 features:
   - Arduino Shield Compatible
   - USB-C

--- a/_board/arduino_nano_rp2040_connect.md
+++ b/_board/arduino_nano_rp2040_connect.md
@@ -8,7 +8,7 @@ board_url:
  - "https://store.arduino.cc/usa/nano-rp2040-connect-with-headers"
 board_image: "arduino_nano_rp2040_connect.jpg"
 date_added: 2021-05-24
-family: raspberrypi
+family: rp2040
 features:
   - Wi-Fi
   - Bluetooth/BTLE

--- a/_board/boardsource_blok.md
+++ b/_board/boardsource_blok.md
@@ -8,7 +8,7 @@ board_url:
  - "https://boardsource.xyz/store/628b95b494dfa308a6581622"
 board_image: "boardsource_blok.jpg"
 date_added: 2021-04-06
-family: raspberrypi
+family: rp2040
 features:
   - Breadboard-Friendly
   - USB-C

--- a/_board/bradanlanestudio_explorer_rp2040.md
+++ b/_board/bradanlanestudio_explorer_rp2040.md
@@ -7,7 +7,7 @@ manufacturer: "Bradán Lane STUDIO"
 board_url: https://aosc.cc/eccn2024
 board_image: "bradanlanestudio_explorer_rp2040.jpg"
 date_added: 2024-05-23
-family: raspberrypi
+family: rp2040
 tags:
 features:
   - Display

--- a/_board/breadstick_raspberry.md
+++ b/_board/breadstick_raspberry.md
@@ -9,7 +9,7 @@ board_url:
  - "https://www.crowdsupply.com/breadstick-innovations/raspberry-breadstick"
 board_image: "breadstick_raspberry.jpg"
 date_added: 2023-12-14
-family: raspberrypi
+family: rp2040
 features:
   - USB-C
   - Breadboard-Friendly

--- a/_board/bwshockley_figpi.md
+++ b/_board/bwshockley_figpi.md
@@ -8,7 +8,7 @@ board_url:
  - "https://minifigboards.com/fig-pi"
 board_image: "bwshockley_figpi.jpg"
 date_added: 2022-08-22
-family: raspberrypi
+family: rp2040
 features:
   - STEMMA QT/QWIIC
 ---

--- a/_board/challenger_nb_rp2040_wifi.md
+++ b/_board/challenger_nb_rp2040_wifi.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.tindie.com/products/invector/challenger-nb-rp2040-wifi/"
 board_image: "challenger_nb_rp2040_wifi.jpg"
 date_added: 2021-11-15
-family: raspberrypi
+family: rp2040
 download_instructions: https://ilabs.se/product/challenger-nb-rp2040-wifi-with-u-fl-connector/#tab-getting-started
 features:
   - Wi-Fi

--- a/_board/challenger_rp2040_lora.md
+++ b/_board/challenger_rp2040_lora.md
@@ -9,7 +9,7 @@ board_url:
  - "https://thepihut.com/products/challenger-rp2040-lora-868mhz"
 board_image: "challenger_rp2040_lora.jpg"
 date_added: 2022-06-09
-family: raspberrypi
+family: rp2040
 download_instructions: https://ilabs.se/product/challenger-rp2040-lora/#tab-getting-started
 features:
   - LoRa/Radio

--- a/_board/challenger_rp2040_lte.md
+++ b/_board/challenger_rp2040_lte.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.tindie.com/products/invector/challenger-rp2040-lte/"
 board_image: "challenger_rp2040_lte.jpg"
 date_added: 2021-11-15
-family: raspberrypi
+family: rp2040
 download_instructions: https://ilabs.se/product/challenger-rp2040-lte/#tab-getting-started
 features:
   - Wi-Fi

--- a/_board/challenger_rp2040_sdrtc.md
+++ b/_board/challenger_rp2040_sdrtc.md
@@ -8,7 +8,7 @@ board_url:
  - "https://ilabs.se/product/challenger-rp2040-sd-rtc/"
 board_image: "challenger_rp2040_sdrtc.jpg"
 date_added: 2022-12-23
-family: raspberrypi
+family: rp2040
 download_instructions: https://ilabs.se/product/challenger-rp2040-sd-rtc/#tab-getting-started
 features:
   - USB-C

--- a/_board/challenger_rp2040_subghz.md
+++ b/_board/challenger_rp2040_subghz.md
@@ -8,7 +8,7 @@ board_url:
  - "https://ilabs.se/product/challenger-rp2040-subghz-915mhz/"
 board_image: "challenger_rp2040_subghz.jpg"
 date_added: 2022-10-06
-family: raspberrypi
+family: rp2040
 download_instructions: https://ilabs.se/product/challenger-rp2040-subghz-915mhz/#tab-getting-started
 features:
   - LoRa/Radio

--- a/_board/challenger_rp2040_wifi.md
+++ b/_board/challenger_rp2040_wifi.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.tindie.com/products/invector/challenger-rp2040-wifi/"
 board_image: "challenger_rp2040_wifi.jpg"
 date_added: 2021-09-16
-family: raspberrypi
+family: rp2040
 download_instructions: https://ilabs.se/product/challenger-2040-wifi-chip/#tab-getting-started
 features:
   - Wi-Fi

--- a/_board/challenger_rp2040_wifi_ble.md
+++ b/_board/challenger_rp2040_wifi_ble.md
@@ -8,7 +8,7 @@ board_url:
  - "https://ilabs.se/product/challenger-rp2040-wifi-ble-with-chip-antenna/"
 board_image: "challenger_rp2040_wifi_ble.jpg"
 date_added: 2022-10-06
-family: raspberrypi
+family: rp2040
 download_instructions: https://ilabs.se/product/challenger-rp2040-wifi-ble-with-chip-antenna/#tab-getting-started
 features:
   - Wi-Fi

--- a/_board/challenger_rp2350_bconnect.md
+++ b/_board/challenger_rp2350_bconnect.md
@@ -8,7 +8,7 @@ board_url:
  - "https://ilabs.se/product/challenger-rp2350-bconnect/"
 board_image: "challenger_rp2350_bconnect.jpg"
 date_added: 2024-09-16
-family: raspberrypi
+family: rp2350
 download_instructions: https://ilabs.se/product/challenger-rp2350-bconnect/#tab-getting-started
 features:
   - USB-C

--- a/_board/challenger_rp2350_wifi6_ble5.md
+++ b/_board/challenger_rp2350_wifi6_ble5.md
@@ -8,7 +8,7 @@ board_url:
  - "https://ilabs.se/product/challenger-rp2350-wifi-ble/"
 board_image: "challenger_rp2350_wifi6_ble5.jpg"
 date_added: 2024-09-16
-family: raspberrypi
+family: rp2350
 download_instructions: https://ilabs.se/product/challenger-rp2350-wifi-ble/#tab-getting-started
 features:
   - USB-C

--- a/_board/cosmo_pico.md
+++ b/_board/cosmo_pico.md
@@ -8,7 +8,7 @@ board_url:
  - "https://edtechzine.jp/article/detail/8715"
 board_image: "cosmo_pico.jpg"
 date_added: 2023-03-01
-family: raspberrypi
+family: rp2040
 features:
   - Wi-Fi
   - Bluetooth/BTLE

--- a/_board/cytron_edu_pico_w.md
+++ b/_board/cytron_edu_pico_w.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.cytron.io/p-edu-project-and-innovation-kits-for-pico-w"
 board_image: "cytron_edu_pico_w.jpg"
 date_added: 2024-01-24
-family: raspberrypi
+family: rp2040
 download_instructions: https://drive.google.com/file/d/11HsdBkVWlOHMAWY-yf4V_Gd5FLM9MIwv/view
 features:
   - Battery Charging

--- a/_board/cytron_iriv_io_controller.md
+++ b/_board/cytron_iriv_io_controller.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.cytron.io/p-iriv-ioc"
 board_image: "cytron_iriv_io_controller.png"
 date_added: 2024-08-08
-family: raspberrypi
+family: rp2350
 
 ---
 

--- a/_board/cytron_maker_nano_rp2040.md
+++ b/_board/cytron_maker_nano_rp2040.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.cytron.io/p-maker-nano-rp2040"
 board_image: "cytron_maker_nano_rp2040.jpg"
 date_added: 2021-12-06
-family: raspberrypi
+family: rp2040
 download_instructions: https://github.com/CytronTechnologies/MAKER-NANO-RP2040#circuitpython
 features:
   - Speaker

--- a/_board/cytron_maker_pi_rp2040.md
+++ b/_board/cytron_maker_pi_rp2040.md
@@ -9,7 +9,7 @@ board_url:
  - "https://www.adafruit.com/product/5129"
 board_image: "cytron_maker_pi_rp2040.jpg"
 date_added: 2021-05-31
-family: raspberrypi
+family: rp2040
 download_instructions: https://github.com/CytronTechnologies/MAKER-PI-RP2040#circuitpython
 features:
   - Battery Charging

--- a/_board/cytron_maker_uno_rp2040.md
+++ b/_board/cytron_maker_uno_rp2040.md
@@ -8,7 +8,7 @@ board_url:
  - "https://my.cytron.io/p-maker-uno-rp2040"
 board_image: "cytron_maker_uno_rp2040.jpg"
 date_added: 2023-12-14
-family: raspberrypi
+family: rp2040
 download_instructions: https://my.cytron.io/tutorial/getting-started-guide-with-maker-uno-rp2040-circuitpython
 features:
   - Battery Charging

--- a/_board/cytron_motion_2350_pro.md
+++ b/_board/cytron_motion_2350_pro.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.cytron.io/p-motion-2350-pro"
 board_image: "cytron_motion_2350_pro.png"
 date_added: 2024-08-08
-family: raspberrypi
+family: rp2350
 download_instructions: https://www.cytron.io/tutorial/getting-started-with-motion-2350-pro-cp
 
 ---

--- a/_board/datanoise_picoadk.md
+++ b/_board/datanoise_picoadk.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.tindie.com/products/datanoisetv/picoadk-audio-development-kit-raspberry-rp2040/"
 board_image: "datanoise_picoadk.jpg"
 date_added: 2023-07-28
-family: raspberrypi
+family: rp2040
 features:
   - STEMMA QT/QWIIC
   - USB-C

--- a/_board/datanoise_picoadk_v2.md
+++ b/_board/datanoise_picoadk_v2.md
@@ -8,7 +8,7 @@ board_url:
  - "https://datanoise.shop/products/picoadk-v2"
 board_image: "datanoise_picoadk_v2.jpg"
 date_added: 2024-10-08
-family: raspberrypi
+family: rp2350
 features:
   - STEMMA QT/QWIIC
   - USB-C

--- a/_board/e_fidget.md
+++ b/_board/e_fidget.md
@@ -8,7 +8,7 @@ board_url:
  - "https://e-fidget.xyz"
 board_image: "e_fidget.jpg"
 date_added: 2023-01-04
-family: raspberrypi
+family: rp2040
 features:
   - Battery Charging
   - USB-C

--- a/_board/elecfreaks_picoed.md
+++ b/_board/elecfreaks_picoed.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.elecfreaks.com/picoed.html"
 board_image: "elecfreaks_picoed.jpg"
 date_added: 2022-04-21
-family: raspberrypi
+family: rp2040
 download_instructions: https://www.elecfreaks.com/learn-en/pico-ed/index.html
 features:
   - Speaker

--- a/_board/electrolama_minik.md
+++ b/_board/electrolama_minik.md
@@ -8,7 +8,7 @@ board_url:
  - "https://github.com/electrolama/minik"
 board_image: "electrolama_minik.jpg"
 date_added: 2022-08-22
-family: raspberrypi
+family: rp2040
 features:
 
 ---

--- a/_board/hack_club_sprig.md
+++ b/_board/hack_club_sprig.md
@@ -8,7 +8,7 @@ board_url:
  - "https://sprig.hackclub.com"
 board_image: "hack_club_sprig.jpeg"
 date_added: 2023-02-03
-family: raspberrypi
+family: rp2040
 features:
   - Display
   - Speaker

--- a/_board/jpconstantineau_encoderpad_rp2040.md
+++ b/_board/jpconstantineau_encoderpad_rp2040.md
@@ -8,7 +8,7 @@ board_url:
  - "https://github.com/jpconstantineau/EncoderPad_RP2040"
 board_image: "jpconstantineau_encoderpad_rp2040.jpg"
 date_added: 2021-09-02
-family: raspberrypi
+family: rp2040
 
 features:
   - USB-C

--- a/_board/jpconstantineau_pykey18.md
+++ b/_board/jpconstantineau_pykey18.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "jpconstantineau_pykey18.jpg"
 downloads_display: true
 date_added: 2021-12-15
-family: raspberrypi
+family: rp2040
 
 features:
   - USB-C

--- a/_board/jpconstantineau_pykey44.md
+++ b/_board/jpconstantineau_pykey44.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "jpconstantineau_pykey44.jpg"
 downloads_display: True
 date_added: 2021-12-15
-family: raspberrypi
+family: rp2040
 
 features:
   - USB-C

--- a/_board/jpconstantineau_pykey60.md
+++ b/_board/jpconstantineau_pykey60.md
@@ -8,7 +8,7 @@ board_url:
  - "https://github.com/jpconstantineau/PyKey60"
 board_image: "jpconstantineau_pykey60.jpg"
 date_added: 2021-09-17
-family: raspberrypi
+family: rp2040
 
 features:
   - USB-C

--- a/_board/jpconstantineau_pykey87.md
+++ b/_board/jpconstantineau_pykey87.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "jpconstantineau_pykey87.jpg"
 downloads_display: true
 date_added: 2021-12-15
-family: raspberrypi
+family: rp2040
 
 features:
   - USB-C

--- a/_board/lilygo_t_display_rp2040.md
+++ b/_board/lilygo_t_display_rp2040.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.lilygo.cc/products/t-display-rp2040"
 board_image: "lilygo_t_display_rp2040.jpg"
 date_added: 2023-05-15
-family: raspberrypi
+family: rp2040
 features:
   - Battery Charging
   - USB-C

--- a/_board/maple_elite_pi.md
+++ b/_board/maple_elite_pi.md
@@ -8,7 +8,7 @@ board_url:
  - "https://keeb.io/products/elite-pi-usb-c-pro-micro-replacement-rp2040"
 board_image: "maple_elite_pi.jpg"
 date_added: 2023-11-15
-family: raspberrypi
+family: rp2040
 features:
   - USB-C
   - Breadboard-Friendly

--- a/_board/melopero_shake_rp2040.md
+++ b/_board/melopero_shake_rp2040.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.melopero.com/melopero-shake-rp2040"
 board_image: "melopero_shake_rp2040.jpg"
 date_added: 2021-09-22
-family: raspberrypi
+family: rp2040
 features:
   - Feather-Compatible
   - Battery Charging

--- a/_board/nullbits_bit_c_pro.md
+++ b/_board/nullbits_bit_c_pro.md
@@ -8,7 +8,7 @@ board_url:
  - "https://nullbits.co/bit-c-pro/"
 board_image: "nullbits_bit_c_pro.jpg"
 date_added: 2023-01-31
-family: raspberrypi
+family: rp2040
 features:
   - USB-C
   - Breadboard-Friendly

--- a/_board/odt_bread_2040.md
+++ b/_board/odt_bread_2040.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.tindie.com/products/24791/"
 board_image: "odt_bread_2040.jpg"
 date_added: 2021-10-17
-family: raspberrypi
+family: rp2040
 features:
   - USB-C
   - Breadboard-Friendly

--- a/_board/odt_cast_away_rp2040.md
+++ b/_board/odt_cast_away_rp2040.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.tindie.com/products/oakdevtech/cast-away-rp2040-a-castellated-rp2040-dev-board/"
 board_image: "odt_cast_away_rp2040.jpg"
 date_added: 2022-01-04
-family: raspberrypi
+family: rp2040
 features:
   - USB-C
   - Breadboard-Friendly

--- a/_board/odt_rpga_feather.md
+++ b/_board/odt_rpga_feather.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.tindie.com/products/oakdevtech/rpga-feather-rp2040-ice40/"
 board_image: "odt_rpga_feather.jpg"
 date_added: 2024-06-07
-family: raspberrypi
+family: rp2040
 features:
   - STEMMA QT/QWIIC
   - USB-C

--- a/_board/pajenicko_picopad.md
+++ b/_board/pajenicko_picopad.md
@@ -8,7 +8,7 @@ board_url:
  - "https://github.com/Pajenicko/Picopad"
 board_image: "pajenicko_picopad.jpg"
 date_added: 2023-07-25
-family: raspberrypi
+family: rp2040
 download_instructions: https://github.com/Pajenicko/Picopad/tree/main/circuitpython
 features:
   - Display

--- a/_board/picomo_v2.md
+++ b/_board/picomo_v2.md
@@ -8,7 +8,7 @@ board_url:
   - "https://go.heia-fr.ch/picomo"
 board_image: "picomo_v2.jpg"
 date_added: 2024-01-25
-family: raspberrypi
+family: rp2040
 features:
   - Speaker
   - Display

--- a/_board/pimoroni_badger2040.md
+++ b/_board/pimoroni_badger2040.md
@@ -8,7 +8,7 @@ board_url:
  - "https://shop.pimoroni.com/products/badger-2040"
 board_image: "pimoroni_badger2040.jpg"
 date_added: 2022-02-24
-family: raspberrypi
+family: rp2040
 download_instructions: https://learn.pimoroni.com/article/getting-started-with-badger-2040
 features:
   - Display

--- a/_board/pimoroni_badger2040w.md
+++ b/_board/pimoroni_badger2040w.md
@@ -8,7 +8,7 @@ board_url:
  - "https://shop.pimoroni.com/products/badger-2040-w"
 board_image: "pimoroni_badger2040w.jpg"
 date_added: 2023-05-09
-family: raspberrypi
+family: rp2040
 download_instructions: https://learn.pimoroni.com/article/getting-started-with-badger-2040
 tags:
   - picow

--- a/_board/pimoroni_inky_frame_5_7.md
+++ b/_board/pimoroni_inky_frame_5_7.md
@@ -8,7 +8,7 @@ board_url:
  - "https://shop.pimoroni.com/products/inky-frame-5-7"
 board_image: "pimoroni_inky_frame_5_7.jpg"
 date_added: 2023-06-05
-family: raspberrypi
+family: rp2040
 download_instructions: https://learn.pimoroni.com/article/getting-started-with-inky-frame
 tags:
   - picow

--- a/_board/pimoroni_inky_frame_7_3.md
+++ b/_board/pimoroni_inky_frame_7_3.md
@@ -8,7 +8,7 @@ board_url:
  - "https://shop.pimoroni.com/products/inky-frame-7-3"
 board_image: "pimoroni_inky_frame_7_3.jpg"
 date_added: 2024-03-13
-family: raspberrypi
+family: rp2040
 download_instructions: https://learn.pimoroni.com/article/getting-started-with-inky-frame
 tags:
   - picow

--- a/_board/pimoroni_interstate75.md
+++ b/_board/pimoroni_interstate75.md
@@ -9,7 +9,7 @@ board_url:
  - "https://www.adafruit.com/product/5342"
 board_image: "pimoroni_interstate75.jpg"
 date_added: 2021-12-02
-family: raspberrypi
+family: rp2040
 download_instructions: https://learn.pimoroni.com/article/getting-started-with-interstate-75#circuitpython
 features:
   - External Display

--- a/_board/pimoroni_keybow2040.md
+++ b/_board/pimoroni_keybow2040.md
@@ -9,7 +9,7 @@ board_url:
  - "https://www.adafruit.com/product/4144"
 board_image: "pimoroni_keybow2040.jpg"
 date_added: 2021-02-24
-family: raspberrypi
+family: rp2040
 download_instructions: https://learn.pimoroni.com/article/circuitpython-and-keybow-2040
 features:
   - USB-C

--- a/_board/pimoroni_motor2040.md
+++ b/_board/pimoroni_motor2040.md
@@ -8,7 +8,7 @@ board_url:
  - "https://shop.pimoroni.com/products/motor-2040"
 board_image: "pimoroni_motor2040.jpg"
 date_added: 2022-06-15
-family: raspberrypi
+family: rp2040
 features:
   - Robotics
   - STEMMA QT/QWIIC

--- a/_board/pimoroni_pga2040.md
+++ b/_board/pimoroni_pga2040.md
@@ -8,7 +8,7 @@ board_url:
  - "https://shop.pimoroni.com/products/pga2040"
 board_image: "pimoroni_pga2040.jpg"
 date_added: 2021-06-10
-family: raspberrypi
+family: rp2040
 ---
 
 A minimal RP2040 breakout board wrangled into a Pin Grid Array, with a maximal dash of retraux style. PGA2040 has no USB port, LED or buttons but it does have an embed-friendly 21mm square footprint, 8MB of flash and lots of exposed RP2040 pins to play with.

--- a/_board/pimoroni_pga2350.md
+++ b/_board/pimoroni_pga2350.md
@@ -8,7 +8,7 @@ board_url:
  - "https://shop.pimoroni.com/products/pga2350"
 board_image: "pimoroni_pga2350.jpg"
 date_added: 2024-08-22
-family: raspberrypi
+family: rp2350
 ---
 
 A minimal but powerful RP2350 breakout board modelled on a Pin Grid Array, with the maximum exposed pins crammed into the smallest possible space.

--- a/_board/pimoroni_pico_dv_base.md
+++ b/_board/pimoroni_pico_dv_base.md
@@ -9,7 +9,7 @@ board_url:
  - "https://www.adafruit.com/product/5674"
 board_image: "pimoroni_pico_dv_base.jpg"
 date_added: 2023-05-04
-family: raspberrypi
+family: rp2040
 ---
 
 A demo board for exploring the digital video and audio capabilities of Raspberry Pi Pico, with

--- a/_board/pimoroni_pico_dv_base_w.md
+++ b/_board/pimoroni_pico_dv_base_w.md
@@ -9,7 +9,7 @@ board_url:
  - "https://www.adafruit.com/product/5674"
 board_image: "pimoroni_pico_dv_base_w.jpg"
 date_added: 2023-08-29
-family: raspberrypi
+family: rp2040
 ---
 
 A demo board for exploring the digital video and audio capabilities of Raspberry Pi Pico or Pico W, with

--- a/_board/pimoroni_pico_plus2.md
+++ b/_board/pimoroni_pico_plus2.md
@@ -8,7 +8,7 @@ board_url:
  - "https://shop.pimoroni.com/products/pimoroni-pico-plus-2"
 board_image: "pimoroni_pico_plus2.jpg"
 date_added: 2024-08-22
-family: raspberrypi
+family: rp2350
 features:
   - Battery Charging
   - USB-C

--- a/_board/pimoroni_pico_plus2w.md
+++ b/_board/pimoroni_pico_plus2w.md
@@ -8,7 +8,7 @@ board_url:
  - "https://shop.pimoroni.com/products/pimoroni-pico-plus-2-w"
 board_image: "pimoroni_pico_plus2w.jpg"
 date_added: 2024-11-24
-family: raspberrypi
+family: rp2350
 features:
   - Battery Charging
   - USB-C

--- a/_board/pimoroni_picolipo_16mb.md
+++ b/_board/pimoroni_picolipo_16mb.md
@@ -8,7 +8,7 @@ board_url:
  - "https://shop.pimoroni.com/products/picolipo"
 board_image: "pimoroni_picolipo.jpg"
 date_added: 2021-05-12
-family: raspberrypi
+family: rp2040
 features:
   - Battery Charging
   - USB-C

--- a/_board/pimoroni_picolipo_4mb.md
+++ b/_board/pimoroni_picolipo_4mb.md
@@ -8,7 +8,7 @@ board_url:
  - "https://shop.pimoroni.com/products/picolipo"
 board_image: "pimoroni_picolipo.jpg"
 date_added: 2021-05-12
-family: raspberrypi
+family: rp2040
 features:
   - Battery Charging
   - USB-C

--- a/_board/pimoroni_picosystem.md
+++ b/_board/pimoroni_picosystem.md
@@ -8,7 +8,7 @@ board_url:
  - "https://shop.pimoroni.com/products/picosystem"
 board_image: "pimoroni_picosystem.jpg"
 date_added: 2021-02-24
-family: raspberrypi
+family: rp2040
 features:
   - Speaker
   - Battery Charging

--- a/_board/pimoroni_plasma2040.md
+++ b/_board/pimoroni_plasma2040.md
@@ -8,7 +8,7 @@ board_url:
  - "https://shop.pimoroni.com/products/plasma-2040"
 board_image: "pimoroni_plasma2040.jpg"
 date_added: 2021-08-11
-family: raspberrypi
+family: rp2040
 download_instructions: https://learn.pimoroni.com/article/plasma-2040#circuitpython
 features:
   - STEMMA QT/QWIIC

--- a/_board/pimoroni_plasma2040w.md
+++ b/_board/pimoroni_plasma2040w.md
@@ -8,7 +8,7 @@ board_url:
  - "https://shop.pimoroni.com/products/plasma-stick-2040-w"
 board_image: "pimoroni_plasma2040w.jpg"
 date_added: 2023-05-09
-family: raspberrypi
+family: rp2040
 download_instructions: https://learn.pimoroni.com/article/plasma-2040#circuitpython
 tags:
   - picow

--- a/_board/pimoroni_plasma2350.md
+++ b/_board/pimoroni_plasma2350.md
@@ -8,7 +8,7 @@ board_url:
  - "https://shop.pimoroni.com/products/plasma-2350"
 board_image: "pimoroni_plasma2350.jpg"
 date_added: 2024-08-22
-family: raspberrypi
+family: rp2350
 features:
   - STEMMA QT/QWIIC
   - USB-C

--- a/_board/pimoroni_servo2040.md
+++ b/_board/pimoroni_servo2040.md
@@ -9,7 +9,7 @@ board_url:
  - "https://www.adafruit.com/product/5437"
 board_image: "pimoroni_servo2040.jpg"
 date_added: 2022-04-01
-family: raspberrypi
+family: rp2040
 features:
   - Robotics
   - STEMMA QT/QWIIC

--- a/_board/pimoroni_tiny2040.md
+++ b/_board/pimoroni_tiny2040.md
@@ -8,7 +8,7 @@ board_url:
  - "https://shop.pimoroni.com/products/tiny-2040"
 board_image: "pimoroni_tiny2040.jpg"
 date_added: 2021-02-24
-family: raspberrypi
+family: rp2040
 
 features:
   - USB-C

--- a/_board/pimoroni_tiny2040_2mb.md
+++ b/_board/pimoroni_tiny2040_2mb.md
@@ -8,7 +8,7 @@ board_url:
  - "https://shop.pimoroni.com/products/tiny-2040?variant=39560012300371"
 board_image: "pimoroni_tiny2040_2mb.jpg"
 date_added: 2021-12-02
-family: raspberrypi
+family: rp2040
 
 features:
   - USB-C

--- a/_board/pimoroni_tiny2350.md
+++ b/_board/pimoroni_tiny2350.md
@@ -8,7 +8,7 @@ board_url:
  - "https://shop.pimoroni.com/products/tiny-2350"
 board_image: "pimoroni_tiny2350.jpg"
 date_added: 2024-08-22
-family: raspberrypi
+family: rp2350
 
 features:
   - USB-C

--- a/_board/pimoroni_tinyfx.md
+++ b/_board/pimoroni_tinyfx.md
@@ -8,7 +8,7 @@ board_url:
  - "https://shop.pimoroni.com/products/tinyfx"
 board_image: "pimoroni_tinyfx.jpg"
 date_added: 2024-09-02
-family: raspberrypi
+family: rp2040
 
 features:
   - USB-C

--- a/_board/raspberry_pi_pico.md
+++ b/_board/raspberry_pi_pico.md
@@ -10,7 +10,7 @@ board_url:
  - "https://www.adafruit.com/product/5525"
 board_image: "raspberry_pi_pico.jpg"
 date_added: 2021-01-21
-family: raspberrypi
+family: rp2040
 download_instructions: https://learn.adafruit.com/getting-started-with-raspberry-pi-pico-circuitpython/circuitpython
 features:
   - Breadboard-Friendly

--- a/_board/raspberry_pi_pico2.md
+++ b/_board/raspberry_pi_pico2.md
@@ -9,7 +9,7 @@ board_url:
 
 board_image: "raspberry_pi_pico2.jpg"
 date_added: 2024-08-08
-family: raspberrypi
+family: rp2350
 tags:
   - pico 2
 features:

--- a/_board/raspberry_pi_pico2_w.md
+++ b/_board/raspberry_pi_pico2_w.md
@@ -8,7 +8,7 @@ board_url:
   - "https://www.adafruit.com/product/6087"
 board_image: "raspberry_pi_pico2_w.jpg"
 date_added: 2024-11-25
-family: raspberrypi
+family: rp2350
 tags:
   - pico 2
   - picow

--- a/_board/raspberry_pi_pico_w.md
+++ b/_board/raspberry_pi_pico_w.md
@@ -9,7 +9,7 @@ board_url:
  - "https://www.adafruit.com/product/5544"
 board_image: "raspberry_pi_pico_w.jpg"
 date_added: 2022-10-02
-family: raspberrypi
+family: rp2040
 download_instructions: https://learn.adafruit.com/pico-w-wifi-with-circuitpython/installing-circuitpython
 tags:
   - picow

--- a/_board/rfguru_rp2040.md
+++ b/_board/rfguru_rp2040.md
@@ -8,7 +8,7 @@ board_url:
  - "https://github.com/Guru-RF/MicroPico"
 board_image: "rfguru_rp2040.jpg"
 date_added: 2024-03-29
-family: raspberrypi
+family: rp2040
 features:
 
 ---

--- a/_board/seeeduino_xiao_rp2040.md
+++ b/_board/seeeduino_xiao_rp2040.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.seeedstudio.com/XIAO-RP2040-v1-0-p-5026.html"
 board_image: "seeeduino_xiao_rp2040.jpg"
 date_added: 2022-01-04
-family: raspberrypi
+family: rp2040
 download_instructions: https://wiki.seeedstudio.com/XIAO-RP2040-with-CircuitPython/
 features:
   - Breadboard-Friendly

--- a/_board/seeeduino_xiao_rp2350.md
+++ b/_board/seeeduino_xiao_rp2350.md
@@ -9,7 +9,7 @@ board_url:
  - "https://www.seeedstudio.com/Seeed-XIAO-RP2350-p-5944.html"
 board_image: "seeeduino_xiao_rp2350.jpg"
 date_added: 2024-08-29
-family: raspberrypi
+family: rp2350
 features:
   - Breadboard-Friendly
   - Xiao / QTPy Form Factor

--- a/_board/silicognition_rp2040_shim.md
+++ b/_board/silicognition_rp2040_shim.md
@@ -8,7 +8,7 @@ board_url:
  - "https://github.com/xorbit/RP2040-Shim"
 board_image: "silicognition-rp2040-shim.jpg"
 date_added: 2022-07-01
-family: raspberrypi
+family: rp2040
 features:
   - Feather-Compatible
   - Breadboard-Friendly

--- a/_board/solderparty_bbq20kbd.md
+++ b/_board/solderparty_bbq20kbd.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.solder.party/docs/bbq20kbd/"
 board_image: "solderparty_bbq20kbd.jpg"
 date_added: 2022-08-20
-family: raspberrypi
+family: rp2040
 bootloader_id: solderparty__bbq20kbd
 downloads_display: true
 blinka: false

--- a/_board/solderparty_rp2040_stamp.md
+++ b/_board/solderparty_rp2040_stamp.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.solder.party/docs/rp2040-stamp/"
 board_image: "solderparty_rp2040_stamp.jpg"
 date_added: 2021-11-15
-family: raspberrypi
+family: rp2040
 bootloader_id: solderparty_rp2040_stamp
 downloads_display: true
 blinka: false

--- a/_board/solderparty_rp2350_stamp.md
+++ b/_board/solderparty_rp2350_stamp.md
@@ -8,7 +8,7 @@ board_url:
     - "https://www.solder.party/docs/rp2350-stamp/"
 board_image: "solderparty_rp2350_stamp.jpg"
 date_added: 2024-08-08
-family: raspberrypi
+family: rp2350
 features:
   - Castellated Pads
 ---

--- a/_board/solderparty_rp2350_stamp_xl.md
+++ b/_board/solderparty_rp2350_stamp_xl.md
@@ -8,7 +8,7 @@ board_url:
     - "https://www.solder.party/docs/rp2350-stamp-xl/"
 board_image: "solderparty_rp2350_stamp_xl.jpg"
 date_added: 2024-08-08
-family: raspberrypi
+family: rp2350
 features:
   - Castellated Pads
 ---

--- a/_board/sparkfun_micromod_rp2040.md
+++ b/_board/sparkfun_micromod_rp2040.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.sparkfun.com/products/17720"
 board_image: "sparkfun_micromod_rp2040.jpg"
 date_added: 2021-05-26
-family: raspberrypi
+family: rp2040
 download_instructions: https://learn.sparkfun.com/tutorials/micromod-rp2040-processor-board-hookup-guide
 features:
 ---

--- a/_board/sparkfun_pro_micro_rp2040.md
+++ b/_board/sparkfun_pro_micro_rp2040.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.sparkfun.com/products/17717"
 board_image: "sparkfun_pro_micro_rp2040.jpg"
 date_added: 2021-04-06
-family: raspberrypi
+family: rp2040
 features:
   - STEMMA QT/QWIIC
   - USB-C

--- a/_board/sparkfun_pro_micro_rp2350.md
+++ b/_board/sparkfun_pro_micro_rp2350.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.sparkfun.com/products/24870"
 board_image: "sparkfun_pro_micro_rp2350.jpg"
 date_added: 2024-08-22
-family: raspberrypi
+family: rp2350
 features:
   - STEMMA QT/QWIIC
   - USB-C

--- a/_board/sparkfun_thing_plus_rp2040.md
+++ b/_board/sparkfun_thing_plus_rp2040.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.sparkfun.com/products/17745"
 board_image: "sparkfun_thing_plus_rp2040.jpg"
 date_added: 2021-04-06
-family: raspberrypi
+family: rp2040
 features:
   - Feather-Compatible
   - Battery Charging

--- a/_board/sparkfun_thing_plus_rp2350.md
+++ b/_board/sparkfun_thing_plus_rp2350.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.sparkfun.com/products/25134"
 board_image: "sparkfun_thing_plus_rp2350.jpg"
 date_added: 2024-11-15
-family: raspberrypi
+family: rp2350
 features:
   - Feather-Compatible
   - Battery Charging

--- a/_board/splitkb_liatris.md
+++ b/_board/splitkb_liatris.md
@@ -8,7 +8,7 @@ board_url:
  - "https://splitkb.com/products/liatris"
 board_image: "splitkb_liatris.jpg"
 date_added: 2023-07-28
-family: raspberrypi
+family: rp2040
 features:
   - STEMMA QT/QWIIC
   - USB-C

--- a/_board/takayoshiotake_octave_rp2040.md
+++ b/_board/takayoshiotake_octave_rp2040.md
@@ -8,7 +8,7 @@ board_url:
  - "https://github.com/takayoshiotake/octave-12-key-macropad"
 board_image: "takayoshiotake_octave_rp2040.jpg"
 date_added: 2022-08-22
-family: raspberrypi
+family: rp2040
 features:
   - USB-C
 ---

--- a/_board/ugame22.md
+++ b/_board/ugame22.md
@@ -8,7 +8,7 @@ board_url:
  - "https://hackaday.io/project/186921-game-22"
 board_image: "ugame22.jpg"
 date_added: 2023-10-27
-family: raspberrypi
+family: rp2040
 features:
   - Display
   - Speaker

--- a/_board/upico.md
+++ b/_board/upico.md
@@ -8,7 +8,7 @@ board_url:
  - "https://github.com/dotcypress/upico"
 board_image: "upico.jpg"
 date_added: 2023-11-29
-family: raspberrypi
+family: rp2040
 features:
 ---
 

--- a/_board/vcc_gnd_yd_rp2040.md
+++ b/_board/vcc_gnd_yd_rp2040.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.aliexpress.us/item/3256803817805852.html"
 board_image: "vcc_gnd_yd_rp2040.jpg"
 date_added: 2022-10-14
-family: raspberrypi
+family: rp2040
 features:
   - Breadboard-Friendly
   - USB-C

--- a/_board/waveshare_rp2040_geek.md
+++ b/_board/waveshare_rp2040_geek.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.waveshare.com/rp2040-geek.htm"
 board_image: "waveshare_rp2040_geek.jpg"
 date_added: 2024-03-29
-family: raspberrypi
+family: rp2040
 features:
   - STEMMA QT/QWIIC
   - Display

--- a/_board/waveshare_rp2040_lcd_0_96.md
+++ b/_board/waveshare_rp2040_lcd_0_96.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "waveshare_rp2040_lcd_0_96.jpg"
 date_added: 2023-04-07
 downloads_display: true
-family: raspberrypi
+family: rp2040
 features:
   - Battery Charging
   - Breadboard-Friendly

--- a/_board/waveshare_rp2040_lcd_1_28.md
+++ b/_board/waveshare_rp2040_lcd_1_28.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.waveshare.com/rp2040-lcd-1.28.htm"
 board_image: "waveshare_rp2040_lcd_1_28.jpg"
 date_added: 2023-01-31
-family: raspberrypi
+family: rp2040
 features:
   - USB-C
   - Battery Charging

--- a/_board/waveshare_rp2040_one.md
+++ b/_board/waveshare_rp2040_one.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.waveshare.com/product/rp2040-one.htm"
 board_image: "waveshare_rp2040_one.jpg"
 date_added: 2024-08-07
-family: raspberrypi
+family: rp2040
 features:
   - Breadboard-Friendly
   - Castellated Pads

--- a/_board/waveshare_rp2040_pizero.md
+++ b/_board/waveshare_rp2040_pizero.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.waveshare.com/rp2040-pizero.htm"
 board_image: "waveshare_rp2040_pizero.jpg"
 date_added: 2024-07-18
-family: raspberrypi
+family: rp2040
 features:
   - USB-C
   - Battery Charging

--- a/_board/waveshare_rp2040_plus_16mb.md
+++ b/_board/waveshare_rp2040_plus_16mb.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.waveshare.com/rp2040-plus.htm"
 board_image: "waveshare_rp2040_plus.jpg"
 date_added: 2023-10-27
-family: raspberrypi
+family: rp2040
 features:
   - USB-C
   - Breadboard-Friendly

--- a/_board/waveshare_rp2040_plus_4mb.md
+++ b/_board/waveshare_rp2040_plus_4mb.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.waveshare.com/rp2040-plus.htm"
 board_image: "waveshare_rp2040_plus.jpg"
 date_added: 2023-10-27
-family: raspberrypi
+family: rp2040
 features:
   - USB-C
   - Breadboard-Friendly

--- a/_board/waveshare_rp2040_tiny.md
+++ b/_board/waveshare_rp2040_tiny.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.waveshare.com/wiki/RP2040-Tiny"
 board_image: "waveshare_rp2040_tiny.jpg"
 date_added: 2024-03-18
-family: raspberrypi
+family: rp2040
 features:
   - Breadboard-Friendly
   - Castellated Pads

--- a/_board/waveshare_rp2040_touch_lcd_1_28.md
+++ b/_board/waveshare_rp2040_touch_lcd_1_28.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.waveshare.com/product/raspberry-pi/boards-kits/raspberry-pi-pico-cat/rp2040-touch-lcd-1.28.htm"
 board_image: "waveshare_rp2040_touch_lcd_1_28.jpg"
 date_added: 2023-10-27
-family: raspberrypi
+family: rp2040
 features:
   - USB-C
   - Battery Charging

--- a/_board/waveshare_rp2040_zero.md
+++ b/_board/waveshare_rp2040_zero.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.waveshare.com/rp2040-zero.htm"
 board_image: "waveshare_rp2040_zero.jpg"
 date_added: 2022-01-12
-family: raspberrypi
+family: rp2040
 features:
   - USB-C
   - Breadboard-Friendly

--- a/_board/weact_studio_pico.md
+++ b/_board/weact_studio_pico.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.aliexpress.com/item/3256803521775546.html"
 board_image: "weact_studio_pico.jpg"
 date_added: 2022-06-09
-family: raspberrypi
+family: rp2040
 features:
   - USB-C
   - Breadboard-Friendly

--- a/_board/weact_studio_pico_16mb.md
+++ b/_board/weact_studio_pico_16mb.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.aliexpress.com/item/3256803521775546.html?skuId=12000026898823783"
 board_image: "weact_studio_pico.jpg"
 date_added: 2022-12-23
-family: raspberrypi
+family: rp2040
 features:
   - USB-C
   - Breadboard-Friendly

--- a/_board/wisdpi_ardu2040m.md
+++ b/_board/wisdpi_ardu2040m.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.wisdpi.com/products/ardu2040m-rp2040-arduino-style-dev-board"
 board_image: "wisdpi_ardu2040m.jpg"
 date_added: 2023-12-11
-family: raspberrypi
+family: rp2040
 features:
   - Display
   - Arduino Shield Compatible

--- a/_board/wisdpi_tiny_rp2040.md
+++ b/_board/wisdpi_tiny_rp2040.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.wisdpi.com/products/wisdpi-tiny-rp2040-a-tiny-cool-rp2040-dev-board-with-4mb-flash"
 board_image: "wisdpi_tiny_rp2040.jpg"
 date_added: 2023-12-11
-family: raspberrypi
+family: rp2040
 features:
   - Breadboard-Friendly
   - USB-C

--- a/_board/wiznet_w5100s_evb_pico.md
+++ b/_board/wiznet_w5100s_evb_pico.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.wiznet.io/product-item/w5100s-evb-pico/"
 board_image: "w5100s-evb-pico.jpg"
 date_added: 2022-04-26
-family: raspberrypi
+family: rp2040
 features:
   - Breadboard-Friendly
   - Castellated Pads

--- a/_board/wiznet_w5100s_evb_pico2.md
+++ b/_board/wiznet_w5100s_evb_pico2.md
@@ -8,7 +8,7 @@ board_url:
  - "https://docs.wiznet.io/Product/iEthernet/W5100S/w5100s-evb-pico2"
 board_image: "wiznet_w5100s_evb_pico2.jpg"
 date_added: 2024-11-15
-family: raspberrypi
+family: rp2350
 features:
   - Breadboard-Friendly
   - Castellated Pads

--- a/_board/wiznet_w5500_evb_pico.md
+++ b/_board/wiznet_w5500_evb_pico.md
@@ -8,7 +8,7 @@ board_url:
  - "https://www.wiznet.io/product-item/w5500-evb-pico/"
 board_image: "w5500-evb-pico.jpg"
 date_added: 2022-07-25
-family: raspberrypi
+family: rp2040
 features:
   - Breadboard-Friendly
   - Castellated Pads

--- a/_board/wk-50.md
+++ b/_board/wk-50.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "wk_50.jpg"
 downloads_display: True
 date_added: 2024-09-12
-family: raspberrypi
+family: rp2040
 
 features:
   - USB-C

--- a/_board/zrichard_rp2.65-f.md
+++ b/_board/zrichard_rp2.65-f.md
@@ -8,7 +8,7 @@ board_url:
  - "https://github.com/BigTuna94/RP2.65-F"
 board_image: "zrichard_rp2.65-f.jpg"
 date_added: 2022-05-16
-family: raspberrypi
+family: rp2040
 features:
 
 ---

--- a/_data/bootloaders.json
+++ b/_data/bootloaders.json
@@ -21,7 +21,8 @@
         "stm": {},
         "cxd56": {},
         "mimxrt10xx": {},
-        "raspberrypi": {},
+        "rp2040": {},
+        "rp2350": {},
         "broadcom": {},
         "litex": {},
         "silabs": {}


### PR DESCRIPTION
As discussed during a recent meeting. Split `raspberrypi` processor family into `rp2040` and `rp2350`