### PR TITLE
include how much flash in 8MB no psram ESP32-S3 board names

### DIFF
--- a/_board/adafruit_feather_esp32s3_nopsram.md
+++ b/_board/adafruit_feather_esp32s3_nopsram.md
@@ -1,8 +1,8 @@
 ---
 layout: download
 board_id: "adafruit_feather_esp32s3_nopsram"
-title: "Feather ESP32-S3 No PSRAM Download"
-name: "Feather ESP32-S3 No PSRAM"
+title: "Feather ESP32-S3 8MB Flash No PSRAM Download"
+name: "Feather ESP32-S3 8MB Flash No PSRAM"
 manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5323"

--- a/_board/adafruit_qtpy_esp32s3_nopsram.md
+++ b/_board/adafruit_qtpy_esp32s3_nopsram.md
@@ -1,8 +1,8 @@
 ---
 layout: download
 board_id: "adafruit_qtpy_esp32s3_nopsram"
-title: "Adafruit QT Py ESP32-S3 No PSRAM Download"
-name: "Adafruit QT Py ESP32-S3 No PSRAM"
+title: "Adafruit QT Py ESP32-S3 8MB Flash No PSRAM Download"
+name: "Adafruit QT Py ESP32-S3 8MB Flash No PSRAM"
 manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5426"


### PR DESCRIPTION
Two ESP32-S3 boards did not include "8MB Flash" in their names. Do this explicitly.

Example of user confusion: https://discord.com/channels/327254708534116352/537365702651150357/1332080125835083839