### PR TITLE
Distinguish the the TQ-T Pro boards apart (second try)

### DIFF
--- a/_board/lilygo_tqt_pro_nopsram.md
+++ b/_board/lilygo_tqt_pro_nopsram.md
@@ -2,7 +2,7 @@
 layout: download
 board_id: "lilygo_tqt_pro_nopsram"
 title: "TQ-T Pro (No PSRAM) Download"
-name: "TQ-T Pro"
+name: "TQ-T Pro (No PSRAM)"
 manufacturer: "LILYGO"
 board_url:
  - "https://lilygo.cc/products/t-qt-pro?variant=43214296285365"

--- a/_board/lilygo_tqt_pro_psram.md
+++ b/_board/lilygo_tqt_pro_psram.md
@@ -2,7 +2,7 @@
 layout: download
 board_id: "lilygo_tqt_pro_psram"
 title: "TQ-T Pro (with PSRAM) Download"
-name: "TQ-T Pro"
+name: "TQ-T Pro (with PSRAM)"
 manufacturer: "LILYGO"
 board_url:
  - "https://lilygo.cc/products/t-qt-pro?variant=42383267823797"


### PR DESCRIPTION
Apparently I only changed the page title and not how it shows in the list of boards. I've verified this does actually fix it.