### PR TITLE
additional warnings for MagTag 2025

### DIFF
--- a/_board/adafruit_magtag_2.9_grayscale.md
+++ b/_board/adafruit_magtag_2.9_grayscale.md
@@ -21,7 +21,7 @@ features:
   - USB-C
 ---
 
-**UPDATE: The Adafruit MagTag has a new 2025 Edition! As of July 22, 2025, the display has been updated (the old one was discontinued). CircuitPython 10.0.0-beta.1 or later is needed to support the new display, and will still also support the old display on older MagTags. If you want to use 9.2.x or an older release on an older board, see the *Previous Versions of CircuitPython* box on this page.**
+**UPDATE: The Adafruit MagTag has a new 2025 Edition!** As of July 22, 2025, the display has been updated (the old one was discontinued). **You must use CircuitPython 10.0.0-beta.1 to support the new display.** It will also work on older MagTags.
 
 The Adafruit MagTag combines the new ESP32-S2 wireless module and a 2.9" grayscale E-Ink display to make a low-power IoT display that can show data on its screen even when power is removed! The ESP32-S2 is great because it builds on the years of code and support for the ESP32 and also adds native USB support so you can use this board with Arduino _or_ CircuitPython!
 

--- a/_includes/download/board.html
+++ b/_includes/download/board.html
@@ -20,18 +20,24 @@
       This is the latest <strong>stable</strong> release of CircuitPython that will work with the {{ page.name }}.
       <strong>Use this release</strong> if you are new to CircuitPython.
     </p>
+    {% if board_id == 'adafruit_magtag_2.9_grayscale' %}
+    <p>
+      <strong>WARNING: The updated Adafruit MagTag 2025 Edition will not work with Circuitpython 9.2.x or earlier</strong>.
+      Use 10.0.0-beta.1 or later, downloaded from below.
+    </p>
+    {% endif %}
     {% else %}
     <p>
       This is the latest development release of CircuitPython that will work with the {{ page.name }}.
     </p>
     {% if page.family == 'esp32s2' or page.family == 'esp32s3' %}
       <p>
-        <strong>On Espressif ESP32-S2 and ESP32-S3 boards with 4MB flash,
-          CircuitPython 10.0.0-beta.0 and later require TinyUF2 bootloader version 0.33.0 or later.
-          Older TinyUF2 bootloaders don't provide enough room for the firmware and cannot load it.
-          See the
-          <a href="https://github.com/adafruit/circuitpython/releases/tag/{{ version.version }}">Release Notes</a>
-          for more details, and see <em>Update UF2 Bootloader</em> below.</strong>
+        <strong>WARNING: On Espressif ESP32-S2 and ESP32-S3 boards with 4MB flash,
+          CircuitPython 10.0.0-beta.0 and later require TinyUF2 bootloader version 0.33.0 or later.</strong>
+        Older TinyUF2 bootloaders don't provide enough room for the firmware and cannot load it.
+        See the
+        <a href="https://github.com/adafruit/circuitpython/releases/tag/{{ version.version }}">Release Notes</a>
+        for more details, and see <em>Update UF2 Bootloader</em> below.
       </p>
     {% endif %}
     <p>


### PR DESCRIPTION
Add board-specific warning that 9.2.x and earlier won't work with Magtag 2025.
Clarify UPDATE in board description.
Use bold a little less for better readability.