### PR TITLE
Add new filter to only use featured guides from circuitpython category

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,7 +40,7 @@ jekyll_get_json:
   - data: libraries
     json: "https://adafruit-circuit-python.s3.amazonaws.com/adabot/web/libraries.v2.json"
   - data: guides
-    json: "https://learn.adafruit.com/api/categories/circuitpython.json?count=10&filter=guides_only,random,exclude_product"
+    json: "https://learn.adafruit.com/api/categories/circuitpython.json?count=10&filter=guides_only,featured,random,exclude_product"
 
 ### Exclude from processing.
 exclude:


### PR DESCRIPTION
Should help curate the home page a bit better so we can limit guides with blurry images or guides that are out of date, etc.