### PR TITLE
Add bootloader_id to some boards

### DIFF
--- a/_board/firebeetle2_esp32s3.md
+++ b/_board/firebeetle2_esp32s3.md
@@ -9,6 +9,7 @@ board_url:
 board_image: "firebeetle2_esp32s3.jpg"
 date_added: 2023-11-21
 family: esp32s3
+bootloader_id: firebeetle2_esp32s3
 download_instructions: https://wiki.dfrobot.com/SKU_DFR0975_FireBeetle_2_Board_ESP32_S3#target_9
 features:
   - Breadboard-Friendly

--- a/_board/yd_esp32_s3_n16r8.md
+++ b/_board/yd_esp32_s3_n16r8.md
@@ -9,6 +9,7 @@ board_url:
 board_image: "yd_esp32_s3.jpg"
 date_added: 2023-05-03
 family: esp32s3
+bootloader_id: yd_esp32_s3_n16r8
 features:
   - Breadboard-Friendly
   - USB-C


### PR DESCRIPTION
Added bootloader_id to:
- firebeetle2_esp32s3
- yd_esp32_s3_n16r8

Available in https://github.com/adafruit/tinyuf2/releases/tag/0.21.0