### PR TITLE
Add missing Bluetooth/BTLE tags to some feathers

### DIFF
--- a/_board/adafruit_feather_esp32s3_4mbflash_2mbpsram.md
+++ b/_board/adafruit_feather_esp32s3_4mbflash_2mbpsram.md
@@ -17,6 +17,7 @@ features:
   - Battery Charging
   - STEMMA QT/QWIIC
   - Wi-Fi
+  - Bluetooth/BTLE
   - USB-C
   - Breadboard-Friendly
 

--- a/_board/adafruit_feather_esp32s3_nopsram.md
+++ b/_board/adafruit_feather_esp32s3_nopsram.md
@@ -17,6 +17,7 @@ features:
   - Battery Charging
   - STEMMA QT/QWIIC
   - Wi-Fi
+  - Bluetooth/BTLE
   - USB-C
   - Breadboard-Friendly
 

--- a/_board/adafruit_feather_esp32s3_reverse_tft.md
+++ b/_board/adafruit_feather_esp32s3_reverse_tft.md
@@ -19,6 +19,7 @@ features:
   - Battery Charging
   - STEMMA QT/QWIIC
   - Wi-Fi
+  - Bluetooth/BTLE
   - USB-C
   - Display
 ---

--- a/_board/adafruit_feather_esp32s3_tft.md
+++ b/_board/adafruit_feather_esp32s3_tft.md
@@ -17,6 +17,7 @@ features:
   - Battery Charging
   - STEMMA QT/QWIIC
   - Wi-Fi
+  - Bluetooth/BTLE
   - USB-C
   - Display
   - Breadboard-Friendly


### PR DESCRIPTION
I was searching through the downloads with the Bluetooth filter and some devices I own didn't come up. Some of the Feather ESP32S3 variants weren't tagged, although Bluetooth is mentioned in the description and other ESP32-S3 boards are tagged with it.  This adds the Bluetooth/BTLE feature to those boards.