### PR TITLE
fix board_id for prokyber ai edge cam.

### DIFF
--- a/_board/ai_on_the_edge_cam.md
+++ b/_board/ai_on_the_edge_cam.md
@@ -1,6 +1,6 @@
 ---
 layout: download
-board_id: "ai_on_the_edge_cam"
+board_id: "prokyber_ai_on_the_edge_cam"
 title: "AI-On-The-Edge-Cam: Esp32-S3 with PoE, SD, Camera Download"
 name: "AI-On-The-Edge-Cam"
 manufacturer: "Prokyber"


### PR DESCRIPTION
Fixes an issue reported in discord: https://discord.com/channels/327254708534116352/327298996332658690/1422214092806033409

I tested this change locally by running dev server and confirming that the S3 button now leads to the proper page that contains firmware files instead of an empty list.