### PR TITLE
Fix: TypeError while searching on Blinka page

### DIFF
--- a/assets/javascript/downloads.js
+++ b/assets/javascript/downloads.js
@@ -353,7 +353,7 @@ function filterResults() {
       // exact tag match re-order
       if (downloadsSearch.searchTerm !== null && downloadsSearch.searchTerm !== undefined) {
         let searched = downloadsSearch.searchTerm.toLowerCase();
-        let tags = download.getAttribute("data-tags").split(",");
+        let tags = download.dataset.tags?.split(",") || [];
         if (searched !== "" && tags.indexOf(searched) >= 0) {
           let parent = download.parentElement;
           parent.removeChild(download);


### PR DESCRIPTION
Typing any phrase in search bar on  "Blinka" page and then removing it does not correctly display all the cards.
The underlying issue is using `.split()` on `undefined`, which prevents the function from completing.

![image](https://github.com/user-attachments/assets/b1659515-d7d1-456c-9ad3-f09209b28904)

Spotted by @FoamyGuy during th Saturday stream: https://www.youtube.com/watch?v=8czmvgN3Q70&t=360s