### PR TITLE
drop 8.x bundles

### DIFF
--- a/libraries/index.html
+++ b/libraries/index.html
@@ -33,7 +33,7 @@ permalink: /libraries
       versions of Python source code.
       <strong>Make sure to download the bundle that matches the major version
       of your CircuitPython</strong>, because the <b>.mpy</b> files can change between versions.
-      For example, if you are running 8.2.7 you should download the 8.x bundle.
+      For example, if you are running 9.2.4 you should download the 9.x bundle.
     </p>
     <p>
       The precompiled <b>.mpy</b> files take up less space on your CIRCUITPY drive than the <b>.py</b> files.
@@ -65,20 +65,12 @@ permalink: /libraries
   </section>
   <section>
     <h2>Bundles</h2>
-    <div class="release-section">
-      <div id="adafruit-circuitpython-bundle-8.x-mpy">
-          <h3>Bundle for Version 8.x</h3>
-          <p>
-              This bundle is built for use with CircuitPython 8.x.x. If you are using
-              CircuitPython 8, please download this bundle.
-          </p>
-      </div>
       <div id="adafruit-circuitpython-bundle-9.x-mpy">
           <h3>Bundle for Version 9.x</h3>
           <p>
               This bundle is built for use with CircuitPython 9.x.x. If you are using
-              CircuitPython 9, please download this bundle. The .mpy format has
-              changed as of CircuitPython 9, so 8.x libraries are <em>not</em> compatible.
+              CircuitPython 9, please download this bundle. The .mpy format
+              changed as of CircuitPython 9: 8.x libraries are <em>not</em> compatible.
           </p>
       </div>
       <div>
@@ -115,19 +107,12 @@ permalink: /libraries
       <a href="https://github.com/adafruit/CircuitPython_Community_Bundle/">Community Bundle</a>.
     </p>
     <div class="release-section">
-      <div id="circuitpython-community-bundle-8.x-mpy">
-        <h3>Bundle for Version 8.x</h3>
-        <p>
-          This bundle is built for use with CircuitPython 8.x.x. If you are using
-          CircuitPython 8, please download this bundle.
-        </p>
-      </div>
       <div id="circuitpython-community-bundle-9.x-mpy">
           <h3>Bundle for Version 9.x</h3>
           <p>
               This bundle is built for use with CircuitPython 9.x.x. If you are using
-              CircuitPython 9, please download this bundle. The .mpy format has
-              changed as of CircuitPython 9, so 8.x libraries are <em>not</em> compatible.
+              CircuitPython 9, please download this bundle. The .mpy format
+              changed as of CircuitPython 9: 8.x libraries are <em>not</em> compatible.
           </p>
       </div>
       <div>


### PR DESCRIPTION
As discussed in the weekly CircuitPython meeting, https://github.com/adafruit/adafruit-circuitpython-weekly-meeting/blob/main/2025/2025-02-03.md#2643-in-the-weeds, we will drop building 8.x bundles.

- This is on the checklist here: https://github.com/adafruit/circuitpython/issues/9001