### PR TITLE
Add WebSerial ESPTool link to Absolute Newest section

### DIFF
--- a/_includes/download/board.html
+++ b/_includes/download/board.html
@@ -220,6 +220,9 @@
   </p>
   <div>
     <a class="download-button-unrecommended" href="https://adafruit-circuit-python.s3.amazonaws.com/index.html?prefix=bin/{{ board_id }}/">BROWSE S3<i class="fas fa-arrow-circle-right" aria-hidden="true"></i></a>
+    {% if bootloader_info and bootloader_info.installer and bootloader_info.installer == true %}
+    <a class="download-button-unrecommended" href="https://adafruit.github.io/Adafruit_WebSerial_ESPTool/">OPEN WEBSERIAL ESPTOOL<i class="fas fa-arrow-circle-right" aria-hidden="true"></i></a>
+    {% endif %}
     <div class="clear"></div>
   </div>
 </div>


### PR DESCRIPTION
## Summary

Adds a link to the [Adafruit WebSerial ESPTool](https://adafruit.github.io/Adafruit_WebSerial_ESPTool/) in the **Absolute Newest** section on board download pages. The link only appears for boards where `bootloader_info.installer == true` (ESP32 variants).

This gives users a convenient way to flash `.bin` files downloaded from the S3 bucket onto their ESP32-based boards.

### Changes

| File | What changed |
|------|-------------|
| `_includes/download/board.html` | Added conditional WebSerial ESPTool button next to the existing BROWSE S3 button |

### Screenshot

On ESP32 board pages, the Absolute Newest section will show:

```
[BROWSE S3 →]  [OPEN WEBSERIAL ESPTOOL →]
```

On non-ESP32 boards, only the existing BROWSE S3 button appears (no change).

Addresses #1572