### PR TITLE
Update bootloaders.json - tinyUF2 0.21.0

### DIFF
--- a/_data/bootloaders.json
+++ b/_data/bootloaders.json
@@ -7,10 +7,10 @@
             "version": "v3.16.0"
         },
         "esp32s2": {
-            "version": "0.20.1"
+            "version": "0.21.0"
         },
         "esp32s3": {
-            "version": "0.20.1"
+            "version": "0.21.0"
         },
         "esp32c2": {},
         "esp32c3": {},


### PR DESCRIPTION
I hadn't spotted the bootloader version was a defined value, and since adding the TDisplayS3 bootloader option it needs the latest tinyUF2 release to pick it up.

Otherwise currently stalls at downloading bootloader stage:
![image](https://github.com/user-attachments/assets/de4ed58b-776e-4674-8203-b37feb21fa1c)


This should pick up https://github.com/adafruit/tinyuf2/releases/tag/0.21.0