### PR TITLE
Add features and board usage sections to Blinka board pages

### DIFF
--- a/_includes/download/blinka.html
+++ b/_includes/download/blinka.html
@@ -17,4 +17,30 @@
     <div class="clear"></div>
   </div>
   {% endif %}
+  {% if page.features %}
+  <p>Features:
+    <span class="features-list">
+    {% for feature in page.features %}
+      <a class="library-link" href="/blinka?features={{ feature }}">{{feature}}</a>{% unless forloop.last %}, {% endunless %}
+    {% endfor %}
+    </span>
+  </p>
+  {% endif %}
+  {% if page.board_usage %}
+  <p>Board Usage:
+    <span class="features-list">
+    {% for usage in page.board_usage %}
+      {% if usage == "Linux" %}
+        <a class="library-link" href="https://learn.adafruit.com/adding-a-single-board-computer-to-blinka/types-of-boards#linux-single-board-computers-3216284">Linux Single Board Computer</a>
+      {% elsif usage == "Attached" %}
+        <a class="library-link" href="https://learn.adafruit.com/adding-a-single-board-computer-to-blinka/types-of-boards#attached-devices-3216284">Attached Device</a>
+      {% elsif usage == "MicroPython" %}
+        <a class="library-link" href="https://learn.adafruit.com/adding-a-single-board-computer-to-blinka/types-of-boards#micropython-boards-3216284">MicroPython Board</a>
+      {% else %}
+        <span class="library-link">{{ usage }}</span>
+      {% endif %}{% unless forloop.last %}, {% endunless %}
+    {% endfor %}
+    </span>
+  </p>
+  {% endif %}
 </div>

--- a/_includes/download/blinka.html
+++ b/_includes/download/blinka.html
@@ -30,15 +30,15 @@
   <p>Board Usage:
     <span class="features-list">
     {% for usage in page.board_usage %}
-      {% if usage == "Linux" %}
+      {%- if usage == "Linux" %}
         <a class="library-link" href="https://learn.adafruit.com/adding-a-single-board-computer-to-blinka/types-of-boards#linux-single-board-computers-3216284">Linux Single Board Computer</a>
-      {% elsif usage == "Attached" %}
+      {%- elsif usage == "Attached" %}
         <a class="library-link" href="https://learn.adafruit.com/adding-a-single-board-computer-to-blinka/types-of-boards#attached-devices-3216284">Attached Device</a>
-      {% elsif usage == "MicroPython" %}
+      {%- elsif usage == "MicroPython" %}
         <a class="library-link" href="https://learn.adafruit.com/adding-a-single-board-computer-to-blinka/types-of-boards#micropython-boards-3216284">MicroPython Board</a>
-      {% else %}
+      {%- else %}
         <span class="library-link">{{ usage }}</span>
-      {% endif %}{% unless forloop.last %}, {% endunless %}
+      {%- endif %}{% unless forloop.last %}, {% endunless %}
     {% endfor %}
     </span>
   </p>

--- a/_includes/download/blinka.html
+++ b/_includes/download/blinka.html
@@ -27,7 +27,7 @@
   </p>
   {% endif %}
   {% if page.board_usage %}
-  <p>Board Usage:
+  <p>Board Usage Options:
     <span class="features-list">
     {% for usage in page.board_usage %}
       {%- if usage == "Linux" %}


### PR DESCRIPTION
Adds features list and board usage links to individual Blinka board download pages, displayed just below the Installation Instructions button.

## Changes

**`_includes/download/blinka.html`**

- **Features section**: Uses the same markup/style as non-Blinka board pages (`features-list` + `library-link` classes). Links point to `/blinka?features=...` to filter the Blinka listing page.
- **Board Usage section**: Maps each `board_usage` front matter value to a descriptive label with a link to the relevant anchor on the [Types of Boards](https://learn.adafruit.com/adding-a-single-board-computer-to-blinka/types-of-boards) learn guide page:
  - `Linux` → "Linux Single Board Computer"
  - `Attached` → "Attached Device"
  - `MicroPython` → "MicroPython Board"
- Boards with multiple usages (e.g. Raspberry Pi Pico) show comma-separated links
- Both sections are conditionally rendered — boards missing the data won't show empty sections

## Data Coverage

- 159 of 166 Blinka boards have `features` populated
- All 166 boards have `board_usage` populated (added in #1767 and #1768)