### PR TITLE
Find bootloader .zip's in board-specific subdirectories

### DIFF
--- a/tools/generate-board-info.py
+++ b/tools/generate-board-info.py
@@ -47,7 +47,7 @@ def main():
     def get_bootloader(chipfamily, bootloader_id):
         if chipfamily in bootloaders and "version" in bootloaders[chipfamily]:
             bootloader_version = bootloaders[chipfamily]["version"]
-            return f"{BOOTLOADER_URL_PREFIX}tinyuf2-{bootloader_id}-{bootloader_version}.zip"
+            return f"{BOOTLOADER_URL_PREFIX}/{bootloader_id}/tinyuf2-{bootloader_id}-{bootloader_version}.zip"
         return None
 
     def generate_boards(folder):


### PR DESCRIPTION
I'm changing where to find the Espressif .bin bootloader files. They used to all be at the top-level of the S3 directory, like
```
s3://adafruit-circuit-python/bootloaders/esp32/tinyuf2-adafruit_feather_esp32s3-0.32.0.zip
```
and now I want them to be in board-specific subdirectories, to be more organized:
```
s3://adafruit-circuit-python/bootloaders/esp32/adafruit_feather_esp32s3/tinyuf2-adafruit_feather_esp32s3-0.32.0.zip
```
I've already done this "by hand" for the existing files, and this PR https://github.com/adafruit/tinyuf2/pull/454 will make the change for future release.

Setting this to draft until that PR is merged.