### PR TITLE
Add a bunch of bootloader ID from tinyuf2

### DIFF
--- a/_board/adafruit_vindie_s2.md
+++ b/_board/adafruit_vindie_s2.md
@@ -8,6 +8,7 @@ board_url:
 board_image: "unknown.jpg"
 date_added: 2024-08-22
 family: esp32s2
+bootloader_id: adafruit_vindie_s2
 downloads_display: false
 ---
 

--- a/_board/firebeetle2_esp32s3.md
+++ b/_board/firebeetle2_esp32s3.md
@@ -9,6 +9,7 @@ board_url:
 board_image: "firebeetle2_esp32s3.jpg"
 date_added: 2023-11-21
 family: esp32s3
+bootloader_id: firebeetle2_esp32s3
 download_instructions: https://wiki.dfrobot.com/SKU_DFR0975_FireBeetle_2_Board_ESP32_S3#target_9
 features:
   - Breadboard-Friendly

--- a/_board/lilygo_tdeck.md
+++ b/_board/lilygo_tdeck.md
@@ -9,6 +9,7 @@ board_url:
 board_image: "lilygo_tdeck.jpg"
 date_added: 2023-11-15
 family: esp32s3
+bootloader_id: lilygo_tdeck
 features:
   - Wi-Fi
   - Bluetooth/BTLE

--- a/_board/m5stack_cores3.md
+++ b/_board/m5stack_cores3.md
@@ -9,6 +9,7 @@ board_url:
 board_image: "m5stack_cores3.jpg"
 date_added: 2024-03-29
 family: esp32s3
+bootloader_id: m5stack_cores3
 features:
   - Speaker
   - Display

--- a/_board/maker_badge.md
+++ b/_board/maker_badge.md
@@ -9,6 +9,7 @@ board_url:
 board_image: "maker_badge.jpg"
 date_added: 2022-11-13
 family: esp32s2
+bootloader_id: maker_badge
 features:
   - Wi-Fi
   - USB-C

--- a/_board/seeed_xiao_esp32s3_sense.md
+++ b/_board/seeed_xiao_esp32s3_sense.md
@@ -9,6 +9,7 @@ board_url:
 board_image: "seeed_xiao_esp32s3_sense.jpg"
 date_added: 2024-09-03
 family: esp32s3
+bootloader_id: seeed_xiao_esp32s3
 features:
   - Breadboard-Friendly
   - Xiao / QTPy Form Factor

--- a/_board/smartbeedesigns_bee_motion_s3.md
+++ b/_board/smartbeedesigns_bee_motion_s3.md
@@ -9,6 +9,7 @@ board_url:
 board_image: "smartbeedesigns_bee_motion_s3.jpg"
 date_added: 2022-08-22
 family: esp32s3
+bootloader_id: smartbeedesigns_bee_motion_s3
 features:
   - Wi-Fi
   - Battery Charging

--- a/_board/smartbeedesigns_bee_s3.md
+++ b/_board/smartbeedesigns_bee_s3.md
@@ -9,6 +9,7 @@ board_url:
 board_image: "smartbeedesigns_bee_s3.jpg"
 date_added: 2022-08-22
 family: esp32s3
+bootloader_id: smartbeedesigns_bee_s3
 features:
   - Wi-Fi
   - USB-C

--- a/_board/unexpectedmaker_bling.md
+++ b/_board/unexpectedmaker_bling.md
@@ -9,6 +9,7 @@ board_url:
 board_image: "unexpectedmaker_bling.jpg"
 date_added: 2023-11-15
 family: esp32s3
+bootloader_id: unexpectedmaker_bling
 features:
 ---
 

--- a/_board/unexpectedmaker_tinywatch_s3.md
+++ b/_board/unexpectedmaker_tinywatch_s3.md
@@ -9,6 +9,7 @@ board_url:
 board_image: "unexpectedmaker_tinywatch_s3.jpg"
 date_added: 2023-11-15
 family: esp32s3
+bootloader_id: unexpectedmaker_tinywatchs3
 features:
   - Battery Charging
   - Bluetooth/BTLE

--- a/_board/waveshare_esp32_s3_zero.md
+++ b/_board/waveshare_esp32_s3_zero.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "waveshare_esp32_s3_zero.png"
 date_added: 2023-10-21
 family: esp32s3
-bootloader_id: adafruit_feather_esp32s3
+bootloader_id: waveshare_esp32_s3_zero
 downloads_display: true
 features:
   - Wi-Fi

--- a/_board/yd_esp32_s3_n16r8.md
+++ b/_board/yd_esp32_s3_n16r8.md
@@ -9,6 +9,7 @@ board_url:
 board_image: "yd_esp32_s3.jpg"
 date_added: 2023-05-03
 family: esp32s3
+bootloader_id: yd_esp32_s3_n16r8
 features:
   - Breadboard-Friendly
   - USB-C

--- a/_board/yd_esp32_s3_n8r8.md
+++ b/_board/yd_esp32_s3_n8r8.md
@@ -9,6 +9,7 @@ board_url:
 board_image: "yd_esp32_s3.jpg"
 date_added: 2023-05-03
 family: esp32s3
+bootloader_id: yd_esp32_s3_n8r8
 features:
   - Breadboard-Friendly
   - USB-C


### PR DESCRIPTION
I ran a script to list available bootloaders from tinyuf2 (0.21.0) on ESP32S2/3 and match with board ids, adding `bootloader_id` to those boards. There are maybe some more that could be added manually after checking that they are the right ones (like the `espressif_esp32s2_devkitc_1` variants).