### PR TITLE
Exchange board description of waveshare_esp32_s3_matrix and waveshare_esp32_s3_eth

### DIFF
--- a/_board/waveshare_esp32_s3_eth.md
+++ b/_board/waveshare_esp32_s3_eth.md
@@ -1,11 +1,11 @@
 ---
 layout: download
 board_id: "waveshare_esp32_s3_eth"
-title: "ESP32-S3-Matrix Development Board Download"
-name: "ESP32-S3-Matrix Development Board"
+title: "ESP32-S3 ETH Development Board Download"
+name: "ESP32-S3 ETH Development Board"
 manufacturer: "Waveshare"
 board_url:
- - "https://www.waveshare.com/product/arduino/boards-kits/esp32/esp32-s3-matrix.htm"
+ - "https://www.waveshare.com/product/arduino/boards-kits/esp32/esp32-s3-eth.htm"
 board_image: "waveshare_esp32_s3_eth.jpg"
 date_added: 2025-01-27
 family: esp32s3
@@ -16,23 +16,24 @@ features:
   - USB-C
 ---
 
-ESP32-S3-Matrix Development Board, Onboard 8×8 RGB LED Matrix and QMI8658 Attitude Sensor, supports Wi-Fi and Bluetooth LE, ESP32 Development Board
+ESP32-S3 ETH Development Board, 10/100Mbps RJ45 Ethernet port, Wi-Fi & Bluetooth Support, 240MHz Dual Core Processor, Onboard Type-C Port And TF Card Slot, Optional For PoE Module And Camera Module
+
+This is an ETH development board based on ESP32-S3R8, supports Wi-Fi and Bluetooth wireless communication, with reliable and efficient wired Ethernet connectivity, optional for PoE function. Onboard camera interface, compatible with OV2640, OV5640 and other mainstream cameras for image and video capture. Compatible with Pico header, it can be used with some Raspberry Pi Pico HATs. Relying on the rich ecology and open source resources of ESP32, users can get started quickly for secondary development. It is suitable for Internet of Things, image acquisition, smart home and other AI projects.
 
 ## Technical details
 
-- Adopts ESP32-S3FH4R2 chip with Xtensa 32-bit LX7 dual-core processor, capable of running at 240 MHz
-- Integrated 512KB SRAM, 384KB ROM, 2MB PSRAM, 4MB Flash memory
-- Integrated 2.4GHz Wi-Fi and Bluetooth LE dual-mode wireless communication, with superior RF performance.
-- Type-C connector, easier to use
-- Onboard QMI8658 6-axis IMU (3-axis accelerometer and 3-axis gyroscope)
-- Onboard 8 × 8 RGB LED matrix for colorful lighting display
-- Adapting Dout pin for extending RGB matrix
-- 17 × multi-function GPIO pins
-- Rich peripheral interfaces for achieving various functions flexibly
-- Supports multiple low-power operating states, adjustable balance between communication distance, data rate and power consumption to meet the power requirements of various application scenarios
+- Adopts ESP32-S3R8 high-performance chip with Xtensa 32-bit LX7 dual-core processor, capable of running at 240 MHz
+- Integrated 512KB SRAM, 384KB ROM, 8MB PSRAM and 16MB Flash memory
+- Integrated 2.4GHz Wi-Fi and Bluetooth 5 (LE) wireless communication, with an onboard antenna. Supports switching to use external antenna
+- Onboard W5500 Ethernet chip for extending 10/100Mbps network port through SPI interface
+- Optional for PoE module to realize Power over Ethernet function (IEEE 802.3af-compliant)
+- Onboard camera interface, compatible with OV2640, OV5640 and other mainstream cameras for image and video capture
+- Onboard USB Type-C port for power supply, program downloading, and debugging, more convenient for development use
+- Onboard TF card slot for external TF card storage of pictures or files
+- Compatible with Pico header, onboard multiple peripheral interfaces, offering strong compatibility and expandability
 
