### PR TITLE
update GitHub CI action versions for Node.24

### DIFF
--- a/.github/workflows/adabot_cron.yml
+++ b/.github/workflows/adabot_cron.yml
@@ -30,13 +30,13 @@ jobs:
         GITHUB_CONTEXT: ${{ toJson(github) }}
       run: echo "$GITHUB_CONTEXT"
     - name: Set up Python 3.x
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.9
     - name: Versions
       run: |
         python3 --version
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         show-progress: false
         submodules: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,14 +28,14 @@ jobs:
     # be limited (they run on all forks' default branches).
     if: startswith(github.repository, 'adafruit/')
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
     - name: Update Awesome CircuitPython
       run: |
         (cd awesome-circuitpython && git fetch origin main:main && git checkout main)
     - name: Set up Python 3.x
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.x
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           show-progress: false
 
@@ -21,7 +21,7 @@ jobs:
           compressOnly: true
       - name: Create New Pull Request If Needed
         if: steps.calibre.outputs.markdown != ''
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v8
         with:
           title: Compressed Images Nightly
           branch-suffix: timestamp


### PR DESCRIPTION
Updated `actions/checkout`, `actions/setup-python` to latest, for Node.24.

Also updated `peter-evans/create-pull-request` from `@v4` to `@v8`. This is a big jump. Let's see if it works. (EDIT: will not get tested until the image updater job runs).