### PR TITLE
Add timeout-minutes to adabot.update_cp_org_libraries action task

### DIFF
--- a/.github/workflows/adabot_cron.yml
+++ b/.github/workflows/adabot_cron.yml
@@ -22,6 +22,7 @@ jobs:
     # Only run the build on Adafruit's repository. Forks won't have the secrets.
     # Its necessary to do this here, since 'schedule' events cannot (currently)
     # be limited (they run on all forks' default branches).
+    timeout-minutes: 150  # 2.5 hours
     if: startswith(github.repository, 'adafruit/')
     steps:
     - name: Dump GitHub context


### PR DESCRIPTION
This would serve as sort of "relief valve" for the long stalled actions task. The configuration is documented here: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes making it give up and get cancelled sooner if it gets stalled.

The default value is 360 which matches the 6 hours that the actions run lasts when it gets stalled. 

I believe with it set to 150 minutes it should get cancelled and stopped after 2.5 hours maximum instead of  6 hours. 

2.5 hours was selected to account for up to 2 of the 1hour wait intervals for API rate limit. I believe that should make it so that along with the fix from https://github.com/adafruit/adabot/pull/397 this should always be able to finish in under 2.5 hours under normal circumstances. The changes from this Adabot PR cap the time it will sleep for to 63 minutes, and it seems like it gets to around 60 minutes in and the negative overflow sleep logic makes it stall for the remainder of the 6 hours when that does happen, so In the same root cause scenario it could get to 60ish minutes, have the overflowed sleep, but with the new logic only sleep for 63 minutes instead, leaving around 30 minutes afterward to be able to finish within the new 2.5 hour limit. 