### PR TITLE
Distinguish the the TQ-T Pro boards apart

### DIFF
--- a/_board/lilygo_tqt_pro_nopsram.md
+++ b/_board/lilygo_tqt_pro_nopsram.md
@@ -1,7 +1,7 @@
 ---
 layout: download
 board_id: "lilygo_tqt_pro_nopsram"
-title: "TQ-T Pro Download"
+title: "TQ-T Pro (No PSRAM) Download"
 name: "TQ-T Pro"
 manufacturer: "LILYGO"
 board_url:

--- a/_board/lilygo_tqt_pro_psram.md
+++ b/_board/lilygo_tqt_pro_psram.md
@@ -1,7 +1,7 @@
 ---
 layout: download
 board_id: "lilygo_tqt_pro_psram"
-title: "TQ-T Pro Download"
+title: "TQ-T Pro (with PSRAM) Download"
 name: "TQ-T Pro"
 manufacturer: "LILYGO"
 board_url:


### PR DESCRIPTION
I just realized the boards didn't say why they were different in their titles.