### PR TITLE
Add bootloader_id for ESP32-S3-DevKitC-1-N32R16

### DIFF
--- a/_board/espressif_esp32s3_devkitc_1_n32r16.md
+++ b/_board/espressif_esp32s3_devkitc_1_n32r16.md
@@ -9,6 +9,7 @@ board_url:
 board_image: "espressif_esp32s3_devkitc_1.jpg"
 date_added: 2026-08-12
 family: esp32s3
+bootloader_id: espressif_esp32s3_devkitc_1_n32r16
 features:
   - Wi-Fi
   - Bluetooth/BTLE

--- a/_board/espressif_esp32s3_devkitc_1_n32r16.md
+++ b/_board/espressif_esp32s3_devkitc_1_n32r16.md
@@ -9,7 +9,7 @@ board_url:
 board_image: "espressif_esp32s3_devkitc_1.jpg"
 date_added: 2026-08-12
 family: esp32s3
-bootloader_id: espressif_esp32s3_devkitc_1_n32r16
+bootloader_id: espressif_esp32s3_devkitc_1
 features:
   - Wi-Fi
   - Bluetooth/BTLE


### PR DESCRIPTION
## What
Adds `bootloader_id` so the [N32R16](https://circuitpython.org/board/espressif_esp32s3_devkitc_1_n32r16/) page shows a TinyUF2 download.

## Why
Reported by @grgrant in adafruit/tinyuf2#482. Without the field the template renders no bootloader section.

## Which id
`espressif_esp32s3_devkitc_1`, per @makermelissa, matching every other DevKitC-1 variant. Resolves to the released 0.35.0 combined.bin.

My first attempt used `espressif_esp32s3_devkitc_1_n32r16`. That board exists in tinyuf2 master but has never been released, so it resolves to nothing.

## Caveat
The released generic build sets `CONFIG_ESPTOOLPY_FLASHSIZE_8MB`. The unreleased n32r16 board sets 32MB.

| tinyuf2 board | flash | released |
|---|---|---|
| `espressif_esp32s3_devkitc_1` | 8MB | 0.35.0 |
| `espressif_esp32s3_devkitc_1_n32r16` | 32MB | no |

So the page gives a working BOOT drive on a layout that leaves flash unused. `_n32r8` is also a 32MB board pointing at the same 8MB build today.

## Hardware tested
@grgrant on an N32R16V: `N32R16BOOT`, 29MB filesystem, CP 10.3.0 loads. That was the unreleased 32MB build, not what this PR points at. Not tested by me.

## Scope
One line in one board file. Revisit the id after the next tinyuf2 release.

## AI assistance
Claude Code traced the template gate and diffed the two tinyuf2 sdkconfigs. I verified the S3 asset myself.
