### PR TITLE
pin ruby minor version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         python-version: 3.x
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3'
+        ruby-version: '3.3'
         bundler-cache: true
     - name: Install Dependencies
       run: |


### PR DESCRIPTION
Fixing only the ruby major version number has been a repeated problem for google-protobuf, which comes precompiled and lags in support for new ruby releases.

Instead, install a known good ruby minor version 3.3.

Closes: #1556 