### PR TITLE
Make Feather ESP32 V2 show up in search for "huzzah"

### DIFF
--- a/_board/adafruit_feather_esp32_v2.md
+++ b/_board/adafruit_feather_esp32_v2.md
@@ -11,6 +11,8 @@ date_added: 2022-08-19
 family: esp32
 downloads_display: true
 download_instructions: https://learn.adafruit.com/adafruit-esp32-feather-v2/circuitpython
+tags:
+    - Huzzah
 features:
   - Feather-Compatible
   - Battery Charging


### PR DESCRIPTION
.. since this word is associated with the Feather ESP32 and is shown in large letters on the bottom of the V2 board.
![image](https://github.com/user-attachments/assets/5dbf87e2-0ea3-41c9-9dde-73a9720287a5)
