### PR TITLE
Add Attached usage to Raspberry Pi Pico Blinka boards

### DIFF
--- a/_blinka/raspberry_pi_pico.md
+++ b/_blinka/raspberry_pi_pico.md
@@ -13,6 +13,7 @@ blinka: true
 date_added: 2021-05-20
 board_usage:
  - MicroPython
+ - Attached
 ---
 
 The Raspberry Pi foundation changed single-board computing when they released the Raspberry Pi computer, now they're ready to do the same for microcontrollers with the release of the brand new **Raspberry Pi Pico**. This low-cost microcontroller board features a powerful new chip, the **RP2040**, and all the fixin's to get started with embedded electronics projects at a stress-free price.

--- a/_blinka/raspberry_pi_pico2.md
+++ b/_blinka/raspberry_pi_pico2.md
@@ -13,6 +13,7 @@ blinka: true
 date_added: 2026-03-02
 board_usage:
  - MicroPython
+ - Attached
 ---
 
 Raspberry Pi Pico 2 is Raspberry Pi Foundation's update to their popular RP2040-based Pico board, now built on **RP2350**: their new high-performance, secure microcontroller. With a higher core clock speed, double the on-chip SRAM (512KB), double the on-board flash memory (4MB), more powerful Arm M33 cores, new security and low-power features, and upgraded interfacing capabilities, the Pico 2 delivers a significant performance and feature boost while retaining hardware and software compatibility with the original Pico.

--- a/_blinka/raspberry_pi_pico2_w.md
+++ b/_blinka/raspberry_pi_pico2_w.md
@@ -16,6 +16,7 @@ features:
   - Bluetooth/BLE
 board_usage:
  - MicroPython
+ - Attached
 ---
 
 Raspberry Pi Pico 2 W combines the power of the **RP2350** microcontroller with on-board wireless connectivity. It is the wireless variant of the Pico 2, adding single-band 2.4GHz WiFi and Bluetooth 5.2 via the Infineon CYW43439 while retaining the same compact Pico form factor.

--- a/_blinka/raspberry_pi_pico_w.md
+++ b/_blinka/raspberry_pi_pico_w.md
@@ -16,6 +16,7 @@ features:
   - Bluetooth/BLE
 board_usage:
  - MicroPython
+ - Attached
 ---
 
 Raspberry Pi Pico W brings WiFi + BLE wireless networking to the Pico platform while retaining complete pin compatibility with its older sibling. It is powered by the **RP2040** microcontroller and adds on-board single-band 2.4GHz wireless interfaces (802.11n) using the Infineon CYW43439 while retaining the Pico form factor.


### PR DESCRIPTION
The Raspberry Pi Pico boards support both MicroPython and U2IF (Attached) usage modes. This adds `Attached` to their `board_usage` field:

- raspberry_pi_pico
- raspberry_pi_pico_w
- raspberry_pi_pico2
- raspberry_pi_pico2_w

All four now have:
```yaml
board_usage:
 - MicroPython
 - Attached
```