### PR TITLE
Fix board date sorting on downloads page

### DIFF
--- a/assets/javascript/downloads.js
+++ b/assets/javascript/downloads.js
@@ -350,8 +350,10 @@ function filterResults() {
     } else {
       download.style.display = 'block';
       board_count++;
-      // exact tag match re-order
-      if (downloadsSearch.searchTerm !== null && downloadsSearch.searchTerm !== undefined) {
+      // exact tag match re-order only for default (downloads) sort
+      var currentSort = document.querySelector("input[name='sort-by']:checked");
+      var currentSortValue = currentSort ? currentSort.value : 'downloads';
+      if (currentSortValue === 'downloads' && downloadsSearch.searchTerm !== null && downloadsSearch.searchTerm !== undefined) {
         let searched = downloadsSearch.searchTerm.toLowerCase();
         let tags = download.dataset.tags?.split(",") || [];
         if (searched !== "" && tags.indexOf(searched) >= 0) {
@@ -376,11 +378,13 @@ function handleSortResults(event) {
   Array.prototype.slice.call(downloads.children)
     .map(function (download) { return downloads.removeChild(download); })
     .sort(function (a, b) {
-      // exact tag match re-order
-      if (searched !== undefined && searched !== "" &&
-          a.dataset.tags.split(",").indexOf(searched) >= 0){
-
-        return -2;
+      // exact tag match re-order only for default (downloads) sort
+      if (sortType === 'downloads' && searched !== undefined && searched !== "") {
+        var aMatch = a.dataset.tags.split(",").indexOf(searched) >= 0;
+        var bMatch = b.dataset.tags.split(",").indexOf(searched) >= 0;
+        if (aMatch !== bMatch) {
+          return aMatch ? -1 : 1;
+        }
       }
       switch(sortType) {
         case 'alpha-asc':
@@ -388,16 +392,16 @@ function handleSortResults(event) {
         case 'alpha-desc':
           return b.dataset.name.localeCompare(a.dataset.name);
         case 'date-asc':
-          dateA = new Date(a.dataset.date)
-          dateB = new Date(b.dataset.date)
-          return dateA.getTime() < dateB.getTime() ? -1 : 1;
+          var dateA = new Date(a.dataset.date);
+          var dateB = new Date(b.dataset.date);
+          return dateA.getTime() - dateB.getTime();
         case 'date-desc':
-          dateA = new Date(a.dataset.date)
-          dateB = new Date(b.dataset.date)
-          return dateA.getTime() < dateB.getTime() ? 1 : -1;
+          var dateA = new Date(a.dataset.date);
+          var dateB = new Date(b.dataset.date);
+          return dateB.getTime() - dateA.getTime();
         default:
           // sort by download count is the default
-          return parseInt(a.dataset.downloads, 10) < parseInt(b.dataset.downloads, 10) ? 1 : -1;
+          return parseInt(b.dataset.downloads, 10) - parseInt(a.dataset.downloads, 10);
       }
     })
     .forEach(function (download) { downloads.appendChild(download); });

--- a/assets/javascript/downloads.js
+++ b/assets/javascript/downloads.js
@@ -392,12 +392,18 @@ function handleSortResults(event) {
         case 'alpha-desc':
           return b.dataset.name.localeCompare(a.dataset.name);
         case 'date-asc':
-          var dateA = new Date(a.dataset.date);
-          var dateB = new Date(b.dataset.date);
-          return dateA.getTime() - dateB.getTime();
         case 'date-desc':
-          var dateA = new Date(a.dataset.date);
-          var dateB = new Date(b.dataset.date);
+          var dateA = a.dataset.date ? new Date(a.dataset.date) : null;
+          var dateB = b.dataset.date ? new Date(b.dataset.date) : null;
+          var validA = dateA && !isNaN(dateA.getTime());
+          var validB = dateB && !isNaN(dateB.getTime());
+          // boards without a valid date go to the end
+          if (!validA && !validB) return 0;
+          if (!validA) return 1;
+          if (!validB) return -1;
+          if (sortType === 'date-asc') {
+            return dateA.getTime() - dateB.getTime();
+          }
           return dateB.getTime() - dateA.getTime();
         default:
           // sort by download count is the default


### PR DESCRIPTION
## Problem

Sorting boards on the downloads page by date (newest/oldest first) produces unexpected results, as reported in #1760.

## Root Cause

The sort comparator in `downloads.js` had several issues:

1. **Tag match overrides all sort modes**: The exact tag match promotion (`return -2`) ran before the sort-type switch statement for *all* sort modes, so when a search term was active, matching boards were always pushed to the top — even when the user explicitly selected date or alphabetical sorting.

2. **Asymmetric tag comparison**: Only item `a` was checked for tag match; item `b` was never tested. This made the comparator inconsistent (violating the sort contract where `compare(a,b)` and `compare(b,a)` should be symmetric).

3. **Missing equality case in comparators**: The date and download-count comparators used ternary returns (`< ? -1 : 1`) instead of subtraction, so they never returned `0` for equal values. This produced unstable sort results for boards sharing the same date or download count.

4. **filterResults also ignores sort selection**: The `filterResults` function prepends tag-matched boards to the DOM regardless of the currently selected sort, undoing an explicit date or alphabetical sort whenever filtering re-runs.

## Fix

- Tag match promotion now only applies when the sort type is `downloads` (the default)
- Both `a` and `b` are checked for tag matches symmetrically
- Date and download comparators use arithmetic subtraction for proper three-way comparison
- `filterResults` checks the active sort radio before doing tag-match reordering

## Testing

- Sort by "Date Added (Newest First)" → boards appear in correct descending date order
- Sort by "Date Added (Oldest First)" → boards appear in correct ascending date order  
- Sort by alphabetical → unaffected by search tag matches
- Default downloads sort with search term → tag matches still promoted to top (existing behavior preserved)