### PR TITLE
update samx bootloaders to v4.0.0

### DIFF
--- a/_data/bootloaders.json
+++ b/_data/bootloaders.json
@@ -4,16 +4,16 @@
             "version": "0.9.2"
         },
         "samd21": {
-            "version": "v3.16.0"
+            "version": "v4.0.0"
         },
         "samd51": {
-            "version": "v3.16.0"
+            "version": "v4.0.0"
         },
         "same51": {
-            "version": "v3.16.0"
+            "version": "v4.0.0"
         },
         "same54": {
-            "version": "v3.16.0"
+            "version": "v4.0.0"
         },
         "esp32s2": {
             "version": "0.35.0",


### PR DESCRIPTION
Update the SAMD and SAME bootloaders to v4.0.0, which includes a vital fix https://github.com/adafruit/uf2-samdx1/pull/231 to allow BOOT drives to work on ChromeOS and recent versions of Linux that use `fwupd` 2.x.x.