### PR TITLE
Switch to download counts from Cloud Front

### DIFF
--- a/_data/files.json
+++ b/_data/files.json
@@ -1,6 +1,6 @@
 [
  {
-  "downloads": 3149,
+  "downloads": 6,
   "id": "01space_lcd042_esp32c3",
   "versions": [
    {
@@ -243,7 +243,7 @@
   ]
  },
  {
-  "downloads": 1186,
+  "downloads": 6,
   "id": "0xcb_gemini",
   "versions": [
    {
@@ -507,7 +507,7 @@
   ]
  },
  {
-  "downloads": 5936,
+  "downloads": 2,
   "id": "0xcb_helios",
   "versions": [
    {
@@ -771,7 +771,7 @@
   ]
  },
  {
-  "downloads": 6141,
+  "downloads": 3,
   "id": "42keebs_frood",
   "versions": [
    {
@@ -1035,7 +1035,7 @@
   ]
  },
  {
-  "downloads": 6488,
+  "downloads": 0,
   "id": "8086_commander",
   "versions": [
    {
@@ -1173,7 +1173,7 @@
   ]
  },
  {
-  "downloads": 628,
+  "downloads": 2,
   "id": "8086_rp2040_interfacer",
   "versions": [
    {
@@ -1437,7 +1437,7 @@
   ]
  },
  {
-  "downloads": 2814,
+  "downloads": 1,
   "id": "8086_usb_interposer",
   "versions": [
    {
@@ -1701,7 +1701,7 @@
   ]
  },
  {
-  "downloads": 5033,
+  "downloads": 4,
   "id": "ADM_B_NRF52840_1",
   "versions": [
    {
@@ -1943,7 +1943,7 @@
   ]
  },
  {
-  "downloads": 8289,
+  "downloads": 32,
   "id": "Seeed_XIAO_nRF52840_Sense",
   "versions": [
    {
@@ -2185,7 +2185,7 @@
   ]
  },
  {
-  "downloads": 4962,
+  "downloads": 0,
   "id": "TG-Watch",
   "versions": [
    {
@@ -2453,7 +2453,7 @@
   ]
  },
  {
-  "downloads": 6562,
+  "downloads": 10,
   "id": "adafruit_esp32s3_camera",
   "versions": [
    {
@@ -2692,7 +2692,7 @@
   ]
  },
  {
-  "downloads": 2981,
+  "downloads": 12,
   "id": "adafruit_feather_esp32_v2",
   "versions": [
    {
@@ -2966,7 +2966,7 @@
   ]
  },
  {
-  "downloads": 1704,
+  "downloads": 1,
   "id": "adafruit_feather_esp32c6_4mbflash_nopsram",
   "versions": [
    {
@@ -3211,7 +3211,7 @@
   ]
  },
  {
-  "downloads": 6912,
+  "downloads": 11,
   "id": "adafruit_feather_esp32s2",
   "versions": [
    {
@@ -3486,7 +3486,7 @@
   ]
  },
  {
-  "downloads": 6916,
+  "downloads": 11,
   "id": "adafruit_feather_esp32s2_reverse_tft",
   "versions": [
    {
@@ -3761,7 +3761,7 @@
   ]
  },
  {
-  "downloads": 6222,
+  "downloads": 13,
   "id": "adafruit_feather_esp32s2_tft",
   "versions": [
    {
@@ -4036,7 +4036,7 @@
   ]
  },
  {
-  "downloads": 10173,
+  "downloads": 27,
   "id": "adafruit_feather_esp32s3_4mbflash_2mbpsram",
   "versions": [
    {
@@ -4305,7 +4305,7 @@
   ]
  },
  {
-  "downloads": 6048,
+  "downloads": 14,
   "id": "adafruit_feather_esp32s3_nopsram",
   "versions": [
    {
@@ -4585,7 +4585,7 @@
   ]
  },
  {
-  "downloads": 6303,
+  "downloads": 16,
   "id": "adafruit_feather_esp32s3_reverse_tft",
   "versions": [
    {
@@ -4854,7 +4854,7 @@
   ]
  },
  {
-  "downloads": 6448,
+  "downloads": 20,
   "id": "adafruit_feather_esp32s3_tft",
   "versions": [
    {
@@ -5123,7 +5123,7 @@
   ]
  },
  {
-  "downloads": 2753,
+  "downloads": 9,
   "id": "adafruit_feather_huzzah32",
   "versions": [
    {
@@ -5384,7 +5384,7 @@
   ]
  },
  {
-  "downloads": 8582,
+  "downloads": 95,
   "id": "adafruit_feather_rp2040",
   "versions": [
    {
@@ -5648,7 +5648,7 @@
   ]
  },
  {
-  "downloads": 3122,
+  "downloads": 7,
   "id": "adafruit_feather_rp2040_adalogger",
   "versions": [
    {
@@ -5912,7 +5912,7 @@
   ]
  },
  {
-  "downloads": 5148,
+  "downloads": 13,
   "id": "adafruit_feather_rp2040_can",
   "versions": [
    {
@@ -6176,7 +6176,7 @@
   ]
  },
  {
-  "downloads": 6001,
+  "downloads": 4,
   "id": "adafruit_feather_rp2040_dvi",
   "versions": [
    {
@@ -6442,7 +6442,7 @@
   ]
  },
  {
-  "downloads": 6500,
+  "downloads": 21,
   "id": "adafruit_feather_rp2040_prop_maker",
   "versions": [
    {
@@ -6706,7 +6706,7 @@
   ]
  },
  {
-  "downloads": 5933,
+  "downloads": 5,
   "id": "adafruit_feather_rp2040_rfm",
   "versions": [
    {
@@ -6970,7 +6970,7 @@
   ]
  },
  {
-  "downloads": 6515,
+  "downloads": 3,
   "id": "adafruit_feather_rp2040_scorpio",
   "versions": [
    {
@@ -7234,7 +7234,7 @@
   ]
  },
  {
-  "downloads": 4665,
+  "downloads": 0,
   "id": "adafruit_feather_rp2040_thinkink",
   "versions": [
    {
@@ -7498,7 +7498,7 @@
   ]
  },
  {
-  "downloads": 5324,
+  "downloads": 6,
   "id": "adafruit_feather_rp2040_usb_host",
   "versions": [
    {
@@ -7762,7 +7762,7 @@
   ]
  },
  {
-  "downloads": 2712,
+  "downloads": 8,
   "id": "adafruit_feather_rp2350",
   "versions": [
    {
@@ -8169,7 +8169,7 @@
   ]
  },
  {
-  "downloads": 3654,
+  "downloads": 0,
   "id": "adafruit_floppsy_rp2040",
   "versions": [
    {
@@ -8429,7 +8429,7 @@
   ]
  },
  {
-  "downloads": 261,
+  "downloads": 7,
   "id": "adafruit_fruit_jam",
   "versions": [
    {
@@ -8697,7 +8697,7 @@
   ]
  },
  {
-  "downloads": 6967,
+  "downloads": 3,
   "id": "adafruit_funhouse",
   "versions": [
    {
@@ -8954,7 +8954,7 @@
   ]
  },
  {
-  "downloads": 1891,
+  "downloads": 0,
   "id": "adafruit_huzzah32_breakout",
   "versions": [
    {
@@ -9217,7 +9217,7 @@
   ]
  },
  {
-  "downloads": 1702,
+  "downloads": 2,
   "id": "adafruit_itsybitsy_esp32",
   "versions": [
    {
@@ -9491,7 +9491,7 @@
   ]
  },
  {
-  "downloads": 5634,
+  "downloads": 1,
   "id": "adafruit_itsybitsy_rp2040",
   "versions": [
    {
@@ -9755,7 +9755,7 @@
   ]
  },
  {
-  "downloads": 7005,
+  "downloads": 35,
   "id": "adafruit_kb2040",
   "versions": [
    {
@@ -10019,7 +10019,7 @@
   ]
  },
  {
-  "downloads": 4782,
+  "downloads": 6,
   "id": "adafruit_led_glasses_nrf52840",
   "versions": [
    {
@@ -10263,7 +10263,7 @@
   ]
  },
  {
-  "downloads": 7538,
+  "downloads": 58,
   "id": "adafruit_macropad_rp2040",
   "versions": [
    {
@@ -10527,7 +10527,7 @@
   ]
  },
  {
-  "downloads": 7901,
+  "downloads": 8,
   "id": "adafruit_magtag_2.9_grayscale",
   "versions": [
    {
@@ -10814,7 +10814,7 @@
   ]
  },
  {
-  "downloads": 7947,
+  "downloads": 61,
   "id": "adafruit_matrixportal_s3",
   "versions": [
    {
@@ -11092,7 +11092,7 @@
   ]
  },
  {
-  "downloads": 5572,
+  "downloads": 6,
   "id": "adafruit_metro_esp32s2",
   "versions": [
    {
@@ -11367,7 +11367,7 @@
   ]
  },
  {
-  "downloads": 5782,
+  "downloads": 12,
   "id": "adafruit_metro_esp32s3",
   "versions": [
    {
@@ -11651,7 +11651,7 @@
   ]
  },
  {
-  "downloads": 5195,
+  "downloads": 4,
   "id": "adafruit_metro_m7_1011_sd",
   "versions": [
    {
@@ -11879,7 +11879,7 @@
   ]
  },
  {
-  "downloads": 4745,
+  "downloads": 1,
   "id": "adafruit_metro_rp2040",
   "versions": [
    {
@@ -12143,7 +12143,7 @@
   ]
  },
  {
-  "downloads": 2052,
+  "downloads": 14,
   "id": "adafruit_metro_rp2350",
   "versions": [
    {
@@ -12411,7 +12411,7 @@
   ]
  },
  {
-  "downloads": 133,
+  "downloads": 1,
   "id": "adafruit_mini_sparkle_motion",
   "versions": [
    {
@@ -12672,7 +12672,7 @@
   ]
  },
  {
-  "downloads": 4755,
+  "downloads": 1,
   "id": "adafruit_neokey_trinkey_m0",
   "versions": [
    {
@@ -12786,7 +12786,7 @@
   ]
  },
  {
-  "downloads": 2128,
+  "downloads": 0,
   "id": "adafruit_pixel_trinkey_m0",
   "versions": [
    {
@@ -12910,7 +12910,7 @@
   ]
  },
  {
-  "downloads": 4566,
+  "downloads": 4,
   "id": "adafruit_proxlight_trinkey_m0",
   "versions": [
    {
@@ -13028,7 +13028,7 @@
   ]
  },
  {
-  "downloads": 4584,
+  "downloads": 11,
   "id": "adafruit_qt2040_trinkey",
   "versions": [
    {
@@ -13292,7 +13292,7 @@
   ]
  },
  {
-  "downloads": 1691,
+  "downloads": 4,
   "id": "adafruit_qtpy_esp32_pico",
   "versions": [
    {
@@ -13564,7 +13564,7 @@
   ]
  },
  {
-  "downloads": 1916,
+  "downloads": 5,
   "id": "adafruit_qtpy_esp32c3",
   "versions": [
    {
@@ -13807,7 +13807,7 @@
   ]
  },
  {
-  "downloads": 5532,
+  "downloads": 28,
   "id": "adafruit_qtpy_esp32s2",
   "versions": [
    {
@@ -14080,7 +14080,7 @@
   ]
  },
  {
-  "downloads": 5677,
+  "downloads": 20,
   "id": "adafruit_qtpy_esp32s3_4mbflash_2mbpsram",
   "versions": [
    {
@@ -14349,7 +14349,7 @@
   ]
  },
  {
-  "downloads": 5561,
+  "downloads": 11,
   "id": "adafruit_qtpy_esp32s3_nopsram",
   "versions": [
    {
@@ -14627,7 +14627,7 @@
   ]
  },
  {
-  "downloads": 6576,
+  "downloads": 52,
   "id": "adafruit_qtpy_rp2040",
   "versions": [
    {
@@ -14891,7 +14891,7 @@
   ]
  },
  {
-  "downloads": 6071,
+  "downloads": 19,
   "id": "adafruit_qualia_s3_rgb666",
   "versions": [
    {
@@ -15177,7 +15177,7 @@
   ]
  },
  {
-  "downloads": 4584,
+  "downloads": 3,
   "id": "adafruit_rotary_trinkey_m0",
   "versions": [
    {
@@ -15293,7 +15293,7 @@
   ]
  },
  {
-  "downloads": 4039,
+  "downloads": 3,
   "id": "adafruit_sht4x_trinkey_m0",
   "versions": [
    {
@@ -15411,7 +15411,7 @@
   ]
  },
  {
-  "downloads": 5190,
+  "downloads": 0,
   "id": "adafruit_slide_trinkey_m0",
   "versions": [
    {
@@ -15529,7 +15529,7 @@
   ]
  },
  {
-  "downloads": 134,
+  "downloads": 1,
   "id": "adafruit_sparkle_motion",
   "versions": [
    {
@@ -15790,7 +15790,7 @@
   ]
  },
  {
-  "downloads": 2310,
+  "downloads": 2,
   "id": "adafruit_trrs_trinkey_m0",
   "versions": [
    {
@@ -15906,7 +15906,7 @@
   ]
  },
  {
-  "downloads": 957,
+  "downloads": 0,
   "id": "adafruit_vindie_s2",
   "versions": [
    {
@@ -16179,7 +16179,7 @@
   ]
  },
  {
-  "downloads": 1975,
+  "downloads": 29,
   "id": "ai-thinker-esp32-cam",
   "versions": [
    {
@@ -16447,7 +16447,7 @@
   ]
  },
  {
-  "downloads": 1452,
+  "downloads": 1,
   "id": "ai_thinker_esp32-c3s",
   "versions": [
    {
@@ -16690,7 +16690,7 @@
   ]
  },
  {
-  "downloads": 870,
+  "downloads": 2,
   "id": "ai_thinker_esp32-c3s-2m",
   "versions": [
    {
@@ -16933,7 +16933,7 @@
   ]
  },
  {
-  "downloads": 5410,
+  "downloads": 8,
   "id": "ai_thinker_esp_12k_nodemcu",
   "versions": [
    {
@@ -17208,7 +17208,7 @@
   ]
  },
  {
-  "downloads": 4060,
+  "downloads": 0,
   "id": "aloriumtech_evo_m51",
   "versions": [
    {
@@ -17447,7 +17447,7 @@
   ]
  },
  {
-  "downloads": 572,
+  "downloads": 0,
   "id": "apard32690",
   "versions": [
    {
@@ -17587,7 +17587,7 @@
   ]
  },
  {
-  "downloads": 3164,
+  "downloads": 0,
   "id": "aramcon2_badge",
   "versions": [
    {
@@ -17829,7 +17829,7 @@
   ]
  },
  {
-  "downloads": 5010,
+  "downloads": 0,
   "id": "aramcon_badge_2019",
   "versions": [
    {
@@ -18069,7 +18069,7 @@
   ]
  },
  {
-  "downloads": 2421,
+  "downloads": 28,
   "id": "archi",
   "versions": [
    {
@@ -18357,7 +18357,7 @@
   ]
  },
  {
-  "downloads": 3618,
+  "downloads": 0,
   "id": "arduino_mkr1300",
   "versions": [
    {
@@ -18477,7 +18477,7 @@
   ]
  },
  {
-  "downloads": 4071,
+  "downloads": 0,
   "id": "arduino_mkrzero",
   "versions": [
    {
@@ -18599,7 +18599,7 @@
   ]
  },
  {
-  "downloads": 4726,
+  "downloads": 3,
   "id": "arduino_nano_33_ble",
   "versions": [
    {
@@ -18839,7 +18839,7 @@
   ]
  },
  {
-  "downloads": 2569,
+  "downloads": 1,
   "id": "arduino_nano_33_ble_rev2",
   "versions": [
    {
@@ -19079,7 +19079,7 @@
   ]
  },
  {
-  "downloads": 5459,
+  "downloads": 0,
   "id": "arduino_nano_33_iot",
   "versions": [
    {
@@ -19197,7 +19197,7 @@
   ]
  },
  {
-  "downloads": 4824,
+  "downloads": 10,
   "id": "arduino_nano_esp32s3",
   "versions": [
    {
@@ -19477,7 +19477,7 @@
   ]
  },
  {
-  "downloads": 4220,
+  "downloads": 0,
   "id": "arduino_nano_esp32s3_inverted_statusled",
   "versions": [
    {
@@ -19757,7 +19757,7 @@
   ]
  },
  {
-  "downloads": 5758,
+  "downloads": 3,
   "id": "arduino_nano_rp2040_connect",
   "versions": [
    {
@@ -20023,7 +20023,7 @@
   ]
  },
  {
-  "downloads": 4309,
+  "downloads": 2,
   "id": "arduino_zero",
   "versions": [
    {
@@ -20143,7 +20143,7 @@
   ]
  },
  {
-  "downloads": 2662,
+  "downloads": 0,
   "id": "artisense_rd00",
   "versions": [
    {
@@ -20418,7 +20418,7 @@
   ]
  },
  {
-  "downloads": 4197,
+  "downloads": 0,
   "id": "atmegazero_esp32s2",
   "versions": [
    {
@@ -20699,7 +20699,7 @@
   ]
  },
  {
-  "downloads": 2588,
+  "downloads": 1,
   "id": "autosportlabs_esp32_can_x2",
   "versions": [
    {
@@ -20983,7 +20983,7 @@
   ]
  },
  {
-  "downloads": 1103,
+  "downloads": 0,
   "id": "barduino",
   "versions": [
    {
@@ -21263,7 +21263,7 @@
   ]
  },
  {
-  "downloads": 3148,
+  "downloads": 0,
   "id": "bast_pro_mini_m0",
   "versions": [
    {
@@ -21383,7 +21383,7 @@
   ]
  },
  {
-  "downloads": 3631,
+  "downloads": 0,
   "id": "bastble",
   "versions": [
    {
@@ -21625,12 +21625,12 @@
   ]
  },
  {
-  "downloads": 2496,
+  "downloads": 0,
   "id": "bdmicro_vina_d21",
   "versions": []
  },
  {
-  "downloads": 3594,
+  "downloads": 0,
   "id": "bdmicro_vina_d51",
   "versions": [
    {
@@ -21879,7 +21879,7 @@
   ]
  },
  {
-  "downloads": 3060,
+  "downloads": 0,
   "id": "bdmicro_vina_d51_pcb7",
   "versions": [
    {
@@ -22128,7 +22128,7 @@
   ]
  },
  {
-  "downloads": 1373,
+  "downloads": 0,
   "id": "beetle-esp32-c3",
   "versions": [
    {
@@ -22371,7 +22371,7 @@
   ]
  },
  {
-  "downloads": 4138,
+  "downloads": 1,
   "id": "bless_dev_board_multi_sensor",
   "versions": [
    {
@@ -22613,7 +22613,7 @@
   ]
  },
  {
-  "downloads": 3489,
+  "downloads": 1,
   "id": "blm_badge",
   "versions": [
    {
@@ -22729,7 +22729,7 @@
   ]
  },
  {
-  "downloads": 4576,
+  "downloads": 0,
   "id": "bluemicro833",
   "versions": [
    {
@@ -22864,7 +22864,7 @@
   ]
  },
  {
-  "downloads": 4695,
+  "downloads": 1,
   "id": "bluemicro840",
   "versions": [
    {
@@ -23162,7 +23162,7 @@
   ]
  },
  {
-  "downloads": 4954,
+  "downloads": 6,
   "id": "boardsource_blok",
   "versions": [
    {
@@ -23430,7 +23430,7 @@
   ]
  },
  {
-  "downloads": 7487,
+  "downloads": 0,
   "id": "bpi_bit_s2",
   "versions": [
    {
@@ -23709,7 +23709,7 @@
   ]
  },
  {
-  "downloads": 3991,
+  "downloads": 0,
   "id": "bpi_leaf_s3",
   "versions": [
    {
@@ -23997,7 +23997,7 @@
   ]
  },
  {
-  "downloads": 5456,
+  "downloads": 3,
   "id": "bpi_picow_s3",
   "versions": [
    {
@@ -24285,7 +24285,7 @@
   ]
  },
  {
-  "downloads": 712,
+  "downloads": 1,
   "id": "bradanlanestudio_coin_m0",
   "versions": [
    {
@@ -24409,7 +24409,7 @@
   ]
  },
  {
-  "downloads": 1725,
+  "downloads": 0,
   "id": "bradanlanestudio_explorer_rp2040",
   "versions": [
    {
@@ -24695,7 +24695,7 @@
   ]
  },
  {
-  "downloads": 4184,
+  "downloads": 0,
   "id": "brainboardz_neuron",
   "versions": [
    {
@@ -24979,7 +24979,7 @@
   ]
  },
  {
-  "downloads": 4185,
+  "downloads": 1,
   "id": "breadstick_raspberry",
   "versions": [
    {
@@ -25251,7 +25251,7 @@
   ]
  },
  {
-  "downloads": 4203,
+  "downloads": 1,
   "id": "bwshockley_figpi",
   "versions": [
    {
@@ -25515,7 +25515,7 @@
   ]
  },
  {
-  "downloads": 4521,
+  "downloads": 0,
   "id": "capablerobot_usbhub",
   "versions": [
    {
@@ -25637,7 +25637,7 @@
   ]
  },
  {
-  "downloads": 4747,
+  "downloads": 0,
   "id": "catwan_usbstick",
   "versions": [
    {
@@ -25757,7 +25757,7 @@
   ]
  },
  {
-  "downloads": 139,
+  "downloads": 0,
   "id": "cezerio_dev_ESP32C6",
   "versions": [
    {
@@ -26002,7 +26002,7 @@
   ]
  },
  {
-  "downloads": 3238,
+  "downloads": 0,
   "id": "challenger_840",
   "versions": [
    {
@@ -26252,7 +26252,7 @@
   ]
  },
  {
-  "downloads": 4057,
+  "downloads": 10,
   "id": "challenger_nb_rp2040_wifi",
   "versions": [
    {
@@ -26518,7 +26518,7 @@
   ]
  },
  {
-  "downloads": 4445,
+  "downloads": 0,
   "id": "challenger_rp2040_lora",
   "versions": [
    {
@@ -26788,7 +26788,7 @@
   ]
  },
  {
-  "downloads": 4101,
+  "downloads": 0,
   "id": "challenger_rp2040_lte",
   "versions": [
    {
@@ -27054,7 +27054,7 @@
   ]
  },
  {
-  "downloads": 4468,
+  "downloads": 0,
   "id": "challenger_rp2040_sdrtc",
   "versions": [
    {
@@ -27324,7 +27324,7 @@
   ]
  },
  {
-  "downloads": 3014,
+  "downloads": 0,
   "id": "challenger_rp2040_subghz",
   "versions": [
    {
@@ -27594,7 +27594,7 @@
   ]
  },
  {
-  "downloads": 4385,
+  "downloads": 2,
   "id": "challenger_rp2040_wifi",
   "versions": [
    {
@@ -27860,7 +27860,7 @@
   ]
  },
  {
-  "downloads": 4691,
+  "downloads": 2,
   "id": "challenger_rp2040_wifi_ble",
   "versions": [
    {
@@ -28126,7 +28126,7 @@
   ]
  },
  {
-  "downloads": 923,
+  "downloads": 0,
   "id": "challenger_rp2350_bconnect",
   "versions": [
    {
@@ -28402,7 +28402,7 @@
   ]
  },
  {
-  "downloads": 3334,
+  "downloads": 4,
   "id": "challenger_rp2350_wifi6_ble5",
   "versions": [
    {
@@ -28678,7 +28678,7 @@
   ]
  },
  {
-  "downloads": 1271,
+  "downloads": 1,
   "id": "circuitart_zero_s3",
   "versions": [
    {
@@ -28970,7 +28970,7 @@
   ]
  },
  {
-  "downloads": 3834,
+  "downloads": 0,
   "id": "circuitbrains_basic_m0",
   "versions": [
    {
@@ -29125,7 +29125,7 @@
   ]
  },
  {
-  "downloads": 3817,
+  "downloads": 2,
   "id": "circuitbrains_deluxe_m4",
   "versions": [
    {
@@ -29361,7 +29361,7 @@
   ]
  },
  {
-  "downloads": 6475,
+  "downloads": 63,
   "id": "circuitplayground_bluefruit",
   "versions": [
    {
@@ -29603,7 +29603,7 @@
   ]
  },
  {
-  "downloads": 9729,
+  "downloads": 114,
   "id": "circuitplayground_express",
   "versions": [
    {
@@ -29761,7 +29761,7 @@
   ]
  },
  {
-  "downloads": 2983,
+  "downloads": 0,
   "id": "circuitplayground_express_4h",
   "versions": [
    {
@@ -29919,7 +29919,7 @@
   ]
  },
  {
-  "downloads": 4788,
+  "downloads": 3,
   "id": "circuitplayground_express_crickit",
   "versions": [
    {
@@ -30077,7 +30077,7 @@
   ]
  },
  {
-  "downloads": 2923,
+  "downloads": 0,
   "id": "circuitplayground_express_digikey_pycon2019",
   "versions": [
    {
@@ -30235,7 +30235,7 @@
   ]
  },
  {
-  "downloads": 4319,
+  "downloads": 0,
   "id": "circuitplayground_express_displayio",
   "versions": [
    {
@@ -30391,7 +30391,7 @@
   ]
  },
  {
-  "downloads": 5050,
+  "downloads": 22,
   "id": "clue_nrf52840_express",
   "versions": [
    {
@@ -30633,7 +30633,7 @@
   ]
  },
  {
-  "downloads": 3038,
+  "downloads": 0,
   "id": "columbia-dsl-sensor",
   "versions": [
    {
@@ -30913,7 +30913,7 @@
   ]
  },
  {
-  "downloads": 3332,
+  "downloads": 0,
   "id": "cosmo_pico",
   "versions": [
    {
@@ -31179,7 +31179,7 @@
   ]
  },
  {
-  "downloads": 2804,
+  "downloads": 0,
   "id": "cp32-m4",
   "versions": [
    {
@@ -31428,7 +31428,7 @@
   ]
  },
  {
-  "downloads": 3375,
+  "downloads": 0,
   "id": "cp_sapling_m0",
   "versions": [
    {
@@ -31548,7 +31548,7 @@
   ]
  },
  {
-  "downloads": 3006,
+  "downloads": 0,
   "id": "cp_sapling_m0_revb",
   "versions": [
    {
@@ -31668,7 +31668,7 @@
   ]
  },
  {
-  "downloads": 3803,
+  "downloads": 0,
   "id": "cp_sapling_m0_spiflash",
   "versions": [
    {
@@ -31818,7 +31818,7 @@
   ]
  },
  {
-  "downloads": 1660,
+  "downloads": 10,
   "id": "crcibernetica-ideaboard",
   "versions": [
    {
@@ -32097,7 +32097,7 @@
   ]
  },
  {
-  "downloads": 4078,
+  "downloads": 0,
   "id": "crumpspace_crumps2",
   "versions": [
    {
@@ -32372,7 +32372,7 @@
   ]
  },
  {
-  "downloads": 4524,
+  "downloads": 10,
   "id": "cytron_edu_pico_w",
   "versions": [
    {
@@ -32676,7 +32676,7 @@
   ]
  },
  {
-  "downloads": 1816,
+  "downloads": 0,
   "id": "cytron_iriv_io_controller",
   "versions": [
    {
@@ -32964,7 +32964,7 @@
   ]
  },
  {
-  "downloads": 3742,
+  "downloads": 0,
   "id": "cytron_maker_feather_aiot_s3",
   "versions": [
    {
@@ -33252,7 +33252,7 @@
   ]
  },
  {
-  "downloads": 4967,
+  "downloads": 0,
   "id": "cytron_maker_nano_rp2040",
   "versions": [
    {
@@ -33524,7 +33524,7 @@
   ]
  },
  {
-  "downloads": 6244,
+  "downloads": 14,
   "id": "cytron_maker_pi_rp2040",
   "versions": [
    {
@@ -33798,7 +33798,7 @@
   ]
  },
  {
-  "downloads": 4796,
+  "downloads": 0,
   "id": "cytron_maker_uno_rp2040",
   "versions": [
    {
@@ -34070,7 +34070,7 @@
   ]
  },
  {
-  "downloads": 2280,
+  "downloads": 10,
   "id": "cytron_motion_2350_pro",
   "versions": [
    {
@@ -34348,7 +34348,7 @@
   ]
  },
  {
-  "downloads": 30,
+  "downloads": 1,
   "id": "daisy_seed_with_sdram",
   "versions": [
    {
@@ -34561,7 +34561,7 @@
   ]
  },
  {
-  "downloads": 4070,
+  "downloads": 0,
   "id": "datalore_ip_m4",
   "versions": [
    {
@@ -34797,7 +34797,7 @@
   ]
  },
  {
-  "downloads": 3773,
+  "downloads": 0,
   "id": "datanoise_picoadk",
   "versions": [
    {
@@ -35065,7 +35065,7 @@
   ]
  },
  {
-  "downloads": 1173,
+  "downloads": 1,
   "id": "datanoise_picoadk_v2",
   "versions": [
    {
@@ -35337,7 +35337,7 @@
   ]
  },
  {
-  "downloads": 3481,
+  "downloads": 0,
   "id": "datum_distance",
   "versions": [
    {
@@ -35457,7 +35457,7 @@
   ]
  },
  {
-  "downloads": 3726,
+  "downloads": 1,
   "id": "datum_imu",
   "versions": [
    {
@@ -35577,7 +35577,7 @@
   ]
  },
  {
-  "downloads": 2808,
+  "downloads": 4,
   "id": "datum_light",
   "versions": [
    {
@@ -35697,7 +35697,7 @@
   ]
  },
  {
-  "downloads": 3082,
+  "downloads": 1,
   "id": "datum_weather",
   "versions": [
    {
@@ -35817,7 +35817,7 @@
   ]
  },
  {
-  "downloads": 1230,
+  "downloads": 3,
   "id": "deneyap_kart",
   "versions": [
    {
@@ -36084,7 +36084,7 @@
   ]
  },
  {
-  "downloads": 1223,
+  "downloads": 0,
   "id": "deneyap_kart_1a",
   "versions": [
    {
@@ -36351,7 +36351,7 @@
   ]
  },
  {
-  "downloads": 3788,
+  "downloads": 4,
   "id": "deneyap_kart_1a_v2",
   "versions": [
    {
@@ -36620,7 +36620,7 @@
   ]
  },
  {
-  "downloads": 1128,
+  "downloads": 0,
   "id": "deneyap_kart_g",
   "versions": [
    {
@@ -36863,7 +36863,7 @@
   ]
  },
  {
-  "downloads": 4405,
+  "downloads": 2,
   "id": "deneyap_mini",
   "versions": [
    {
@@ -37136,7 +37136,7 @@
   ]
  },
  {
-  "downloads": 5322,
+  "downloads": 2,
   "id": "deneyap_mini_v2",
   "versions": [
    {
@@ -37413,7 +37413,7 @@
   ]
  },
  {
-  "downloads": 1196,
+  "downloads": 0,
   "id": "devkit_xg24_brd2601b",
   "versions": [
    {
@@ -37611,7 +37611,7 @@
   ]
  },
  {
-  "downloads": 3040,
+  "downloads": 2,
   "id": "diodes_delight_piunora",
   "versions": [
    {
@@ -37825,7 +37825,7 @@
   ]
  },
  {
-  "downloads": 4722,
+  "downloads": 41,
   "id": "doit_esp32_devkit_v1",
   "versions": [
    {
@@ -38088,7 +38088,7 @@
   ]
  },
  {
-  "downloads": 3740,
+  "downloads": 1,
   "id": "dynalora_usb",
   "versions": [
    {
@@ -38218,7 +38218,7 @@
   ]
  },
  {
-  "downloads": 4175,
+  "downloads": 0,
   "id": "dynossat_edu_eps",
   "versions": [
    {
@@ -38370,7 +38370,7 @@
   ]
  },
  {
-  "downloads": 4479,
+  "downloads": 5,
   "id": "dynossat_edu_obc",
   "versions": [
    {
@@ -38619,7 +38619,7 @@
   ]
  },
  {
-  "downloads": 3071,
+  "downloads": 4,
   "id": "e_fidget",
   "versions": [
    {
@@ -38885,7 +38885,7 @@
   ]
  },
  {
-  "downloads": 4394,
+  "downloads": 3,
   "id": "edgebadge",
   "versions": [
    {
@@ -39118,7 +39118,7 @@
   ]
  },
  {
-  "downloads": 4839,
+  "downloads": 1,
   "id": "elecfreaks_picoed",
   "versions": [
    {
@@ -39400,7 +39400,7 @@
   ]
  },
  {
-  "downloads": 34,
+  "downloads": 0,
   "id": "elecrow_crowpanel_4_2_epaper",
   "versions": [
    {
@@ -39672,7 +39672,7 @@
   ]
  },
  {
-  "downloads": 3105,
+  "downloads": 0,
   "id": "electrolama_minik",
   "versions": [
    {
@@ -39938,7 +39938,7 @@
   ]
  },
  {
-  "downloads": 4014,
+  "downloads": 2,
   "id": "electroniccats_bastwifi",
   "versions": [
    {
@@ -40207,7 +40207,7 @@
   ]
  },
  {
-  "downloads": 3580,
+  "downloads": 3,
   "id": "electronut_labs_blip",
   "versions": [
    {
@@ -40451,7 +40451,7 @@
   ]
  },
  {
-  "downloads": 5654,
+  "downloads": 0,
   "id": "electronut_labs_papyr",
   "versions": [
    {
@@ -40693,7 +40693,7 @@
   ]
  },
  {
-  "downloads": 2296,
+  "downloads": 0,
   "id": "es3ink",
   "versions": [
    {
@@ -40977,7 +40977,7 @@
   ]
  },
  {
-  "downloads": 4927,
+  "downloads": 1,
   "id": "escornabot_makech",
   "versions": [
    {
@@ -41095,7 +41095,7 @@
   ]
  },
  {
-  "downloads": 1036,
+  "downloads": 4,
   "id": "esp32-wrover-dev-cam",
   "versions": [
    {
@@ -41363,7 +41363,7 @@
   ]
  },
  {
-  "downloads": 2886,
+  "downloads": 44,
   "id": "espressif_esp32_devkitc_v4_wroom_32e",
   "versions": [
    {
@@ -41626,7 +41626,7 @@
   ]
  },
  {
-  "downloads": 1719,
+  "downloads": 6,
   "id": "espressif_esp32_devkitc_v4_wrover",
   "versions": [
    {
@@ -41896,7 +41896,7 @@
   ]
  },
  {
-  "downloads": 1370,
+  "downloads": 3,
   "id": "espressif_esp32_eye",
   "versions": [
    {
@@ -42137,7 +42137,7 @@
   ]
  },
  {
-  "downloads": 1312,
+  "downloads": 1,
   "id": "espressif_esp32_lyrat",
   "versions": [
    {
@@ -42400,7 +42400,7 @@
   ]
  },
  {
-  "downloads": 1774,
+  "downloads": 3,
   "id": "espressif_esp32c3_devkitm_1_n4",
   "versions": [
    {
@@ -42643,7 +42643,7 @@
   ]
  },
  {
-  "downloads": 1960,
+  "downloads": 5,
   "id": "espressif_esp32c6_devkitc_1_n8",
   "versions": [
    {
@@ -42894,7 +42894,7 @@
   ]
  },
  {
-  "downloads": 2302,
+  "downloads": 9,
   "id": "espressif_esp32c6_devkitm_1_n4",
   "versions": [
    {
@@ -43136,7 +43136,7 @@
   ]
  },
  {
-  "downloads": 1486,
+  "downloads": 5,
   "id": "espressif_esp32h2_devkitm_1_n4",
   "versions": [
    {
@@ -43376,7 +43376,7 @@
   ]
  },
  {
-  "downloads": 5719,
+  "downloads": 4,
   "id": "espressif_esp32p4_function_ev",
   "versions": [
    {
@@ -43625,7 +43625,7 @@
   ]
  },
  {
-  "downloads": 3876,
+  "downloads": 4,
   "id": "espressif_esp32s2_devkitc_1_n4",
   "versions": [
    {
@@ -43896,7 +43896,7 @@
   ]
  },
  {
-  "downloads": 4690,
+  "downloads": 2,
   "id": "espressif_esp32s2_devkitc_1_n4r2",
   "versions": [
    {
@@ -44171,7 +44171,7 @@
   ]
  },
  {
-  "downloads": 3878,
+  "downloads": 0,
   "id": "espressif_esp32s2_devkitc_1_n8r2",
   "versions": [
    {
@@ -44452,7 +44452,7 @@
   ]
  },
  {
-  "downloads": 4184,
+  "downloads": 0,
   "id": "espressif_esp32s3_box",
   "versions": [
    {
@@ -44732,7 +44732,7 @@
   ]
  },
  {
-  "downloads": 5008,
+  "downloads": 1,
   "id": "espressif_esp32s3_box_lite",
   "versions": [
    {
@@ -45012,7 +45012,7 @@
   ]
  },
  {
-  "downloads": 1888,
+  "downloads": 15,
   "id": "espressif_esp32s3_devkitc_1_n16",
   "versions": [
    {
@@ -45292,7 +45292,7 @@
   ]
  },
  {
-  "downloads": 4382,
+  "downloads": 3,
   "id": "espressif_esp32s3_devkitc_1_n32r8",
   "versions": [
    {
@@ -45576,7 +45576,7 @@
   ]
  },
  {
-  "downloads": 5622,
+  "downloads": 17,
   "id": "espressif_esp32s3_devkitc_1_n8",
   "versions": [
    {
@@ -45856,7 +45856,7 @@
   ]
  },
  {
-  "downloads": 5279,
+  "downloads": 4,
   "id": "espressif_esp32s3_devkitc_1_n8r2",
   "versions": [
    {
@@ -46140,7 +46140,7 @@
   ]
  },
  {
-  "downloads": 4982,
+  "downloads": 11,
   "id": "espressif_esp32s3_devkitc_1_n8r8",
   "versions": [
    {
@@ -46424,7 +46424,7 @@
   ]
  },
  {
-  "downloads": 3834,
+  "downloads": 0,
   "id": "espressif_esp32s3_devkitc_1_n8r8_hacktablet",
   "versions": [
    {
@@ -46710,7 +46710,7 @@
   ]
  },
  {
-  "downloads": 4645,
+  "downloads": 1,
   "id": "espressif_esp32s3_devkitm_1_n8",
   "versions": [
    {
@@ -46990,7 +46990,7 @@
   ]
  },
  {
-  "downloads": 4429,
+  "downloads": 11,
   "id": "espressif_esp32s3_eye",
   "versions": [
    {
@@ -47274,7 +47274,7 @@
   ]
  },
  {
-  "downloads": 4990,
+  "downloads": 12,
   "id": "espressif_esp32s3_lcd_ev",
   "versions": [
    {
@@ -47560,7 +47560,7 @@
   ]
  },
  {
-  "downloads": 1508,
+  "downloads": 6,
   "id": "espressif_esp32s3_lcd_ev_v1.5",
   "versions": [
    {
@@ -47846,7 +47846,7 @@
   ]
  },
  {
-  "downloads": 4253,
+  "downloads": 3,
   "id": "espressif_esp32s3_usb_otg_n8",
   "versions": [
    {
@@ -48126,7 +48126,7 @@
   ]
  },
  {
-  "downloads": 767,
+  "downloads": 1,
   "id": "espressif_esp8684_devkitc_02_n4",
   "versions": [
    {
@@ -48358,7 +48358,7 @@
   ]
  },
  {
-  "downloads": 4450,
+  "downloads": 1,
   "id": "espressif_hmi_devkit_1",
   "versions": [
    {
@@ -48633,7 +48633,7 @@
   ]
  },
  {
-  "downloads": 3602,
+  "downloads": 0,
   "id": "espressif_kaluga_1",
   "versions": [
    {
@@ -48908,7 +48908,7 @@
   ]
  },
  {
-  "downloads": 3748,
+  "downloads": 5,
   "id": "espressif_kaluga_1.3",
   "versions": [
    {
@@ -49183,7 +49183,7 @@
   ]
  },
  {
-  "downloads": 4650,
+  "downloads": 7,
   "id": "espressif_saola_1_wroom",
   "versions": [
    {
@@ -49454,7 +49454,7 @@
   ]
  },
  {
-  "downloads": 4287,
+  "downloads": 0,
   "id": "espressif_saola_1_wrover",
   "versions": [
    {
@@ -49729,7 +49729,7 @@
   ]
  },
  {
-  "downloads": 1469,
+  "downloads": 0,
   "id": "espruino_banglejs2",
   "versions": [
    {
@@ -49939,7 +49939,7 @@
   ]
  },
  {
-  "downloads": 1235,
+  "downloads": 0,
   "id": "espruino_pico",
   "versions": [
    {
@@ -50116,7 +50116,7 @@
   ]
  },
  {
-  "downloads": 1202,
+  "downloads": 0,
   "id": "espruino_wifi",
   "versions": [
    {
@@ -50328,7 +50328,7 @@
   ]
  },
  {
-  "downloads": 1301,
+  "downloads": 0,
   "id": "explorerkit_xg24_brd2703a",
   "versions": [
    {
@@ -50526,7 +50526,7 @@
   ]
  },
  {
-  "downloads": 4358,
+  "downloads": 9,
   "id": "feather_bluefruit_sense",
   "versions": [
    {
@@ -50768,7 +50768,7 @@
   ]
  },
  {
-  "downloads": 3931,
+  "downloads": 2,
   "id": "feather_m0_adalogger",
   "versions": [
    {
@@ -50890,7 +50890,7 @@
   ]
  },
  {
-  "downloads": 4306,
+  "downloads": 5,
   "id": "feather_m0_basic",
   "versions": [
    {
@@ -51012,7 +51012,7 @@
   ]
  },
  {
-  "downloads": 4994,
+  "downloads": 10,
   "id": "feather_m0_express",
   "versions": [
    {
@@ -51166,7 +51166,7 @@
   ]
  },
  {
-  "downloads": 4504,
+  "downloads": 2,
   "id": "feather_m0_express_crickit",
   "versions": [
    {
@@ -51316,7 +51316,7 @@
   ]
  },
  {
-  "downloads": 4479,
+  "downloads": 1,
   "id": "feather_m0_rfm69",
   "versions": [
    {
@@ -51432,7 +51432,7 @@
   ]
  },
  {
-  "downloads": 3940,
+  "downloads": 8,
   "id": "feather_m0_rfm9x",
   "versions": [
    {
@@ -51550,7 +51550,7 @@
   ]
  },
  {
-  "downloads": 2979,
+  "downloads": 0,
   "id": "feather_m0_supersized",
   "versions": [
    {
@@ -51705,7 +51705,7 @@
   ]
  },
  {
-  "downloads": 4364,
+  "downloads": 6,
   "id": "feather_m4_can",
   "versions": [
    {
@@ -51941,7 +51941,7 @@
   ]
  },
  {
-  "downloads": 6563,
+  "downloads": 52,
   "id": "feather_m4_express",
   "versions": [
    {
@@ -52178,7 +52178,7 @@
   ]
  },
  {
-  "downloads": 5509,
+  "downloads": 1,
   "id": "feather_m7_1011",
   "versions": [
    {
@@ -52414,7 +52414,7 @@
   ]
  },
  {
-  "downloads": 5154,
+  "downloads": 0,
   "id": "feather_mimxrt1011",
   "versions": [
    {
@@ -52650,7 +52650,7 @@
   ]
  },
  {
-  "downloads": 4615,
+  "downloads": 2,
   "id": "feather_mimxrt1062",
   "versions": [
    {
@@ -52878,7 +52878,7 @@
   ]
  },
  {
-  "downloads": 5188,
+  "downloads": 27,
   "id": "feather_nrf52840_express",
   "versions": [
    {
@@ -53125,7 +53125,7 @@
   "versions": []
  },
  {
-  "downloads": 1746,
+  "downloads": 7,
   "id": "feather_stm32f405_express",
   "versions": [
    {
@@ -53357,7 +53357,7 @@
   ]
  },
  {
-  "downloads": 5371,
+  "downloads": 4,
   "id": "firebeetle2_esp32s3",
   "versions": [
    {
@@ -53645,7 +53645,7 @@
   ]
  },
  {
-  "downloads": 11847,
+  "downloads": 36,
   "id": "flipperzero_wifi_dev",
   "versions": [
    {
@@ -53920,7 +53920,7 @@
   ]
  },
  {
-  "downloads": 3129,
+  "downloads": 0,
   "id": "fluff_m0",
   "versions": [
    {
@@ -54040,7 +54040,7 @@
   ]
  },
  {
-  "downloads": 4173,
+  "downloads": 4,
   "id": "fomu",
   "versions": [
    {
@@ -54196,7 +54196,7 @@
   ]
  },
  {
-  "downloads": 5369,
+  "downloads": 2,
   "id": "franzininho_wifi_wroom",
   "versions": [
    {
@@ -54467,7 +54467,7 @@
   ]
  },
  {
-  "downloads": 4598,
+  "downloads": 0,
   "id": "franzininho_wifi_wrover",
   "versions": [
    {
@@ -54742,7 +54742,7 @@
   ]
  },
  {
-  "downloads": 5795,
+  "downloads": 8,
   "id": "gemma_m0",
   "versions": [
    {
@@ -54862,7 +54862,7 @@
   ]
  },
  {
-  "downloads": 2994,
+  "downloads": 0,
   "id": "gemma_m0_pycon2018",
   "versions": [
    {
@@ -54982,7 +54982,7 @@
   ]
  },
  {
-  "downloads": 4877,
+  "downloads": 7,
   "id": "grandcentral_m4_express",
   "versions": [
    {
@@ -55237,7 +55237,7 @@
   ]
  },
  {
-  "downloads": 3862,
+  "downloads": 0,
   "id": "gravitech_cucumber_m",
   "versions": [
    {
@@ -55508,7 +55508,7 @@
   ]
  },
  {
-  "downloads": 3529,
+  "downloads": 0,
   "id": "gravitech_cucumber_ms",
   "versions": [
    {
@@ -55779,7 +55779,7 @@
   ]
  },
  {
-  "downloads": 3848,
+  "downloads": 0,
   "id": "gravitech_cucumber_r",
   "versions": [
    {
@@ -56054,7 +56054,7 @@
   ]
  },
  {
-  "downloads": 3824,
+  "downloads": 0,
   "id": "gravitech_cucumber_rs",
   "versions": [
    {
@@ -56329,7 +56329,7 @@
   ]
  },
  {
-  "downloads": 3611,
+  "downloads": 0,
   "id": "hack_club_sprig",
   "versions": [
    {
@@ -56595,7 +56595,7 @@
   ]
  },
  {
-  "downloads": 4530,
+  "downloads": 2,
   "id": "hallowing_m0_express",
   "versions": [
    {
@@ -56757,7 +56757,7 @@
   ]
  },
  {
-  "downloads": 4666,
+  "downloads": 1,
   "id": "hallowing_m4_express",
   "versions": [
    {
@@ -56988,7 +56988,7 @@
   ]
  },
  {
-  "downloads": 7787,
+  "downloads": 1,
   "id": "hardkernel_odroid_go",
   "versions": [
    {
@@ -57262,7 +57262,7 @@
   ]
  },
  {
-  "downloads": 3898,
+  "downloads": 0,
   "id": "heiafr_picomo_v2",
   "versions": [
    {
@@ -57540,7 +57540,7 @@
   ]
  },
  {
-  "downloads": 651,
+  "downloads": 0,
   "id": "heiafr_picomo_v3",
   "versions": [
    {
@@ -57818,7 +57818,7 @@
   ]
  },
  {
-  "downloads": 1833,
+  "downloads": 3,
   "id": "heltec_esp32s3_wifi_lora_v3",
   "versions": [
    {
@@ -58096,7 +58096,7 @@
   ]
  },
  {
-  "downloads": 264,
+  "downloads": 3,
   "id": "heltec_vision_master_e290",
   "versions": [
    {
@@ -58376,7 +58376,7 @@
   ]
  },
  {
-  "downloads": 146,
+  "downloads": 0,
   "id": "heltec_wireless_paper",
   "versions": [
    {
@@ -58648,7 +58648,7 @@
   ]
  },
  {
-  "downloads": 2559,
+  "downloads": 0,
   "id": "hexky_s2",
   "versions": [
    {
@@ -58927,7 +58927,7 @@
   ]
  },
  {
-  "downloads": 5274,
+  "downloads": 10,
   "id": "hiibot_bluefi",
   "versions": [
    {
@@ -59169,7 +59169,7 @@
   ]
  },
  {
-  "downloads": 3827,
+  "downloads": 5,
   "id": "hiibot_iots2",
   "versions": [
    {
@@ -59450,7 +59450,7 @@
   ]
  },
  {
-  "downloads": 4683,
+  "downloads": 1,
   "id": "huntercat_nfc",
   "versions": [
    {
@@ -59606,7 +59606,7 @@
   ]
  },
  {
-  "downloads": 509,
+  "downloads": 6,
   "id": "hxr_sao_dmm",
   "versions": [
    {
@@ -59886,7 +59886,7 @@
   ]
  },
  {
-  "downloads": 3097,
+  "downloads": 0,
   "id": "ikigaisense_vita",
   "versions": [
    {
@@ -60128,7 +60128,7 @@
   ]
  },
  {
-  "downloads": 4280,
+  "downloads": 3,
   "id": "imxrt1010_evk",
   "versions": [
    {
@@ -60364,7 +60364,7 @@
   ]
  },
  {
-  "downloads": 3637,
+  "downloads": 7,
   "id": "imxrt1015_evk",
   "versions": [
    {
@@ -60592,7 +60592,7 @@
   ]
  },
  {
-  "downloads": 4373,
+  "downloads": 0,
   "id": "imxrt1020_evk",
   "versions": [
    {
@@ -60820,7 +60820,7 @@
   ]
  },
  {
-  "downloads": 5061,
+  "downloads": 1,
   "id": "imxrt1040_evk",
   "versions": [
    {
@@ -61048,7 +61048,7 @@
   ]
  },
  {
-  "downloads": 3928,
+  "downloads": 3,
   "id": "imxrt1050_evkb",
   "versions": [
    {
@@ -61280,7 +61280,7 @@
   ]
  },
  {
-  "downloads": 5545,
+  "downloads": 3,
   "id": "imxrt1060_evk",
   "versions": [
    {
@@ -61512,7 +61512,7 @@
   ]
  },
  {
-  "downloads": 3602,
+  "downloads": 5,
   "id": "imxrt1060_evkb",
   "versions": [
    {
@@ -61744,7 +61744,7 @@
   ]
  },
  {
-  "downloads": 4763,
+  "downloads": 8,
   "id": "itsybitsy_m0_express",
   "versions": [
    {
@@ -61898,7 +61898,7 @@
   ]
  },
  {
-  "downloads": 5868,
+  "downloads": 12,
   "id": "itsybitsy_m4_express",
   "versions": [
    {
@@ -62131,7 +62131,7 @@
   ]
  },
  {
-  "downloads": 4923,
+  "downloads": 8,
   "id": "itsybitsy_nrf52840_express",
   "versions": [
    {
@@ -62373,7 +62373,7 @@
   ]
  },
  {
-  "downloads": 4899,
+  "downloads": 7,
   "id": "jpconstantineau_encoderpad_rp2040",
   "versions": [
    {
@@ -62637,7 +62637,7 @@
   ]
  },
  {
-  "downloads": 4266,
+  "downloads": 1,
   "id": "jpconstantineau_pykey18",
   "versions": [
    {
@@ -62903,7 +62903,7 @@
   ]
  },
  {
-  "downloads": 3653,
+  "downloads": 0,
   "id": "jpconstantineau_pykey44",
   "versions": [
    {
@@ -63169,7 +63169,7 @@
   ]
  },
  {
-  "downloads": 4434,
+  "downloads": 0,
   "id": "jpconstantineau_pykey60",
   "versions": [
    {
@@ -63435,7 +63435,7 @@
   ]
  },
  {
-  "downloads": 5714,
+  "downloads": 0,
   "id": "jpconstantineau_pykey87",
   "versions": [
    {
@@ -63701,7 +63701,7 @@
   ]
  },
  {
-  "downloads": 4114,
+  "downloads": 0,
   "id": "kicksat-sprite",
   "versions": [
    {
@@ -63863,7 +63863,7 @@
   ]
  },
  {
-  "downloads": 5140,
+  "downloads": 4,
   "id": "lilygo_t_display_rp2040",
   "versions": [
    {
@@ -64129,7 +64129,7 @@
   ]
  },
  {
-  "downloads": 8462,
+  "downloads": 5,
   "id": "lilygo_tdeck",
   "versions": [
    {
@@ -64405,7 +64405,7 @@
   ]
  },
  {
-  "downloads": 5261,
+  "downloads": 16,
   "id": "lilygo_tdisplay_s3",
   "versions": [
    {
@@ -64689,7 +64689,7 @@
   ]
  },
  {
-  "downloads": 2333,
+  "downloads": 0,
   "id": "lilygo_tdisplay_s3_pro",
   "versions": [
    {
@@ -64973,7 +64973,7 @@
   ]
  },
  {
-  "downloads": 225,
+  "downloads": 23,
   "id": "lilygo_tdongle_s3",
   "versions": [
    {
@@ -65257,7 +65257,7 @@
   ]
  },
  {
-  "downloads": 4832,
+  "downloads": 14,
   "id": "lilygo_tembed_esp32s3",
   "versions": [
    {
@@ -65541,7 +65541,7 @@
   ]
  },
  {
-  "downloads": 232,
+  "downloads": 6,
   "id": "lilygo_tqt_pro_nopsram",
   "versions": [
    {
@@ -65819,7 +65819,7 @@
   ]
  },
  {
-  "downloads": 216,
+  "downloads": 2,
   "id": "lilygo_tqt_pro_psram",
   "versions": [
    {
@@ -66088,7 +66088,7 @@
   ]
  },
  {
-  "downloads": 984,
+  "downloads": 1,
   "id": "lilygo_ttgo_t-01c3",
   "versions": [
    {
@@ -66334,7 +66334,7 @@
   ]
  },
  {
-  "downloads": 1307,
+  "downloads": 0,
   "id": "lilygo_ttgo_t-oi-plus",
   "versions": [
    {
@@ -66577,7 +66577,7 @@
   ]
  },
  {
-  "downloads": 3945,
+  "downloads": 9,
   "id": "lilygo_ttgo_t8_esp32_s2_wroom",
   "versions": [
    {
@@ -66848,7 +66848,7 @@
   ]
  },
  {
-  "downloads": 3885,
+  "downloads": 0,
   "id": "lilygo_ttgo_t8_s2",
   "versions": [
    {
@@ -67123,7 +67123,7 @@
   ]
  },
  {
-  "downloads": 4954,
+  "downloads": 0,
   "id": "lilygo_ttgo_t8_s2_st7789",
   "versions": [
    {
@@ -67398,7 +67398,7 @@
   ]
  },
  {
-  "downloads": 1827,
+  "downloads": 4,
   "id": "lilygo_ttgo_tdisplay_esp32_16m",
   "versions": [
    {
@@ -67668,7 +67668,7 @@
   ]
  },
  {
-  "downloads": 1416,
+  "downloads": 2,
   "id": "lilygo_ttgo_tdisplay_esp32_4m",
   "versions": [
    {
@@ -67931,7 +67931,7 @@
   ]
  },
  {
-  "downloads": 1423,
+  "downloads": 2,
   "id": "lilygo_twatch_2020_v3",
   "versions": [
    {
@@ -68205,7 +68205,7 @@
   ]
  },
  {
-  "downloads": 1874,
+  "downloads": 2,
   "id": "lilygo_twatch_s3",
   "versions": [
    {
@@ -68485,7 +68485,7 @@
   ]
  },
  {
-  "downloads": 2468,
+  "downloads": 0,
   "id": "loc_ber_m4_base_board",
   "versions": [
    {
@@ -68617,7 +68617,7 @@
   ]
  },
  {
-  "downloads": 1485,
+  "downloads": 4,
   "id": "lolin_c3_mini",
   "versions": [
    {
@@ -68860,7 +68860,7 @@
   ]
  },
  {
-  "downloads": 1397,
+  "downloads": 0,
   "id": "lolin_c3_pico",
   "versions": [
    {
@@ -69105,7 +69105,7 @@
   ]
  },
  {
-  "downloads": 14214,
+  "downloads": 39,
   "id": "lolin_s2_mini",
   "versions": [
    {
@@ -69384,7 +69384,7 @@
   ]
  },
  {
-  "downloads": 3666,
+  "downloads": 3,
   "id": "lolin_s2_pico",
   "versions": [
    {
@@ -69663,7 +69663,7 @@
   ]
  },
  {
-  "downloads": 4598,
+  "downloads": 7,
   "id": "lolin_s3",
   "versions": [
    {
@@ -69943,7 +69943,7 @@
   ]
  },
  {
-  "downloads": 8470,
+  "downloads": 1,
   "id": "lolin_s3_mini",
   "versions": [
    {
@@ -70214,7 +70214,7 @@
   ]
  },
  {
-  "downloads": 279,
+  "downloads": 4,
   "id": "lolin_s3_mini_pro",
   "versions": [
    {
@@ -70485,7 +70485,7 @@
   ]
  },
  {
-  "downloads": 3131,
+  "downloads": 2,
   "id": "lolin_s3_pro",
   "versions": [
    {
@@ -70765,7 +70765,7 @@
   ]
  },
  {
-  "downloads": 1899,
+  "downloads": 4,
   "id": "luatos_core_esp32c3",
   "versions": [
    {
@@ -71008,7 +71008,7 @@
   ]
  },
  {
-  "downloads": 1602,
+  "downloads": 7,
   "id": "luatos_core_esp32c3_ch343",
   "versions": [
    {
@@ -71251,7 +71251,7 @@
   ]
  },
  {
-  "downloads": 1424,
+  "downloads": 3,
   "id": "m5stack_atom_echo",
   "versions": [
    {
@@ -71514,7 +71514,7 @@
   ]
  },
  {
-  "downloads": 1599,
+  "downloads": 4,
   "id": "m5stack_atom_lite",
   "versions": [
    {
@@ -71777,7 +71777,7 @@
   ]
  },
  {
-  "downloads": 1371,
+  "downloads": 3,
   "id": "m5stack_atom_matrix",
   "versions": [
    {
@@ -72040,7 +72040,7 @@
   ]
  },
  {
-  "downloads": 1323,
+  "downloads": 1,
   "id": "m5stack_atom_u",
   "versions": [
    {
@@ -72303,7 +72303,7 @@
   ]
  },
  {
-  "downloads": 4318,
+  "downloads": 7,
   "id": "m5stack_atoms3",
   "versions": [
    {
@@ -72583,7 +72583,7 @@
   ]
  },
  {
-  "downloads": 5135,
+  "downloads": 9,
   "id": "m5stack_atoms3_lite",
   "versions": [
    {
@@ -72863,7 +72863,7 @@
   ]
  },
  {
-  "downloads": 5968,
+  "downloads": 5,
   "id": "m5stack_atoms3u",
   "versions": [
    {
@@ -73143,7 +73143,7 @@
   ]
  },
  {
-  "downloads": 8824,
+  "downloads": 24,
   "id": "m5stack_cardputer",
   "versions": [
    {
@@ -73419,7 +73419,7 @@
   ]
  },
  {
-  "downloads": 1599,
+  "downloads": 2,
   "id": "m5stack_core2",
   "versions": [
    {
@@ -73705,7 +73705,7 @@
   ]
  },
  {
-  "downloads": 1455,
+  "downloads": 3,
   "id": "m5stack_core_basic",
   "versions": [
    {
@@ -73975,7 +73975,7 @@
   ]
  },
  {
-  "downloads": 1407,
+  "downloads": 0,
   "id": "m5stack_core_fire",
   "versions": [
    {
@@ -74245,7 +74245,7 @@
   ]
  },
  {
-  "downloads": 2904,
+  "downloads": 1,
   "id": "m5stack_cores3",
   "versions": [
    {
@@ -74541,7 +74541,7 @@
   ]
  },
  {
-  "downloads": 3663,
+  "downloads": 3,
   "id": "m5stack_dial",
   "versions": [
    {
@@ -74819,7 +74819,7 @@
   ]
  },
  {
-  "downloads": 1417,
+  "downloads": 3,
   "id": "m5stack_m5paper",
   "versions": [
    {
@@ -75089,7 +75089,7 @@
   ]
  },
  {
-  "downloads": 1438,
+  "downloads": 0,
   "id": "m5stack_stamp_c3",
   "versions": [
    {
@@ -75332,7 +75332,7 @@
   ]
  },
  {
-  "downloads": 3778,
+  "downloads": 6,
   "id": "m5stack_stamp_s3",
   "versions": [
    {
@@ -75616,7 +75616,7 @@
   ]
  },
  {
-  "downloads": 1455,
+  "downloads": 3,
   "id": "m5stack_stick_c",
   "versions": [
    {
@@ -75879,7 +75879,7 @@
   ]
  },
  {
-  "downloads": 1594,
+  "downloads": 4,
   "id": "m5stack_stick_c_plus",
   "versions": [
    {
@@ -76142,7 +76142,7 @@
   ]
  },
  {
-  "downloads": 229,
+  "downloads": 4,
   "id": "m5stack_stick_c_plus2",
   "versions": [
    {
@@ -76416,7 +76416,7 @@
   ]
  },
  {
-  "downloads": 1363,
+  "downloads": 0,
   "id": "m5stack_timer_camera_x",
   "versions": [
    {
@@ -76683,7 +76683,7 @@
   ]
  },
  {
-  "downloads": 4152,
+  "downloads": 2,
   "id": "magiclick_s3_n4r2",
   "versions": [
    {
@@ -76954,7 +76954,7 @@
   ]
  },
  {
-  "downloads": 3814,
+  "downloads": 0,
   "id": "maker_badge",
   "versions": [
    {
@@ -77243,7 +77243,7 @@
   ]
  },
  {
-  "downloads": 1309,
+  "downloads": 1,
   "id": "makerdiary_imxrt1011_nanokit",
   "versions": [
    {
@@ -77477,7 +77477,7 @@
   ]
  },
  {
-  "downloads": 4292,
+  "downloads": 2,
   "id": "makerdiary_m60_keyboard",
   "versions": [
    {
@@ -77719,7 +77719,7 @@
   ]
  },
  {
-  "downloads": 4186,
+  "downloads": 0,
   "id": "makerdiary_nrf52840_connectkit",
   "versions": [
    {
@@ -77969,7 +77969,7 @@
   ]
  },
  {
-  "downloads": 4015,
+  "downloads": 1,
   "id": "makerdiary_nrf52840_m2_devkit",
   "versions": [
    {
@@ -78211,7 +78211,7 @@
   ]
  },
  {
-  "downloads": 3663,
+  "downloads": 0,
   "id": "makerdiary_nrf52840_mdk",
   "versions": [
    {
@@ -78453,7 +78453,7 @@
   ]
  },
  {
-  "downloads": 5122,
+  "downloads": 15,
   "id": "makerdiary_nrf52840_mdk_usb_dongle",
   "versions": [
    {
@@ -78697,7 +78697,7 @@
   ]
  },
  {
-  "downloads": 6066,
+  "downloads": 0,
   "id": "makerfabs_tft7",
   "versions": [
    {
@@ -78983,7 +78983,7 @@
   ]
  },
  {
-  "downloads": 2608,
+  "downloads": 31,
   "id": "makergo_esp32c3_supermini",
   "versions": [
    {
@@ -79226,7 +79226,7 @@
   ]
  },
  {
-  "downloads": 414,
+  "downloads": 1,
   "id": "makergo_esp32c6_supermini",
   "versions": [
    {
@@ -79471,7 +79471,7 @@
   ]
  },
  {
-  "downloads": 3740,
+  "downloads": 1,
   "id": "maple_elite_pi",
   "versions": [
    {
@@ -79735,7 +79735,7 @@
   ]
  },
  {
-  "downloads": 7507,
+  "downloads": 71,
   "id": "matrixportal_m4",
   "versions": [
    {
@@ -79982,7 +79982,7 @@
   ]
  },
  {
-  "downloads": 588,
+  "downloads": 1,
   "id": "max32690evkit",
   "versions": [
    {
@@ -80122,7 +80122,7 @@
   ]
  },
  {
-  "downloads": 3240,
+  "downloads": 0,
   "id": "melopero_shake_rp2040",
   "versions": [
    {
@@ -80388,7 +80388,7 @@
   ]
  },
  {
-  "downloads": 6571,
+  "downloads": 2,
   "id": "meowbit_v121",
   "versions": [
    {
@@ -80593,7 +80593,7 @@
   ]
  },
  {
-  "downloads": 4017,
+  "downloads": 1,
   "id": "meowmeow",
   "versions": [
    {
@@ -80711,7 +80711,7 @@
   ]
  },
  {
-  "downloads": 5350,
+  "downloads": 9,
   "id": "metro_m0_express",
   "versions": [
    {
@@ -80863,7 +80863,7 @@
   ]
  },
  {
-  "downloads": 4536,
+  "downloads": 6,
   "id": "metro_m4_airlift_lite",
   "versions": [
    {
@@ -81102,7 +81102,7 @@
   ]
  },
  {
-  "downloads": 5416,
+  "downloads": 8,
   "id": "metro_m4_express",
   "versions": [
    {
@@ -81339,7 +81339,7 @@
   ]
  },
  {
-  "downloads": 4653,
+  "downloads": 7,
   "id": "metro_m7_1011",
   "versions": [
    {
@@ -81575,7 +81575,7 @@
   ]
  },
  {
-  "downloads": 5191,
+  "downloads": 0,
   "id": "metro_nrf52840_express",
   "versions": [
    {
@@ -81819,7 +81819,7 @@
   ]
  },
  {
-  "downloads": 8949,
+  "downloads": 24,
   "id": "microbit_v2",
   "versions": [
    {
@@ -81950,7 +81950,7 @@
   ]
  },
  {
-  "downloads": 1289,
+  "downloads": 2,
   "id": "microdev_micro_c3",
   "versions": [
    {
@@ -82193,7 +82193,7 @@
   ]
  },
  {
-  "downloads": 4004,
+  "downloads": 0,
   "id": "microdev_micro_s2",
   "versions": [
    {
@@ -82474,7 +82474,7 @@
   ]
  },
  {
-  "downloads": 5296,
+  "downloads": 1,
   "id": "mini_sam_m4",
   "versions": [
    {
@@ -82715,7 +82715,7 @@
   ]
  },
  {
-  "downloads": 4085,
+  "downloads": 0,
   "id": "mixgo_ce_serial",
   "versions": [
    {
@@ -83030,7 +83030,7 @@
   ]
  },
  {
-  "downloads": 4693,
+  "downloads": 3,
   "id": "mixgo_ce_udisk",
   "versions": [
    {
@@ -83348,7 +83348,7 @@
   ]
  },
  {
-  "downloads": 4886,
+  "downloads": 1,
   "id": "monster_m4sk",
   "versions": [
    {
@@ -83571,7 +83571,7 @@
   ]
  },
  {
-  "downloads": 2120,
+  "downloads": 0,
   "id": "morpheans_morphesp-240",
   "versions": [
    {
@@ -83842,7 +83842,7 @@
   ]
  },
  {
-  "downloads": 443,
+  "downloads": 8,
   "id": "mtm_computer",
   "versions": [
    {
@@ -84107,7 +84107,7 @@
   ]
  },
  {
-  "downloads": 3992,
+  "downloads": 0,
   "id": "muselab_nanoesp32_s2_wroom",
   "versions": [
    {
@@ -84378,7 +84378,7 @@
   ]
  },
  {
-  "downloads": 3864,
+  "downloads": 3,
   "id": "muselab_nanoesp32_s2_wrover",
   "versions": [
    {
@@ -84653,7 +84653,7 @@
   ]
  },
  {
-  "downloads": 3031,
+  "downloads": 0,
   "id": "ndgarage_ndbit6",
   "versions": [
    {
@@ -84773,7 +84773,7 @@
   ]
  },
  {
-  "downloads": 3726,
+  "downloads": 2,
   "id": "ndgarage_ndbit6_v2",
   "versions": [
    {
@@ -84893,7 +84893,7 @@
   ]
  },
  {
-  "downloads": 5188,
+  "downloads": 7,
   "id": "neopixel_trinkey_m0",
   "versions": [
    {
@@ -85007,7 +85007,7 @@
   ]
  },
  {
-  "downloads": 4933,
+  "downloads": 0,
   "id": "nfc_copy_cat",
   "versions": [
    {
@@ -85129,7 +85129,7 @@
   ]
  },
  {
-  "downloads": 6147,
+  "downloads": 27,
   "id": "nice_nano",
   "versions": [
    {
@@ -85371,7 +85371,7 @@
   ]
  },
  {
-  "downloads": 851,
+  "downloads": 5,
   "id": "nodemcu_esp32c2",
   "versions": [
    {
@@ -85603,7 +85603,7 @@
   ]
  },
  {
-  "downloads": 319,
+  "downloads": 3,
   "id": "nordic_nrf5340dk",
   "versions": [
    {
@@ -85685,7 +85685,7 @@
   ]
  },
  {
-  "downloads": 395,
+  "downloads": 3,
   "id": "nordic_nrf54l15dk",
   "versions": [
    {
@@ -85765,7 +85765,7 @@
   ]
  },
  {
-  "downloads": 261,
+  "downloads": 1,
   "id": "nordic_nrf7002dk",
   "versions": [
    {
@@ -85853,7 +85853,7 @@
   ]
  },
  {
-  "downloads": 1341,
+  "downloads": 3,
   "id": "nucleo_f446re",
   "versions": [
    {
@@ -85997,7 +85997,7 @@
   ]
  },
  {
-  "downloads": 1222,
+  "downloads": 0,
   "id": "nucleo_f746zg",
   "versions": [
    {
@@ -86207,7 +86207,7 @@
   ]
  },
  {
-  "downloads": 1301,
+  "downloads": 0,
   "id": "nucleo_f767zi",
   "versions": [
    {
@@ -86417,7 +86417,7 @@
   ]
  },
  {
-  "downloads": 1223,
+  "downloads": 0,
   "id": "nucleo_h743zi_2",
   "versions": [
    {
@@ -86623,7 +86623,7 @@
   ]
  },
  {
-  "downloads": 3293,
+  "downloads": 3,
   "id": "nullbits_bit_c_pro",
   "versions": [
    {
@@ -86887,7 +86887,7 @@
   ]
  },
  {
-  "downloads": 3215,
+  "downloads": 0,
   "id": "odt_bread_2040",
   "versions": [
    {
@@ -87153,7 +87153,7 @@
   ]
  },
  {
-  "downloads": 3336,
+  "downloads": 0,
   "id": "odt_cast_away_rp2040",
   "versions": [
    {
@@ -87419,7 +87419,7 @@
   ]
  },
  {
-  "downloads": 3839,
+  "downloads": 0,
   "id": "odt_pixelwing_esp32_s2",
   "versions": [
    {
@@ -87694,7 +87694,7 @@
   ]
  },
  {
-  "downloads": 3179,
+  "downloads": 0,
   "id": "odt_rpga_feather",
   "versions": [
    {
@@ -87958,7 +87958,7 @@
   ]
  },
  {
-  "downloads": 4789,
+  "downloads": 5,
   "id": "ohs2020_badge",
   "versions": [
    {
@@ -88200,7 +88200,7 @@
   ]
  },
  {
-  "downloads": 4285,
+  "downloads": 0,
   "id": "openbook_m4",
   "versions": [
    {
@@ -88436,7 +88436,7 @@
   ]
  },
  {
-  "downloads": 1259,
+  "downloads": 0,
   "id": "openmv_h7",
   "versions": [
    {
@@ -88642,7 +88642,7 @@
   ]
  },
  {
-  "downloads": 1286,
+  "downloads": 0,
   "id": "oxocard_artwork",
   "versions": [
    {
@@ -88912,7 +88912,7 @@
   ]
  },
  {
-  "downloads": 1295,
+  "downloads": 0,
   "id": "oxocard_connect",
   "versions": [
    {
@@ -89182,7 +89182,7 @@
   ]
  },
  {
-  "downloads": 1117,
+  "downloads": 0,
   "id": "oxocard_galaxy",
   "versions": [
    {
@@ -89452,7 +89452,7 @@
   ]
  },
  {
-  "downloads": 1254,
+  "downloads": 0,
   "id": "oxocard_science",
   "versions": [
    {
@@ -89722,7 +89722,7 @@
   ]
  },
  {
-  "downloads": 4792,
+  "downloads": 0,
   "id": "p1am_200",
   "versions": [
    {
@@ -89971,7 +89971,7 @@
   ]
  },
  {
-  "downloads": 5000,
+  "downloads": 4,
   "id": "pajenicko_picopad",
   "versions": [
    {
@@ -90259,7 +90259,7 @@
   ]
  },
  {
-  "downloads": 4062,
+  "downloads": 2,
   "id": "particle_argon",
   "versions": [
    {
@@ -90501,7 +90501,7 @@
   ]
  },
  {
-  "downloads": 4080,
+  "downloads": 5,
   "id": "particle_boron",
   "versions": [
    {
@@ -90743,7 +90743,7 @@
   ]
  },
  {
-  "downloads": 4576,
+  "downloads": 5,
   "id": "particle_xenon",
   "versions": [
    {
@@ -90985,7 +90985,7 @@
   ]
  },
  {
-  "downloads": 4818,
+  "downloads": 0,
   "id": "pca10056",
   "versions": [
    {
@@ -91229,7 +91229,7 @@
   ]
  },
  {
-  "downloads": 4364,
+  "downloads": 11,
   "id": "pca10059",
   "versions": [
    {
@@ -91473,7 +91473,7 @@
   ]
  },
  {
-  "downloads": 4859,
+  "downloads": 2,
   "id": "pca10100",
   "versions": [
    {
@@ -91606,7 +91606,7 @@
   ]
  },
  {
-  "downloads": 3433,
+  "downloads": 0,
   "id": "pctel_wsc_1450",
   "versions": [
    {
@@ -91848,7 +91848,7 @@
   ]
  },
  {
-  "downloads": 4516,
+  "downloads": 0,
   "id": "pewpew10",
   "versions": [
    {
@@ -91968,7 +91968,7 @@
   ]
  },
  {
-  "downloads": 4642,
+  "downloads": 0,
   "id": "pewpew_lcd",
   "versions": [
    {
@@ -92090,7 +92090,7 @@
   ]
  },
  {
-  "downloads": 4468,
+  "downloads": 0,
   "id": "pewpew_m4",
   "versions": [
    {
@@ -92232,7 +92232,7 @@
   ]
  },
  {
-  "downloads": 3090,
+  "downloads": 4,
   "id": "picoplanet",
   "versions": [
    {
@@ -92352,7 +92352,7 @@
   ]
  },
  {
-  "downloads": 4697,
+  "downloads": 0,
   "id": "pillbug",
   "versions": [
    {
@@ -92594,7 +92594,7 @@
   ]
  },
  {
-  "downloads": 4987,
+  "downloads": 7,
   "id": "pimoroni_badger2040",
   "versions": [
    {
@@ -92856,7 +92856,7 @@
   ]
  },
  {
-  "downloads": 4629,
+  "downloads": 4,
   "id": "pimoroni_badger2040w",
   "versions": [
    {
@@ -93136,7 +93136,7 @@
   ]
  },
  {
-  "downloads": 3380,
+  "downloads": 0,
   "id": "pimoroni_inky_frame_5_7",
   "versions": [
    {
@@ -93418,7 +93418,7 @@
   ]
  },
  {
-  "downloads": 3290,
+  "downloads": 0,
   "id": "pimoroni_inky_frame_7_3",
   "versions": [
    {
@@ -93698,7 +93698,7 @@
   ]
  },
  {
-  "downloads": 5003,
+  "downloads": 5,
   "id": "pimoroni_interstate75",
   "versions": [
    {
@@ -93964,7 +93964,7 @@
   ]
  },
  {
-  "downloads": 5841,
+  "downloads": 15,
   "id": "pimoroni_keybow2040",
   "versions": [
    {
@@ -94230,7 +94230,7 @@
   ]
  },
  {
-  "downloads": 6071,
+  "downloads": 1,
   "id": "pimoroni_motor2040",
   "versions": [
    {
@@ -94496,7 +94496,7 @@
   ]
  },
  {
-  "downloads": 4530,
+  "downloads": 2,
   "id": "pimoroni_pga2040",
   "versions": [
    {
@@ -94762,7 +94762,7 @@
   ]
  },
  {
-  "downloads": 1659,
+  "downloads": 21,
   "id": "pimoroni_pga2350",
   "versions": [
    {
@@ -95032,7 +95032,7 @@
   ]
  },
  {
-  "downloads": 5168,
+  "downloads": 5,
   "id": "pimoroni_pico_dv_base",
   "versions": [
    {
@@ -95304,7 +95304,7 @@
   ]
  },
  {
-  "downloads": 3709,
+  "downloads": 3,
   "id": "pimoroni_pico_dv_base_w",
   "versions": [
    {
@@ -95588,7 +95588,7 @@
   ]
  },
  {
-  "downloads": 2038,
+  "downloads": 7,
   "id": "pimoroni_pico_plus2",
   "versions": [
    {
@@ -95858,7 +95858,7 @@
   ]
  },
  {
-  "downloads": 2970,
+  "downloads": 6,
   "id": "pimoroni_pico_plus2w",
   "versions": [
    {
@@ -96140,7 +96140,7 @@
   ]
  },
  {
-  "downloads": 4859,
+  "downloads": 2,
   "id": "pimoroni_picolipo_16mb",
   "versions": [
    {
@@ -96406,7 +96406,7 @@
   ]
  },
  {
-  "downloads": 4995,
+  "downloads": 0,
   "id": "pimoroni_picolipo_4mb",
   "versions": [
    {
@@ -96672,7 +96672,7 @@
   ]
  },
  {
-  "downloads": 4899,
+  "downloads": 2,
   "id": "pimoroni_picosystem",
   "versions": [
    {
@@ -96946,7 +96946,7 @@
   ]
  },
  {
-  "downloads": 4788,
+  "downloads": 3,
   "id": "pimoroni_plasma2040",
   "versions": [
    {
@@ -97208,7 +97208,7 @@
   ]
  },
  {
-  "downloads": 3144,
+  "downloads": 0,
   "id": "pimoroni_plasma2040w",
   "versions": [
    {
@@ -97486,7 +97486,7 @@
   ]
  },
  {
-  "downloads": 1568,
+  "downloads": 3,
   "id": "pimoroni_plasma2350",
   "versions": [
    {
@@ -97756,7 +97756,7 @@
   ]
  },
  {
-  "downloads": 511,
+  "downloads": 1,
   "id": "pimoroni_plasma2350w",
   "versions": [
    {
@@ -98032,7 +98032,7 @@
   ]
  },
  {
-  "downloads": 4535,
+  "downloads": 7,
   "id": "pimoroni_servo2040",
   "versions": [
    {
@@ -98298,7 +98298,7 @@
   ]
  },
  {
-  "downloads": 5700,
+  "downloads": 13,
   "id": "pimoroni_tiny2040",
   "versions": [
    {
@@ -98564,7 +98564,7 @@
   ]
  },
  {
-  "downloads": 4796,
+  "downloads": 2,
   "id": "pimoroni_tiny2040_2mb",
   "versions": [
    {
@@ -98830,7 +98830,7 @@
   ]
  },
  {
-  "downloads": 2116,
+  "downloads": 12,
   "id": "pimoroni_tiny2350",
   "versions": [
    {
@@ -99100,7 +99100,7 @@
   ]
  },
  {
-  "downloads": 1417,
+  "downloads": 1,
   "id": "pimoroni_tinyfx",
   "versions": [
    {
@@ -99367,7 +99367,7 @@
   "versions": []
  },
  {
-  "downloads": 4402,
+  "downloads": 9,
   "id": "pitaya_go",
   "versions": [
    {
@@ -99609,7 +99609,7 @@
   ]
  },
  {
-  "downloads": 252,
+  "downloads": 1,
   "id": "proveskit_rp2040_v4",
   "versions": [
    {
@@ -99873,7 +99873,7 @@
   ]
  },
  {
-  "downloads": 1263,
+  "downloads": 0,
   "id": "pyb_nano_v2",
   "versions": [
    {
@@ -100082,7 +100082,7 @@
   ]
  },
  {
-  "downloads": 6315,
+  "downloads": 17,
   "id": "pybadge",
   "versions": [
    {
@@ -100320,7 +100320,7 @@
   "versions": []
  },
  {
-  "downloads": 1357,
+  "downloads": 2,
   "id": "pyboard_v11",
   "versions": [
    {
@@ -100552,7 +100552,7 @@
   ]
  },
  {
-  "downloads": 4814,
+  "downloads": 0,
   "id": "pycubed",
   "versions": [
    {
@@ -100756,7 +100756,7 @@
   ]
  },
  {
-  "downloads": 4250,
+  "downloads": 0,
   "id": "pycubed_mram",
   "versions": [
    {
@@ -100960,7 +100960,7 @@
   ]
  },
  {
-  "downloads": 4208,
+  "downloads": 0,
   "id": "pycubed_mram_v05",
   "versions": [
    {
@@ -101164,7 +101164,7 @@
   ]
  },
  {
-  "downloads": 4185,
+  "downloads": 0,
   "id": "pycubed_v05",
   "versions": [
    {
@@ -101368,7 +101368,7 @@
   ]
  },
  {
-  "downloads": 5031,
+  "downloads": 6,
   "id": "pygamer",
   "versions": [
    {
@@ -101606,7 +101606,7 @@
   "versions": []
  },
  {
-  "downloads": 6644,
+  "downloads": 19,
   "id": "pyportal",
   "versions": [
    {
@@ -101871,7 +101871,7 @@
   ]
  },
  {
-  "downloads": 4904,
+  "downloads": 2,
   "id": "pyportal_pynt",
   "versions": [
    {
@@ -102136,7 +102136,7 @@
   ]
  },
  {
-  "downloads": 5489,
+  "downloads": 22,
   "id": "pyportal_titano",
   "versions": [
    {
@@ -102401,7 +102401,7 @@
   ]
  },
  {
-  "downloads": 4630,
+  "downloads": 17,
   "id": "pyruler",
   "versions": [
    {
@@ -102521,7 +102521,7 @@
   ]
  },
  {
-  "downloads": 6472,
+  "downloads": 14,
   "id": "qtpy_m0",
   "versions": [
    {
@@ -102641,7 +102641,7 @@
   ]
  },
  {
-  "downloads": 5527,
+  "downloads": 2,
   "id": "qtpy_m0_haxpress",
   "versions": [
    {
@@ -102797,7 +102797,7 @@
   ]
  },
  {
-  "downloads": 30449,
+  "downloads": 1471,
   "id": "raspberry_pi_pico",
   "versions": [
    {
@@ -103065,7 +103065,7 @@
   ]
  },
  {
-  "downloads": 9089,
+  "downloads": 221,
   "id": "raspberry_pi_pico2",
   "versions": [
    {
@@ -103335,7 +103335,7 @@
   ]
  },
  {
-  "downloads": 6660,
+  "downloads": 299,
   "id": "raspberry_pi_pico2_w",
   "versions": [
    {
@@ -103617,7 +103617,7 @@
   ]
  },
  {
-  "downloads": 19852,
+  "downloads": 585,
   "id": "raspberry_pi_pico_w",
   "versions": [
    {
@@ -103891,7 +103891,7 @@
   ]
  },
  {
-  "downloads": 3252,
+  "downloads": 0,
   "id": "raspberrypi_cm4",
   "versions": [
    {
@@ -104105,7 +104105,7 @@
   ]
  },
  {
-  "downloads": 2814,
+  "downloads": 2,
   "id": "raspberrypi_cm4io",
   "versions": [
    {
@@ -104319,7 +104319,7 @@
   ]
  },
  {
-  "downloads": 7165,
+  "downloads": 36,
   "id": "raspberrypi_pi4b",
   "versions": [
    {
@@ -104533,7 +104533,7 @@
   ]
  },
  {
-  "downloads": 6109,
+  "downloads": 11,
   "id": "raspberrypi_zero",
   "versions": [
    {
@@ -104747,7 +104747,7 @@
   ]
  },
  {
-  "downloads": 6757,
+  "downloads": 39,
   "id": "raspberrypi_zero2w",
   "versions": [
    {
@@ -104961,7 +104961,7 @@
   ]
  },
  {
-  "downloads": 6833,
+  "downloads": 17,
   "id": "raspberrypi_zero_w",
   "versions": [
    {
@@ -105175,7 +105175,7 @@
   ]
  },
  {
-  "downloads": 1795,
+  "downloads": 0,
   "id": "raytac_mdbt50q-db-40",
   "versions": [
    {
@@ -105417,7 +105417,7 @@
   ]
  },
  {
-  "downloads": 4330,
+  "downloads": 1,
   "id": "raytac_mdbt50q-rx",
   "versions": [
    {
@@ -105659,7 +105659,7 @@
   ]
  },
  {
-  "downloads": 222,
+  "downloads": 2,
   "id": "red-s2-wroom",
   "versions": [
    {
@@ -105930,7 +105930,7 @@
   ]
  },
  {
-  "downloads": 316,
+  "downloads": 1,
   "id": "renesas_ek_ra6m5",
   "versions": [
    {
@@ -106010,7 +106010,7 @@
   ]
  },
  {
-  "downloads": 232,
+  "downloads": 4,
   "id": "renesas_ek_ra8d1",
   "versions": [
    {
@@ -106090,7 +106090,7 @@
   ]
  },
  {
-  "downloads": 1125,
+  "downloads": 0,
   "id": "renode_cortex_m0plus",
   "versions": [
    {
@@ -106182,7 +106182,7 @@
   ]
  },
  {
-  "downloads": 2289,
+  "downloads": 2,
   "id": "rfguru_rp2040",
   "versions": [
    {
@@ -106448,7 +106448,7 @@
   ]
  },
  {
-  "downloads": 4006,
+  "downloads": 0,
   "id": "robohatmm1_m4",
   "versions": [
    {
@@ -106661,7 +106661,7 @@
   ]
  },
  {
-  "downloads": 4373,
+  "downloads": 6,
   "id": "sam32",
   "versions": [
    {
@@ -106914,7 +106914,7 @@
   ]
  },
  {
-  "downloads": 4402,
+  "downloads": 0,
   "id": "same54_xplained",
   "versions": [
    {
@@ -107151,7 +107151,7 @@
   ]
  },
  {
-  "downloads": 1807,
+  "downloads": 45,
   "id": "seeed_xiao_esp32_s3_sense",
   "versions": [
    {
@@ -107435,7 +107435,7 @@
   ]
  },
  {
-  "downloads": 3100,
+  "downloads": 20,
   "id": "seeed_xiao_esp32c3",
   "versions": [
    {
@@ -107678,7 +107678,7 @@
   ]
  },
  {
-  "downloads": 1386,
+  "downloads": 20,
   "id": "seeed_xiao_esp32c6",
   "versions": [
    {
@@ -107923,7 +107923,7 @@
   ]
  },
  {
-  "downloads": 5415,
+  "downloads": 6,
   "id": "seeeduino_wio_terminal",
   "versions": [
    {
@@ -108158,7 +108158,7 @@
   ]
  },
  {
-  "downloads": 8165,
+  "downloads": 15,
   "id": "seeeduino_xiao",
   "versions": [
    {
@@ -108278,7 +108278,7 @@
   ]
  },
  {
-  "downloads": 5047,
+  "downloads": 3,
   "id": "seeeduino_xiao_kb",
   "versions": [
    {
@@ -108402,7 +108402,7 @@
   ]
  },
  {
-  "downloads": 6153,
+  "downloads": 25,
   "id": "seeeduino_xiao_rp2040",
   "versions": [
    {
@@ -108666,7 +108666,7 @@
   ]
  },
  {
-  "downloads": 1245,
+  "downloads": 12,
   "id": "seeeduino_xiao_rp2350",
   "versions": [
    {
@@ -108934,7 +108934,7 @@
   ]
  },
  {
-  "downloads": 3341,
+  "downloads": 4,
   "id": "sensebox_mcu",
   "versions": [
    {
@@ -109052,7 +109052,7 @@
   ]
  },
  {
-  "downloads": 2768,
+  "downloads": 0,
   "id": "sensebox_mcu_esp32s2",
   "versions": [
    {
@@ -109327,7 +109327,7 @@
   ]
  },
  {
-  "downloads": 4585,
+  "downloads": 0,
   "id": "serpente",
   "versions": [
    {
@@ -109483,7 +109483,7 @@
   ]
  },
  {
-  "downloads": 3068,
+  "downloads": 6,
   "id": "shirtty",
   "versions": [
    {
@@ -109603,7 +109603,7 @@
   ]
  },
  {
-  "downloads": 3370,
+  "downloads": 2,
   "id": "silicognition-m4-shim",
   "versions": [
    {
@@ -109839,7 +109839,7 @@
   ]
  },
  {
-  "downloads": 2509,
+  "downloads": 0,
   "id": "silicognition_rp2040_shim",
   "versions": [
    {
@@ -110103,7 +110103,7 @@
   ]
  },
  {
-  "downloads": 3398,
+  "downloads": 0,
   "id": "simmel",
   "versions": [
    {
@@ -110222,7 +110222,7 @@
   ]
  },
  {
-  "downloads": 2834,
+  "downloads": 4,
   "id": "smartbeedesigns_bee_data_logger",
   "versions": [
    {
@@ -110514,7 +110514,7 @@
   ]
  },
  {
-  "downloads": 3300,
+  "downloads": 3,
   "id": "smartbeedesigns_bee_motion_s3",
   "versions": [
    {
@@ -110798,7 +110798,7 @@
   ]
  },
  {
-  "downloads": 2456,
+  "downloads": 0,
   "id": "smartbeedesigns_bee_s3",
   "versions": [
    {
@@ -111082,7 +111082,7 @@
   ]
  },
  {
-  "downloads": 4217,
+  "downloads": 1,
   "id": "snekboard",
   "versions": [
    {
@@ -111238,7 +111238,7 @@
   ]
  },
  {
-  "downloads": 5817,
+  "downloads": 3,
   "id": "solderparty_bbq20kbd",
   "versions": [
    {
@@ -111508,7 +111508,7 @@
   ]
  },
  {
-  "downloads": 274,
+  "downloads": 2,
   "id": "solderparty_esp32p4_stamp_xl",
   "versions": [
    {
@@ -111757,7 +111757,7 @@
   ]
  },
  {
-  "downloads": 5181,
+  "downloads": 0,
   "id": "solderparty_rp2040_stamp",
   "versions": [
    {
@@ -112039,7 +112039,7 @@
   ]
  },
  {
-  "downloads": 1728,
+  "downloads": 2,
   "id": "solderparty_rp2350_stamp",
   "versions": [
    {
@@ -112323,7 +112323,7 @@
   ]
  },
  {
-  "downloads": 1365,
+  "downloads": 7,
   "id": "solderparty_rp2350_stamp_xl",
   "versions": [
    {
@@ -112607,7 +112607,7 @@
   ]
  },
  {
-  "downloads": 3430,
+  "downloads": 0,
   "id": "sparkfun_lumidrive",
   "versions": [
    {
@@ -112761,7 +112761,7 @@
   ]
  },
  {
-  "downloads": 3441,
+  "downloads": 1,
   "id": "sparkfun_micromod_rp2040",
   "versions": [
    {
@@ -113025,7 +113025,7 @@
   ]
  },
  {
-  "downloads": 3349,
+  "downloads": 0,
   "id": "sparkfun_nrf52840_micromod",
   "versions": [
    {
@@ -113267,7 +113267,7 @@
   ]
  },
  {
-  "downloads": 3597,
+  "downloads": 2,
   "id": "sparkfun_nrf52840_mini",
   "versions": [
    {
@@ -113505,7 +113505,7 @@
   ]
  },
  {
-  "downloads": 5746,
+  "downloads": 6,
   "id": "sparkfun_pro_micro_rp2040",
   "versions": [
    {
@@ -113769,7 +113769,7 @@
   ]
  },
  {
-  "downloads": 1483,
+  "downloads": 3,
   "id": "sparkfun_pro_micro_rp2350",
   "versions": [
    {
@@ -114037,7 +114037,7 @@
   ]
  },
  {
-  "downloads": 2461,
+  "downloads": 0,
   "id": "sparkfun_qwiic_micro_no_flash",
   "versions": [
    {
@@ -114157,7 +114157,7 @@
   ]
  },
  {
-  "downloads": 3351,
+  "downloads": 1,
   "id": "sparkfun_qwiic_micro_with_flash",
   "versions": [
    {
@@ -114279,7 +114279,7 @@
   ]
  },
  {
-  "downloads": 3945,
+  "downloads": 0,
   "id": "sparkfun_redboard_turbo",
   "versions": [
    {
@@ -114431,7 +114431,7 @@
   ]
  },
  {
-  "downloads": 3125,
+  "downloads": 0,
   "id": "sparkfun_samd21_dev",
   "versions": [
    {
@@ -114551,7 +114551,7 @@
   ]
  },
  {
-  "downloads": 4011,
+  "downloads": 0,
   "id": "sparkfun_samd21_mini",
   "versions": [
    {
@@ -114671,7 +114671,7 @@
   ]
  },
  {
-  "downloads": 4840,
+  "downloads": 1,
   "id": "sparkfun_samd51_micromod",
   "versions": [
    {
@@ -114920,7 +114920,7 @@
   ]
  },
  {
-  "downloads": 4656,
+  "downloads": 3,
   "id": "sparkfun_samd51_thing_plus",
   "versions": [
    {
@@ -115169,7 +115169,7 @@
   ]
  },
  {
-  "downloads": 2650,
+  "downloads": 0,
   "id": "sparkfun_stm32_thing_plus",
   "versions": [
    {
@@ -115403,7 +115403,7 @@
   ]
  },
  {
-  "downloads": 641,
+  "downloads": 0,
   "id": "sparkfun_stm32f405_micromod",
   "versions": [
    {
@@ -115635,7 +115635,7 @@
   ]
  },
  {
-  "downloads": 2850,
+  "downloads": 1,
   "id": "sparkfun_teensy_micromod",
   "versions": [
    {
@@ -115869,7 +115869,7 @@
   ]
  },
  {
-  "downloads": 3862,
+  "downloads": 5,
   "id": "sparkfun_thing_plus_rp2040",
   "versions": [
    {
@@ -116133,7 +116133,7 @@
   ]
  },
  {
-  "downloads": 884,
+  "downloads": 7,
   "id": "sparkfun_thing_plus_rp2350",
   "versions": [
    {
@@ -116415,7 +116415,7 @@
   ]
  },
  {
-  "downloads": 727,
+  "downloads": 0,
   "id": "sparkfun_thingplus_matter_mgm240p_brd2704a",
   "versions": [
    {
@@ -116613,7 +116613,7 @@
   ]
  },
  {
-  "downloads": 4456,
+  "downloads": 1,
   "id": "splitkb_liatris",
   "versions": [
    {
@@ -116877,7 +116877,7 @@
   ]
  },
  {
-  "downloads": 497,
+  "downloads": 3,
   "id": "spotpear_esp32c3_lcd_1_44",
   "versions": [
    {
@@ -117120,7 +117120,7 @@
   ]
  },
  {
-  "downloads": 34,
+  "downloads": 2,
   "id": "spotpear_esp32c3_lcd_1_69",
   "versions": [
    {
@@ -117372,7 +117372,7 @@
   ]
  },
  {
-  "downloads": 3592,
+  "downloads": 2,
   "id": "spresense",
   "versions": [
    {
@@ -117539,7 +117539,7 @@
   ]
  },
  {
-  "downloads": 497,
+  "downloads": 2,
   "id": "sqfmi_watchy",
   "versions": [
    {
@@ -117802,7 +117802,7 @@
   ]
  },
  {
-  "downloads": 4088,
+  "downloads": 0,
   "id": "ssci_isp1807_dev_board",
   "versions": [
    {
@@ -118044,7 +118044,7 @@
   ]
  },
  {
-  "downloads": 3868,
+  "downloads": 0,
   "id": "ssci_isp1807_micro_board",
   "versions": [
    {
@@ -118286,7 +118286,7 @@
   ]
  },
  {
-  "downloads": 232,
+  "downloads": 1,
   "id": "st_nucleo_u575zi_q",
   "versions": [
    {
@@ -118366,7 +118366,7 @@
   ]
  },
  {
-  "downloads": 275,
+  "downloads": 2,
   "id": "st_stm32h7b3i_dk",
   "versions": [
    {
@@ -118446,7 +118446,7 @@
   ]
  },
  {
-  "downloads": 2426,
+  "downloads": 0,
   "id": "stackrduino_m0_pro",
   "versions": [
    {
@@ -118598,7 +118598,7 @@
   ]
  },
  {
-  "downloads": 1257,
+  "downloads": 6,
   "id": "stm32f411ce_blackpill",
   "versions": [
    {
@@ -118810,7 +118810,7 @@
   ]
  },
  {
-  "downloads": 805,
+  "downloads": 2,
   "id": "stm32f411ce_blackpill_with_flash",
   "versions": [
    {
@@ -119032,7 +119032,7 @@
   ]
  },
  {
-  "downloads": 715,
+  "downloads": 0,
   "id": "stm32f411ve_discovery",
   "versions": [
    {
@@ -119229,7 +119229,7 @@
   ]
  },
  {
-  "downloads": 668,
+  "downloads": 0,
   "id": "stm32f412zg_discovery",
   "versions": [
    {
@@ -119453,7 +119453,7 @@
   ]
  },
  {
-  "downloads": 813,
+  "downloads": 3,
   "id": "stm32f4_discovery",
   "versions": [
    {
@@ -119683,7 +119683,7 @@
   ]
  },
  {
-  "downloads": 719,
+  "downloads": 0,
   "id": "stm32f746g_discovery",
   "versions": [
    {
@@ -119893,7 +119893,7 @@
   ]
  },
  {
-  "downloads": 3231,
+  "downloads": 0,
   "id": "stringcar_m0_express",
   "versions": [
    {
@@ -120047,7 +120047,7 @@
   ]
  },
  {
-  "downloads": 704,
+  "downloads": 1,
   "id": "sunton_esp32_2424S012",
   "versions": [
    {
@@ -120290,7 +120290,7 @@
   ]
  },
  {
-  "downloads": 185,
+  "downloads": 5,
   "id": "sunton_esp32_2432S024C",
   "versions": [
    {
@@ -120553,7 +120553,7 @@
   ]
  },
  {
-  "downloads": 2448,
+  "downloads": 25,
   "id": "sunton_esp32_2432S028",
   "versions": [
    {
@@ -120816,7 +120816,7 @@
   ]
  },
  {
-  "downloads": 678,
+  "downloads": 5,
   "id": "sunton_esp32_2432S032C",
   "versions": [
    {
@@ -121080,7 +121080,7 @@
   ]
  },
  {
-  "downloads": 318,
+  "downloads": 4,
   "id": "sunton_esp32_8048S050",
   "versions": [
    {
@@ -121358,7 +121358,7 @@
   ]
  },
  {
-  "downloads": 763,
+  "downloads": 2,
   "id": "sunton_esp32_8048S070",
   "versions": [
    {
@@ -121636,7 +121636,7 @@
   ]
  },
  {
-  "downloads": 5489,
+  "downloads": 31,
   "id": "supermini_nrf52840",
   "versions": [
    {
@@ -121878,7 +121878,7 @@
   ]
  },
  {
-  "downloads": 2673,
+  "downloads": 7,
   "id": "swan_r5",
   "versions": [
    {
@@ -122091,7 +122091,7 @@
   ]
  },
  {
-  "downloads": 2610,
+  "downloads": 4,
   "id": "takayoshiotake_octave_rp2040",
   "versions": [
    {
@@ -122355,7 +122355,7 @@
   ]
  },
  {
-  "downloads": 2954,
+  "downloads": 6,
   "id": "targett_module_clip_wroom",
   "versions": [
    {
@@ -122626,7 +122626,7 @@
   ]
  },
  {
-  "downloads": 3891,
+  "downloads": 0,
   "id": "targett_module_clip_wrover",
   "versions": [
    {
@@ -122901,7 +122901,7 @@
   ]
  },
  {
-  "downloads": 3929,
+  "downloads": 6,
   "id": "teensy40",
   "versions": [
    {
@@ -123131,7 +123131,7 @@
   ]
  },
  {
-  "downloads": 6777,
+  "downloads": 22,
   "id": "teensy41",
   "versions": [
    {
@@ -123367,7 +123367,7 @@
   ]
  },
  {
-  "downloads": 3303,
+  "downloads": 0,
   "id": "teknikio_bluebird",
   "versions": [
    {
@@ -123609,7 +123609,7 @@
   ]
  },
  {
-  "downloads": 3587,
+  "downloads": 2,
   "id": "thingpulse_pendrive_s3",
   "versions": [
    {
@@ -123884,7 +123884,7 @@
   ]
  },
  {
-  "downloads": 425,
+  "downloads": 0,
   "id": "thunderpack_v11",
   "versions": [
    {
@@ -124091,7 +124091,7 @@
   ]
  },
  {
-  "downloads": 566,
+  "downloads": 0,
   "id": "thunderpack_v12",
   "versions": [
    {
@@ -124296,7 +124296,7 @@
   ]
  },
  {
-  "downloads": 2931,
+  "downloads": 0,
   "id": "tinkeringtech_scoutmakes_azul",
   "versions": [
    {
@@ -124538,7 +124538,7 @@
   ]
  },
  {
-  "downloads": 5169,
+  "downloads": 3,
   "id": "trellis_m4_express",
   "versions": [
    {
@@ -124770,7 +124770,7 @@
   ]
  },
  {
-  "downloads": 6068,
+  "downloads": 30,
   "id": "trinket_m0",
   "versions": [
    {
@@ -124890,7 +124890,7 @@
   ]
  },
  {
-  "downloads": 3449,
+  "downloads": 0,
   "id": "trinket_m0_haxpress",
   "versions": [
    {
@@ -125044,7 +125044,7 @@
   ]
  },
  {
-  "downloads": 2014,
+  "downloads": 1,
   "id": "ttgo_t8_v1_7",
   "versions": [
    {
@@ -125308,7 +125308,7 @@
   ]
  },
  {
-  "downloads": 1366,
+  "downloads": 0,
   "id": "uartlogger2",
   "versions": [
    {
@@ -125544,7 +125544,7 @@
   ]
  },
  {
-  "downloads": 3234,
+  "downloads": 0,
   "id": "uchip",
   "versions": [
    {
@@ -125666,7 +125666,7 @@
   ]
  },
  {
-  "downloads": 3638,
+  "downloads": 4,
   "id": "ugame10",
   "versions": [
    {
@@ -125820,7 +125820,7 @@
   ]
  },
  {
-  "downloads": 3316,
+  "downloads": 0,
   "id": "ugame22",
   "versions": [
    {
@@ -126094,7 +126094,7 @@
   ]
  },
  {
-  "downloads": 2603,
+  "downloads": 0,
   "id": "unexpectedmaker_bling",
   "versions": [
    {
@@ -126386,7 +126386,7 @@
   ]
  },
  {
-  "downloads": 2465,
+  "downloads": 0,
   "id": "unexpectedmaker_blizzard_s3",
   "versions": [
    {
@@ -126676,7 +126676,7 @@
   ]
  },
  {
-  "downloads": 3716,
+  "downloads": 5,
   "id": "unexpectedmaker_feathers2",
   "versions": [
    {
@@ -126957,7 +126957,7 @@
   ]
  },
  {
-  "downloads": 2406,
+  "downloads": 2,
   "id": "unexpectedmaker_feathers2_neo",
   "versions": [
    {
@@ -127236,7 +127236,7 @@
   ]
  },
  {
-  "downloads": 2191,
+  "downloads": 0,
   "id": "unexpectedmaker_feathers2_prerelease",
   "versions": [
    {
@@ -127517,7 +127517,7 @@
   ]
  },
  {
-  "downloads": 4433,
+  "downloads": 11,
   "id": "unexpectedmaker_feathers3",
   "versions": [
    {
@@ -127805,7 +127805,7 @@
   ]
  },
  {
-  "downloads": 1563,
+  "downloads": 0,
   "id": "unexpectedmaker_feathers3_neo",
   "versions": [
    {
@@ -128093,7 +128093,7 @@
   ]
  },
  {
-  "downloads": 2299,
+  "downloads": 0,
   "id": "unexpectedmaker_nanos3",
   "versions": [
    {
@@ -128381,7 +128381,7 @@
   ]
  },
  {
-  "downloads": 1041,
+  "downloads": 0,
   "id": "unexpectedmaker_omgs3",
   "versions": [
    {
@@ -128671,7 +128671,7 @@
   ]
  },
  {
-  "downloads": 4592,
+  "downloads": 7,
   "id": "unexpectedmaker_pros3",
   "versions": [
    {
@@ -128959,7 +128959,7 @@
   ]
  },
  {
-  "downloads": 924,
+  "downloads": 0,
   "id": "unexpectedmaker_rgbtouch_mini",
   "versions": [
    {
@@ -129249,7 +129249,7 @@
   ]
  },
  {
-  "downloads": 730,
+  "downloads": 1,
   "id": "unexpectedmaker_tinyc6",
   "versions": [
    {
@@ -129504,7 +129504,7 @@
   ]
  },
  {
-  "downloads": 727,
+  "downloads": 1,
   "id": "unexpectedmaker_tinypico",
   "versions": [
    {
@@ -129771,7 +129771,7 @@
   ]
  },
  {
-  "downloads": 637,
+  "downloads": 0,
   "id": "unexpectedmaker_tinypico_nano",
   "versions": [
    {
@@ -130038,7 +130038,7 @@
   ]
  },
  {
-  "downloads": 2814,
+  "downloads": 2,
   "id": "unexpectedmaker_tinys2",
   "versions": [
    {
@@ -130319,7 +130319,7 @@
   ]
  },
  {
-  "downloads": 3149,
+  "downloads": 2,
   "id": "unexpectedmaker_tinys3",
   "versions": [
    {
@@ -130609,7 +130609,7 @@
   ]
  },
  {
-  "downloads": 2856,
+  "downloads": 0,
   "id": "unexpectedmaker_tinywatch_s3",
   "versions": [
    {
@@ -130899,7 +130899,7 @@
   ]
  },
  {
-  "downloads": 8393,
+  "downloads": 81,
   "id": "vcc_gnd_yd_rp2040",
   "versions": [
    {
@@ -131165,7 +131165,7 @@
   ]
  },
  {
-  "downloads": 256,
+  "downloads": 0,
   "id": "vidi_x",
   "versions": [
    {
@@ -131439,7 +131439,7 @@
   ]
  },
  {
-  "downloads": 1466,
+  "downloads": 0,
   "id": "warmbit_bluepixel",
   "versions": [
    {
@@ -131681,7 +131681,7 @@
   ]
  },
  {
-  "downloads": 335,
+  "downloads": 18,
   "id": "waveshare_esp32_c6_lcd_1_47",
   "versions": [
    {
@@ -131926,7 +131926,7 @@
   ]
  },
  {
-  "downloads": 2736,
+  "downloads": 10,
   "id": "waveshare_esp32_s2_pico_lcd",
   "versions": [
    {
@@ -132201,7 +132201,7 @@
   ]
  },
  {
-  "downloads": 519,
+  "downloads": 0,
   "id": "waveshare_esp32_s3_eth",
   "versions": [
    {
@@ -132485,7 +132485,7 @@
   ]
  },
  {
-  "downloads": 2621,
+  "downloads": 9,
   "id": "waveshare_esp32_s3_geek",
   "versions": [
    {
@@ -132769,7 +132769,7 @@
   ]
  },
  {
-  "downloads": 654,
+  "downloads": 3,
   "id": "waveshare_esp32_s3_lcd_1_28",
   "versions": [
    {
@@ -133041,7 +133041,7 @@
   ]
  },
  {
-  "downloads": 424,
+  "downloads": 6,
   "id": "waveshare_esp32_s3_matrix",
   "versions": [
    {
@@ -133312,7 +133312,7 @@
   ]
  },
  {
-  "downloads": 3924,
+  "downloads": 2,
   "id": "waveshare_esp32_s3_pico",
   "versions": [
    {
@@ -133596,7 +133596,7 @@
   ]
  },
  {
-  "downloads": 1791,
+  "downloads": 0,
   "id": "waveshare_esp32_s3_tiny",
   "versions": [
    {
@@ -133869,7 +133869,7 @@
   ]
  },
  {
-  "downloads": 195,
+  "downloads": 9,
   "id": "waveshare_esp32_s3_touch_lcd_2",
   "versions": [
    {
@@ -134153,7 +134153,7 @@
   ]
  },
  {
-  "downloads": 4991,
+  "downloads": 27,
   "id": "waveshare_esp32_s3_zero",
   "versions": [
    {
@@ -134424,7 +134424,7 @@
   ]
  },
  {
-  "downloads": 3897,
+  "downloads": 1,
   "id": "waveshare_esp32s2_pico",
   "versions": [
    {
@@ -134699,7 +134699,7 @@
   ]
  },
  {
-  "downloads": 3625,
+  "downloads": 6,
   "id": "waveshare_rp2040_geek",
   "versions": [
    {
@@ -134965,7 +134965,7 @@
   ]
  },
  {
-  "downloads": 4993,
+  "downloads": 7,
   "id": "waveshare_rp2040_lcd_0_96",
   "versions": [
    {
@@ -135231,7 +135231,7 @@
   ]
  },
  {
-  "downloads": 4286,
+  "downloads": 8,
   "id": "waveshare_rp2040_lcd_1_28",
   "versions": [
    {
@@ -135497,7 +135497,7 @@
   ]
  },
  {
-  "downloads": 1808,
+  "downloads": 5,
   "id": "waveshare_rp2040_one",
   "versions": [
    {
@@ -135763,7 +135763,7 @@
   ]
  },
  {
-  "downloads": 2367,
+  "downloads": 3,
   "id": "waveshare_rp2040_pizero",
   "versions": [
    {
@@ -136027,7 +136027,7 @@
   ]
  },
  {
-  "downloads": 4398,
+  "downloads": 6,
   "id": "waveshare_rp2040_plus_16mb",
   "versions": [
    {
@@ -136293,7 +136293,7 @@
   ]
  },
  {
-  "downloads": 4195,
+  "downloads": 5,
   "id": "waveshare_rp2040_plus_4mb",
   "versions": [
    {
@@ -136559,7 +136559,7 @@
   ]
  },
  {
-  "downloads": 3041,
+  "downloads": 2,
   "id": "waveshare_rp2040_tiny",
   "versions": [
    {
@@ -136825,7 +136825,7 @@
   ]
  },
  {
-  "downloads": 4123,
+  "downloads": 3,
   "id": "waveshare_rp2040_touch_lcd_1_28",
   "versions": [
    {
@@ -137091,7 +137091,7 @@
   ]
  },
  {
-  "downloads": 9858,
+  "downloads": 132,
   "id": "waveshare_rp2040_zero",
   "versions": [
    {
@@ -137357,7 +137357,7 @@
   ]
  },
  {
-  "downloads": 541,
+  "downloads": 6,
   "id": "waveshare_rp2350_geek",
   "versions": [
    {
@@ -137627,7 +137627,7 @@
   ]
  },
  {
-  "downloads": 770,
+  "downloads": 8,
   "id": "waveshare_rp2350_lcd_0_96",
   "versions": [
    {
@@ -137897,7 +137897,7 @@
   ]
  },
  {
-  "downloads": 623,
+  "downloads": 7,
   "id": "waveshare_rp2350_lcd_1_28",
   "versions": [
    {
@@ -138167,7 +138167,7 @@
   ]
  },
  {
-  "downloads": 572,
+  "downloads": 5,
   "id": "waveshare_rp2350_one",
   "versions": [
    {
@@ -138437,7 +138437,7 @@
   ]
  },
  {
-  "downloads": 780,
+  "downloads": 6,
   "id": "waveshare_rp2350_plus",
   "versions": [
    {
@@ -138707,7 +138707,7 @@
   ]
  },
  {
-  "downloads": 717,
+  "downloads": 0,
   "id": "waveshare_rp2350_tiny",
   "versions": [
    {
@@ -138977,7 +138977,7 @@
   ]
  },
  {
-  "downloads": 633,
+  "downloads": 1,
   "id": "waveshare_rp2350_touch_lcd_1_28",
   "versions": [
    {
@@ -139247,7 +139247,7 @@
   ]
  },
  {
-  "downloads": 608,
+  "downloads": 8,
   "id": "waveshare_rp2350_zero",
   "versions": [
    {
@@ -139517,7 +139517,7 @@
   ]
  },
  {
-  "downloads": 750,
+  "downloads": 1,
   "id": "weact_esp32c6_n4",
   "versions": [
    {
@@ -139759,7 +139759,7 @@
   ]
  },
  {
-  "downloads": 724,
+  "downloads": 1,
   "id": "weact_esp32c6_n8",
   "versions": [
    {
@@ -140010,7 +140010,7 @@
   ]
  },
  {
-  "downloads": 4147,
+  "downloads": 14,
   "id": "weact_studio_pico",
   "versions": [
    {
@@ -140276,7 +140276,7 @@
   ]
  },
  {
-  "downloads": 5040,
+  "downloads": 3,
   "id": "weact_studio_pico_16mb",
   "versions": [
    {
@@ -140542,7 +140542,7 @@
   ]
  },
  {
-  "downloads": 803,
+  "downloads": 9,
   "id": "wemos_lolin32_lite",
   "versions": [
    {
@@ -140805,7 +140805,7 @@
   ]
  },
  {
-  "downloads": 3013,
+  "downloads": 0,
   "id": "winterbloom_big_honking_button",
   "versions": [
    {
@@ -140935,7 +140935,7 @@
   ]
  },
  {
-  "downloads": 3007,
+  "downloads": 0,
   "id": "winterbloom_sol",
   "versions": [
    {
@@ -141119,7 +141119,7 @@
   ]
  },
  {
-  "downloads": 4148,
+  "downloads": 0,
   "id": "wisdpi_ardu2040m",
   "versions": [
    {
@@ -141385,7 +141385,7 @@
   ]
  },
  {
-  "downloads": 3413,
+  "downloads": 1,
   "id": "wisdpi_tiny_rp2040",
   "versions": [
    {
@@ -141653,7 +141653,7 @@
   ]
  },
  {
-  "downloads": 4431,
+  "downloads": 0,
   "id": "wiznet_w5100s_evb_pico",
   "versions": [
    {
@@ -141917,7 +141917,7 @@
   ]
  },
  {
-  "downloads": 739,
+  "downloads": 4,
   "id": "wiznet_w5100s_evb_pico2",
   "versions": [
    {
@@ -142189,7 +142189,7 @@
   ]
  },
  {
-  "downloads": 4542,
+  "downloads": 10,
   "id": "wiznet_w5500_evb_pico",
   "versions": [
    {
@@ -142453,7 +142453,7 @@
   ]
  },
  {
-  "downloads": 3,
+  "downloads": 0,
   "id": "wiznet_w5500_evb_pico2",
   "versions": [
    {
@@ -142594,7 +142594,7 @@
   ]
  },
  {
-  "downloads": 490,
+  "downloads": 0,
   "id": "wk-50",
   "versions": [
    {
@@ -142866,7 +142866,7 @@
   ]
  },
  {
-  "downloads": 2652,
+  "downloads": 0,
   "id": "xinabox_cc03",
   "versions": [
    {
@@ -142980,7 +142980,7 @@
   ]
  },
  {
-  "downloads": 3121,
+  "downloads": 0,
   "id": "xinabox_cs11",
   "versions": [
    {
@@ -143092,7 +143092,7 @@
   ]
  },
  {
-  "downloads": 10704,
+  "downloads": 77,
   "id": "yd_esp32_s3_n16r8",
   "versions": [
    {
@@ -143380,7 +143380,7 @@
   ]
  },
  {
-  "downloads": 3356,
+  "downloads": 1,
   "id": "yd_esp32_s3_n8r8",
   "versions": [
    {
@@ -143668,7 +143668,7 @@
   ]
  },
  {
-  "downloads": 3673,
+  "downloads": 1,
   "id": "zrichard_rp2.65-f",
   "versions": [
    {


### PR DESCRIPTION
Previous numbers were from S3 direct logs. Cloud front requests from S3 on cache miss only. The user agent was also cloud front instead of the actual requester. Cloud front logs have the actual user agent and we use it to filter out bot requests.

So, the old numbers (relatively) under counted popular boards and over counted boards that only bots cared about. These numbers should be truer to reality.