### PR TITLE
Fix typo in index.html

### DIFF
--- a/libraries/index.html
+++ b/libraries/index.html
@@ -39,7 +39,7 @@ permalink: /libraries
       The precompiled <b>.mpy</b> files take up less space on your CIRCUITPY drive than the <b>.py</b> files.
       They also load faster, and for some low-RAM boards, are required because the <b>.py</b> files
       are too large to compile on the board itself.
-      <strong>Unless you need the source version, choose the appropiate <b>.mpy</b> library bundle!</strong>
+      <strong>Unless you need the source version, choose the appropriate <b>.mpy</b> library bundle!</strong>
       If you need to compile <b>.py</b> files to <b>.mpy</b>, you can
       <a href="https://learn.adafruit.com/welcome-to-circuitpython/frequently-asked-questions#how-can-i-create-my-own-mpy-files-3020687-11">run the <b>mpy-cross</b>
       cross-compiler yourself</a>.


### PR DESCRIPTION
Change 'appropiate' to 'appropriate'.