### PR TITLE
differentiate original Feather HUZZAH32 and Feather ESP32 V2

### DIFF
--- a/_board/adafruit_feather_esp32_v2.md
+++ b/_board/adafruit_feather_esp32_v2.md
@@ -2,7 +2,7 @@
 layout: download
 board_id: "adafruit_feather_esp32_v2"
 title: "Adafruit Feather ESP32 V2 Download"
-name: "Adafruit Feather ESP32 V2"
+name: "Adafruit Feather ESP32 V2 (HUZZAH32 V2)"
 manufacturer: "Adafruit"
 board_url:
  - "https://www.adafruit.com/product/5400"
@@ -23,9 +23,11 @@ features:
   - STEMMA QT/QWIIC
 ---
 
-One of our star Feathers is the [Adafruit HUZZAH32 ESP32 Feather](https://www.adafruit.com/product/3405) - with the fabulous ESP32 WROOM module on there, it makes quick work of WiFi and Bluetooth projects that take advantage of Espressifs most popular chipset. Recently we had to redesign this feather to move from the obsolete CP2104 to the available CH9102F and one thing led to another and before you know it we made a completely refreshed design: the **Adafruit ESP32 Feather V2**.
+The **Adafruit Feather ESP32 V2** is a new version of the original Adafruit HUZZAH32 ESP32 Feather. Both have the fabulous ESP32 WROOM module on there, which makes quick work of WiFi and Bluetooth projects that take advantage of Espressifs most popular chipset. We completely refreshed the board while moving from the obsolete CP2104 USB-serial chip to the available CH9102F.
 
-The V2 is a significant redesign, enough so we consider it a completely new product. It *still* features the ESP32 chip but has many upgrades and improvements:
+Both boards say "HUZZAH32" on the bottom side, but they are different. Make sure you've chosen the correct download for the your board.
+
+The Feather ESP32 V2 is a significant redesign, enough so we consider it a completely new product. It *still* features the ESP32 chip but has many upgrades and improvements:
 
 - Compared to the original Feather with 4 MB Flash and no PSRAM, the V2 has **8 MB Flash and 2 MB PSRAM**
 - Additional **user button tactile switch** on input pin 38

--- a/_board/adafruit_feather_huzzah32.md
+++ b/_board/adafruit_feather_huzzah32.md
@@ -20,15 +20,15 @@ features:
   - Breadboard-Friendly
 ---
 
-Aww yeah, it's the Feather you have been waiting for! The **HUZZAH32** is our ESP32-based Feather, made with the official WROOM32 module. We packed everything you love about Feathers: built in USB-to-Serial converter, automatic bootloader reset, Lithium Ion/Polymer charger, and just about all of the GPIOs brought out so you can use it with any of our Feather Wings. [We have other boards in the Feather family, check'em out here.](https://www.adafruit.com/feather)
+The **Adafruit Feather HUZZAH32** is our original ESP32-based Feather, made with the official WROOM32 module. We packed everything you love about Feathers: built in USB-to-Serial converter, automatic bootloader reset, Lithium Ion/Polymer charger, and just about all of the GPIOs brought out so you can use it with any of our Feather Wings. [We have other boards in the Feather family, check'em out here.](https://www.adafruit.com/feather)
 
 That module nestled in at the end of this Feather contains a dual-core ESP32 chip, 4 MB of SPI Flash, tuned antenna, and all the passives you need to take advantage of this powerful new processor. The ESP32 has both WiFi *and* Bluetooth Classic/LE support. That means it's perfect for just about any wireless or Internet-connected project.
+
+Don't confuse this board with the similar, newer, [Adafruit Feather ESP32 V2](https://circuitpython.org/board/adafruit_feather_esp32_v2/). Both boards say "HUZZAH32" on the bottom side, but they are different. Make sure you've chosen the correct download for your board.
 
 Because it's part of our [Feather eco-system, you can take advantage of the 50+ Wings](https://www.adafruit.com/category/814) that we've designed to add all sorts of cool accessories.
 
 The ESP32 is a perfect upgrade from the ESP8266 that has been so popular. In comparison, the ESP32 has way more GPIO, plenty of analog inputs, two analog outputs, multiple extra peripherals (like a spare UART), two cores so you don't have to yield to the WiFi manager, much higher-speed processor, etc. etc! We think that as the ESP32 gets traction, we'll see more people move to this chip exclusively, as it is so full-featured.
-
-**Please note: The ESP32 is still targeted to developers**. Not all of the peripherals are fully documented with example code, and there are some bugs still being found and fixed. We got all of our Featherwings working under Arduino IDE, so you can expect things like I2C and SPI and analog reads to work. But other elements are still under development. For that reason, we recommend this Feather for makers who have some experience with microcontroller programming, and not as a first dev board.
 
 Here are [specifications from Espressif about the ESP32](https://espressif.com/en/products/hardware/esp32/overview):
 


### PR DESCRIPTION
A few users have confused the original Feather HUZZAH32 and Fthe eather ESP32 V2. Add some cautionary text. The latest user with this issue also asked that the name include "HUZZA32" (which is on the bottom of the board).

I also added some alert boxes already in the two guides.

I deliberately took the link to the original HUZZAH32 Feather out of the description of the V2. I also removed some obsolete "it's early" language from the original description.