### PR TITLE
Add board_usage to remaining Blinka boards and require field

### DIFF
--- a/_blinka/banana_pi_bpi_p2_pro.md
+++ b/_blinka/banana_pi_bpi_p2_pro.md
@@ -15,6 +15,8 @@ features:
   - Wi-Fi
   - Bluetooth/BLE
   - 40-pin GPIO
+board_usage:
+ - Linux
 ---
 
 Banana Pi BPI-P2 Pro is a compact development board based on the Rockchip RK3308B-S chip. With a high-performance 4-core ARM Cortex-A35 processor, 512MB DDR3 RAM, and 8GB eMMC onboard storage, it supports PoE (Power over Ethernet) functionality. The chip has a wealth of interfaces including I2S, PCM, TDM, I2C, UART, SPDIF, HDMI ARC, and more to meet a variety of application needs.

--- a/_blinka/luckyfox_pico_ultra.md
+++ b/_blinka/luckyfox_pico_ultra.md
@@ -14,6 +14,8 @@ features:
   - Ethernet
   - Wi-Fi
   - Bluetooth/BLE
+board_usage:
+ - Linux
 ---
 
 LuckFox Pico Ultra is a low-cost Linux micro development board based on the Rockchip RV1106G3 chip. RV1106 is a highly integrated IPC visual processing SoC designed for AI-related applications. It is built on a single-core ARM Cortex-A7 32-bit core with integrated NEON and FPU, and features a built-in NPU that supports INT4/INT8/INT16 mixed operations, with a computing power of up to 1 TOPS.

--- a/_blinka/orange_pi_5_ultra.md
+++ b/_blinka/orange_pi_5_ultra.md
@@ -18,6 +18,8 @@ features:
   - Wi-Fi
   - Bluetooth/BLE
   - 40-pin GPIO
+board_usage:
+ - Linux
 ---
 
 Orange Pi 5 Ultra is powered by the Rockchip RK3588 8-core 64-bit processor with 4 Cortex-A76 (2.4GHz) and 4 Cortex-A55 (1.8GHz) cores with independent NEON coprocessor. Adopting 8nm process design, it integrates an ARM Mali-G610 GPU compatible with OpenGL ES 1.1/2.0/3.2, OpenCL 2.2, and Vulkan 1.2. The embedded NPU supports INT4/INT8/INT16/FP16 hybrid computing with up to 6 TOPS of computing power.

--- a/_blinka/raspberry_pi_pico2.md
+++ b/_blinka/raspberry_pi_pico2.md
@@ -11,6 +11,8 @@ download_instructions: "https://learn.adafruit.com/circuitpython-libraries-on-mi
 downloads_display: true
 blinka: true
 date_added: 2026-03-02
+board_usage:
+ - MicroPython
 ---
 
 Raspberry Pi Pico 2 is Raspberry Pi Foundation's update to their popular RP2040-based Pico board, now built on **RP2350**: their new high-performance, secure microcontroller. With a higher core clock speed, double the on-chip SRAM (512KB), double the on-board flash memory (4MB), more powerful Arm M33 cores, new security and low-power features, and upgraded interfacing capabilities, the Pico 2 delivers a significant performance and feature boost while retaining hardware and software compatibility with the original Pico.

--- a/_blinka/raspberry_pi_pico2_w.md
+++ b/_blinka/raspberry_pi_pico2_w.md
@@ -14,6 +14,8 @@ date_added: 2026-03-02
 features:
   - Wi-Fi
   - Bluetooth/BLE
+board_usage:
+ - MicroPython
 ---
 
 Raspberry Pi Pico 2 W combines the power of the **RP2350** microcontroller with on-board wireless connectivity. It is the wireless variant of the Pico 2, adding single-band 2.4GHz WiFi and Bluetooth 5.2 via the Infineon CYW43439 while retaining the same compact Pico form factor.

--- a/_blinka/raspberry_pi_pico_w.md
+++ b/_blinka/raspberry_pi_pico_w.md
@@ -14,6 +14,8 @@ date_added: 2026-03-02
 features:
   - Wi-Fi
   - Bluetooth/BLE
+board_usage:
+ - MicroPython
 ---
 
 Raspberry Pi Pico W brings WiFi + BLE wireless networking to the Pico platform while retaining complete pin compatibility with its older sibling. It is powered by the **RP2040** microcontroller and adds on-board single-band 2.4GHz wireless interfaces (802.11n) using the Infineon CYW43439 while retaining the Pico form factor.

--- a/tools/check-boards.py
+++ b/tools/check-boards.py
@@ -130,7 +130,10 @@ def verify_board_usage(folder, valid_usages):
             if board_id == "unknown":
                 continue
             board_usage = metadata.get('board_usage')
-            if board_usage is not None:
+            if board_usage is None:
+                print(f"{filename}:0: board_usage field is missing for {board_id}")
+                valid = False
+            else:
                 for usage in board_usage:
                     if usage not in valid_usages:
                         print(f"{filename}:0: Non-standard board_usage: {usage}")


### PR DESCRIPTION
Follow-up to #1765. Adds `board_usage` to the 6 boards added in #1763:

- **Linux:** banana_pi_bpi_p2_pro, luckyfox_pico_ultra, orange_pi_5_ultra
- **MicroPython:** raspberry_pi_pico2, raspberry_pi_pico2_w, raspberry_pi_pico_w

Also makes `board_usage` a required field in `check-boards.py` validation. All Blinka boards now have `board_usage` set.