### PR TITLE
espressif_esp32_devkitc_v4_wroom_32e: fix title and name from WROVER (wrong)

### DIFF
--- a/_board/espressif_esp32_devkitc_v4_wroom_32e.md
+++ b/_board/espressif_esp32_devkitc_v4_wroom_32e.md
@@ -1,8 +1,8 @@
 ---
 layout: download
 board_id: "espressif_esp32_devkitc_v4_wroom_32e"
-title: "ESP32-DevKitC-VE-WROVER Download"
-name: "ESP32-DevKitC-VE-WROVER"
+title: "ESP32-DevKitC-V4-WROOM-32E Download"
+name: "ESP32-DevKitC-V4-WROOM-32E"
 manufacturer: "Espressif"
 board_url:
  - "https://www.adafruit.com/product/3269"
@@ -19,8 +19,6 @@ features:
 The ESP8266 started a small revolution by bringing WiFi to a small and cheap package that also had enough processing power and enough pins to get small things done. Now get ready to take your bite-sized WiFi capabilities to the next level with the **ESP32 Development Board!**
 
 The development board breaks out all the module’s pins to 0.1″ headers and provides a CP2102 USB-TTL serial adapter, programming and reset buttons, and a power regulator to supply the ESP32 with a stable 3.3 V. Espressif doubled-down on the CPU resources for the ESP32 with a dual core, running at 160MHz and tons more pins and peripherals.
-
-**Please note: The ESP32 is still targeted to developers**. Not all of the peripherals are fully documented with example code, and there are some bugs still being found and fixed. We got many sensors and displays working under Arduino IDE, so you can expect things like I2C and SPI and analog reads to work. But other elements are still under development. This board is designed for use with the Tensilica toolchain (ESP IDF) so we recommend that for better hardware-support coverage.
 
 Color of PCB may vary. Note that is is exactly large enough to cover both sides of a solderless breadboard with no left-over pins, so if you want to use with a solderless breadboard, use two side-by-side!
 


### PR DESCRIPTION
The human-readable name and title of this board were wrong.

(Stumbled on this due to https://github.com/adafruit/circuitpython/issues/9960)

Also I removed some obsolete verbiage about the newness. That's still on the product page.