### PR TITLE
some boards missing bootloader_id

### DIFF
--- a/_board/espressif_esp32s2_devkitc_1_n4.md
+++ b/_board/espressif_esp32s2_devkitc_1_n4.md
@@ -7,6 +7,7 @@ manufacturer: "Espressif"
 board_url:
  - "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-s2-devkitc-1.html"
 board_image: "espressif_esp32s2_devkitc_1_n4.jpg"
+bootloader_id: espressif_esp32s2_devkitc_1
 date_added: 2022-04-01
 family: esp32s2
 features:

--- a/_board/espressif_esp32s2_devkitc_1_n4r2.md
+++ b/_board/espressif_esp32s2_devkitc_1_n4r2.md
@@ -7,6 +7,7 @@ manufacturer: "Espressif"
 board_url:
  - "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-s2-devkitc-1.html"
 board_image: "espressif_esp32s2_devkitc_1_n4r2.jpg"
+bootloader_id: espressif_esp32s2_devkitc_1
 date_added: 2022-02-14
 family: esp32s2
 features:

--- a/_board/lilygo_tdisplay_s3_pro.md
+++ b/_board/lilygo_tdisplay_s3_pro.md
@@ -7,6 +7,7 @@ manufacturer: "LILYGO"
 board_url:
  - "https://www.lilygo.cc/products/t-display-s3-pro"
 board_image: "lilygo_tdisplay_s3_pro.jpg"
+bootloader_id: lilygo_tdisplay_s3_pro
 date_added: 2024-07-18
 family: esp32s3
 features:

--- a/_board/lilygo_tdongle_s3.md
+++ b/_board/lilygo_tdongle_s3.md
@@ -7,6 +7,7 @@ manufacturer: "LILYGO"
 board_url:
  - "https://lilygo.cc/products/t-dongle-s3"
 board_image: "lilygo_tdongle_s3.jpg"
+bootloader_id: lilygo_tdongle_s3
 date_added: 2024-07-18
 family: esp32s3
 features:

--- a/_board/waveshare_esp32_s3_matrix.md
+++ b/_board/waveshare_esp32_s3_matrix.md
@@ -7,6 +7,7 @@ manufacturer: "Waveshare"
 board_url:
  - "https://www.waveshare.com/product/arduino/boards-kits/esp32/esp32-s3-matrix.htm"
 board_image: "waveshare_esp32_s3_matrix.jpg"
+bootloader_id: waveshare_esp32_s3_matrix
 date_added: 2025-01-27
 family: esp32s3
 features:
@@ -35,4 +36,3 @@ Waveshare Wiki [link](https://www.waveshare.com/wiki/ESP32-S3-Matrix).
 
 ## Purchase
 * [Waveshare](https://www.waveshare.com/product/arduino/boards-kits/esp32/esp32-s3-matrix.htm)
-

--- a/_board/waveshare_esp32_s3_touch_lcd_2.md
+++ b/_board/waveshare_esp32_s3_touch_lcd_2.md
@@ -8,6 +8,8 @@ board_url:
  - "https://www.waveshare.com/esp32-s3-touch-lcd-2.htm"
 board_image: "waveshare_esp32_s3_touch_lcd_2.jpg"
 date_added: 2024-04-17
+bootloader_id: waveshare_esp32_s3_touch_lcd_2
+downloads_display: true
 family: esp32s3
 features:
   - USB-C


### PR DESCRIPTION
Some boards were missing `bootloader_id:` fields, even though they did have bootloaders available from https://github.com/adafruit/tinyuf2/tree/master/ports/espressif/boards.

Motivated by https://forums.adafruit.com/viewtopic.php?t=219773