### PR TITLE
Add board_usage to remaining Blinka boards and require field

### DIFF
--- a/_blinka/banana_pi_bpi_p2_pro.md
+++ b/_blinka/banana_pi_bpi_p2_pro.md
@@ -1,0 +1,41 @@
+---
+layout: download
+board_id: "banana_pi_bpi_p2_pro"
+title: "Banana Pi BPI-P2 Pro Download"
+name: "Banana Pi BPI-P2 Pro"
+manufacturer: "SinoVoip"
+board_url:
+ - "https://wiki.banana-pi.org/Banana_Pi_BPI-P2_Pro"
+board_image: "banana_pi_bpi_p2_pro.jpg"
+downloads_display: true
+blinka: true
+date_added: 2025-12-31
+features:
+  - Ethernet
+  - Wi-Fi
+  - Bluetooth/BLE
+  - 40-pin GPIO
+board_usage:
+ - Linux
+---
+
+Banana Pi BPI-P2 Pro is a compact development board based on the Rockchip RK3308B-S chip. With a high-performance 4-core ARM Cortex-A35 processor, 512MB DDR3 RAM, and 8GB eMMC onboard storage, it supports PoE (Power over Ethernet) functionality. The chip has a wealth of interfaces including I2S, PCM, TDM, I2C, UART, SPDIF, HDMI ARC, and more to meet a variety of application needs.
+
+RK3308 has rich voice interfaces with its own eight ADC inputs, multi-channel I2S and multi-channel PDM interfaces. This provides a wealth of audio interface choices while reducing hardware design difficulty and cost.
+
+### Specifications
+
+- CPU: 64-bit Quad-core ARM Cortex-A35 Rockchip RK3308B-S
+- RAM: 512MB DDR3
+- Storage: 8GB eMMC onboard, MicroSD card slot (max 64GB)
+- Network: 100M Ethernet LAN
+- PoE: IEEE 802.3af PoE support
+- WiFi + BT: 802.11 a/b/g/n/ac & BT 5.0 (AP6256)
+- GPIO: 40-pin + 12-pin headers
+- USB: 1x USB 2.0, 1x Type-C
+- Audio: Built-in audio CODEC with ADC×8 and DAC×2
+- Power: Type-C 5V/2A or PoE
+- Size: 65mm × 52.5mm
+
+## Purchase
+* [Banana Pi](https://wiki.banana-pi.org/Banana_Pi_BPI-P2_Pro)

--- a/_blinka/luckyfox_pico_ultra.md
+++ b/_blinka/luckyfox_pico_ultra.md
@@ -1,0 +1,43 @@
+---
+layout: download
+board_id: "luckyfox_pico_ultra"
+title: "LuckyFox Pico Ultra Download"
+name: "LuckyFox Pico Ultra"
+manufacturer: "LuckyFox"
+board_url:
+ - "https://www.luckfox.com/Luckfox-Pico/EN-Luckfox-Pico-Ultra"
+board_image: "luckyfox_pico_ultra.jpg"
+downloads_display: true
+blinka: true
+date_added: 2025-11-20
+features:
+  - Ethernet
+  - Wi-Fi
+  - Bluetooth/BLE
+board_usage:
+ - Linux
+---
+
+LuckFox Pico Ultra is a low-cost Linux micro development board based on the Rockchip RV1106G3 chip. RV1106 is a highly integrated IPC visual processing SoC designed for AI-related applications. It is built on a single-core ARM Cortex-A7 32-bit core with integrated NEON and FPU, and features a built-in NPU that supports INT4/INT8/INT16 mixed operations, with a computing power of up to 1 TOPS.
+
+It features a hardware-based ISP that supports various algorithm accelerators such as HDR, 3A, LSC, 3DNR, 2DNR, sharpening, haze removal, gamma correction, and more. Additionally, it has a built-in 16-bit DDR3L DRAM to maintain demanding memory bandwidth, as well as built-in POR, audio codec, and MAC PHY.
+
+The board supports multiple interfaces including GPIO, UART, SPI, I2C, USB, and more, facilitating rapid development and debugging. The Ultra variant includes 256MB DDR3L memory, 8GB eMMC onboard storage, a 10/100M Ethernet port, PoE support, and a reserved header for optional WiFi 6 + Bluetooth 5.2 module (available on the Ultra W variant).
+
+### Specifications
+
+- Processor: Rockchip RV1106G3
+- CPU: Cortex-A7 @ 1.2GHz
+- NPU: 1 TOPS, supports INT4/INT8/INT16
+- ISP: Max input 5M @ 30fps
+- Memory: 256MB DDR3L
+- Storage: 8GB eMMC
+- USB: USB 2.0 Host/Device
+- Camera: MIPI CSI 2-lane
+- Display: RGB666 DPI interface
+- PoE: IEEE 802.3af
+- GPIO: 33 GPIO pins
+- Ethernet: 10/100M Ethernet controller and embedded PHY
+
+## Purchase
+* [LuckyFox](https://www.luckfox.com/Luckfox-Pico/EN-Luckfox-Pico-Ultra)

--- a/_blinka/orange_pi_5_ultra.md
+++ b/_blinka/orange_pi_5_ultra.md
@@ -1,0 +1,48 @@
+---
+layout: download
+board_id: "orange_pi_5_ultra"
+title: "Orange Pi 5 Ultra Download"
+name: "Orange Pi 5 Ultra"
+manufacturer: "Shenzhen Xunlong Software CO., Limited"
+board_url:
+ - "http://www.orangepi.org/html/hardWare/computerAndMicrocontrollers/details/Orange-Pi-5-Ultra.html"
+board_image: "orange_pi_5_ultra.jpg"
+downloads_display: true
+blinka: true
+date_added: 2026-03-02
+features:
+  - Ethernet
+  - USB 3.0
+  - HDMI/DisplayPort
+  - NVME/M.2 Connector
+  - Wi-Fi
+  - Bluetooth/BLE
+  - 40-pin GPIO
+board_usage:
+ - Linux
+---
+
+Orange Pi 5 Ultra is powered by the Rockchip RK3588 8-core 64-bit processor with 4 Cortex-A76 (2.4GHz) and 4 Cortex-A55 (1.8GHz) cores with independent NEON coprocessor. Adopting 8nm process design, it integrates an ARM Mali-G610 GPU compatible with OpenGL ES 1.1/2.0/3.2, OpenCL 2.2, and Vulkan 1.2. The embedded NPU supports INT4/INT8/INT16/FP16 hybrid computing with up to 6 TOPS of computing power.
+
+It has 4GB/8GB/16GB LPDDR5, up to 8K display processing capability, supports eMMC storage, and has Wi-Fi 6E + BT 5.3 with BLE support. The board provides abundant interfaces including HDMI 2.1 output (8K@60), HDMI 2.0 input (4K@60), GPIO, USB 2.0, USB 3.0, a 3.5mm headphone jack, a PCIe-extended 2.5G Ethernet port, and an M.2 M-Key slot (PCIe 3.0 4-Lane) supporting NVMe or SATA SSDs.
+
+Orange Pi 5 Ultra is compact at just 89mm × 57mm, and supports Orange Pi OS, Ubuntu, Android 13, Debian and other operating systems.
+
+### Specifications
+
+- SoC: Rockchip RK3588 (8nm LP process)
+- CPU: 8-core 64-bit (4× Cortex-A76 @ 2.4GHz, 4× Cortex-A55 @ 1.8GHz)
+- GPU: ARM Mali-G610 (OpenGL ES 3.2, OpenCL 2.2, Vulkan 1.2)
+- NPU: 6 TOPS (INT4/INT8/INT16/FP16)
+- RAM: 4GB/8GB/16GB LPDDR5
+- Storage: eMMC (32/64/128/256GB), 16MB QSPI NOR Flash, MicroSD, M.2 NVMe
+- Video Out: HDMI 2.1 (8K@60), MIPI DSI
+- Video In: HDMI 2.0 (4K@60), 2× MIPI CSI 4-lane, 1× MIPI D-PHY RX 4-lane
+- Network: PCIe 2.5G Ethernet (RTL8125BG)
+- WiFi + BT: Wi-Fi 6E + BT 5.3/BLE (AP6611)
+- USB: 2× USB 3.0, 2× USB 2.0
+- GPIO: 40-pin header
+- Power: Type-C 5V/5A
+
+## Purchase
+* [Orange Pi](http://www.orangepi.org/html/hardWare/computerAndMicrocontrollers/details/Orange-Pi-5-Ultra.html)

--- a/_blinka/raspberry_pi_pico2.md
+++ b/_blinka/raspberry_pi_pico2.md
@@ -1,0 +1,37 @@
+---
+layout: download
+board_id: "raspberry_pi_pico2"
+title: "Pico 2 Download"
+name: "Pico 2"
+manufacturer: "Raspberry Pi"
+board_url:
+ - "https://www.adafruit.com/product/6083"
+board_image: "raspberry_pi_pico2.jpg"
+download_instructions: "https://learn.adafruit.com/circuitpython-libraries-on-micropython-using-the-raspberry-pi-pico"
+downloads_display: true
+blinka: true
+date_added: 2026-03-02
+board_usage:
+ - MicroPython
+---
+
+Raspberry Pi Pico 2 is Raspberry Pi Foundation's update to their popular RP2040-based Pico board, now built on **RP2350**: their new high-performance, secure microcontroller. With a higher core clock speed, double the on-chip SRAM (512KB), double the on-board flash memory (4MB), more powerful Arm M33 cores, new security and low-power features, and upgraded interfacing capabilities, the Pico 2 delivers a significant performance and feature boost while retaining hardware and software compatibility with the original Pico.
+
+The unique dual-core, dual-architecture capability of RP2350 allows users to choose between a pair of industry-standard Arm Cortex-M33 cores and a pair of open-hardware Hazard3 RISC-V cores. The M33 has an FPU and is roughly 2× as fast as the M0+ of the RP2040.
+
+Not only is the Pico 2 twice as fast, it has twice as much RAM (520KB vs 264KB) and twice as much flash (4MB vs 2MB). There are also 3 PIO blocks with 4 state machines each (up from 2), plus HSTX (high speed transmission) for high-frequency output signals like DVI.
+
+Blinka supports the Pico 2 via both [MicroPython](https://learn.adafruit.com/circuitpython-libraries-on-micropython-using-the-raspberry-pi-pico) and [u2if (USB-to-IF)](https://learn.adafruit.com/circuitpython-libraries-on-any-computer-with-raspberry-pi-pico), allowing you to use CircuitPython libraries either directly on the board or from a connected computer.
+
+**RP2350 Chip features:**
+* Dual ARM Cortex-M33 or dual Hazard3 RISC-V @ 150MHz
+* 520kB on-chip SRAM
+* 4MB of on-board QSPI Flash
+* 2 UARTs, 2 SPI controllers, 2 I2C controllers
+* 24 PWM channels
+* USB 1.1 controller and PHY, with host and device support
+* 12 PIO state machines (3 blocks × 4)
+* HSTX peripheral
+
+## Purchase
+* [Adafruit](https://www.adafruit.com/product/6083)

--- a/_blinka/raspberry_pi_pico2_w.md
+++ b/_blinka/raspberry_pi_pico2_w.md
@@ -1,0 +1,44 @@
+---
+layout: download
+board_id: "raspberry_pi_pico2_w"
+title: "Pico 2 W Download"
+name: "Pico 2 W"
+manufacturer: "Raspberry Pi"
+board_url:
+ - "https://www.adafruit.com/product/6087"
+board_image: "raspberry_pi_pico2_w.jpg"
+download_instructions: "https://learn.adafruit.com/circuitpython-libraries-on-micropython-using-the-raspberry-pi-pico"
+downloads_display: true
+blinka: true
+date_added: 2026-03-02
+features:
+  - Wi-Fi
+  - Bluetooth/BLE
+board_usage:
+ - MicroPython
+---
+
+Raspberry Pi Pico 2 W combines the power of the **RP2350** microcontroller with on-board wireless connectivity. It is the wireless variant of the Pico 2, adding single-band 2.4GHz WiFi and Bluetooth 5.2 via the Infineon CYW43439 while retaining the same compact Pico form factor.
+
+With a higher core clock speed, double the on-chip SRAM (512KB), double the on-board flash memory (4MB), more powerful Arm M33 cores, and upgraded interfacing capabilities, the Pico 2 W delivers a significant performance and feature boost while retaining hardware and software compatibility with earlier Pico boards.
+
+The unique dual-core, dual-architecture capability of RP2350 allows users to choose between a pair of Arm Cortex-M33 cores and a pair of open-hardware Hazard3 RISC-V cores. The M33 has an FPU and is roughly 2× as fast as the M0+ of the RP2040.
+
+Blinka supports the Pico 2 W via both [MicroPython](https://learn.adafruit.com/circuitpython-libraries-on-micropython-using-the-raspberry-pi-pico) and [u2if (USB-to-IF)](https://learn.adafruit.com/circuitpython-libraries-on-any-computer-with-raspberry-pi-pico), allowing you to use CircuitPython libraries either directly on the board or from a connected computer.
+
+**RP2350 Chip features:**
+* Dual ARM Cortex-M33 or dual Hazard3 RISC-V @ 150MHz
+* 520kB on-chip SRAM
+* 4MB of on-board QSPI Flash
+* 2 UARTs, 2 SPI controllers, 2 I2C controllers
+* 24 PWM channels
+* USB 1.1 controller and PHY, with host and device support
+* 12 PIO state machines (3 blocks × 4)
+* HSTX peripheral
+
+**Wireless features:**
+* 802.11n WiFi (2.4 GHz) with WPA3
+* Bluetooth 5.2 / BLE
+
+## Purchase
+* [Adafruit](https://www.adafruit.com/product/6087)

--- a/_blinka/raspberry_pi_pico_w.md
+++ b/_blinka/raspberry_pi_pico_w.md
@@ -1,0 +1,42 @@
+---
+layout: download
+board_id: "raspberry_pi_pico_w"
+title: "Pico W Download"
+name: "Pico W"
+manufacturer: "Raspberry Pi"
+board_url:
+ - "https://www.adafruit.com/product/5526"
+board_image: "raspberry_pi_pico_w.jpg"
+download_instructions: "https://learn.adafruit.com/circuitpython-libraries-on-micropython-using-the-raspberry-pi-pico"
+downloads_display: true
+blinka: true
+date_added: 2026-03-02
+features:
+  - Wi-Fi
+  - Bluetooth/BLE
+board_usage:
+ - MicroPython
+---
+
+Raspberry Pi Pico W brings WiFi + BLE wireless networking to the Pico platform while retaining complete pin compatibility with its older sibling. It is powered by the **RP2040** microcontroller and adds on-board single-band 2.4GHz wireless interfaces (802.11n) using the Infineon CYW43439 while retaining the Pico form factor.
+
+The on-board 2.4GHz wireless interface has the following features:
+
+- Wireless (802.11n), Single-band (2.4 GHz) WiFi with WPA3 and Soft Access Point supporting up to 4 clients
+- Bluetooth Low Energy (BLE)
+
+The Pico W has the same 0.825" × 2" form factor as the original Pico and can have headers soldered in for use in a breadboard, or be soldered directly onto a PCB with the castellated pads. You get a total of 26 GPIO pins, 3 of which can be used as analog inputs. All GPIO pins are 3.3V logic.
+
+Blinka supports the Pico W via both [MicroPython](https://learn.adafruit.com/circuitpython-libraries-on-micropython-using-the-raspberry-pi-pico) and [u2if (USB-to-IF)](https://learn.adafruit.com/circuitpython-libraries-on-any-computer-with-raspberry-pi-pico), allowing you to use CircuitPython libraries either directly on the board or from a connected computer.
+
+**RP2040 Chip features:**
+* Dual ARM Cortex-M0+ @ 133MHz
+* 264kB on-chip SRAM in six independent banks
+* 2MB of on-board QSPI Flash
+* 2 UARTs, 2 SPI controllers, 2 I2C controllers
+* 16 PWM channels
+* USB 1.1 controller and PHY, with host and device support
+* 8 PIO state machines
+
+## Purchase
+* [Adafruit](https://www.adafruit.com/product/5526)

--- a/tools/check-boards.py
+++ b/tools/check-boards.py
@@ -130,7 +130,10 @@ def verify_board_usage(folder, valid_usages):
             if board_id == "unknown":
                 continue
             board_usage = metadata.get('board_usage')
-            if board_usage is not None:
+            if board_usage is None:
+                print(f"{filename}:0: board_usage field is missing for {board_id}")
+                valid = False
+            else:
                 for usage in board_usage:
                     if usage not in valid_usages:
                         print(f"{filename}:0: Non-standard board_usage: {usage}")


### PR DESCRIPTION
Follow-up to #1765. Adds `board_usage` to the 6 boards that were added in #1763:

- **Linux:** banana_pi_bpi_p2_pro, luckyfox_pico_ultra, orange_pi_5_ultra
- **MicroPython:** raspberry_pi_pico2, raspberry_pi_pico2_w, raspberry_pi_pico_w

Also makes `board_usage` a required field in `check-boards.py` validation. All Blinka boards now have `board_usage` set.