### PR TITLE
download layout: load CryptoJS so installer can verify flash writes

### DIFF
--- a/_layouts/download.html
+++ b/_layouts/download.html
@@ -33,6 +33,13 @@ layout: default
 {% assign bootloaders = site.data.bootloaders.bootloaders %}
 {% assign bootloader_info = bootloaders[page.family] %}
 {% if bootloader_info and bootloader_info.installer and bootloader_info.installer == true %}
+<!--
+  CryptoJS enables post-flash MD5 verification inside the installer
+  (see adafruit/web-firmware-installer-js#23). Without it, esptool-js
+  silently skips the readback hash check, which can mask flash
+  corruption on some USB-serial bridges.
+-->
+<script src="https://cdn.jsdelivr.net/npm/crypto-js@4.2.0/crypto-js.min.js"></script>
 <script
   src="https://cdn.jsdelivr.net/gh/adafruit/web-firmware-installer-js@2/dist/cpinstaller.min.js"
   type="module"


### PR DESCRIPTION
## Summary

Follow-up to [adafruit/web-firmware-installer-js#23](https://github.com/adafruit/web-firmware-installer-js/pull/23), which fixed [issue #22](https://github.com/adafruit/web-firmware-installer-js/issues/22) (OPEN INSTALLER hang on Feather ESP32 V2).

The installer fix enables post-flash MD5 verification by passing a `calculateMD5Hash` callback to `esptool-js`'s `writeFlash`. esptool-js only runs the readback hash check when that callback is supplied, and the callback in turn relies on a hashing library being present on the host page. To keep the installer drop-in for all consumers, that library is **optional**: when it isn't loaded, the installer's callback returns `null` and esptool-js skips verification (preserving the prior behavior).

This PR loads `crypto-js` on the download pages that render the installer, which is what activates the verification path in production.

## Change

Adds one `<script>` tag to `_layouts/download.html`, inside the same `{% if bootloader_info and bootloader_info.installer == true %}` block that already loads `cpinstaller.min.js`, so the cost is bounded to pages where the installer is actually rendered. Source is the same `cdn.jsdelivr.net` we already use for the installer bundle.

```html
<script src="https://cdn.jsdelivr.net/npm/crypto-js@4.2.0/crypto-js.min.js"></script>
```

Minified CryptoJS is ~50&nbsp;kB. It loads in parallel with the installer module and is a no-op if cached.

## Why this matters

Without this script tag, `esptool-js` silently trusts every flash write. On flaky USB-serial bridges (notably Pi 5 + CP2104) that masked active flash corruption and made boards boot-loop with `invalid header: 0xffffffff` after a successful-looking install &mdash; which is exactly what issue #22 was. With CryptoJS loaded, the installer now surfaces the upstream `MD5 of file does not match data in flash!` error instead of producing a silently bricked board.

## Testing

* `adafruit/web-firmware-installer-js` already detects `CryptoJS` at runtime, so once this change is deployed the verification path runs automatically for every installer launch. No installer-side change is required here.
* Verified locally that the script ordering (`crypto-js` before the `cpinstaller.min.js` module) makes the global available when the module evaluates.

## Related

* Installer fix: adafruit/web-firmware-installer-js#23
* Original bug: adafruit/web-firmware-installer-js#22