-Waveshare Wiki [link](https://www.waveshare.com/wiki/ESP32-S3-Matrix).
+Waveshare Wiki [link](https://www.waveshare.com/wiki/ESP32-S3-ETH).
 
 ## Purchase
-* [Waveshare](https://www.waveshare.com/product/arduino/boards-kits/esp32/esp32-s3-matrix.htm)
+* [Waveshare](https://www.waveshare.com/product/arduino/boards-kits/esp32/esp32-s3-eth.htm)
 

--- a/_board/waveshare_esp32_s3_matrix.md
+++ b/_board/waveshare_esp32_s3_matrix.md
@@ -1,11 +1,11 @@
 ---
 layout: download
 board_id: "waveshare_esp32_s3_matrix"
-title: "ESP32-S3 ETH Development Board Download"
-name: "ESP32-S3 ETH Development Board"
+title: "ESP32-S3-Matrix Development Board Download"
+name: "ESP32-S3-Matrix Development Board"
 manufacturer: "Waveshare"
 board_url:
- - "https://www.waveshare.com/product/arduino/boards-kits/esp32/esp32-s3-eth.htm"
+ - "https://www.waveshare.com/product/arduino/boards-kits/esp32/esp32-s3-matrix.htm"
 board_image: "waveshare_esp32_s3_matrix.jpg"
 date_added: 2025-01-27
 family: esp32s3
@@ -16,24 +16,23 @@ features:
   - Display
 ---
 
-ESP32-S3 ETH Development Board, 10/100Mbps RJ45 Ethernet port, Wi-Fi & Bluetooth Support, 240MHz Dual Core Processor, Onboard Type-C Port And TF Card Slot, Optional For PoE Module And Camera Module
-
-This is an ETH development board based on ESP32-S3R8, supports Wi-Fi and Bluetooth wireless communication, with reliable and efficient wired Ethernet connectivity, optional for PoE function. Onboard camera interface, compatible with OV2640, OV5640 and other mainstream cameras for image and video capture. Compatible with Pico header, it can be used with some Raspberry Pi Pico HATs. Relying on the rich ecology and open source resources of ESP32, users can get started quickly for secondary development. It is suitable for Internet of Things, image acquisition, smart home and other AI projects.
+ESP32-S3-Matrix Development Board, Onboard 8×8 RGB LED Matrix and QMI8658 Attitude Sensor, supports Wi-Fi and Bluetooth LE, ESP32 Development Board
 
 ## Technical details
 
-- Adopts ESP32-S3R8 high-performance chip with Xtensa 32-bit LX7 dual-core processor, capable of running at 240 MHz
-- Integrated 512KB SRAM, 384KB ROM, 8MB PSRAM and 16MB Flash memory
-- Integrated 2.4GHz Wi-Fi and Bluetooth 5 (LE) wireless communication, with an onboard antenna. Supports switching to use external antenna
-- Onboard W5500 Ethernet chip for extending 10/100Mbps network port through SPI interface
-- Optional for PoE module to realize Power over Ethernet function (IEEE 802.3af-compliant)
-- Onboard camera interface, compatible with OV2640, OV5640 and other mainstream cameras for image and video capture
-- Onboard USB Type-C port for power supply, program downloading, and debugging, more convenient for development use
-- Onboard TF card slot for external TF card storage of pictures or files
-- Compatible with Pico header, onboard multiple peripheral interfaces, offering strong compatibility and expandability
+- Adopts ESP32-S3FH4R2 chip with Xtensa 32-bit LX7 dual-core processor, capable of running at 240 MHz
+- Integrated 512KB SRAM, 384KB ROM, 2MB PSRAM, 4MB Flash memory
+- Integrated 2.4GHz Wi-Fi and Bluetooth LE dual-mode wireless communication, with superior RF performance.
+- Type-C connector, easier to use
+- Onboard QMI8658 6-axis IMU (3-axis accelerometer and 3-axis gyroscope)
+- Onboard 8 × 8 RGB LED matrix for colorful lighting display
+- Adapting Dout pin for extending RGB matrix
+- 17 × multi-function GPIO pins
+- Rich peripheral interfaces for achieving various functions flexibly
+- Supports multiple low-power operating states, adjustable balance between communication distance, data rate and power consumption to meet the power requirements of various application scenarios
 
-Waveshare Wiki [link](https://www.waveshare.com/wiki/ESP32-S3-ETH).
+Waveshare Wiki [link](https://www.waveshare.com/wiki/ESP32-S3-Matrix).
 
 ## Purchase
-* [Waveshare](https://www.waveshare.com/product/arduino/boards-kits/esp32/esp32-s3-eth.htm)
+* [Waveshare](https://www.waveshare.com/product/arduino/boards-kits/esp32/esp32-s3-matrix.htm)
 


### PR DESCRIPTION
Somehow the board descriptions of these two boards are swapped.